### PR TITLE
Remove CanvasRenderer types from mixin-cache-as-bitmap and accessibility

### DIFF
--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -25,7 +25,6 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "@pixi/canvas-renderer": "6.1.1",
     "@pixi/core": "6.1.1",
     "@pixi/display": "6.1.1",
     "@pixi/utils": "6.1.1"

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -4,8 +4,7 @@ import { accessibleTarget } from './accessibleTarget';
 
 import type { Rectangle } from '@pixi/math';
 import type { Container } from '@pixi/display';
-import type { Renderer } from '@pixi/core';
-import type { CanvasRenderer } from '@pixi/canvas-renderer';
+import type { Renderer, AbstractRenderer } from '@pixi/core';
 import type { IAccessibleHTMLElement } from './accessibleTarget';
 
 // add some extra variables to the container..
@@ -45,7 +44,7 @@ export class AccessibilityManager
      *
      * @type {PIXI.CanvasRenderer|PIXI.Renderer}
      */
-    public renderer: CanvasRenderer|Renderer;
+    public renderer: AbstractRenderer|Renderer;
 
     /** Internal variable, see isActive getter. */
     private _isActive = false;
@@ -77,7 +76,7 @@ export class AccessibilityManager
     /**
      * @param {PIXI.CanvasRenderer|PIXI.Renderer} renderer - A reference to the current renderer
      */
-    constructor(renderer: CanvasRenderer|Renderer)
+    constructor(renderer: AbstractRenderer|Renderer)
     {
         this._hookDiv = null;
 

--- a/packages/mixin-cache-as-bitmap/global.d.ts
+++ b/packages/mixin-cache-as-bitmap/global.d.ts
@@ -12,8 +12,8 @@ declare namespace GlobalMixins
         _initCachedDisplayObject(renderer: import('@pixi/core').Renderer): void;
         _calculateCachedBounds(): void;
         _getCachedLocalBounds(): import('@pixi/math').Rectangle;
-        _renderCachedCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
-        _initCachedDisplayObjectCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+        _renderCachedCanvas(renderer: import('@pixi/core').AbstractRenderer): void;
+        _initCachedDisplayObjectCanvas(renderer: import('@pixi/core').AbstractRenderer): void;
         _destroyCachedDisplayObject(): void;
         _cacheAsBitmapDestroy(options?: import('@pixi/display').IDestroyOptions|boolean): void;
     }

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -26,7 +26,6 @@
     "*.d.ts"
   ],
   "peerDependencies": {
-    "@pixi/canvas-renderer": "6.1.1",
     "@pixi/core": "6.1.1",
     "@pixi/display": "6.1.1",
     "@pixi/math": "6.1.1",

--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -1,11 +1,16 @@
-import { Texture, BaseTexture, RenderTexture, Renderer, MaskData } from '@pixi/core';
+import { Texture, BaseTexture, RenderTexture, Renderer, MaskData, AbstractRenderer } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
 import { Container, DisplayObject, IDestroyOptions } from '@pixi/display';
 import { IPointData, Matrix, Rectangle } from '@pixi/math';
 import { uid } from '@pixi/utils';
 import { settings } from '@pixi/settings';
 import { MSAA_QUALITY } from '@pixi/constants';
-import type { CanvasRenderer } from '@pixi/canvas-renderer';
+
+// Don't import CanvasRender to remove dependency on this optional package
+// this type should satisify these requirements for cacheAsBitmap types
+interface CanvasRenderer extends AbstractRenderer {
+    context: CanvasRenderingContext2D;
+}
 
 const _tempMatrix = new Matrix();
 
@@ -26,7 +31,7 @@ export class CacheData
 {
     public textureCacheId: string;
     public originalRender: (renderer: Renderer) => void;
-    public originalRenderCanvas: (renderer: CanvasRenderer) => void;
+    public originalRenderCanvas: (renderer: AbstractRenderer) => void;
     public originalCalculateBounds: () => void;
     public originalGetLocalBounds: (rect?: Rectangle) => Rectangle;
     public originalUpdateTransform: () => void;
@@ -350,7 +355,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
  * @memberof PIXI.DisplayObject#
  * @param {PIXI.CanvasRenderer} renderer - The canvas renderer
  */
-DisplayObject.prototype._renderCachedCanvas = function _renderCachedCanvas(renderer: CanvasRenderer): void
+DisplayObject.prototype._renderCachedCanvas = function _renderCachedCanvas(renderer: AbstractRenderer): void
 {
     if (!this.visible || this.worldAlpha <= 0 || !this.renderable)
     {


### PR DESCRIPTION
Fix #7683