### PR TITLE
Blit in Renderer.generateTexture

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -494,41 +494,6 @@ export class Renderer extends AbstractRenderer
     }
 
     /**
-     * Please use the options argument instead.
-     *
-     * @override
-     * @method PIXI.Renderer#generateTexture
-     * @deprecated Since 6.1.0
-     * @param displayObject - The displayObject the object will be generated from.
-     * @param scaleMode - The scale mode of the texture.
-     * @param resolution - The resolution / device pixel ratio of the texture being generated.
-     * @param region - The region of the displayObject, that shall be rendered,
-     *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @return A texture of the graphics object.
-     */
-    generateTexture(
-        displayObject: IRenderableObject,
-        scaleMode?: SCALE_MODES,
-        resolution?: number,
-        region?: Rectangle): RenderTexture;
-
-    /**
-     * Useful function that returns a texture of the display object that can then be used to create sprites
-     * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
-     * @override
-     * @method PIXI.Renderer#generateTexture
-     * @param displayObject - The displayObject the object will be generated from.
-     * @param {object} options - Generate texture options.
-     * @param {PIXI.SCALE_MODES} options.scaleMode - The scale mode of the texture.
-     * @param {number} options.resolution - The resolution / device pixel ratio of the texture being generated.
-     * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
-     *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @param {PIXI.MSAA_QUALITY} options.multisample - The number of samples of the frame buffer.
-     * @return A texture of the graphics object.
-     */
-    generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture;
-
-    /**
      * @override
      * @ignore
      */


### PR DESCRIPTION
##### Description of change

Fixes #7628.

I probably made a mess overriding the method: I copied all the method definitions from `AbtractRenderer`. But I noticed that the new version `generateTexture` doesn't show up in the `Renderer` [docs](https://pixijs.download/dev/docs/PIXI.Renderer.html); only the deprecated version for some reason.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
