### PR TITLE
Fix dependency design flaws

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16722,7 +16722,7 @@
       "name": "@pixi/accessibility",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -16733,20 +16733,20 @@
       "name": "@pixi/app",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3"
-      },
       "devDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
+        "@pixi/core": "6.1.0-rc.3",
+        "@pixi/display": "6.1.0-rc.3"
       }
     },
     "packages/basis": {
       "name": "@pixi/basis",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/compressed-textures": "6.1.0-rc.3",
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
@@ -16758,7 +16758,7 @@
       "name": "@pixi/canvas-display",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/display": "6.1.0-rc.3"
       }
     },
@@ -16766,7 +16766,7 @@
       "name": "@pixi/canvas-extract",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -16778,7 +16778,7 @@
       "name": "@pixi/canvas-graphics",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-display": "6.1.0-rc.3",
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/constants": "6.1.0-rc.3",
@@ -16791,24 +16791,24 @@
       "name": "@pixi/canvas-mesh",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@pixi/core": "6.1.0-rc.3",
+        "@pixi/sprite": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
         "@pixi/canvas-display": "6.1.0-rc.3",
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/mesh": "6.1.0-rc.3",
         "@pixi/mesh-extras": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3"
-      },
-      "devDependencies": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3"
       }
     },
     "packages/canvas/canvas-particle-container": {
       "name": "@pixi/canvas-particle-container",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/particle-container": "6.1.0-rc.3"
       }
     },
@@ -16825,7 +16825,7 @@
       "name": "@pixi/canvas-prepare",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/prepare": "6.1.0-rc.3"
@@ -16835,24 +16835,24 @@
       "name": "@pixi/canvas-renderer",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@pixi/display": "6.1.0-rc.3",
+        "@pixi/graphics": "6.1.0-rc.3",
+        "@pixi/sprite": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
-      },
-      "devDependencies": {
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3"
       }
     },
     "packages/canvas/canvas-sprite": {
       "name": "@pixi/canvas-sprite",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-display": "6.1.0-rc.3",
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/constants": "6.1.0-rc.3",
@@ -16865,7 +16865,7 @@
       "name": "@pixi/canvas-sprite-tiling",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/canvas-sprite": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
@@ -16877,7 +16877,7 @@
       "name": "@pixi/canvas-text",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-sprite": "6.1.0-rc.3",
         "@pixi/sprite": "6.1.0-rc.3",
         "@pixi/text": "6.1.0-rc.3"
@@ -16887,7 +16887,7 @@
       "name": "@pixi/compressed-textures",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/loaders": "6.1.0-rc.3",
@@ -16903,24 +16903,24 @@
       "name": "@pixi/core",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
+      },
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/runner": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3",
         "@pixi/ticker": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/pixijs"
       }
     },
     "packages/display": {
       "name": "@pixi/display",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
@@ -16930,7 +16930,7 @@
       "name": "@pixi/events",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/display": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
@@ -16940,7 +16940,7 @@
       "name": "@pixi/extract",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
@@ -16950,7 +16950,7 @@
       "name": "@pixi/filter-alpha",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3"
       }
     },
@@ -16958,7 +16958,7 @@
       "name": "@pixi/filter-blur",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3"
       }
@@ -16967,7 +16967,7 @@
       "name": "@pixi/filter-color-matrix",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3"
       }
     },
@@ -16975,7 +16975,7 @@
       "name": "@pixi/filter-displacement",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3"
       }
@@ -16984,7 +16984,7 @@
       "name": "@pixi/filter-fxaa",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3"
       }
     },
@@ -16992,7 +16992,7 @@
       "name": "@pixi/filter-noise",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3"
       }
     },
@@ -17000,7 +17000,7 @@
       "name": "@pixi/graphics",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17013,7 +17013,7 @@
       "name": "@pixi/graphics-extras",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/graphics": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3"
       }
