### PR TITLE
Fixed wrong information on the compressed-loader docs

### DIFF
--- a/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
+++ b/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
@@ -56,14 +56,24 @@ export class CompressedTextureLoader
      * ```js
      * import { INTERNAL_FORMATS } from '@pixi/constants';
      *
-     * // The following should be present in a *.compressed-texture.json file!
-     * const manifest = JSON.stringify({
-     *   COMPRESSED_RGBA_S3TC_DXT5_EXT: "asset.s3tc.ktx",
-     *   COMPRESSED_RGBA8_ETC2_EAC: "asset.etc.ktx",
-     *   RGBA_PVRTC_4BPPV1_IMG: "asset.pvrtc.ktx",
-     *   textureID: "asset.png",
-     *   fallback: "asset.png"
-     * });
+     * type CompressedTextureManifest = {
+     *  textures: Array<{ src: string, format?: keyof INTERNAL_FORMATS}>,
+     *  cacheID: string;
+     * };
+     * ```
+     *
+     * This is an example of a .json manifest file
+     *
+     * ```json
+     * {
+     *   "cacheID":"asset",
+     *   "textures":[
+     *     { "url":"asset.fallback.png" },
+     *     { "format":"COMPRESSED_RGBA_S3TC_DXT5_EXT", "url":"asset.s3tc.ktx" },
+     *     { "format":"COMPRESSED_RGBA8_ETC2_EAC", "url":"asset.etc.ktx" },
+     *     { "format":"RGBA_PVRTC_4BPPV1_IMG", "url":"asset.pvrtc.ktx" }
+     *   ]
+     * }
      * ```
      */
     static use(resource: ILoaderResource, next: (...args: any[]) => void): void

--- a/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
+++ b/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
@@ -68,10 +68,10 @@ export class CompressedTextureLoader
      * {
      *   "cacheID":"asset",
      *   "textures":[
-     *     { "url":"asset.fallback.png" },
-     *     { "format":"COMPRESSED_RGBA_S3TC_DXT5_EXT", "url":"asset.s3tc.ktx" },
-     *     { "format":"COMPRESSED_RGBA8_ETC2_EAC", "url":"asset.etc.ktx" },
-     *     { "format":"RGBA_PVRTC_4BPPV1_IMG", "url":"asset.pvrtc.ktx" }
+     *     { "src":"asset.fallback.png" },
+     *     { "format":"COMPRESSED_RGBA_S3TC_DXT5_EXT", "src":"asset.s3tc.ktx" },
+     *     { "format":"COMPRESSED_RGBA8_ETC2_EAC", "src":"asset.etc.ktx" },
+     *     { "format":"RGBA_PVRTC_4BPPV1_IMG", "src":"asset.pvrtc.ktx" }
      *   ]
      * }
      * ```


### PR DESCRIPTION
This changes the documentation for the compressed loader.
I don't know why the old docs talk about the manifest filename being required to contain `compressed-texture` in the name and the json format being different.

Rewrote it to better reflect what the code expects.

I wanted to comment this on #7584 but work got in the way and it got merged because I could do it 😅 

##### Description of change
Rewrote the documentation of `compressed-loader` because the old one was incorrect (probably outdated).

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)