### PR TITLE
Set _isConnectedToTicker to false when disposing VideoResource

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -333,6 +333,7 @@ export class VideoResource extends BaseImageResource
         if (this._isConnectedToTicker)
         {
             Ticker.shared.remove(this.update, this);
+            this._isConnectedToTicker = false;
         }
 
         const source = this.source as HTMLVideoElement;


### PR DESCRIPTION
Fixes #7400

##### Description of change

This will help in debugging (so developers don't think there's a listener leak in disposed VideoResources)
