### PR TITLE
Fix Text vertical gradient so that it handles overlapping lines

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -538,12 +538,30 @@ export class Text extends Sprite
             // Actual height of the text itself, not counting spacing for lineHeight/leading/dropShadow etc
             const textHeight = metrics.fontProperties.fontSize + style.strokeThickness;
 
-            // textHeight, but as a 0-1 size in global gradient stop space
-            const gradStopLineHeight = textHeight / height;
-
             for (let i = 0; i < lines.length; i++)
             {
+                const lastLineBottom = (metrics.lineHeight * (i - 1)) + textHeight;
                 const thisLineTop = metrics.lineHeight * i;
+                let thisLineGradientStart = thisLineTop;
+
+                // Handle case where last & this line overlap
+                if (i > 0 && lastLineBottom > thisLineTop)
+                {
+                    thisLineGradientStart = (thisLineTop + lastLineBottom) / 2;
+                }
+
+                const thisLineBottom = thisLineTop + textHeight;
+                const nextLineTop = metrics.lineHeight * (i + 1);
+                let thisLineGradientEnd = thisLineBottom;
+
+                // Handle case where this & next line overlap
+                if (i + 1 < lines.length && nextLineTop < thisLineBottom)
+                {
+                    thisLineGradientEnd = (thisLineBottom + nextLineTop) / 2;
+                }
+
+                // textHeight, but as a 0-1 size in global gradient stop space
+                const gradStopLineHeight = (thisLineGradientEnd - thisLineGradientStart) / height;
 
                 for (let j = 0; j < fill.length; j++)
                 {
@@ -559,7 +577,8 @@ export class Text extends Sprite
                         lineStop = j / fill.length;
                     }
 
-                    let globalStop = Math.min(1, Math.max(0, (thisLineTop / height) + (lineStop * gradStopLineHeight)));
+                    let globalStop = Math.min(1, Math.max(0,
+                        (thisLineGradientStart / height) + (lineStop * gradStopLineHeight)));
 
                     // There's potential for floating point precision issues at the seams between gradient repeats.
                     globalStop = Number(globalStop.toFixed(5));

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -547,7 +547,7 @@ export class Text extends Sprite
                 // Handle case where last & this line overlap
                 if (i > 0 && lastLineBottom > thisLineTop)
                 {
-                    thisLineGradientStart = thisLineTop;
+                    thisLineGradientStart = (thisLineTop + lastLineBottom) / 2;
                 }
 
                 const thisLineBottom = thisLineTop + textHeight;
@@ -557,7 +557,7 @@ export class Text extends Sprite
                 // Handle case where this & next line overlap
                 if (i + 1 < lines.length && nextLineTop < thisLineBottom)
                 {
-                    thisLineGradientEnd = nextLineTop;
+                    thisLineGradientEnd = (thisLineBottom + nextLineTop) / 2;
                 }
 
                 // textHeight, but as a 0-1 size in global gradient stop space

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -547,7 +547,7 @@ export class Text extends Sprite
                 // Handle case where last & this line overlap
                 if (i > 0 && lastLineBottom > thisLineTop)
                 {
-                    thisLineGradientStart = (thisLineTop + lastLineBottom) / 2;
+                    thisLineGradientStart = thisLineTop;
                 }
 
                 const thisLineBottom = thisLineTop + textHeight;
@@ -557,7 +557,7 @@ export class Text extends Sprite
                 // Handle case where this & next line overlap
                 if (i + 1 < lines.length && nextLineTop < thisLineBottom)
                 {
-                    thisLineGradientEnd = (thisLineBottom + nextLineTop) / 2;
+                    thisLineGradientEnd = nextLineTop;
                 }
 
                 // textHeight, but as a 0-1 size in global gradient stop space


### PR DESCRIPTION
Fixes #7540 

##### Description of change

This change will make the vertical gradient handle cases in which consecutive lines overlap. It will calculate the midpoint between the prior line's bottom and next line's top and check if they are in increasing order; if not, it will set the gradient stop at their midpoint (for both prior & next line). There are two cases for this - previous line's bottom and current line's top, current line's bottom and next line's top.

##### Proof

(before) [https://pixijs.io/pixi-text-style/#%7B%22s...](https://pixijs.io/pixi-text-style/#%7B%22style%22%3A%7B%22fill%22%3A%5B%22white%22%2C%22red%22%5D%2C%22fontSize%22%3A86%2C%22lineHeight%22%3A50%2C%22padding%22%3A10%7D%2C%22text%22%3A%22Hello%5CnWorld%22%2C%22background%22%3A%22%23000000%22%7D.)

| lineHeight=66px | lineHeight=50px |
| ----------------  | ----------------  |
| <img width="321" alt="Screen Shot 2021-07-05 at 5 16 29 PM" src="https://user-images.githubusercontent.com/22450567/124518566-bd9d8180-ddb4-11eb-9561-6531e06072aa.png"> | <img width="278" alt="Screen Shot 2021-07-05 at 5 15 50 PM" src="https://user-images.githubusercontent.com/22450567/124518538-a8285780-ddb4-11eb-8f47-548f73b48f70.png"> | 



(after) https://www.pixiplayground.com/#/edit/MX5ftft1c0i5Fvb5U1mWz

| lineHeight=66px | lineHeight=50px |
| ----------------  | ----------------  |
| <img width="236" alt="Screen Shot 2021-07-05 at 5 15 13 PM" src="https://user-images.githubusercontent.com/22450567/124518506-90e96a00-ddb4-11eb-9bc9-af6e9f52c9ba.png"> | <img width="240" alt="Screen Shot 2021-07-05 at 5 13 51 PM" src="https://user-images.githubusercontent.com/22450567/124518525-9e065900-ddb4-11eb-9777-ee9d21cd4b1e.png"> |
