### PR TITLE
Fix minor documentation errors

### DIFF
--- a/packages/basis/src/Basis.ts
+++ b/packages/basis/src/Basis.ts
@@ -89,7 +89,7 @@ export const BASIS_FORMATS_ALPHA: { [id: number]: boolean } = {
  * Binding to C++ {@code BasisFile} wrapper class.
  *
  * @see https://github.com/BinomialLLC/basis_universal/blob/master/webgl/transcoder/basis_wrappers.cpp
- * @ignore
+ * @private
  */
 export declare class BasisFile
 {

--- a/packages/core/src/shader/GLProgram.ts
+++ b/packages/core/src/shader/GLProgram.ts
@@ -1,5 +1,8 @@
 import type { Dict } from '@pixi/utils';
 
+/**
+ * @private
+ */
 export class IGLUniformData
 {
     location: WebGLUniformLocation;

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -1065,6 +1065,9 @@ export abstract class DisplayObject extends EventEmitter
     }
 }
 
+/**
+ * @private
+ */
 export class TemporaryDisplayObject extends DisplayObject
 {
     calculateBounds: () => null;

--- a/packages/mesh-extras/src/geometry/PlaneGeometry.ts
+++ b/packages/mesh-extras/src/geometry/PlaneGeometry.ts
@@ -1,5 +1,8 @@
 import { MeshGeometry } from '@pixi/mesh';
 
+/**
+ * @memberof PIXI
+ */
 export class PlaneGeometry extends MeshGeometry
 {
     public segWidth: number;
@@ -7,6 +10,12 @@ export class PlaneGeometry extends MeshGeometry
     public width: number;
     public height: number;
 
+    /**
+     * @param width - The width of the plane.
+     * @param height - The height of the plane.
+     * @param segWidth - Number of horizontal segments.
+     * @param segHeight - Number of vertical segments.
+     */
     constructor(width = 100, height = 100, segWidth = 10, segHeight = 10)
     {
         super();


### PR DESCRIPTION
There were a few private classes popping up in the docs, as well as some classes not part of `PIXI`.  This tidies this up.

Before: https://pixijs.download/dev/docs/index.html
After: https://pixijs.download/fix/docs-cleanup/docs/index.html