### PR TITLE
Fix canvas resizing in Text when resolution is not 1

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -202,8 +202,8 @@ export class Text extends Sprite
         const maxLineWidth = measured.maxLineWidth;
         const fontProperties = measured.fontProperties;
 
-        this.canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2)) * this._resolution);
-        this.canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2)) * this._resolution);
+        this.canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2))) * this._resolution;
+        this.canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2))) * this._resolution;
 
         context.scale(this._resolution, this._resolution);
 

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -202,8 +202,8 @@ export class Text extends Sprite
         const maxLineWidth = measured.maxLineWidth;
         const fontProperties = measured.fontProperties;
 
-        this.canvas.width = Math.ceil((Math.max(1, width) + (style.padding * 2))) * this._resolution;
-        this.canvas.height = Math.ceil((Math.max(1, height) + (style.padding * 2))) * this._resolution;
+        this.canvas.width = Math.ceil(Math.ceil((Math.max(1, width) + (style.padding * 2))) * this._resolution);
+        this.canvas.height = Math.ceil(Math.ceil((Math.max(1, height) + (style.padding * 2))) * this._resolution);
 
         context.scale(this._resolution, this._resolution);
 


### PR DESCRIPTION
Fixes #7551 

##### Description of change
Since resolution basically scales the Text's canvas, it makes sense to multiply the canvas dimensions _after_ rounding it - where the rounded dimensions are natural 1x scale dimensions.

(before) https://jsfiddle.net/ShukantPal/29Lz8xej/
(after) https://jsfiddle.net/ShukantPal/Lkbqvs0y/

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
