### PR TITLE
Allow multiple objects to have the same mask

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -768,7 +768,7 @@ export abstract class DisplayObject extends EventEmitter
 
         this.parent = null;
         this._bounds = null;
-        this._mask = null;
+        this.mask = null;
 
         this.filters = null;
         this.filterArea = null;

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -222,7 +222,6 @@ export abstract class DisplayObject extends EventEmitter
     public _bounds: Bounds;
     public _localBounds: Bounds;
 
-    protected _maskRefCount: number;
     protected _zIndex: number;
     protected _enabledFilters: Filter[];
     protected _boundsID: number;
@@ -230,6 +229,7 @@ export abstract class DisplayObject extends EventEmitter
     protected _localBoundsRect: Rectangle;
     protected _destroyed: boolean;
 
+    private _maskRefCount: number;
     private tempDisplayObjectParent: TemporaryDisplayObject;
     public displayObjectUpdateTransform: () => void;
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -411,7 +411,7 @@ export abstract class DisplayObject extends EventEmitter
          * The number of times this object is used as a mask by another object.
          *
          * @member {number}
-         * @protected
+         * @private
          */
         this._maskRefCount = 0;
 

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -222,6 +222,7 @@ export abstract class DisplayObject extends EventEmitter
     public _bounds: Bounds;
     public _localBounds: Bounds;
 
+    protected _maskRefCount: number;
     protected _zIndex: number;
     protected _enabledFilters: Filter[];
     protected _boundsID: number;
@@ -405,6 +406,14 @@ export abstract class DisplayObject extends EventEmitter
          * @protected
          */
         this._mask = null;
+
+        /**
+         * The number of times this object is used as a mask by another object.
+         *
+         * @member {number}
+         * @protected
+         */
+        this._maskRefCount = 0;
 
         /**
          * If the object has been destroyed via destroy(). If true, it should not be used.
@@ -1045,12 +1054,22 @@ export abstract class DisplayObject extends EventEmitter
 
     set mask(value: Container|MaskData|null)
     {
+        if (this._mask === value)
+        {
+            return;
+        }
+
         if (this._mask)
         {
             const maskObject = ((this._mask as MaskData).maskObject || this._mask) as Container;
 
-            maskObject.renderable = true;
-            maskObject.isMask = false;
+            maskObject._maskRefCount--;
+
+            if (maskObject._maskRefCount === 0)
+            {
+                maskObject.renderable = true;
+                maskObject.isMask = false;
+            }
         }
 
         this._mask = value;
@@ -1059,8 +1078,13 @@ export abstract class DisplayObject extends EventEmitter
         {
             const maskObject = ((this._mask as MaskData).maskObject || this._mask) as Container;
 
-            maskObject.renderable = false;
-            maskObject.isMask = true;
+            if (maskObject._maskRefCount === 0)
+            {
+                maskObject.renderable = false;
+                maskObject.isMask = true;
+            }
+
+            maskObject._maskRefCount++;
         }
     }
 }

--- a/packages/display/test/DisplayObject.tests.ts
+++ b/packages/display/test/DisplayObject.tests.ts
@@ -146,6 +146,73 @@ describe('DisplayObject', function ()
         });
     });
 
+    describe('mask', function ()
+    {
+        it('should set isMask and renderable properties correctly even if the same mask is used by multiple objects',
+            function ()
+            {
+                const mask1 = new DisplayObject();
+                const mask2 = new DisplayObject();
+                const container1 = new Container();
+                const container2 = new Container();
+
+                expect(mask1.isMask).to.be.false;
+                expect(mask1.renderable).to.be.true;
+                expect(mask2.isMask).to.be.false;
+                expect(mask2.renderable).to.be.true;
+
+                container1.mask = mask1;
+
+                expect(mask1.isMask).to.be.true;
+                expect(mask1.renderable).to.be.false;
+                expect(mask2.isMask).to.be.false;
+                expect(mask2.renderable).to.be.true;
+
+                container1.mask = mask1;
+
+                expect(mask1.isMask).to.be.true;
+                expect(mask1.renderable).to.be.false;
+                expect(mask2.isMask).to.be.false;
+                expect(mask2.renderable).to.be.true;
+
+                container2.mask = mask1;
+
+                expect(mask1.isMask).to.be.true;
+                expect(mask2.isMask).to.be.false;
+                expect(mask1.renderable).to.be.false;
+                expect(mask2.renderable).to.be.true;
+
+                container1.mask = mask2;
+
+                expect(mask1.isMask).to.be.true;
+                expect(mask1.renderable).to.be.false;
+                expect(mask2.isMask).to.be.true;
+                expect(mask2.renderable).to.be.false;
+
+                container2.mask = mask2;
+
+                expect(mask1.isMask).to.be.false;
+                expect(mask1.renderable).to.be.true;
+                expect(mask2.isMask).to.be.true;
+                expect(mask2.renderable).to.be.false;
+
+                container1.mask = null;
+
+                expect(mask1.isMask).to.be.false;
+                expect(mask1.renderable).to.be.true;
+                expect(mask2.isMask).to.be.true;
+                expect(mask2.renderable).to.be.false;
+
+                container2.mask = null;
+
+                expect(mask1.isMask).to.be.false;
+                expect(mask1.renderable).to.be.true;
+                expect(mask2.isMask).to.be.false;
+                expect(mask2.renderable).to.be.true;
+            }
+        );
+    });
+
     describe('remove', function ()
     {
         it('should trigger removed listeners', function ()

--- a/packages/display/test/DisplayObject.tests.ts
+++ b/packages/display/test/DisplayObject.tests.ts
@@ -209,6 +209,16 @@ describe('DisplayObject', function ()
                 expect(mask1.renderable).to.be.true;
                 expect(mask2.isMask).to.be.false;
                 expect(mask2.renderable).to.be.true;
+
+                container1.mask = mask1;
+
+                expect(mask1.isMask).to.be.true;
+                expect(mask1.renderable).to.be.false;
+
+                container1.destroy();
+
+                expect(mask1.isMask).to.be.false;
+                expect(mask1.renderable).to.be.true;
             }
         );
     });


### PR DESCRIPTION
##### Description of change

Multiple objects having the same mask is possible, but the code doesn't seem to be written with that in mind. `isMask` can easily end up being false even if the object is still used as a mask. The current implementation can cause problems if the mask object is before the object that is masked in the scene graph: the mask is rendered normally for one frame after isMask is set to false and renderable to true when the mask is removed from another object; isMask remains false, but renderable is set to false again by the mask system. Here a demo where the the mask is added and removed from some other object every frame and so the mask is rendered normally in the background. https://www.pixiplayground.com/#/edit/jC73hmNsD59Hgyp6kseVL. If the mask is after the all objects that use the mask in the scene graph, this visual bug wouldn't occur; only `isMask` would be incorrectly false.

I fixed this problem by adding a reference counter that counts the number of times the object is used as a mask.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
