### PR TITLE
Fix: Graphics color/textureId filling

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -1038,7 +1038,7 @@ export class GraphicsGeometry extends BatchGeometry
         color: number,
         alpha: number,
         size: number,
-        offset: number = 0): void
+        offset = 0): void
     {
         // TODO use the premultiply bits Ivan added
         const rgb = (color >> 16) + (color & 0xff00) + ((color & 0xff) << 16);
@@ -1066,7 +1066,7 @@ export class GraphicsGeometry extends BatchGeometry
         textureIds: Array<number>,
         id: number,
         size: number,
-        offset: number = 0): void
+        offset = 0): void
     {
         textureIds.length = Math.max(textureIds.length, offset + size);
 

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -803,8 +803,8 @@ export class GraphicsGeometry extends BatchGeometry
 
             textureId = nextTexture._batchLocation;
 
-            this.addColors(colors, style.color, style.alpha, data.attribSize);
-            this.addTextureIds(textureIds, textureId, data.attribSize);
+            this.addColors(colors, style.color, style.alpha, data.attribSize, data.attribStart);
+            this.addTextureIds(textureIds, textureId, data.attribSize, data.attribStart);
         }
 
         BaseTexture._globalBatch = TICK;
@@ -1031,17 +1031,25 @@ export class GraphicsGeometry extends BatchGeometry
      * @param {number} color - Color to add
      * @param {number} alpha - Alpha to use
      * @param {number} size - Number of colors to add
+     * @param {number} offset
      */
-    protected addColors(colors: Array<number>, color: number, alpha: number, size: number): void
+    protected addColors(
+        colors: Array<number>,
+        color: number,
+        alpha: number,
+        size: number,
+        offset: number = 0): void
     {
         // TODO use the premultiply bits Ivan added
         const rgb = (color >> 16) + (color & 0xff00) + ((color & 0xff) << 16);
 
         const rgba =  premultiplyTint(rgb, alpha);
 
-        while (size-- > 0)
+        colors.length = Math.max(colors.length, offset + size);
+
+        for (let i = 0; i < size; i++)
         {
-            colors.push(rgba);
+            colors[offset + i] = rgba;
         }
     }
 
@@ -1052,12 +1060,19 @@ export class GraphicsGeometry extends BatchGeometry
      * @param {number[]} textureIds
      * @param {number} id
      * @param {number} size
+     * @param {number} offset
      */
-    protected addTextureIds(textureIds: Array<number>, id: number, size: number): void
+    protected addTextureIds(
+        textureIds: Array<number>,
+        id: number,
+        size: number,
+        offset: number = 0): void
     {
-        while (size-- > 0)
+        textureIds.length = Math.max(textureIds.length, offset + size);
+
+        for (let i = 0; i < size; i++)
         {
-            textureIds.push(id);
+            textureIds[offset + i] = id;
         }
     }
 


### PR DESCRIPTION
fix: https://github.com/pixijs/pixijs/issues/7512

Fix filling color and textureId attributes for un-batched rendering mode.
Bug reproduce on all versions since 5.*

##### Simple reproduce demo
https://www.pixiplayground.com/#/edit/G8DSY5iggOY3xtR4mRzxA

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
