### PR TITLE
Remove node types from leaking in core package

### DIFF
--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -9,6 +9,7 @@ import type { IRenderingContext } from '../IRenderingContext';
 import type { Geometry } from './Geometry';
 import type { Shader } from '../shader/Shader';
 import type { Program } from '../shader/Program';
+import type { Buffer } from './Buffer';
 import type { Dict } from '@pixi/utils';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };


### PR DESCRIPTION
Fixes #7674

There was a reference to Buffer without import which was adding node types inappropriately.