### PR TITLE
Chore: Upgrade webdoc to 1.5.3 so we can strip out @member data-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@rollup/plugin-typescript": "^6.0.0",
         "@types/mocha": "^8.2.3",
-        "@webdoc/cli": "^1.3.4",
+        "@webdoc/cli": "^1.5.3",
         "chai": "~3.5.0",
         "copyfiles": "^2.1.0",
         "cross-env": "^5.2.0",
@@ -180,15 +180,6 @@
         "globals": "^11.1.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.1",
       "dev": true,
@@ -236,15 +227,6 @@
         "source-map": "^0.5.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/generator/node_modules/jsesc": {
       "version": "2.5.2",
       "dev": true,
@@ -265,20 +247,15 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.12.13",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
@@ -313,30 +290,12 @@
         "@babel/types": "^7.12.13"
       }
     },
-    "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-get-function-arity": {
       "version": "7.12.13",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.12.13"
-      }
-    },
-    "node_modules/@babel/helper-get-function-arity/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -347,30 +306,16 @@
         "@babel/types": "^7.13.12"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.13.12",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.13.12"
-      }
-    },
-    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
+        "@babel/types": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
@@ -403,15 +348,6 @@
         "globals": "^11.1.0"
       }
     },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-module-transforms/node_modules/debug": {
       "version": "4.3.1",
       "dev": true,
@@ -441,19 +377,14 @@
         "@babel/types": "^7.12.13"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.13.0",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.13.12",
@@ -479,15 +410,6 @@
         "@babel/types": "^7.14.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-replace-supers/node_modules/debug": {
@@ -519,15 +441,6 @@
         "@babel/types": "^7.13.12"
       }
     },
-    "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.12.13",
       "dev": true,
@@ -536,24 +449,23 @@
         "@babel/types": "^7.12.13"
       }
     },
-    "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-      "version": "7.14.1",
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.12.17",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helpers": {
       "version": "7.14.0",
@@ -578,15 +490,6 @@
         "@babel/types": "^7.14.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helpers/node_modules/debug": {
@@ -632,85 +535,100 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.12.13",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.12.13",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.13.12",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.13.12"
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.17",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+      "integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.12.17"
+        "@babel/plugin-transform-react-jsx": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.12.1",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+      "integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.13.13",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
+      "integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-transform-react-display-name": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.13.12",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.17",
-        "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-react-display-name": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
+        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
+        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -734,19 +652,11 @@
         "@babel/types": "^7.12.13"
       }
     },
-    "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/traverse": {
       "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.8.3",
         "@babel/generator": "^7.9.5",
@@ -760,26 +670,39 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.1.1",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/traverse/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.9.5",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.9.5",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@changesets/types": {
@@ -3757,18 +3680,19 @@
       "license": "ISC"
     },
     "node_modules/@webdoc/cli": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/cli/-/cli-1.5.3.tgz",
+      "integrity": "sha512-LcionOglnQen5yxxnMmagPFpGDOlhSNWQLzYpisoROyzIanEsVDKEE8yAFaby56X/7gsTBUiCDKYp4ZfNJAGpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webdoc/default-template": "^1.3.4",
-        "@webdoc/externalize": "^1.3.4",
-        "@webdoc/legacy-template": "^1.3.4",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/parser": "^1.3.4",
-        "@webdoc/plugin-markdown": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/default-template": "^1.5.3",
+        "@webdoc/externalize": "^1.5.3",
+        "@webdoc/legacy-template": "^1.5.3",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/parser": "^1.5.3",
+        "@webdoc/plugin-markdown": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "array.prototype.flatmap": "~1.2.3",
         "fs-extra": "^9.0.1",
         "globby": "11.0.0",
@@ -4245,25 +4169,28 @@
       }
     },
     "node_modules/@webdoc/default-template": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/default-template/-/default-template-1.5.3.tgz",
