### PR TITLE
Workaround webdoc issue with overloading and inheritance

### DIFF
--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -309,6 +309,21 @@ export abstract class AbstractRenderer extends EventEmitter
     }
 
     /**
+     * Useful function that returns a texture of the display object that can then be used to create sprites
+     * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
+     * @method PIXI.AbstractRenderer#generateTexture
+     * @param displayObject - The displayObject the object will be generated from.
+     * @param {object} options - Generate texture options.
+     * @param {PIXI.SCALE_MODES} options.scaleMode - The scale mode of the texture.
+     * @param {number} options.resolution - The resolution / device pixel ratio of the texture being generated.
+     * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
+     *        if no region is specified, defaults to the local bounds of the displayObject.
+     * @param {PIXI.MSAA_QUALITY} options.multisample - The number of samples of the frame buffer.
+     * @return A texture of the graphics object.
+     */
+    generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture;
+
+    /**
      * Please use the options argument instead.
      *
      * @method PIXI.AbstractRenderer#generateTexture
@@ -325,21 +340,6 @@ export abstract class AbstractRenderer extends EventEmitter
         scaleMode?: SCALE_MODES,
         resolution?: number,
         region?: Rectangle): RenderTexture;
-
-    /**
-     * Useful function that returns a texture of the display object that can then be used to create sprites
-     * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
-     * @method PIXI.AbstractRenderer#generateTexture
-     * @param displayObject - The displayObject the object will be generated from.
-     * @param {object} options - Generate texture options.
-     * @param {PIXI.SCALE_MODES} options.scaleMode - The scale mode of the texture.
-     * @param {number} options.resolution - The resolution / device pixel ratio of the texture being generated.
-     * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
-     *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @param {PIXI.MSAA_QUALITY} options.multisample - The number of samples of the frame buffer.
-     * @return A texture of the graphics object.
-     */
-    generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture;
 
     /**
      * @ignore


### PR DESCRIPTION
Issue brought up in #7633 and follow-up to #7629.

Workaround for underlying issue https://github.com/webdoc-labs/webdoc/issues/133

### Examples

Broken: https://pixijs.download/dev/docs/PIXI.Renderer.html#generateTexture (show deprecated only)
Fixed: https://pixijs.download/fix/generate-texture-docs/docs/PIXI.Renderer.html#generateTexture (show non-deprecated only)