### PR TITLE
Fix overlapping types of events and interaction

### DIFF
--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -1,7 +1,8 @@
 declare namespace GlobalMixins
 {
+    type FederatedEventTarget = import('@pixi/events').FederatedEventTarget;
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface DisplayObject extends Required<Partial<import('@pixi/events').FederatedEventTarget>>
+    interface DisplayObject extends FederatedEventTarget
     {
 
     }

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -142,7 +142,7 @@ export class EventBoundary
     /**
      * The cursor preferred by the event targets underneath this boundary.
      */
-    public cursor: Cursor;
+    public cursor: Cursor | string;
 
     /**
      * This flag would emit `pointermove`, `touchmove`, and `mousemove` events on all DisplayObjects.

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -52,7 +52,7 @@ export interface IHitArea {
  */
 export interface FederatedEventTarget extends EventEmitter, EventTarget {
     /** The cursor preferred when the mouse pointer is hovering over. */
-    readonly cursor?: Cursor;
+    cursor: Cursor | string;
 
     /** The parent of this event target. */
     readonly parent?: FederatedEventTarget;
@@ -75,7 +75,7 @@ export interface FederatedEventTarget extends EventEmitter, EventTarget {
 
 export const FederatedDisplayObject: Omit<
     FederatedEventTarget,
-    'parent' | 'children' | keyof EventEmitter
+    'parent' | 'children' | keyof EventEmitter | 'cursor'
 > = {
     /**
      * Enable interaction events for the DisplayObject. Touch, pointer and mouse

--- a/packages/interaction/global.d.ts
+++ b/packages/interaction/global.d.ts
@@ -1,11 +1,8 @@
 declare namespace GlobalMixins
 {
-    // @deprecated
+    type InteractiveTarget = import('@pixi/interaction').InteractiveTarget;
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface DisplayObject extends Omit<
-        Partial<import('@pixi/interaction').InteractiveTarget>,
-        'cursor' | 'interactive' | 'interactiveChildren' | 'hitArea'
-    >
+    interface DisplayObject extends InteractiveTarget
     {
 
     }


### PR DESCRIPTION
Fixes #7611

Interaction and Events had incongruent overlapping types because cursor was different. This resolves that issue.
