### PR TITLE
Fix bug in FramebufferSystem.forceStencil

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -332,7 +332,14 @@ export class FramebufferSystem implements ISystem
 
         const colorTextures = framebuffer.colorTextures;
 
-        for (let i = 0; i < colorTextures.length; i++)
+        let count = colorTextures.length;
+
+        if (!gl.drawBuffers)
+        {
+            count = Math.min(count, 1);
+        }
+
+        for (let i = 0; i < count; i++)
         {
             const texture = colorTextures[i];
             const parentTexture = texture.parentTextureArray || texture;
@@ -340,7 +347,7 @@ export class FramebufferSystem implements ISystem
             this.renderer.texture.bind(parentTexture, 0);
         }
 
-        if (framebuffer.depthTexture)
+        if (framebuffer.depthTexture && this.writeDepthTexture)
         {
             this.renderer.texture.bind(framebuffer.depthTexture, 0);
         }

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -654,7 +654,8 @@ export class FramebufferSystem implements ISystem
         {
             return;
         }
-        framebuffer.enableStencil();
+
+        framebuffer.stencil = true;
 
         const w = framebuffer.width;
         const h = framebuffer.height;

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -436,9 +436,9 @@ export class FramebufferSystem implements ISystem
             }
         }
 
-        if (!fbo.stencil && (framebuffer.stencil || framebuffer.depth))
+        if ((framebuffer.stencil || framebuffer.depth) && !(framebuffer.depthTexture && this.writeDepthTexture))
         {
-            fbo.stencil = gl.createRenderbuffer();
+            fbo.stencil = fbo.stencil || gl.createRenderbuffer();
 
             gl.bindRenderbuffer(gl.RENDERBUFFER, fbo.stencil);
 
@@ -451,25 +451,13 @@ export class FramebufferSystem implements ISystem
             {
                 gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, framebuffer.width, framebuffer.height);
             }
-            // TODO.. this is depth AND stencil?
-            if (!framebuffer.depthTexture)
-            { // you can't have both, so one should take priority if enabled
-                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, fbo.stencil);
-            }
+
+            gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, fbo.stencil);
         }
         else if (fbo.stencil)
         {
-            gl.bindRenderbuffer(gl.RENDERBUFFER, fbo.stencil);
-
-            if (fbo.msaaBuffer)
-            {
-                gl.renderbufferStorageMultisample(gl.RENDERBUFFER, fbo.multisample,
-                    gl.DEPTH24_STENCIL8, framebuffer.width, framebuffer.height);
-            }
-            else
-            {
-                gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, framebuffer.width, framebuffer.height);
-            }
+            gl.deleteRenderbuffer(fbo.stencil);
+            fbo.stencil = null;
         }
     }
 


### PR DESCRIPTION
##### Description of change

This fixes a severe bug in `Framebuffer.forceStencil` that in combination with filters had the effect that stencil masks didn't work at all. `forceStencil` calls `enableStencil`, which invalidates the framebuffer. So when the first stencil mask is drawn, `forceStencil` is called, and the current framebuffer is invalidated. Then the filter textures are bound and afterwards the render target again. But since it was invalided, `updateFramebuffer` is called: the stencil buffer is reinitialized and therefore wiped.

Before the multisample fix PR `updateFramebuffer` failed to resize/update the stencil buffer. That bug canceled the bug in `forceStencil`. `forceStencil` must not invalidate the framebuffer, but only create and attach the stencil buffer if necessary. This was fixed by replacing `framebuffer.enableStencil()` by `framebuffer.stencil = true`.

I also made some non-critical adjustments to `resizeFramebuffer` and `updateFramebuffer`:

1. Made some changes to `resizeFramebuffer` to match with the behavior of `updateFramebuffer` more closely.
2. Cleaned the stencil buffer mess up in `updateFramebuffer`: the stencil buffer is now properly deleted if it isn't used anymore, and it's only created if necessary and no depth texture is attached.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