+      "integrity": "sha512-7sQFvpMhVKjtKOcKvlZLDiBIXpBw0N6M3or3FhoFCiWY2pYg5I6pVjihZuvgpDC6w9qztkd6HsYPDuTPLQenpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.9.0",
         "@babel/preset-react": "^7.10.1",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "code-prettify": "^0.1.0",
         "fs-extra": "^9.0.1",
+        "highlight.js": "~10.7.2",
         "markdown-it": "^11.0.0",
         "markdown-it-highlightjs": "^3.1.0"
       }
     },
     "node_modules/@webdoc/default-template/node_modules/fs-extra": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -4276,8 +4203,9 @@
     },
     "node_modules/@webdoc/default-template/node_modules/jsonfile": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4287,30 +4215,33 @@
     },
     "node_modules/@webdoc/default-template/node_modules/universalify": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@webdoc/externalize": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/externalize/-/externalize-1.5.3.tgz",
+      "integrity": "sha512-baUZFg78j5zpdLHmReOfYoPqGD937kT4VtoXf5Sn4J15IvVCIDYrv3l7zhhWg6aB2h5YnxeTTNrXwxvDSv9UtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.9.0",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "lodash": "^4.17.20"
       }
     },
     "node_modules/@webdoc/legacy-template": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/legacy-template/-/legacy-template-1.5.3.tgz",
+      "integrity": "sha512-Sx7TR0grFxJMhSjnBQnyoasguGQiPNB6bF2wKlC1LVDIxvY9dXMQSMZCZcsNpZJTi2S4GVd8GGsShz0Y34lNvQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
         "bluebird": "^3.7.2",
         "code-prettify": "^0.1.0",
         "color-themes-for-google-code-prettify": "^2.0.4",
@@ -4328,8 +4259,9 @@
     },
     "node_modules/@webdoc/legacy-template/node_modules/escape-string-regexp": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-3.0.0.tgz",
+      "integrity": "sha512-11dXIUC3umvzEViLP117d0KN6LJzZxh5+9F4E/7WLAAw7GrHk8NpUR+g9iJi/pe9C0py4F8rs0hreyRCwlAuZg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4339,8 +4271,9 @@
     },
     "node_modules/@webdoc/legacy-template/node_modules/fs-extra": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -4353,8 +4286,9 @@
     },
     "node_modules/@webdoc/legacy-template/node_modules/jsonfile": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4364,55 +4298,71 @@
     },
     "node_modules/@webdoc/legacy-template/node_modules/universalify": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@webdoc/model": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.5.3.tgz",
+      "integrity": "sha512-zEYoERnjm26M3c36qFJvhhIeTBTfttQgnHvireG3gFPrnWRHiW41v5CdSGJn9DXclqS4XbFWEc7mS1ee+cUGvA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/types": "^1.5.3",
         "catharsis": "0.8.11",
         "nanoid": "~3.1.16",
         "taffydb": "2.7.3"
       }
     },
     "node_modules/@webdoc/parser": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/parser/-/parser-1.5.3.tgz",
+      "integrity": "sha512-UfhnUT8MsjalZ4VMZs9zF6WsWqN8sfmNjMZt8IWw7HdiouUPumg1Ro3JZR57UUaITfqwytuyhlcWTbasnRfxLA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.9.4",
         "@babel/traverse": "7.9.5",
         "@babel/types": "7.9.5",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "lodash": "^4.17.20",
         "missionlog": "1.6.0",
         "nanoid": "~3.1.16"
       }
     },
-    "node_modules/@webdoc/plugin-markdown": {
-      "version": "1.3.4",
+    "node_modules/@webdoc/parser/node_modules/@babel/types": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.9.5",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@webdoc/plugin-markdown": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/plugin-markdown/-/plugin-markdown-1.5.3.tgz",
+      "integrity": "sha512-i6ErIL+DucmuanMJncOLC+bGfH/EWlhG7Y80tYIcO9D/1qIyt4i7Iuyc2RqHxVuRwgdf/PU1joQ6S2wuB/EySg==",
+      "dev": true,
       "dependencies": {
         "markdown-it": "^11.0.0",
         "markdown-it-highlightjs": "^3.1.0"
       }
     },
     "node_modules/@webdoc/template-library": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.5.3.tgz",
