### PR TITLE
Expose IPoint in globals instead of Point / ObservablePoint

### DIFF
--- a/packages/math/global.d.ts
+++ b/packages/math/global.d.ts
@@ -7,12 +7,7 @@ declare namespace GlobalMixins
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Point
-    {
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface ObservablePoint
+    interface IPoint
     {
     }
 

--- a/packages/math/src/IPoint.ts
+++ b/packages/math/src/IPoint.ts
@@ -1,6 +1,6 @@
 import { IPointData } from './IPointData';
 
-export interface IPoint extends IPointData
+export interface IPoint extends IPointData, GlobalMixins.IPoint
 {
     copyFrom(p: IPointData): this;
     copyTo<T extends IPoint>(p: T): T;


### PR DESCRIPTION
Continuation of #7548

Its better to expose IPoint than Point/ObservablePoint because some of our generics use `IPoint` 

I dont see cases when we have to expose those classes.
