### PR TITLE
Add automatic multisample selection option to cacheAsBitmap

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -89,7 +89,8 @@ Object.defineProperties(DisplayObject.prototype, {
     },
 
     /**
-     * The number of samples to use for cacheAsBitmap.
+     * The number of samples to use for cacheAsBitmap. If set to `null`, the renderer's
+     * sample count is used.
      * If `cacheAsBitmap` is set to `true`, this will re-render with the new number of samples.
      *
      * @member {number} cacheAsBitmapMultisample
@@ -278,7 +279,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
         width: bounds.width,
         height: bounds.height,
         resolution: this.cacheAsBitmapResolution || renderer.resolution,
-        multisample: this.cacheAsBitmapMultisample,
+        multisample: this.cacheAsBitmapMultisample ?? renderer.multisample,
     });
 
     const textureCacheId = `cacheAsBitmap_${uid()}`;


### PR DESCRIPTION
##### Description of change

This was something I included in #7441 at first, but then removed it. Now we have `Renderer.multisample`, so it can be done correctly.

The default multisample is still `NONE`.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