+      "integrity": "sha512-yE+JqexWGTkUz74UmB2IgCb0TC8w1ZnmRiV5JsXCe9h0dnDQsSPyr3MRsjZtH9zSuEYQ8DbZ36W2R8U6/QEDuw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@webdoc/externalize": "^1.3.4",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/externalize": "^1.5.3",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "catharsis": "0.8.11",
         "fs-extra": "^9.0.1",
         "git-branch": "2.0.1",
@@ -4457,9 +4407,10 @@
       }
     },
     "node_modules/@webdoc/types": {
-      "version": "1.3.4",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.5.3.tgz",
+      "integrity": "sha512-gkS2rtxXKHyp+mFpiARYvaLDEuySvch56lf8BXHX/FLsCDxuGc0Ul7dJLqfae5/vXxGn/fzXYNICNW7K0jGOKg==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9544,9 +9495,10 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.4.0",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
@@ -11165,8 +11117,9 @@
     },
     "node_modules/marked": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "marked": "bin/marked"
       },
@@ -17211,14 +17164,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "dev": true,
@@ -17249,14 +17194,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "jsesc": {
           "version": "2.5.2",
           "dev": true
@@ -17268,20 +17205,12 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.12.13",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-compilation-targets": {
@@ -17307,16 +17236,6 @@
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-get-function-arity": {
@@ -17324,16 +17243,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -17341,33 +17250,15 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.13.12",
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "^7.15.4"
       }
     },
     "@babel/helper-module-transforms": {
@@ -17398,14 +17289,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "dev": true,
@@ -17424,20 +17307,12 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.13.0",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
@@ -17464,14 +17339,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "dev": true,
@@ -17490,16 +17357,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -17507,24 +17364,18 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.0",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.17",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
       "dev": true
     },
     "@babel/helpers": {
@@ -17548,14 +17399,6 @@
             "@babel/types": "^7.14.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -17585,65 +17428,67 @@
       "dev": true
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.12.13",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.12.13",
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha512-yQZ/i/pUCJAHI/LbtZr413S3VT26qNrEm0M5RRxQJA947/YNYwbZbBaXGDrq6CG5QsZycI1VIP6d7pQaBfP+8Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.13.12",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha512-30PeETvS+AeD1f58i1OVyoDlVYQhap/K20ZrMjLmmzmC2AYR/G43D4sdJAaDAqCD3MYpSWbmrz3kES158QSLjw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.12.13",
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.13.12"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.17",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+      "integrity": "sha512-rdwG/9jC6QybWxVe2UVOa7q6cnTpw8JRRHOxntG/h6g/guAOe6AhtQHJuJh5FwmnXIT1bdm5vC2/5huV8ZOorQ==",
       "dev": true,
       "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.12.17"
+        "@babel/plugin-transform-react-jsx": "^7.14.5"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.12.1",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+      "integrity": "sha512-3X4HpBJimNxW4rhUy/SONPyNQHp5YRr0HhJdT2OH1BRp0of7u3Dkirc7x9FRJMKMqTBI079VZ1hzv7Ouuz///g==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-plugin-utils": "^7.10.4"
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/preset-react": {
-      "version": "7.13.13",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.14.5.tgz",
+      "integrity": "sha512-XFxBkjyObLvBaAvkx1Ie95Iaq4S/GUEIrejyrntQ/VCMKUYvKLoyKxOBzJ2kjA3b6rC9/KL6KXfDC2GqvLiNqQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-transform-react-display-name": "^7.12.13",
-        "@babel/plugin-transform-react-jsx": "^7.13.12",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.17",
-        "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-react-display-name": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
+        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
+        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
       }
     },
     "@babel/runtime": {
@@ -17660,20 +17505,12 @@
         "@babel/code-frame": "^7.12.13",
         "@babel/parser": "^7.12.13",
         "@babel/types": "^7.12.13"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.14.1",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.0",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/traverse": {
       "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
@@ -17688,24 +17525,29 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
           "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.9.5",
+      "version": "7.15.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.5",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.14.9",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -19870,17 +19712,19 @@
       "dev": true
     },
     "@webdoc/cli": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/cli/-/cli-1.5.3.tgz",
