### PR TITLE
Fix default type and internalFormat of GLTexture

### DIFF
--- a/packages/core/src/textures/GLTexture.ts
+++ b/packages/core/src/textures/GLTexture.ts
@@ -1,3 +1,5 @@
+import { FORMATS, TYPES } from '@pixi/constants';
+
 /**
  * Internal texture for WebGL context
  * @class
@@ -66,13 +68,13 @@ export class GLTexture
          * Type copied from baseTexture
          * @member {number}
          */
-        this.type = 5121;
+        this.type = TYPES.UNSIGNED_BYTE;
 
         /**
          * Type copied from baseTexture
          * @member {number}
          */
-        this.internalFormat = 6408;
+        this.internalFormat = FORMATS.RGBA;
 
         this.samplerType = 0;
     }

--- a/packages/core/src/textures/GLTexture.ts
+++ b/packages/core/src/textures/GLTexture.ts
@@ -66,13 +66,13 @@ export class GLTexture
          * Type copied from baseTexture
          * @member {number}
          */
-        this.type = 6408;
+        this.type = 5121;
 
         /**
          * Type copied from baseTexture
          * @member {number}
          */
-        this.internalFormat = 5121;
+        this.internalFormat = 6408;
 
         this.samplerType = 0;
     }


### PR DESCRIPTION
### Description of change

Swap the default values of `GLTexture.type` and `GLTexture.internalFormat`, because it's the wrong way around.

```
GL_UNSIGNED_BYTE = 5121
GL_RGBA          = 6408 
```

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
