### PR TITLE
Fix #7620 - Interaction with unrendered Graphics

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1242,6 +1242,9 @@ export class Graphics extends Container
         {
             // we don't need to add extra point in the end because buildLine will take care of that
             currentPath.closeStroke = true;
+            // ensure that the polygon is completed, and is available for hit detection
+            // (even if the graphics is not rendered yet)
+            this.finishPoly();
         }
 
         return this;

--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -294,7 +294,7 @@ describe('Graphics', function ()
 
     describe('containsPoint', function ()
     {
-        it('should return true when point inside', function ()
+        it('should return true when point inside a standard shape', function ()
         {
             const point = new Point(1, 1);
             const graphics = new Graphics();
@@ -305,13 +305,44 @@ describe('Graphics', function ()
             expect(graphics.containsPoint(point)).to.be.true;
         });
 
-        it('should return false when point outside', function ()
+        it('should return false when point outside a standard shape', function ()
         {
             const point = new Point(20, 20);
             const graphics = new Graphics();
 
             graphics.beginFill(0);
             graphics.drawRect(0, 0, 10, 10);
+
+            expect(graphics.containsPoint(point)).to.be.false;
+        });
+
+        it('should return true when point inside just lines', function ()
+        {
+            const point = new Point(1, 1);
+            const graphics = new Graphics();
+
+            graphics.beginFill(0);
+            graphics.moveTo(0, 0);
+            graphics.lineTo(0, 10);
+            graphics.lineTo(10, 10);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(0, 0);
+            graphics.closePath();
+
+            expect(graphics.containsPoint(point)).to.be.true;
+        });
+
+        it('should return false when point outside just lines', function ()
+        {
+            const point = new Point(20, 20);
+            const graphics = new Graphics();
+
+            graphics.moveTo(0, 0);
+            graphics.lineTo(0, 10);
+            graphics.lineTo(10, 10);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(0, 0);
+            graphics.closePath();
 
             expect(graphics.containsPoint(point)).to.be.false;
         });


### PR DESCRIPTION
##### Description of change
Fix #7620 so that Graphics drawn with `lineTo()` and completed with `closePath()` don't have to be rendered to be interacted with.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
