### PR TITLE
Added `tint(color, multiply)` method to ColorMatrixFilter.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17043,6 +17043,34 @@
         "@pixi/utils": "5.2.1"
       }
     },
+    "packages/loaders/node_modules/@pixi/settings": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.2.1.tgz",
+      "integrity": "sha512-QQfCywlYrWKUekn06P2hy1KR5MYXUyqVU0fbqEItjsH3RvN0LzE9ry2sDxf53qQ2/uCjKDXcT59YV9JcHEfwHA==",
+      "dev": true,
+      "dependencies": {
+        "ismobilejs": "^1.0.3"
+      }
+    },
+    "packages/loaders/node_modules/@pixi/utils": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.2.1.tgz",
+      "integrity": "sha512-JKa/IDKK3cbwrJbhU4q3hdN5tPTsuiWco+WDSlEWq6vblrwJkhI+0dRQkooo2fL+Tso7k+hWQ+4k95YapTX5Og==",
+      "dev": true,
+      "dependencies": {
+        "@pixi/constants": "5.2.1",
+        "@pixi/settings": "5.2.1",
+        "earcut": "^2.1.5",
+        "eventemitter3": "^3.1.0",
+        "url": "^0.11.0"
+      }
+    },
+    "packages/loaders/node_modules/@pixi/utils/node_modules/@pixi/constants": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.2.1.tgz",
+      "integrity": "sha512-RYeP1Q5R6qVyVioM00/fhGXFAhJjD+mJW4+TOiNZQASKP0t6wF51yuIfROEIxf5a6I6INOB3aSit1jUkSpYgTA==",
+      "dev": true
+    },
     "packages/math": {
       "name": "@pixi/math",
       "version": "6.0.4",
@@ -19711,8 +19739,40 @@
       "requires": {
         "@pixi/constants": "6.0.4",
         "@pixi/core": "6.0.4",
-        "@pixi/utils": "6.0.4",
+        "@pixi/utils": "5.2.1",
         "resource-loader": "^3.0.1"
+      },
+      "dependencies": {
+        "@pixi/settings": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.2.1.tgz",
+          "integrity": "sha512-QQfCywlYrWKUekn06P2hy1KR5MYXUyqVU0fbqEItjsH3RvN0LzE9ry2sDxf53qQ2/uCjKDXcT59YV9JcHEfwHA==",
+          "dev": true,
+          "requires": {
+            "ismobilejs": "^1.0.3"
+          }
+        },
+        "@pixi/utils": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.2.1.tgz",
+          "integrity": "sha512-JKa/IDKK3cbwrJbhU4q3hdN5tPTsuiWco+WDSlEWq6vblrwJkhI+0dRQkooo2fL+Tso7k+hWQ+4k95YapTX5Og==",
+          "dev": true,
+          "requires": {
+            "@pixi/constants": "5.2.1",
+            "@pixi/settings": "5.2.1",
+            "earcut": "^2.1.5",
+            "eventemitter3": "^3.1.0",
+            "url": "^0.11.0"
+          },
+          "dependencies": {
+            "@pixi/constants": {
+              "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.2.1.tgz",
+              "integrity": "sha512-RYeP1Q5R6qVyVioM00/fhGXFAhJjD+mJW4+TOiNZQASKP0t6wF51yuIfROEIxf5a6I6INOB3aSit1jUkSpYgTA==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "@pixi/math": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17043,34 +17043,6 @@
         "@pixi/utils": "5.2.1"
       }
     },
-    "packages/loaders/node_modules/@pixi/settings": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.2.1.tgz",
-      "integrity": "sha512-QQfCywlYrWKUekn06P2hy1KR5MYXUyqVU0fbqEItjsH3RvN0LzE9ry2sDxf53qQ2/uCjKDXcT59YV9JcHEfwHA==",
-      "dev": true,
-      "dependencies": {
-        "ismobilejs": "^1.0.3"
-      }
-    },
-    "packages/loaders/node_modules/@pixi/utils": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.2.1.tgz",
-      "integrity": "sha512-JKa/IDKK3cbwrJbhU4q3hdN5tPTsuiWco+WDSlEWq6vblrwJkhI+0dRQkooo2fL+Tso7k+hWQ+4k95YapTX5Og==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "5.2.1",
-        "@pixi/settings": "5.2.1",
-        "earcut": "^2.1.5",
-        "eventemitter3": "^3.1.0",
-        "url": "^0.11.0"
-      }
-    },
-    "packages/loaders/node_modules/@pixi/utils/node_modules/@pixi/constants": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.2.1.tgz",
-      "integrity": "sha512-RYeP1Q5R6qVyVioM00/fhGXFAhJjD+mJW4+TOiNZQASKP0t6wF51yuIfROEIxf5a6I6INOB3aSit1jUkSpYgTA==",
-      "dev": true
-    },
     "packages/math": {
       "name": "@pixi/math",
       "version": "6.0.4",
@@ -19739,40 +19711,8 @@
       "requires": {
         "@pixi/constants": "6.0.4",
         "@pixi/core": "6.0.4",
-        "@pixi/utils": "5.2.1",
+        "@pixi/utils": "6.0.4",
         "resource-loader": "^3.0.1"
-      },
-      "dependencies": {
-        "@pixi/settings": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.2.1.tgz",
-          "integrity": "sha512-QQfCywlYrWKUekn06P2hy1KR5MYXUyqVU0fbqEItjsH3RvN0LzE9ry2sDxf53qQ2/uCjKDXcT59YV9JcHEfwHA==",
-          "dev": true,
-          "requires": {
-            "ismobilejs": "^1.0.3"
-          }
-        },
-        "@pixi/utils": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.2.1.tgz",
-          "integrity": "sha512-JKa/IDKK3cbwrJbhU4q3hdN5tPTsuiWco+WDSlEWq6vblrwJkhI+0dRQkooo2fL+Tso7k+hWQ+4k95YapTX5Og==",
-          "dev": true,
-          "requires": {
-            "@pixi/constants": "5.2.1",
-            "@pixi/settings": "5.2.1",
-            "earcut": "^2.1.5",
-            "eventemitter3": "^3.1.0",
-            "url": "^0.11.0"
-          },
-          "dependencies": {
-            "@pixi/constants": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.2.1.tgz",
-              "integrity": "sha512-RYeP1Q5R6qVyVioM00/fhGXFAhJjD+mJW4+TOiNZQASKP0t6wF51yuIfROEIxf5a6I6INOB3aSit1jUkSpYgTA==",
-              "dev": true
-            }
-          }
-        }
       }
     },
     "@pixi/math": {

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -142,6 +142,30 @@ export class ColorMatrixFilter extends Filter
     }
 
     /**
+     * Sets each channel on the diagonal of the color matrix.
+     * This achieves a tinting effect.
+     *
+     * @param {number} color - Color of the tint. This is a hex value.
+     * @param {boolean} multiply - if true, current matrix and matrix are multiplied. If false,
+     *  just set the current matrix with @param matrix
+     */
+    public tint(color: number, multiply: boolean): void
+    {
+        const r = (color >> 16) & 0xff;
+        const g = (color >> 8) & 0xff;
+        const b = color & 0xff;
+
+        const matrix: ColorMatrix = [
+            r/255, 0, 0, 0, 0,
+            0, g/255, 0, 0, 0,
+            0, 0, b/255, 0, 0,
+            0, 0, 0, 1, 0,
+        ];
+
+        this._loadMatrix(matrix, multiply);
+    }
+
+    /**
      * Set the matrices in grey scales
      *
      * @param {number} scale - value of the grey (0-1, where 0 is black)

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -149,7 +149,7 @@ export class ColorMatrixFilter extends Filter
      * @param {boolean} multiply - if true, current matrix and matrix are multiplied. If false,
      *  just set the current matrix with @param matrix
      */
