### PR TITLE
Fix roundPixels

### DIFF
--- a/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -195,6 +195,20 @@ export class CanvasMeshRenderer
         context.save();
         context.beginPath();
 
+        if (mesh.roundPixels)
+        {
+            const { a, b, c, d } = mesh.worldTransform;
+            const sx = Math.sqrt((a * a) + (b * b));
+            const sy = Math.sqrt((c * c) + (d * d));
+
+            x0 = Math.round(x0 * sx) / sx;
+            y0 = Math.round(y0 * sy) / sy;
+            x1 = Math.round(x1 * sx) / sx;
+            y1 = Math.round(y1 * sy) / sy;
+            x2 = Math.round(x2 * sx) / sx;
+            y2 = Math.round(y2 * sy) / sy;
+        }
+
         context.moveTo(x0, y0);
         context.lineTo(x1, y1);
         context.lineTo(x2, y2);

--- a/packages/canvas/canvas-mesh/src/NineSlicePlane.ts
+++ b/packages/canvas/canvas-mesh/src/NineSlicePlane.ts
@@ -92,18 +92,43 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer: Canvas
     renderer.setBlendMode(this.blendMode);
     renderer.setContextTransform(transform, this.roundPixels);
 
+    let sx;
+    let sy;
+
+    if (this.roundPixels)
+    {
+        const { a, b, c, d } = transform;
+
+        sx = Math.sqrt((a * a) + (b * b));
+        sy = Math.sqrt((c * c) + (d * d));
+    }
+
     for (let row = 0; row < 3; row++)
     {
         for (let col = 0; col < 3; col++)
         {
             const ind = (col * 2) + (row * 8);
-            const sw = Math.max(1, uvs[col + 1] - uvs[col]);
-            const sh = Math.max(1, uvs[row + 5] - uvs[row + 4]);
-            const dw = Math.max(1, vertices[ind + 10] - vertices[ind]);
-            const dh = Math.max(1, vertices[ind + 11] - vertices[ind + 1]);
+            let dx = vertices[ind];
+            let dy = vertices[ind + 1];
+            let dw = vertices[ind + 10] - dx;
+            let dh = vertices[ind + 11] - dy;
 
-            context.drawImage(textureSource, uvs[col], uvs[row + 4], sw, sh,
-                vertices[ind], vertices[ind + 1], dw, dh);
+            if (this.roundPixels)
+            {
+                dx = Math.round(dx * sx) / sx;
+                dy = Math.round(dy * sy) / sy;
+                dw = Math.round(dw * sx) / sx;
+                dh = Math.round(dh * sy) / sy;
+            }
+
+            {
+                const sx = uvs[col];
+                const sy = uvs[row + 4];
+                const sw = uvs[col + 1] - sx;
+                const sh = uvs[row + 5] - sy;
+
+                context.drawImage(textureSource, sx, sy, sw, sh, dx, dy, dw, dh);
+            }
         }
     }
 };

