### PR TITLE
Move texture.valid check

### DIFF
--- a/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -53,6 +53,11 @@ export class CanvasSpriteRenderer
         const renderer = this.renderer;
         const context = renderer.context;
 
+        if (!texture.valid)
+        {
+            return;
+        }
+
         const width = texture._frame.width;
         const height = texture._frame.height;
 
@@ -63,11 +68,6 @@ export class CanvasSpriteRenderer
         const source = texture.baseTexture.getDrawableSource();
 
         if (texture.orig.width <= 0 || texture.orig.height <= 0 || !texture.valid || !source)
-        {
-            return;
-        }
-
-        if (!texture.valid)
         {
             return;
         }

--- a/packages/canvas/canvas-sprite/test/.eslintrc.json
+++ b/packages/canvas/canvas-sprite/test/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "globals": {
+        "expect": false,
+        "assert": false,
+        "sinon": false,
+        "PIXI": false
+    },
+    "rules": {
+        "func-names": 0,
+        "no-unused-expressions": 0
+    }
+}

--- a/packages/canvas/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
+++ b/packages/canvas/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
@@ -1,0 +1,26 @@
+import { Texture } from '@pixi/core';
+import { Sprite } from '@pixi/sprite';
+import { CanvasRenderer } from '@pixi/canvas-renderer';
+import { expect } from 'chai';
+
+describe('CanvasSpriteRenderer', function ()
+{
+    it('should still render a sprite after texture is destroyed', function ()
+    {
+        const renderer = new CanvasRenderer({ width: 1, height: 1 });
+        const texture = new Texture(Texture.WHITE);
+        const sprite = new Sprite(texture);
+
+        renderer.render(sprite);
+        texture.destroy();
+
+        try
+        {
+            expect(() => { renderer.render(sprite); }).to.not.throw();
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+});


### PR DESCRIPTION
##### Description of change
Move
`if (!texture.valid) return; `
so that it comes before the call to 
`texture._frame.width `

This prevents a crash when destroying the texture of a sprite currently being rendered.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