@@ -17022,13 +17022,6 @@
       "name": "@pixi/interaction",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/ticker": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      },
       "devDependencies": {
         "@pixi/canvas-display": "6.1.0-rc.3",
         "@pixi/canvas-graphics": "6.1.0-rc.3",
@@ -17036,6 +17029,13 @@
         "@pixi/canvas-sprite": "6.1.0-rc.3",
         "@pixi/graphics": "6.1.0-rc.3",
         "@pixi/sprite": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
+        "@pixi/core": "6.1.0-rc.3",
+        "@pixi/display": "6.1.0-rc.3",
+        "@pixi/math": "6.1.0-rc.3",
+        "@pixi/ticker": "6.1.0-rc.3",
+        "@pixi/utils": "6.1.0-rc.3"
       }
     },
     "packages/loaders": {
@@ -17043,13 +17043,12 @@
       "version": "6.1.0-rc.3",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3",
         "resource-loader": "^3.0.1"
       },
-      "devDependencies": {
-        "@pixi/utils": "5.2.1"
+      "peerDependencies": {
+        "@pixi/constants": "6.1.0-rc.3",
+        "@pixi/core": "6.1.0-rc.3",
+        "@pixi/utils": "6.1.0-rc.3"
       }
     },
     "packages/math": {
@@ -17061,7 +17060,7 @@
       "name": "@pixi/mesh",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17074,22 +17073,22 @@
       "name": "@pixi/mesh-extras",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@pixi/loaders": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/mesh": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
-      },
-      "devDependencies": {
-        "@pixi/loaders": "6.1.0-rc.3"
       }
     },
     "packages/mixin-cache-as-bitmap": {
       "name": "@pixi/mixin-cache-as-bitmap",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17103,24 +17102,20 @@
       "name": "@pixi/mixin-get-child-by-name",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/display": "6.1.0-rc.3"
       }
     },
     "packages/mixin-get-global-position": {
       "name": "@pixi/mixin-get-global-position",
       "version": "6.1.0-rc.3",
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3"
-      }
+      "license": "MIT"
     },
     "packages/particle-container": {
       "name": "@pixi/particle-container",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17158,7 +17153,7 @@
       "name": "@pixi/prepare",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
         "@pixi/graphics": "6.1.0-rc.3",
@@ -17184,7 +17179,7 @@
       "name": "@pixi/sprite",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17197,7 +17192,7 @@
       "name": "@pixi/sprite-animated",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/sprite": "6.1.0-rc.3",
         "@pixi/ticker": "6.1.0-rc.3"
@@ -17207,7 +17202,7 @@
       "name": "@pixi/sprite-tiling",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
@@ -17220,7 +17215,7 @@
       "name": "@pixi/spritesheet",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/loaders": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
@@ -17231,24 +17226,27 @@
       "name": "@pixi/text",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@pixi/canvas-display": "6.1.0-rc.3",
+        "@pixi/canvas-renderer": "6.1.0-rc.3",
+        "@pixi/canvas-sprite": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/math": "6.1.0-rc.3",
         "@pixi/settings": "6.1.0-rc.3",
         "@pixi/sprite": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
-      },
-      "devDependencies": {
-        "@pixi/canvas-display": "6.1.0-rc.3",
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/canvas-sprite": "6.1.0-rc.3"
       }
     },
     "packages/text-bitmap": {
       "name": "@pixi/text-bitmap",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
+        "@pixi/spritesheet": "6.1.0-rc.3"
+      },
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
         "@pixi/loaders": "6.1.0-rc.3",
@@ -17257,16 +17255,13 @@
         "@pixi/settings": "6.1.0-rc.3",
         "@pixi/text": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
-      },
-      "devDependencies": {
-        "@pixi/spritesheet": "6.1.0-rc.3"
       }
     },
     "packages/ticker": {
       "name": "@pixi/ticker",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/settings": "6.1.0-rc.3"
       }
     },
@@ -17274,7 +17269,7 @@
       "name": "@pixi/unsafe-eval",
       "version": "6.1.0-rc.3",
       "license": "MIT",
-      "dependencies": {
+      "peerDependencies": {
         "@pixi/core": "6.1.0-rc.3"
       }
     },