--- a/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas/canvas-renderer/src/CanvasRenderer.ts
@@ -368,41 +368,31 @@ export class CanvasRenderer extends AbstractRenderer
      */
     setContextTransform(transform: Matrix, roundPixels?: boolean, localResolution?: number): void
     {
-        let mat = transform;
+        const mat = transform.copyTo(tempMatrix);
         const proj = this._projTransform;
         const resolution = this.resolution;
 
-        localResolution = localResolution || resolution;
-
-        if (proj)
-        {
-            mat = tempMatrix;
-            mat.copyFrom(transform);
-            mat.prepend(proj);
-        }
+        localResolution = localResolution || this.resolution;
 
         if (roundPixels)
         {
-            this.context.setTransform(
-                mat.a * localResolution,
-                mat.b * localResolution,
-                mat.c * localResolution,
-                mat.d * localResolution,
-                (mat.tx * resolution) | 0,
-                (mat.ty * resolution) | 0
-            );
+            mat.tx = Math.round(mat.tx);
+            mat.ty = Math.round(mat.ty);
         }
-        else
+
+        if (proj)
         {
-            this.context.setTransform(
-                mat.a * localResolution,
-                mat.b * localResolution,
-                mat.c * localResolution,
-                mat.d * localResolution,
-                mat.tx * resolution,
-                mat.ty * resolution
-            );
+            mat.prepend(proj);
         }
+
+        this.context.setTransform(
+            mat.a * localResolution,
+            mat.b * localResolution,
+            mat.c * localResolution,
+            mat.d * localResolution,
+            mat.tx * resolution,
+            mat.ty * resolution
+        );
     }
 
     /**

--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -60,15 +60,12 @@ export class CanvasSpriteRenderer
         let wt = sprite.transform.worldTransform;
         let dx = 0;
         let dy = 0;
+        let dw = width;
+        let dh = height;
 
         const source = texture.baseTexture.getDrawableSource();
 
         if (texture.orig.width <= 0 || texture.orig.height <= 0 || !texture.valid || !source)
-        {
-            return;
-        }
-
-        if (!texture.valid)
         {
             return;
         }
@@ -110,12 +107,18 @@ export class CanvasSpriteRenderer
         dx -= width / 2;
         dy -= height / 2;
 
-        renderer.setContextTransform(wt, sprite.roundPixels, 1);
-        // Allow for pixel rounding
+        renderer.setContextTransform(wt, sprite.roundPixels);
+
         if (sprite.roundPixels)
         {
-            dx = dx | 0;
-            dy = dy | 0;
+            const { a, b, c, d } = wt;
+            const sx = Math.sqrt((a * a) + (b * b));
+            const sy = Math.sqrt((c * c) + (d * d));
+
+            dx = Math.round(dx * sx) / sx;
+            dy = Math.round(dy * sy) / sy;
+            dw = Math.round(dw * sx) / sx;
+            dh = Math.round(dh * sy) / sy;
         }
 
         const resolution = texture.baseTexture.resolution;
@@ -125,12 +128,7 @@ export class CanvasSpriteRenderer
         {
             context.save();
             context.beginPath();
-            context.rect(
-                dx * renderer.resolution,
-                dy * renderer.resolution,
-                width * renderer.resolution,
-                height * renderer.resolution
-            );
+            context.rect(dx, dy, dw, dh);
             context.clip();
         }
 
@@ -148,12 +146,12 @@ export class CanvasSpriteRenderer
                 sprite._tintedCanvas,
                 0,
                 0,
-                Math.floor(width * resolution),
-                Math.floor(height * resolution),
-                Math.floor(dx * renderer.resolution),
-                Math.floor(dy * renderer.resolution),
-                Math.floor(width * renderer.resolution),
-                Math.floor(height * renderer.resolution)
+                width * resolution,
+                height * resolution,
+                dx,
+                dy,
+                dw,
+                dh
             );
         }
         else
@@ -162,12 +160,12 @@ export class CanvasSpriteRenderer
                 source,
                 texture._frame.x * resolution,
                 texture._frame.y * resolution,
-                Math.floor(width * resolution),
-                Math.floor(height * resolution),
-                Math.floor(dx * renderer.resolution),
-                Math.floor(dy * renderer.resolution),
-                Math.floor(width * renderer.resolution),
-                Math.floor(height * renderer.resolution)
+                width * resolution,
+                height * resolution,
+                dx,
+                dy,
+                dw,
+                dh
             );
         }
 

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -149,6 +149,7 @@ export class Mesh<T extends Shader = MeshMaterial> extends Container
          * Internal roundPixels field
          *
          * @member {boolean}
+         * @default PIXI.settings.ROUND_PIXELS
          * @private
          */
         this._roundPixels = settings.ROUND_PIXELS;
@@ -217,13 +218,13 @@ export class Mesh<T extends Shader = MeshMaterial> extends Container
     }
 
     /**
-     * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
+     * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
      * Advantages can include sharper image quality (like text) and faster rendering on canvas.
      * The main disadvantage is movement of objects may appear less smooth.
-     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}
+     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}.
      *
      * @member {boolean}
-     * @default false
+     * @default PIXI.settings.ROUND_PIXELS
      */
     set roundPixels(value: boolean)
     {

--- a/packages/particles/package.json
+++ b/packages/particles/package.json
@@ -29,6 +29,7 @@
     "@pixi/core": "6.0.4",
     "@pixi/display": "6.0.4",
     "@pixi/math": "6.0.4",
+    "@pixi/settings": "6.0.4",
     "@pixi/utils": "6.0.4"
   }
 }

--- a/packages/particles/src/ParticleContainer.ts
+++ b/packages/particles/src/ParticleContainer.ts
@@ -1,6 +1,7 @@
 import { BLEND_MODES } from '@pixi/constants';
 import { Container } from '@pixi/display';
 import { hex2rgb } from '@pixi/utils';
+import { settings } from '@pixi/settings';
 
 import type { BaseTexture, Renderer } from '@pixi/core';
 import type { ParticleBuffer } from './ParticleBuffer';
