### PR TITLE
Fix degradaton on IE11

### DIFF
--- a/packages/core/src/shader/utils/getAttributeData.ts
+++ b/packages/core/src/shader/utils/getAttributeData.ts
@@ -21,7 +21,7 @@ export function getAttributeData(program: WebGLProgram, gl: WebGLRenderingContex
     {
         const attribData = gl.getActiveAttrib(program, i);
 
-        if (attribData.name.startsWith('gl_'))
+        if (attribData.name.indexOf('gl_') === 0)
         {
             continue;
         }


### PR DESCRIPTION
##### Description of change
fix for: #7775 

`startsWith` not exist on IE11, replace onto `indexOf() === 0`

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