-    public tint(color: number, multiply: boolean): void
+    public tint(color: number, multiply?: boolean): void
     {
         const r = (color >> 16) & 0xff;
         const g = (color >> 8) & 0xff;

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -156,9 +156,9 @@ export class ColorMatrixFilter extends Filter
         const b = color & 0xff;
 
         const matrix: ColorMatrix = [
-            r/255, 0, 0, 0, 0,
-            0, g/255, 0, 0, 0,
-            0, 0, b/255, 0, 0,
+            r / 255, 0, 0, 0, 0,
+            0, g / 255, 0, 0, 0,
+            0, 0, b / 255, 0, 0,
             0, 0, 0, 1, 0,
         ];
 

--- a/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filters/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -143,7 +143,8 @@ export class ColorMatrixFilter extends Filter
 
     /**
      * Sets each channel on the diagonal of the color matrix.
-     * This achieves a tinting effect.
+     * This can be used to achieve a tinting effect on Containers similar to the tint field of some
+     * display objects like Sprite, Text, Graphics, and Mesh.
      *
      * @param {number} color - Color of the tint. This is a hex value.
      * @param {boolean} multiply - if true, current matrix and matrix are multiplied. If false,


### PR DESCRIPTION
##### Description of change
Added `tint(color, multiply)` method to ColorMatrixFilter. It transforms the matrix to achieve an effect similar to the `tint` field of sprites. This was a feature discussed on slack.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
(no ColorMatrixFilter specific tests exist)