### PR TITLE
Fix UBO handling mat3 Matrix uniforms

### DIFF
--- a/packages/core/src/shader/utils/uniformParsers.ts
+++ b/packages/core/src/shader/utils/uniformParsers.ts
@@ -66,10 +66,17 @@ export const uniformParsers: IUniformParser[] = [
             `
                 var ${name}_matrix = uv.${name}.toArray(true);
 
-                for(var i = 0; i < 9; i++)
-                {
-                    data[offset + i] = ${name}_matrix[i];
-                }
+                data[offset] = ${name}_matrix[0];
+                data[offset+1] = ${name}_matrix[1];
+                data[offset+2] = ${name}_matrix[2];
+        
+                data[offset + 4] = ${name}_matrix[3];
+                data[offset + 5] = ${name}_matrix[4];
+                data[offset + 6] = ${name}_matrix[5];
+        
+                data[offset + 8] = ${name}_matrix[6];
+                data[offset + 9] = ${name}_matrix[7];
+                data[offset + 10] = ${name}_matrix[8];
             `
         ,
 


### PR DESCRIPTION
Fixes #7421 

##### Description of change

This basically matches what we had in `UBO_TO_SINGLE_SETTERS` when you passed an array instead of `Matrix`.

<img width="455" alt="Screen Shot 2021-05-15 at 12 49 30 PM" src="https://user-images.githubusercontent.com/22450567/118371755-ffac0300-b57b-11eb-83eb-53a123bd3b1c.png">

You can verify the fix by using this branch's build in https://replit.com/@SukantPal/UBOs#main.js and remove the `toArray` here (tested this locally)

<img width="471" alt="Screen Shot 2021-05-15 at 12 49 08 PM" src="https://user-images.githubusercontent.com/22450567/118371736-f1f67d80-b57b-11eb-9ef2-9e549a9af450.png">

