### PR TITLE
Typing fix

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -210,7 +210,7 @@ export class Spritesheet
      * @param {Function} callback - Callback when complete returns
      *        a map of the Textures for this spritesheet.
      */
-    public parse(callback: () => void): void
+    public parse(callback: (textures?: Dict<Texture>) => void): void
     {
         this._batchIndex = 0;
         this._callback = callback;


### PR DESCRIPTION
Typings fix: Spritesheet.parse method now accepts a list of textures as…an argument for the callback


##### Description of change
When using spritesheet parse method, the client now do the following to get the textures in callback

```js
spritesheet.parse((textures: Texture[]) => {
  console.log(textures);
});
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests passed (`npm run test`)
