### PR TITLE
Fix regression in RoundedRectangle

### DIFF
--- a/packages/graphics/src/utils/buildRoundedRectangle.ts
+++ b/packages/graphics/src/utils/buildRoundedRectangle.ts
@@ -71,6 +71,12 @@ function quadraticBezierCurve(
         x = getPt(xa, xb, j);
         y = getPt(ya, yb, j);
 
+        // Handle case when first curve points overlaps and earcut fails to triangulate
+        if (i === 0 && points[points.length - 2] === x && points[points.length - 1] === y)
+        {
+            continue;
+        }
+
         points.push(x, y);
     }
 
@@ -100,10 +106,7 @@ export const buildRoundedRectangle: IShapeBuildCommand = {
         const height = rrectData.height;
 
         // Don't allow negative radius or greater than half the smallest width
-        // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
-        // TODO - fix this properly, this is not very elegant.. but it works for now.
-        const maxRadius = (Math.min(width, height) / 2) - 0.0000000001;
-        const radius = Math.max(0, Math.min(rrectData.radius, maxRadius));
+        const radius = Math.max(0, Math.min(rrectData.radius, Math.min(width, height) / 2));
 
         points.length = 0;
 

--- a/packages/graphics/src/utils/buildRoundedRectangle.ts
+++ b/packages/graphics/src/utils/buildRoundedRectangle.ts
@@ -100,7 +100,10 @@ export const buildRoundedRectangle: IShapeBuildCommand = {
         const height = rrectData.height;
 
         // Don't allow negative radius or greater than half the smallest width
-        const radius = Math.max(0, Math.min(rrectData.radius, Math.min(width, height) / 2));
+        // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
+        // TODO - fix this properly, this is not very elegant.. but it works for now.
+        const maxRadius = (Math.min(width, height) / 2) - 0.0000000001;
+        const radius = Math.max(0, Math.min(rrectData.radius, maxRadius));
 
         points.length = 0;
 
@@ -131,9 +134,6 @@ export const buildRoundedRectangle: IShapeBuildCommand = {
                 x, y + height - radius,
                 points);
         }
-
-        // this tiny number deals with the issue that occurs when points overlap and earcut fails to triangulate the item.
-        // TODO - fix this properly, this is not very elegant.. but it works for now.
     },
 
     triangulate(graphicsData, graphicsGeometry)


### PR DESCRIPTION
Fixes #7515 

~~There was a similar hack in v4 that somehow got removed although the comment was still there! This applies a similar workaround to v6. If someone has a better idea how to fix, welcome! I believe this is an earcut issue ultimately.~~ Found a better hack-less solution.

Broken (v6.0.4)
https://jsfiddle.net/bigtimebuddy/kphz6o8e/

Fixed (fix/rounded-rect-max-radius)
https://jsfiddle.net/bigtimebuddy/9pneg8Lb/