### PR TITLE
Fix accessibleChildren type

### DIFF
--- a/packages/accessibility/src/accessibleTarget.ts
+++ b/packages/accessibility/src/accessibleTarget.ts
@@ -21,7 +21,7 @@ export interface IAccessibleTarget {
     _accessibleDiv: IAccessibleHTMLElement;
     accessibleType: string;
     accessiblePointerEvents: PointerEvents;
-    accessibleChildren: true;
+    accessibleChildren: boolean;
     renderId: number;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
This fixes a minor type convenience issue: `accessibleChildren`'s type is defined as `true` (with `undefined` being allowed via `Partial`), and although this works fine, it's a `boolean` in practice, and the overly strict type can lead to more verbose/non-idiomatic code, e.g.

```ts
container.accessibleChildren = someCondition ? true : undefined; // valid
```
vs
```ts
container.accessibleChildren = !!someCondition; // Type 'boolean' is not assignable to type 'true | undefined'
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- ~[ ] Tests and/or benchmarks are included~ N/A
- ~[ ] Documentation is changed or added~ N/A
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