@@ -17283,8 +17278,6 @@
       "version": "6.1.0-rc.3",
       "license": "MIT",
       "dependencies": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
         "@types/earcut": "^2.1.0",
         "earcut": "^2.2.2",
         "eventemitter3": "^3.1.0",
@@ -17292,6 +17285,10 @@
       },
       "devDependencies": {
         "css-color-names": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@pixi/constants": "6.1.0-rc.3",
+        "@pixi/settings": "6.1.0-rc.3"
       }
     },
     "tools/integration-tests": {
@@ -19477,158 +19474,80 @@
     },
     "@pixi/accessibility": {
       "version": "file:packages/accessibility",
-      "requires": {
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/app": {
       "version": "file:packages/app",
       "requires": {
         "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
         "@pixi/utils": "6.1.0-rc.3"
       }
     },
     "@pixi/basis": {
       "version": "file:packages/basis",
-      "requires": {
-        "@pixi/compressed-textures": "6.1.0-rc.3",
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/loaders": "6.1.0-rc.3",
-        "@pixi/runner": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-display": {
       "version": "file:packages/canvas/canvas-display",
-      "requires": {
-        "@pixi/display": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-extract": {
       "version": "file:packages/canvas/canvas-extract",
-      "requires": {
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-graphics": {
       "version": "file:packages/canvas/canvas-graphics",
-      "requires": {
-        "@pixi/canvas-display": "6.1.0-rc.3",
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-mesh": {
       "version": "file:packages/canvas/canvas-mesh",
       "requires": {
-        "@pixi/canvas-display": "6.1.0-rc.3",
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/constants": "6.1.0-rc.3",
         "@pixi/core": "6.1.0-rc.3",
-        "@pixi/mesh": "6.1.0-rc.3",
-        "@pixi/mesh-extras": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
         "@pixi/sprite": "6.1.0-rc.3"
       }
     },
     "@pixi/canvas-particle-container": {
       "version": "file:packages/canvas/canvas-particle-container",
-      "requires": {
-        "@pixi/particle-container": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-prepare": {
       "version": "file:packages/canvas/canvas-prepare",
-      "requires": {
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/prepare": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-renderer": {
       "version": "file:packages/canvas/canvas-renderer",
       "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
         "@pixi/display": "6.1.0-rc.3",
         "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
+        "@pixi/sprite": "6.1.0-rc.3"
       }
     },
     "@pixi/canvas-sprite": {
       "version": "file:packages/canvas/canvas-sprite",
-      "requires": {
-        "@pixi/canvas-display": "6.1.0-rc.3",
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-sprite-tiling": {
       "version": "file:packages/canvas/canvas-sprite-tiling",
-      "requires": {
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/canvas-sprite": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/sprite-tiling": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/canvas-text": {
       "version": "file:packages/canvas/canvas-text",
-      "requires": {
-        "@pixi/canvas-sprite": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/text": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/compressed-textures": {
       "version": "file:packages/compressed-textures",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/loaders": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/constants": {
       "version": "file:packages/constants"
     },
     "@pixi/core": {
       "version": "file:packages/core",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/runner": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/ticker": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/display": {
       "version": "file:packages/display",
-      "requires": {
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/eslint-config": {
       "version": "2.0.1",
@@ -19642,75 +19561,43 @@
     },
     "@pixi/events": {
       "version": "file:packages/events",
-      "requires": {
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/extract": {
       "version": "file:packages/extract",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-alpha": {
       "version": "file:packages/filters/filter-alpha",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-blur": {
       "version": "file:packages/filters/filter-blur",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-color-matrix": {
       "version": "file:packages/filters/filter-color-matrix",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-displacement": {
       "version": "file:packages/filters/filter-displacement",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-fxaa": {
       "version": "file:packages/filters/filter-fxaa",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/filter-noise": {
       "version": "file:packages/filters/filter-noise",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/graphics": {
       "version": "file:packages/graphics",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/graphics-extras": {
       "version": "file:packages/graphics-extras",
-      "requires": {
-        "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/interaction": {
       "version": "file:packages/interaction",
@@ -19719,21 +19606,13 @@
         "@pixi/canvas-graphics": "6.1.0-rc.3",
         "@pixi/canvas-renderer": "6.1.0-rc.3",
         "@pixi/canvas-sprite": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
         "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/ticker": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
+        "@pixi/sprite": "6.1.0-rc.3"
       }
     },
     "@pixi/loaders": {
       "version": "file:packages/loaders",
       "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3",
         "resource-loader": "^3.0.1"
       }
     },
@@ -19742,60 +19621,28 @@
     },
     "@pixi/mesh": {
       "version": "file:packages/mesh",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/mesh-extras": {
       "version": "file:packages/mesh-extras",
       "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/loaders": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/mesh": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
+        "@pixi/loaders": "6.1.0-rc.3"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
       "version": "file:packages/mixin-cache-as-bitmap",
-      "requires": {
-        "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-child-by-name": {
       "version": "file:packages/mixin-get-child-by-name",
-      "requires": {
-        "@pixi/display": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/mixin-get-global-position": {
-      "version": "file:packages/mixin-get-global-position",
-      "requires": {
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3"
-      }
+      "version": "file:packages/mixin-get-global-position"
     },
     "@pixi/particle-container": {
       "version": "file:packages/particle-container",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/polyfill": {
       "version": "file:packages/polyfill",
@@ -19808,14 +19655,7 @@
     },
     "@pixi/prepare": {
       "version": "file:packages/prepare",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/graphics": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/text": "6.1.0-rc.3",
-        "@pixi/ticker": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/runner": {
       "version": "file:packages/runner"
@@ -19828,87 +19668,45 @@
     },
     "@pixi/sprite": {
       "version": "file:packages/sprite",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/sprite-animated": {
       "version": "file:packages/sprite-animated",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/ticker": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/sprite-tiling": {
       "version": "file:packages/sprite-tiling",
-      "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/spritesheet": {
       "version": "file:packages/spritesheet",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/loaders": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/text": {
       "version": "file:packages/text",
       "requires": {
         "@pixi/canvas-display": "6.1.0-rc.3",
         "@pixi/canvas-renderer": "6.1.0-rc.3",
-        "@pixi/canvas-sprite": "6.1.0-rc.3",
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/sprite": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
+        "@pixi/canvas-sprite": "6.1.0-rc.3"
       }
     },
     "@pixi/text-bitmap": {
       "version": "file:packages/text-bitmap",
       "requires": {
-        "@pixi/core": "6.1.0-rc.3",
-        "@pixi/display": "6.1.0-rc.3",
-        "@pixi/loaders": "6.1.0-rc.3",
-        "@pixi/math": "6.1.0-rc.3",
-        "@pixi/mesh": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
-        "@pixi/spritesheet": "6.1.0-rc.3",
-        "@pixi/text": "6.1.0-rc.3",
-        "@pixi/utils": "6.1.0-rc.3"
+        "@pixi/spritesheet": "6.1.0-rc.3"
       }
     },
     "@pixi/ticker": {
       "version": "file:packages/ticker",
-      "requires": {
-        "@pixi/settings": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/unsafe-eval": {
       "version": "file:packages/unsafe-eval",
-      "requires": {
-        "@pixi/core": "6.1.0-rc.3"
-      }
+      "requires": {}
     },
     "@pixi/utils": {
       "version": "file:packages/utils",
       "requires": {
-        "@pixi/constants": "6.1.0-rc.3",
-        "@pixi/settings": "6.1.0-rc.3",
         "@types/earcut": "^2.1.0",
         "css-color-names": "^1.0.1",
         "earcut": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prerelease": "npm run clean:build && npm test",
     "postversion": "npm run build:prod && npm run build:types",
     "release": "lerna version --exact --force-publish --no-push --no-git-tag-version",
-    "postrelease": "./scripts/tag-release.sh",
+    "postrelease": "ts-node scripts/fixPeerVersions.ts && ./scripts/tag-release.sh",
     "publish-ci": "lerna publish from-package --yes --no-verify-access",
     "webdoc": "webdoc"
   },

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3"
   },

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -32,7 +32,7 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/compressed-textures": "6.1.0-rc.3",
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",

--- a/packages/canvas/canvas-display/package.json
+++ b/packages/canvas/canvas-display/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/display": "6.1.0-rc.3"
   }
 }

--- a/packages/canvas/canvas-extract/package.json
+++ b/packages/canvas/canvas-extract/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/canvas/canvas-graphics/package.json
+++ b/packages/canvas/canvas-graphics/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-display": "6.1.0-rc.3",
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/constants": "6.1.0-rc.3",

--- a/packages/canvas/canvas-mesh/package.json
+++ b/packages/canvas/canvas-mesh/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-display": "6.1.0-rc.3",
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/constants": "6.1.0-rc.3",

--- a/packages/canvas/canvas-particle-container/package.json
+++ b/packages/canvas/canvas-particle-container/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/particle-container": "6.1.0-rc.3"
   }
 }

--- a/packages/canvas/canvas-prepare/package.json
+++ b/packages/canvas/canvas-prepare/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/prepare": "6.1.0-rc.3"

--- a/packages/canvas/canvas-renderer/package.json
+++ b/packages/canvas/canvas-renderer/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",

--- a/packages/canvas/canvas-sprite-tiling/package.json
+++ b/packages/canvas/canvas-sprite-tiling/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/canvas-sprite": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",

--- a/packages/canvas/canvas-sprite/package.json
+++ b/packages/canvas/canvas-sprite/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-display": "6.1.0-rc.3",
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/constants": "6.1.0-rc.3",

--- a/packages/canvas/canvas-text/package.json
+++ b/packages/canvas/canvas-text/package.json
@@ -22,7 +22,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-sprite": "6.1.0-rc.3",
     "@pixi/sprite": "6.1.0-rc.3",
     "@pixi/text": "6.1.0-rc.3"

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -34,7 +34,7 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/loaders": "6.1.0-rc.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "type": "opencollective",
     "url": "https://opencollective.com/pixijs"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",
     "@pixi/runner": "6.1.0-rc.3",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/math": "6.1.0-rc.3",
     "@pixi/settings": "6.1.0-rc.3",
     "@pixi/utils": "6.1.0-rc.3"

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/display": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",
     "@pixi/utils": "6.1.0-rc.3"

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",
     "@pixi/utils": "6.1.0-rc.3"

--- a/packages/filters/filter-alpha/package.json
+++ b/packages/filters/filter-alpha/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3"
   }
 }

--- a/packages/filters/filter-blur/package.json
+++ b/packages/filters/filter-blur/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/settings": "6.1.0-rc.3"
   }

--- a/packages/filters/filter-color-matrix/package.json
+++ b/packages/filters/filter-color-matrix/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3"
   }
 }

--- a/packages/filters/filter-displacement/package.json
+++ b/packages/filters/filter-displacement/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3"
   }

--- a/packages/filters/filter-fxaa/package.json
+++ b/packages/filters/filter-fxaa/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3"
   }
 }

--- a/packages/filters/filter-noise/package.json
+++ b/packages/filters/filter-noise/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3"
   }
 }

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -22,7 +22,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/graphics": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3"
   }

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -25,12 +25,11 @@
     "*.d.ts"
   ],
   "dependencies": {
-    "@pixi/constants": "6.1.0-rc.3",
-    "@pixi/core": "6.1.0-rc.3",
-    "@pixi/utils": "6.1.0-rc.3",
     "resource-loader": "^3.0.1"
   },
-  "devDependencies": {
-    "@pixi/utils": "5.2.1"
+  "peerDependencies": {
+    "@pixi/constants": "6.1.0-rc.3",
+    "@pixi/core": "6.1.0-rc.3",
+    "@pixi/utils": "6.1.0-rc.3"
   }
 }

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/canvas-renderer": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/display": "6.1.0-rc.3"
   }
 }

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -25,7 +25,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/display": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3"
   }

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",
     "@pixi/graphics": "6.1.0-rc.3",

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/sprite": "6.1.0-rc.3",
     "@pixi/ticker": "6.1.0-rc.3"

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/constants": "6.1.0-rc.3",
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/loaders": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/display": "6.1.0-rc.3",
     "@pixi/loaders": "6.1.0-rc.3",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3",
     "@pixi/math": "6.1.0-rc.3",
     "@pixi/settings": "6.1.0-rc.3",

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -24,7 +24,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/settings": "6.1.0-rc.3"
   }
 }

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -23,7 +23,7 @@
     "dist/",
     "*.d.ts"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@pixi/core": "6.1.0-rc.3"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,12 +26,14 @@
     "*.d.ts"
   ],
   "dependencies": {
-    "@pixi/constants": "6.1.0-rc.3",
-    "@pixi/settings": "6.1.0-rc.3",
     "@types/earcut": "^2.1.0",
     "earcut": "^2.2.2",
     "eventemitter3": "^3.1.0",
     "url": "^0.11.0"
+  },
+  "peerDependencies": {
+    "@pixi/constants": "6.1.0-rc.3",
+    "@pixi/settings": "6.1.0-rc.3"
   },
   "devDependencies": {
     "css-color-names": "^1.0.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -138,7 +138,8 @@ async function main()
         ].join('\n');
 
         // Check for bundle folder