+      "integrity": "sha512-LcionOglnQen5yxxnMmagPFpGDOlhSNWQLzYpisoROyzIanEsVDKEE8yAFaby56X/7gsTBUiCDKYp4ZfNJAGpA==",
       "dev": true,
       "requires": {
-        "@webdoc/default-template": "^1.3.4",
-        "@webdoc/externalize": "^1.3.4",
-        "@webdoc/legacy-template": "^1.3.4",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/parser": "^1.3.4",
-        "@webdoc/plugin-markdown": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/default-template": "^1.5.3",
+        "@webdoc/externalize": "^1.5.3",
+        "@webdoc/legacy-template": "^1.5.3",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/parser": "^1.5.3",
+        "@webdoc/plugin-markdown": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "array.prototype.flatmap": "~1.2.3",
         "fs-extra": "^9.0.1",
         "globby": "11.0.0",
@@ -20179,22 +20023,27 @@
       }
     },
     "@webdoc/default-template": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/default-template/-/default-template-1.5.3.tgz",
+      "integrity": "sha512-7sQFvpMhVKjtKOcKvlZLDiBIXpBw0N6M3or3FhoFCiWY2pYg5I6pVjihZuvgpDC6w9qztkd6HsYPDuTPLQenpA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
         "@babel/preset-react": "^7.10.1",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "code-prettify": "^0.1.0",
         "fs-extra": "^9.0.1",
+        "highlight.js": "~10.7.2",
         "markdown-it": "^11.0.0",
         "markdown-it-highlightjs": "^3.1.0"
       },
       "dependencies": {
         "fs-extra": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -20205,6 +20054,8 @@
         },
         "jsonfile": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
@@ -20213,26 +20064,32 @@
         },
         "universalify": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
     },
     "@webdoc/externalize": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/externalize/-/externalize-1.5.3.tgz",
+      "integrity": "sha512-baUZFg78j5zpdLHmReOfYoPqGD937kT4VtoXf5Sn4J15IvVCIDYrv3l7zhhWg6aB2h5YnxeTTNrXwxvDSv9UtQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "lodash": "^4.17.20"
       }
     },
     "@webdoc/legacy-template": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/legacy-template/-/legacy-template-1.5.3.tgz",
+      "integrity": "sha512-Sx7TR0grFxJMhSjnBQnyoasguGQiPNB6bF2wKlC1LVDIxvY9dXMQSMZCZcsNpZJTi2S4GVd8GGsShz0Y34lNvQ==",
       "dev": true,
       "requires": {
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/template-library": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/template-library": "^1.5.3",
         "bluebird": "^3.7.2",
         "code-prettify": "^0.1.0",
         "color-themes-for-google-code-prettify": "^2.0.4",
@@ -20250,10 +20107,14 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-3.0.0.tgz",
+          "integrity": "sha512-11dXIUC3umvzEViLP117d0KN6LJzZxh5+9F4E/7WLAAw7GrHk8NpUR+g9iJi/pe9C0py4F8rs0hreyRCwlAuZg==",
           "dev": true
         },
         "fs-extra": {
           "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -20264,6 +20125,8 @@
         },
         "jsonfile": {
           "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
@@ -20272,36 +20135,57 @@
         },
         "universalify": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }
     },
     "@webdoc/model": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/model/-/model-1.5.3.tgz",
