### PR TITLE
Remove StencilSystem._getBitwiseMask

### DIFF
--- a/packages/core/src/mask/StencilSystem.ts
+++ b/packages/core/src/mask/StencilSystem.ts
@@ -56,7 +56,7 @@ export class StencilSystem extends AbstractMaskSystem
 
         // Increment the reference stencil value where the new mask overlaps with the old ones.
         gl.colorMask(false, false, false, false);
-        gl.stencilFunc(gl.EQUAL, prevMaskCount, this._getBitwiseMask());
+        gl.stencilFunc(gl.EQUAL, prevMaskCount, 0xFFFFFFFF);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.INCR);
 
         maskObject.renderable = true;
@@ -80,8 +80,8 @@ export class StencilSystem extends AbstractMaskSystem
         {
             // the stack is empty!
             gl.disable(gl.STENCIL_TEST);
-            gl.clear(gl.STENCIL_BUFFER_BIT);
             gl.clearStencil(0);
+            gl.clear(gl.STENCIL_BUFFER_BIT);
         }
         else
         {
@@ -107,17 +107,7 @@ export class StencilSystem extends AbstractMaskSystem
         const gl = this.renderer.gl;
 
         gl.colorMask(true, true, true, true);
-        gl.stencilFunc(gl.EQUAL, this.getStackLength(), this._getBitwiseMask());
+        gl.stencilFunc(gl.EQUAL, this.getStackLength(), 0xFFFFFFFF);
         gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-    }
-
-    /**
-     * Fill 1s equal to the number of acitve stencil masks.
-     * @private
-     * @return {number} The bitwise mask.
-     */
-    _getBitwiseMask(): number
-    {
-        return (1 << this.getStackLength()) - 1;
     }
 }


### PR DESCRIPTION
##### Description of change

The bit mask returned by `_getBitwiseMask` doesn't seem to make a lot of sense. Maybe it's a leftover from a previous implementation. So I removed it.

Bonus bug fix: `gl.clearStencil(0)` needs to be before `gl.clear(gl.STENCIL_BUFFER_BIT)` not after.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
