### PR TITLE
Fix spritesheetLoader to pass metadata to all loaded multipack resources (#7714)

### DIFF
--- a/packages/spritesheet/src/SpritesheetLoader.ts
+++ b/packages/spritesheet/src/SpritesheetLoader.ts
@@ -82,6 +82,7 @@ export class SpritesheetLoader
                     loadType: LoaderResource.LOAD_TYPE.XHR,
                     xhrType: LoaderResource.XHR_RESPONSE_TYPE.JSON,
                     parentResource: resource,
+                    metadata: resource.metadata
                 };
 
                 loader.add(itemName, itemUrl, options);

--- a/packages/spritesheet/test/SpritesheetLoader.tests.ts
+++ b/packages/spritesheet/test/SpritesheetLoader.tests.ts
@@ -264,6 +264,24 @@ describe('SpritesheetLoader', function ()
         result = url.resolve('/some/dir/spritesheet.json', '../spritesheet-1.json');
         expect(result).to.be.equals('/some/spritesheet-1.json');
     });
+
+    it('should use metadata to load all multipack resources', function (done)
+    {
+        // clear the caches only to avoid cluttering the output
+        clearTextureCache();
+
+        const loader = new Loader();
+        const metadata = { key: 'value' };
+
+        loader.add('building1-0', path.join(__dirname, 'resources', 'building1-0.json'), { metadata });
+        loader.load((loader, resources) =>
+        {
+            expect(resources['building1-0'].metadata).to.be.equals(metadata);
+            expect(resources['building1-1'].metadata).to.be.equals(metadata);
+
+            done();
+        });
+    });
 });
 
 function createMockResource(type, data)


### PR DESCRIPTION
##### Description of change
Fix SpritesheetLoader to pass metadata to all loaded multipack resources, currently, metadata are used only to the first (parent) resource.

Related Issue: https://github.com/pixijs/pixijs/issues/7714

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
