### PR TITLE
Fix geometry merging when geometries are of different sizes

### DIFF
--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -438,7 +438,7 @@ export class Geometry
                     geometryOut.indexBuffer.data[j + offset2] += offset;
                 }
 
-                offset += geometry.buffers[bufferIndexToCount].data.length / (stride);
+                offset += geometries[i].buffers[bufferIndexToCount].data.length / (stride);
                 offset2 += indexBufferData.length;
             }
         }

--- a/packages/core/test/Geometry.js
+++ b/packages/core/test/Geometry.js
@@ -102,4 +102,17 @@ describe('PIXI.Geometry', function ()
             renderer.destroy();
         }
     });
+
+    it('should correctly merge the index buffers of geometries with different length', function () {
+        const geom0 = new Geometry()
+            .addAttribute('aVertexPosition', [0, 0, 1, 1, 2, 2], 2)
+            .addIndex([0, 1, 2]);
+        const geom1 = new Geometry()
+            .addAttribute('aVertexPosition', [0, 0, 1, 1, 2, 2, 3, 3], 2)
+            .addIndex([0, 1, 2, 3]);
+
+        const geom = Geometry.merge([geom0, geom1]);
+
+        expect([...geom.getIndex().data]).to.have.members([0, 1, 2, 3, 4, 5, 6]);
+    });
 });

--- a/packages/core/test/Geometry.js
+++ b/packages/core/test/Geometry.js
@@ -103,7 +103,8 @@ describe('PIXI.Geometry', function ()
         }
     });
 
-    it('should correctly merge the index buffers of geometries with different length', function () {
+    it('should correctly merge the index buffers of geometries with different length', function ()
+    {
         const geom0 = new Geometry()
             .addAttribute('aVertexPosition', [0, 0, 1, 1, 2, 2], 2)
             .addIndex([0, 1, 2]);


### PR DESCRIPTION
Fixes #7456

##### Description of change

Add the size of the currently geometry to the vertex offset (instead of the last geometry). That means the vertices of the next geometry will get the current offset in the out-geometry.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