@@ -154,12 +155,12 @@ export class ParticleContainer extends Container
          * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
          * Advantages can include sharper image quality (like text) and faster rendering on canvas.
          * The main disadvantage is movement of objects may appear less smooth.
-         * Default to true here as performance is usually the priority for particles.
+         * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}.
          *
          * @member {boolean}
-         * @default true
+         * @default PIXI.settings.ROUND_PIXELS
          */
-        this.roundPixels = true;
+        this.roundPixels = settings.ROUND_PIXELS;
 
         /**
          * The texture used to render the children.

--- a/packages/particles/src/ParticleContainer.ts
+++ b/packages/particles/src/ParticleContainer.ts
@@ -151,7 +151,7 @@ export class ParticleContainer extends Container
         this.autoResize = autoResize;
 
         /**
-         * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
+         * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
          * Advantages can include sharper image quality (like text) and faster rendering on canvas.
          * The main disadvantage is movement of objects may appear less smooth.
          * Default to true here as performance is usually the priority for particles.

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -267,7 +267,7 @@ export const settings: ISettings = {
     CREATE_IMAGE_BITMAP: false,
 
     /**
-     * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
+     * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
      * Advantages can include sharper image quality (like text) and faster rendering on canvas.
      * The main disadvantage is movement of objects may appear less smooth.
      *

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -219,6 +219,7 @@ export class Sprite extends Container
          * Internal roundPixels field
          *
          * @member {boolean}
+         * @default PIXI.settings.ROUND_PIXELS
          * @private
          */
         this._roundPixels = settings.ROUND_PIXELS;
@@ -575,13 +576,13 @@ export class Sprite extends Container
     }
 
     /**
-     * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
+     * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
      * Advantages can include sharper image quality (like text) and faster rendering on canvas.
      * The main disadvantage is movement of objects may appear less smooth.
-     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}
+     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}.
      *
      * @member {boolean}
-     * @default false
+     * @default PIXI.settings.ROUND_PIXELS
      */
     set roundPixels(value: boolean)
     {

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -286,8 +286,8 @@ export class Sprite extends Container
         const b = wt.b;
         const c = wt.c;
         const d = wt.d;
-        const tx = wt.tx;
-        const ty = wt.ty;
+        let tx = wt.tx;
+        let ty = wt.ty;
         const vertexData = this.vertexData;
         const trim = texture.trim;
         const orig = texture.orig;
@@ -303,19 +303,36 @@ export class Sprite extends Container
             // if the sprite is trimmed and is not a tilingsprite then we need to add the extra
             // space before transforming the sprite coords.
             w1 = trim.x - (anchor._x * orig.width);
-            w0 = w1 + trim.width;
+            w0 = trim.width;
 
             h1 = trim.y - (anchor._y * orig.height);
-            h0 = h1 + trim.height;
+            h0 = trim.height;
         }
         else
         {
             w1 = -anchor._x * orig.width;
-            w0 = w1 + orig.width;
+            w0 = orig.width;
 
             h1 = -anchor._y * orig.height;
-            h0 = h1 + orig.height;
+            h0 = orig.height;
         }
+
+        if (this._roundPixels)
+        {
+            tx = Math.round(tx);
+            ty = Math.round(ty);
+
+            const sx = Math.sqrt((a * a) + (b * b));
+            const sy = Math.sqrt((c * c) + (d * d));
+
+            w0 = Math.round(w0 * sx) / sx;
+            w1 = Math.round(w1 * sx) / sx;
+            h0 = Math.round(h0 * sy) / sy;
+            h1 = Math.round(h1 * sy) / sy;
+        }
+
+        w0 += w1;
+        h0 += h1;
 
         // xy
         vertexData[0] = (a * w1) + (c * h1) + tx;
@@ -332,16 +349,6 @@ export class Sprite extends Container
         // xy
         vertexData[6] = (a * w1) + (c * h0) + tx;
         vertexData[7] = (d * h0) + (b * w1) + ty;
