### PR TITLE
Add multisample property to Renderer

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -341,7 +341,30 @@ export class Renderer extends AbstractRenderer
 
     protected contextChange(): void
     {
-        const samples = this.gl.getParameter(this.gl.SAMPLES);
+        const gl = this.gl;
+
+        let samples;
+
+        if (this.context.webGLVersion === 1)
+        {
+            const framebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
+
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+            samples = gl.getParameter(gl.SAMPLES);
+
+            gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        }
+        else
+        {
+            const framebuffer = gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING);
+
+            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+
+            samples = gl.getParameter(gl.SAMPLES);
+
+            gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebuffer);
+        }
 
         if (samples >= MSAA_QUALITY.HIGH)
         {


### PR DESCRIPTION
##### Description of change

This adds the multisample property to `Renderer`, which returns the number of msaa samples of the canvas.

The documentation of `gl.getParameter(gl.SAMPLES)` is somewhat limited (at least I didn't find much with respect to the webgl canvas), but I tested it in Firefox and Chrome, and it works.

This is much better and much more convenient than the following, which I used in #7618 and proposed in #7441. Also since the `antialias` parameter is merely a hint that can be ignored by the browser the following code isn't even correct technically.

```js
if (renderer.gl.getContextAttributes().antialias) {
    multisample = MSAA_QUALITY.HIGH;
} else {
    multisample = MSAA_QUALITY.NONE;
}
```

Also the default framebuffer msaa samples at least on my machine in Firefox and Chrome is 4; so HIGH samples would have been to much in the code above.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
