### PR TITLE
Fix running unit-tests on Windows

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -29,7 +29,7 @@ require.extensions['.vert'] = requireAsStrings;
 // Synchronously generate the list of testable packages
 const script = path.join(__dirname, './packages.ts');
 
-const isWin = /^win/.test(process.platform);
+const isWin = (/^win/).test(process.platform);
 const cmd = `ts-node-transpile-only${isWin ? '.cmd' : ''}`;
 const packagesBuffer = execFileSync(cmd, [script]).toString();
 const packages = JSON.parse(packagesBuffer) as PackageResult[];

--- a/test/index.ts
+++ b/test/index.ts
@@ -29,7 +29,9 @@ require.extensions['.vert'] = requireAsStrings;
 // Synchronously generate the list of testable packages
 const script = path.join(__dirname, './packages.ts');
 
-const packagesBuffer = execFileSync('ts-node-transpile-only', [script]).toString();
+const isWin = /^win/.test(process.platform);
+const cmd = `ts-node-transpile-only${isWin ? '.cmd' : ''}`;
+const packagesBuffer = execFileSync(cmd, [script]).toString();
 const packages = JSON.parse(packagesBuffer) as PackageResult[];
 
 // Filter any packages from the commandline options


### PR DESCRIPTION
Small platform bug running execFileSync on Windows machines that prevented running of unit-tests.