### PR TITLE
Bind empty if texture is invalid

### DIFF
--- a/packages/core/test/TextureSystem.tests.ts
+++ b/packages/core/test/TextureSystem.tests.ts
@@ -125,4 +125,20 @@ describe('TextureSystem', function ()
         expect(boundTextures[1]).to.be.null;
         expect(boundTextures[2]).to.equal(sampleTex2);
     });
+
+    it('should bind empty texture if texture is invalid', function ()
+    {
+        const textureSystem = this.renderer.texture;
+
+        expect(Texture.WHITE.baseTexture.valid).to.be.true;
+
+        textureSystem.bind(Texture.WHITE.baseTexture, 0);
+
+        expect(textureSystem.boundTextures[0]).to.equal(Texture.WHITE.baseTexture);
+        expect(Texture.EMPTY.baseTexture.valid).to.be.false;
+
+        textureSystem.bind(Texture.EMPTY.baseTexture, 0);
+
+        expect(textureSystem.boundTextures[0]).to.equal(null);
+    });
 });


### PR DESCRIPTION
##### Description of change

Binding an invalid texture does nothing at the moment, i.e. the texture bindings don't change. Consequently, the last bound texture is used instead: [example](https://www.pixiplayground.com/#/edit/BLiI4gXywBluF0E6IJXJa). I assume this is not intended. It should bind an empty texture.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
