### PR TITLE
Fix filter-system frame rounding precision-issue

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -599,7 +599,8 @@ export class FilterSystem implements ISystem
 
             // Skip if skew/rotation present in matrix, except for multiple of 90° rotation. If rotation
             // is a multiple of 90°, then either pair of (b,c) or (a,d) will be (0,0).
-            if ((b !== 0 || c !== 0) && (a !== 0 || d !== 0))
+            if ((Math.abs(b) > 1e-4 || Math.abs(c) > 1e-4) &&
+                (Math.abs(a) > 1e-4 || Math.abs(d) > 1e-4))
             {
                 return;
             }

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -599,8 +599,8 @@ export class FilterSystem implements ISystem
 
             // Skip if skew/rotation present in matrix, except for multiple of 90° rotation. If rotation
             // is a multiple of 90°, then either pair of (b,c) or (a,d) will be (0,0).
-            if ((Math.abs(b) > 1e-4 || Math.abs(c) > 1e-4) &&
-                (Math.abs(a) > 1e-4 || Math.abs(d) > 1e-4))
+            if ((Math.abs(b) > 1e-4 || Math.abs(c) > 1e-4)
+                && (Math.abs(a) > 1e-4 || Math.abs(d) > 1e-4))
             {
                 return;
             }


### PR DESCRIPTION
Fixes #7468 

##### Description of change
Use floating-point equality test instead

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
