### PR TITLE
Convert Filter resolution from property to accessor

### DIFF
--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -187,7 +187,6 @@ import type { Dict } from '@pixi/utils';
 export class Filter extends Shader
 {
     public padding: number;
-    public resolution: number;
     public multisample: MSAA_QUALITY;
     public enabled: boolean;
     public autoFit: boolean;
@@ -197,6 +196,8 @@ export class Filter extends Shader
      */
     public legacy: boolean;
     state: State;
+    
+    private _resolution: number;
     /**
      * @param {string} [vertexSrc] - The source of the vertex shader.
      * @param {string} [fragmentSrc] - The source of the fragment shader.
@@ -218,12 +219,6 @@ export class Filter extends Shader
          */
         this.padding = 0;
 
-        /**
-         * The resolution of the filter. Setting this to be lower will lower the quality but
-         * increase the performance of the filter.
-         *
-         * @member {number}
-         */
         this.resolution = settings.FILTER_RESOLUTION;
 
         /**
@@ -292,6 +287,22 @@ export class Filter extends Shader
         this.state.blendMode = value;
     }
 
+    /**
+     * The resolution of the filter. Setting this to be lower will lower the quality but
+     * increase the performance of the filter.
+     *
+     * @member {number}
+     */
+    get resolution(): number
+    {
+        return this._resolution;
+    }
+
+    set resolution(value: number)
+    {
+        this._resolution = value;
+    }
+    
     /**
      * The default vertex shader source
      *

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -197,7 +197,7 @@ export class Filter extends Shader
     public legacy: boolean;
     state: State;
 
-    private _resolution: number;
+    protected _resolution: number;
     /**
      * @param {string} [vertexSrc] - The source of the vertex shader.
      * @param {string} [fragmentSrc] - The source of the fragment shader.

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -196,7 +196,7 @@ export class Filter extends Shader
      */
     public legacy: boolean;
     state: State;
-    
+
     private _resolution: number;
     /**
      * @param {string} [vertexSrc] - The source of the vertex shader.
@@ -302,7 +302,7 @@ export class Filter extends Shader
     {
         this._resolution = value;
     }
-    
+
     /**
      * The default vertex shader source
      *


### PR DESCRIPTION
##### Description of change
This PR is an attempt to fix this issue that I've had with the PIXI Advanced Blur Filter (documented here: https://github.com/pixijs/filters/issues/301). I describe the issue in detail there, but here's a short summary:

`Filter` has a public property named `resolution`.  `AdvancedBloomFilter` overrides this property with an accessor named `resolution`. `AdvancedBloomFilter` maintains a private `_resolution` property which is set by this accessor (along with some other side-effects, which seems to be the whole purpose of using an accessor instead of a property).

However, as of https://github.com/microsoft/TypeScript/pull/37894, `tsc` now treats overriding a property with an accessor as an error.

This PR converts the definition of `resolution` in the base `Filter` class to an accessor to avoid this error.

##### Pre-Merge Checklist


- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
