### PR TITLE
Use modern canvas2D api for text when avalilable

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -333,8 +333,16 @@ export class Text extends Sprite
         // letterSpacing of 0 means normal
         const letterSpacing = style.letterSpacing;
 
-        if (letterSpacing === 0)
+        // Checking that we can use moddern canvas2D api
+        // https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
+        const modernAPI = 'letterSpacing' in this.context;
+
+        if (letterSpacing === 0 || modernAPI)
         {
+            if (modernAPI) {
+                (<any> this.context).letterSpacing = letterSpacing;
+            }
+
             if (isStroke)
             {
                 this.context.strokeText(text, x, y);


### PR DESCRIPTION
Partial solution for #7729 on latest Chrome by newest Canvas2D API.

See:
https://github.com/fserb/canvas2D/blob/master/spec/text-modifiers.md
https://chromestatus.com/feature/6051647656558592

##### Description of change
Using canvas2D `letterSpacing` for avoid flipping text for RTL and broking a glyphs for ligatures-heavy language.

#### Example:
https://exponenta.games/games/fix-spacing/

NOTE: You should use Chrome Canary or enable `chrome://flags/#new-canvas-2d-api` in stable chrome.
Xurrent version of chrome 92 origin trials still not workig (for me) how should.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
