### PR TITLE
Ignore built-in attributes that start with 'gl_'

### DIFF
--- a/packages/core/src/shader/utils/getAttributeData.ts
+++ b/packages/core/src/shader/utils/getAttributeData.ts
@@ -20,8 +20,12 @@ export function getAttributeData(program: WebGLProgram, gl: WebGLRenderingContex
     for (let i = 0; i < totalAttributes; i++)
     {
         const attribData = gl.getActiveAttrib(program, i);
-        const type = mapType(gl, attribData.type);
 
+        if (attribData.name.startsWith('gl_')) {
+            continue;
+        }
+
+        const type = mapType(gl, attribData.type);
         const data = {
             type,
             name: attribData.name,

--- a/packages/core/src/shader/utils/getAttributeData.ts
+++ b/packages/core/src/shader/utils/getAttributeData.ts
@@ -21,7 +21,8 @@ export function getAttributeData(program: WebGLProgram, gl: WebGLRenderingContex
     {
         const attribData = gl.getActiveAttrib(program, i);
 
-        if (attribData.name.startsWith('gl_')) {
+        if (attribData.name.startsWith('gl_'))
+        {
             continue;
         }
 


### PR DESCRIPTION
##### Description of change
Fix for:
https://github.com/pixijs/pixijs/issues/7526

We can't activate built-in attributes, but they represented in `activeAttributeList`

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
