### PR TITLE
Remove misleading description

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -53,9 +53,6 @@ export enum BUFFER_BITS {
 /**
  * Various blend modes supported by PIXI.
  *
- * IMPORTANT - The WebGL renderer only supports the NORMAL, ADD, MULTIPLY and SCREEN blend modes.
- * Anything else will silently act like NORMAL.
- *
  * @memberof PIXI
  * @name BLEND_MODES
  * @enum {number}


### PR DESCRIPTION
##### Description of change
Description of ``BLEND_MODES`` is out of date. The WebGL renderer supports for each blend mode.