+      "integrity": "sha512-zEYoERnjm26M3c36qFJvhhIeTBTfttQgnHvireG3gFPrnWRHiW41v5CdSGJn9DXclqS4XbFWEc7mS1ee+cUGvA==",
       "dev": true,
       "requires": {
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/types": "^1.5.3",
         "catharsis": "0.8.11",
         "nanoid": "~3.1.16",
         "taffydb": "2.7.3"
       }
     },
     "@webdoc/parser": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/parser/-/parser-1.5.3.tgz",
+      "integrity": "sha512-UfhnUT8MsjalZ4VMZs9zF6WsWqN8sfmNjMZt8IWw7HdiouUPumg1Ro3JZR57UUaITfqwytuyhlcWTbasnRfxLA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
         "@babel/traverse": "7.9.5",
         "@babel/types": "7.9.5",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "lodash": "^4.17.20",
         "missionlog": "1.6.0",
         "nanoid": "~3.1.16"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.9.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+          "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.5",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@webdoc/plugin-markdown": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/plugin-markdown/-/plugin-markdown-1.5.3.tgz",
+      "integrity": "sha512-i6ErIL+DucmuanMJncOLC+bGfH/EWlhG7Y80tYIcO9D/1qIyt4i7Iuyc2RqHxVuRwgdf/PU1joQ6S2wuB/EySg==",
       "dev": true,
       "requires": {
         "markdown-it": "^11.0.0",
@@ -20309,12 +20193,14 @@
       }
     },
     "@webdoc/template-library": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/template-library/-/template-library-1.5.3.tgz",
+      "integrity": "sha512-yE+JqexWGTkUz74UmB2IgCb0TC8w1ZnmRiV5JsXCe9h0dnDQsSPyr3MRsjZtH9zSuEYQ8DbZ36W2R8U6/QEDuw==",
       "dev": true,
       "requires": {
-        "@webdoc/externalize": "^1.3.4",
-        "@webdoc/model": "^1.3.4",
-        "@webdoc/types": "^1.3.4",
+        "@webdoc/externalize": "^1.5.3",
+        "@webdoc/model": "^1.5.3",
+        "@webdoc/types": "^1.5.3",
         "catharsis": "0.8.11",
         "fs-extra": "^9.0.1",
         "git-branch": "2.0.1",
@@ -20350,7 +20236,9 @@
       }
     },
     "@webdoc/types": {
-      "version": "1.3.4",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@webdoc/types/-/types-1.5.3.tgz",
+      "integrity": "sha512-gkS2rtxXKHyp+mFpiARYvaLDEuySvch56lf8BXHX/FLsCDxuGc0Ul7dJLqfae5/vXxGn/fzXYNICNW7K0jGOKg==",
       "dev": true
     },
     "abbrev": {
@@ -23817,7 +23705,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.4.0",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -24922,6 +24812,8 @@
     },
     "marked": {
       "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
     },
     "matcher": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/mocha": "^8.2.3",
-    "@webdoc/cli": "^1.3.4",
+    "@webdoc/cli": "^1.5.3",
     "chai": "~3.5.0",
     "copyfiles": "^2.1.0",
     "cross-env": "^5.2.0",

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -89,15 +89,12 @@ export class Graphics extends Container
      *
      * @static
      * @private
-     * @member {PIXI.Point}
      */
     static _TEMP_POINT = new Point();
 
     /**
      * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
      * Can be shared between multiple Graphics objects.
-     *
-     * @member {PIXI.Shader}
      */
     public shader: Shader = null;
 
@@ -149,7 +146,7 @@ export class Graphics extends Container
      */
     protected _matrix: Matrix = null;
 
-    /**  Current hole mode is enabled. */
+    /** Current hole mode is enabled. */
     protected _holeMode = false;
     protected _transformID: number;
     protected _tint: number;


### PR DESCRIPTION
Unblocks #7787 

You can see that `Graphics.shader` no longer needs the explicit `@member` tag now.