### PR TITLE
Warn instead of error log when compressed textures are not available

### DIFF
--- a/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
+++ b/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
@@ -168,7 +168,7 @@ export class CompressedTextureLoader
         if (!gl)
         {
             // #if _DEBUG
-            console.error('WebGL not available for compressed textures. Silently failing.');
+            console.warn('WebGL not available for compressed textures. Silently failing.');
             // #endif
 
             return;


### PR DESCRIPTION
Fixes #7554 

##### Description of change

Replace error log with warning log.