### PR TITLE
Group unit-tests together by package name

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -3,7 +3,8 @@ import { execFileSync } from 'child_process';
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import fs from 'fs';
-import { FlossOptions } from 'floss';
+import type { FlossOptions } from 'floss';
+import type { PackageResult } from './packages';
 
 // Support for global otpions
 declare global {
@@ -29,7 +30,7 @@ require.extensions['.vert'] = requireAsStrings;
 const script = path.join(__dirname, './packages.ts');
 
 const packagesBuffer = execFileSync('ts-node-transpile-only', [script]).toString();
-const { availableSuites, locations } = JSON.parse(packagesBuffer);
+const packages = JSON.parse(packagesBuffer) as PackageResult[];
 
 // Filter any packages from the commandline options
 const onlyPackages = options.args
@@ -37,22 +38,29 @@ const onlyPackages = options.args
     .map((arg) => arg.replace('--package=', ''));
 
 // Filter the tests in case we have options to narrow scope
-const enabledSuites = !onlyPackages.length ? availableSuites
-    : availableSuites.filter((pkg) => onlyPackages.some((p) => pkg.startsWith(locations[p])));
+const scopedPackages = !onlyPackages.length ? packages
+    : packages.filter((pkg) => onlyPackages.some((name) => pkg.name === name));
 
-if (!enabledSuites.length)
+// Ignore packages without tests suites
+const availableSuites = scopedPackages.filter((pkg) => pkg.available);
+
+if (!availableSuites.length)
 {
-    const invalidNames = onlyPackages.filter((pkg) => !locations[pkg]);
+    // Find any invalid package names
+    const invalidNames = onlyPackages.filter((name) => !packages.some((pkg) => pkg.name === name));
 
     // eslint-disable-next-line no-console
     console.log(`WARNING: Invalid package name${invalidNames.length > 1 ? 's' : ''}:`, `"${invalidNames.join('", "')}"`);
 }
 
-for (const pkg of enabledSuites)
+for (const pkg of availableSuites)
 {
-    fs.readdirSync(pkg)
-        .filter((file) => file.endsWith('.tests.ts'))
-        .map((file) => path.join(pkg, file))
-        // eslint-disable-next-line global-require
-        .forEach((file) => require(file));
+    describe(pkg.name, () =>
+    {
+        fs.readdirSync(pkg.tests)
+            .filter((file) => file.endsWith('.tests.ts'))
+            .map((file) => path.join(pkg.tests, file))
+            // eslint-disable-next-line global-require
+            .forEach((file) => require(file));
+    });
 }

--- a/test/packages.ts
+++ b/test/packages.ts
@@ -17,21 +17,32 @@ async function getSortedPackages()
         .reduce((arr, batch) => arr.concat(batch), []);
 }
 
+interface PackageResult {
+    name: string;
+    location: string;
+    tests: string;
+    available: boolean;
+}
+
 async function main()
 {
-    const buffer = [];
-    const locations = {};
-
-    (await getSortedPackages()).forEach((pkg) =>
+    const packages: PackageResult[] = (await getSortedPackages()).map((pkg) =>
     {
-        locations[pkg.name] = pkg.location;
-        buffer.push(`${pkg.location}/test`);
+        const tests = path.join(pkg.location, 'test');
+        const available = fs.existsSync(tests);
+
+        return {
+            name: pkg.name,
+            location: pkg.location,
+            tests,
+            available,
+        };
     });
+
     // eslint-disable-next-line no-console
-    console.log(JSON.stringify({
-        availableSuites: buffer.filter(fs.existsSync),
-        locations,
-    }, null, '  '));
+    console.log(JSON.stringify(packages, null, '  '));
 }
 
 main();
+
+export type { PackageResult };


### PR DESCRIPTION
This change groups unit-tests together by package name. This should make it easier to identify the source of problems, especially where some tests names might overlap, in the case of mixins or canvas packages.

## Example Snippet

```
  @pixi/canvas-mesh
    NineSlicePlane
      ✓ should be renderable with renderTexture in canvas

  @pixi/canvas-renderer
    CanvasMaskManager
      ✓ should work on all graphics masks inside container
      ✓ should set correct transform for graphics
    CanvasRenderer
      ✓ should default context to rootContext
      ✓ should allow clear() to work despite no containers added to the renderer
      ✓ should update transform in case of temp parent

  @pixi/app
    Application
      ✓ should generate application
      ✓ register a new plugin, then destroy it
      ✓ should remove canvas when destroyed
      ✓ should not destroy children by default
      ✓ should allow children destroy
      resizeTo
        ✓ should assign resizeTo
        ✓ should force multiple immediate resizes
        ✓ should throttle multiple resizes (62ms)
        ✓ should cancel resize on destroy
        ✓ should resize cancel resize queue
        ✓ should resizeTo with resolution
        ✓ should resizeTo with resolution and autoDensity
```