### PR TITLE
@pixi/events: removeEvents() now sets eventsAdded to false

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -459,6 +459,7 @@ export class EventSystem
         this.domElement.removeEventListener('wheel', this.onWheel, true);
 
         this.domElement = null;
+        this.eventsAdded = false;
     }
 
     /**


### PR DESCRIPTION
##### Description of change
`removeEvents` was not setting the `eventsAdded` back to false and thus, the first check on `addEvents` was returning early, making it impossible to re-add the events.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