-
-        if (this._roundPixels)
-        {
-            const resolution = settings.RESOLUTION;
-
-            for (let i = 0; i < vertexData.length; ++i)
-            {
-                vertexData[i] = Math.round((vertexData[i] * resolution | 0) / resolution);
-            }
-        }
     }
 
     /**
@@ -374,14 +381,31 @@ export class Sprite extends Container
         const b = wt.b;
         const c = wt.c;
         const d = wt.d;
-        const tx = wt.tx;
-        const ty = wt.ty;
+        let tx = wt.tx;
+        let ty = wt.ty;
 
-        const w1 = -anchor._x * orig.width;
-        const w0 = w1 + orig.width;
+        let w1 = -anchor._x * orig.width;
+        let w0 = orig.width;
 
-        const h1 = -anchor._y * orig.height;
-        const h0 = h1 + orig.height;
+        let h1 = -anchor._y * orig.height;
+        let h0 = orig.height;
+
+        if (this._roundPixels)
+        {
+            tx = Math.round(tx);
+            ty = Math.round(ty);
+
+            const sx = Math.sqrt((a * a) + (b * b));
+            const sy = Math.sqrt((c * c) + (d * d));
+
+            w0 = Math.round(w0 * sx) / sx;
+            w1 = Math.round(w1 * sx) / sx;
+            h0 = Math.round(h0 * sy) / sy;
+            h1 = Math.round(h1 * sy) / sy;
+        }
+
+        w0 += w1;
+        h0 += h1;
 
         // xy
         vertexData[0] = (a * w1) + (c * h1) + tx;

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -210,7 +210,7 @@ export class BitmapText extends Container
         this._anchor = new ObservablePoint((): void => { this.dirty = true; }, this, 0, 0);
 
         /**
-         * If true PixiJS will Math.floor() x/y values when rendering
+         * If true PixiJS will Math.round() x/y values when rendering
          *
          * @member {boolean}
          * @default PIXI.settings.ROUND_PIXELS
@@ -840,10 +840,10 @@ export class BitmapText extends Container
     }
 
     /**
-     * If true PixiJS will Math.floor() x/y values when rendering, stopping pixel interpolation.
+     * If true PixiJS will Math.round() x/y values when rendering, stopping pixel interpolation.
      * Advantages can include sharper image quality (like text) and faster rendering on canvas.
      * The main disadvantage is movement of objects may appear less smooth.
-     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}
+     * To set the global default, change {@link PIXI.settings.ROUND_PIXELS}.
      *
      * @member {boolean}
      * @default PIXI.settings.ROUND_PIXELS


### PR DESCRIPTION
##### Description of change

Fixes #7049.

First off all, I consistently used `Math.round()` everywhere. `getBounds()` doesn't have access to the resolution, i.e., is independent of resolution, but we want it to match what is rendered. Also the renderer's resolution isn't necessarily the same resolution as render target's resolution when rendering to texture. So we can't really round to real pixels easily. Rounding world css pixels won't give crisp results when the resolution is non-integer, or when the camera transform isn't rounded, but that are problems that must be solved manually somehow. I also didn't like how the old pixel rounding used `settings.RESOLUTION` in Mesh, since it isn't necessarily the resolution of the current render target, so I got rid of that. Mesh rounded each point to the world grid, but that can cause [distortions](https://www.pixiplayground.com/#/edit/wm9D-u30IMoltS9hS9Q8j) in a way that is very likely not desired. So I round in local space w.r.t. the scaling factors of the world transform and round the translation part of the word transform.

```js
const { a, b, c, d } = worldTransform;
// extract scaling factors sx and sy
const sx = Math.sqrt((a * a) + (b * b));
const sy = Math.sqrt((c * c) + (d * d));

x = Math.round(x * sx) / sx;
y = Math.round(y * sy) / sy;
```

```js
worldTransform.tx = Math.round(worldTransform.tx);
worldTransform.ty = Math.round(worldTransform.ty);
```

Then each point lands on the world grid exactly, if no rotation is present in the world transform; and if there is rotation, it won't get distorted. So essentially rounding happens in between the scaling part and the rotation part of the world transform.

Added round pixels code (which was missing) to ParticleRenderer (webgl), Mesh (webgl, non-batching), Mesh (canvas2d).

Changed the roundPixels default in ParticleContainer to use `settings.ROUND_PIXELS` like everywhere else. It was `true` before and said something about improved performance, but that wouldn't be true in webgl, I suppose.

`CanvasRenderer.setContextTransform()` now just rounds tx/ty of the word transform (and not tx/ty of the entire context transform matrix with projection) to match the behavior in webgl mode.

One thing I haven't addressed yet: sx/sy are unnecessarily computed every time `CanvasMeshRenderer._renderDrawTriangle()` is called when it only needs to be computed once in `CanvasMeshRenderer.render()`.

canvas2d and webgl pixel rounding should give exactly the same results now.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