-        const external = Object.keys(pkg.dependencies || []);
+        const external = Object.keys(pkg.dependencies || [])
+            .concat(Object.keys(pkg.peerDependencies || []));
         const basePath = path.relative(__dirname, pkg.location);
         let input = path.join(basePath, 'src/index.ts');
 

--- a/scripts/fixPeerVersions.ts
+++ b/scripts/fixPeerVersions.ts
@@ -1,0 +1,56 @@
+import { getPackages } from '@lerna/project';
+import path from 'path';
+import fs from 'fs';
+import util from 'util';
+
+/**
+ * Simplified interface for a package.json
+ */
+interface Package
+{
+    location: string;
+    name: string;
+    version: string;
+    peerDependencies: Record<string, string>;
+    toJSON(): { peerDependencies: Record<string, string> };
+}
+
+// Create utils for writing JSON file
+const writeFile = util.promisify(fs.writeFile);
+const writeJson = (file: string, data: unknown) => writeFile(file, `${JSON.stringify(data, null, 2)}\n`);
+
+/**
+ * The goal of this script is to sync the peer versions to exact. Lerna does
+ * not take care of this when we do a version bump.
+ */
+async function main(): Promise<void>
+{
+    const packages = await getPackages(process.cwd()) as Package[];
+    const packagesHavePeers = packages.filter((p) => !!p.peerDependencies);
+
+    // We are using exact version now, but this
+    // will insulate us if we decide to not do this
+    // and use fuzzy versioning again.
+    const versions = packages.reduce(
+        (list, pkg) => ({ ...list, [pkg.name]: pkg.version }),
+        {} as Record<string, string>
+    );
+
+    for (const p of packagesHavePeers)
+    {
+        const json = p.toJSON();
+        const peers = json.peerDependencies;
+
+        for (const n in peers)
+        {
+            if (n in versions)
+            {
+                peers[n] = versions[n];
+            }
+        }
+
+        await writeJson(path.join(p.location, 'package.json'), json);
+    }
+}
+
+main();


### PR DESCRIPTION
Addresses #7368

### Overview

This change converts the internal-PixiJS `dependencies` to `peerDependencies`. This has created serious issues in developers dependency graph _especially_ when users are upgrading versions of PixiJS. Often the only solution is users nuke their node_module and lock file to upgrade. Converting to peer dependencies should fix much of this pain.

Note: peerDependencies have been the standard usage in [pixijs/filters](https://github.com/pixijs/filters) for awhile now without issue.

Also, this change requires a special script to update the peerDependencies versions because Lerna ignores these when doing a version bump.
