### PR TITLE
Make Mesh.geometry writable

### DIFF
--- a/packages/mesh/test/Mesh.tests.ts
+++ b/packages/mesh/test/Mesh.tests.ts
@@ -1,0 +1,55 @@
+import { Mesh, MeshGeometry, MeshMaterial } from '@pixi/mesh';
+import { skipHello } from '@pixi/utils';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+skipHello();
+
+describe('Mesh', function ()
+{
+    it('should dispose geometry correctly', function ()
+    {
+        const geometry1 = new MeshGeometry();
+        const geometry2 = new MeshGeometry();
+
+        const dispose1 = sinon.spy(geometry1, 'dispose');
+        const dispose2 = sinon.spy(geometry2, 'dispose');
+
+        expect(geometry1.refCount).to.equal(0);
+        expect(geometry2.refCount).to.equal(0);
+        expect(dispose1.called).to.be.false;
+        expect(dispose2.called).to.be.false;
+
+        const mesh = new Mesh(geometry1, new MeshMaterial());
+
+        expect(mesh.geometry).to.equal(geometry1);
+        expect(geometry1.refCount).to.equal(1);
+        expect(geometry2.refCount).to.equal(0);
+        expect(dispose1.called).to.be.false;
+        expect(dispose2.called).to.be.false;
+
+        mesh.geometry = geometry1;
+
+        expect(mesh.geometry).to.equal(geometry1);
+        expect(geometry1.refCount).to.equal(1);
+        expect(geometry2.refCount).to.equal(0);
+        expect(dispose1.called).to.be.false;
+        expect(dispose2.called).to.be.false;
+
+        mesh.geometry = geometry2;
+
+        expect(mesh.geometry).to.equal(geometry2);
+        expect(geometry1.refCount).to.equal(0);
+        expect(geometry2.refCount).to.equal(1);
+        expect(dispose1.called).to.be.true;
+        expect(dispose2.called).to.be.false;
+
+        mesh.destroy();
+
+        expect(mesh.geometry).to.equal(null);
+        expect(geometry1.refCount).to.equal(0);
+        expect(geometry2.refCount).to.equal(0);
+        expect(dispose1.called).to.be.true;
+        expect(dispose2.called).to.be.true;
+    });
+});

--- a/packages/mesh/test/Mesh.tests.ts
+++ b/packages/mesh/test/Mesh.tests.ts
@@ -9,8 +9,8 @@ describe('Mesh', function ()
 {
     it('should dispose geometry correctly', function ()
     {
-        const geometry1 = new MeshGeometry();
-        const geometry2 = new MeshGeometry();
+        const geometry1 = new MeshGeometry([0, 0]);
+        const geometry2 = new MeshGeometry([1, 1]);
 
         const dispose1 = sinon.spy(geometry1, 'dispose');
         const dispose2 = sinon.spy(geometry2, 'dispose');
@@ -23,14 +23,24 @@ describe('Mesh', function ()
         const mesh = new Mesh(geometry1, new MeshMaterial());
 
         expect(mesh.geometry).to.equal(geometry1);
+        expect(mesh.vertexDirty).to.equal(-1);
         expect(geometry1.refCount).to.equal(1);
         expect(geometry2.refCount).to.equal(0);
         expect(dispose1.called).to.be.false;
         expect(dispose2.called).to.be.false;
 
+        mesh.calculateVertices();
+
+        expect(mesh.vertexDirty).to.equal(mesh.verticesBuffer._updateID);
+        expect(mesh.vertexData[0]).to.equal(0);
+        expect(mesh.vertexData[1]).to.equal(0);
+
         mesh.geometry = geometry1;
 
         expect(mesh.geometry).to.equal(geometry1);
+        expect(mesh.vertexDirty).to.equal(mesh.verticesBuffer._updateID);
+        expect(mesh.vertexData[0]).to.equal(0);
+        expect(mesh.vertexData[1]).to.equal(0);
         expect(geometry1.refCount).to.equal(1);
         expect(geometry2.refCount).to.equal(0);
         expect(dispose1.called).to.be.false;
@@ -39,14 +49,22 @@ describe('Mesh', function ()
         mesh.geometry = geometry2;
 
         expect(mesh.geometry).to.equal(geometry2);
+        expect(mesh.vertexDirty).to.equal(-1);
         expect(geometry1.refCount).to.equal(0);
         expect(geometry2.refCount).to.equal(1);
         expect(dispose1.called).to.be.true;
         expect(dispose2.called).to.be.false;
 
+        mesh.calculateVertices();
+
+        expect(mesh.vertexDirty).to.equal(mesh.verticesBuffer._updateID);
+        expect(mesh.vertexData[0]).to.equal(1);
+        expect(mesh.vertexData[1]).to.equal(1);
+
         mesh.destroy();
 
         expect(mesh.geometry).to.equal(null);
+        expect(mesh.vertexDirty).to.equal(-1);
         expect(geometry1.refCount).to.equal(0);
         expect(geometry2.refCount).to.equal(0);
         expect(dispose1.called).to.be.true;


### PR DESCRIPTION
##### Description of change

I added getter and setters for `Mesh.geometry`. I didn't see a reason why this property should be read only.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
