### PR TITLE
VideoResource should override source type

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -25,6 +25,8 @@ export interface IVideoResourceOptionsElement
  */
 export class VideoResource extends BaseImageResource
 {
+    /** Override the source to be the video element. */
+    public source: HTMLVideoElement;
     protected _autoUpdate: boolean;
     protected _isConnectedToTicker: boolean;
     protected _updateFPS: number;


### PR DESCRIPTION
Fixes #7810 

Since VideoResource extends BaseImageResource the `source` property is type `HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|ImageBitmap` when we actually should be more specific. This change forces `source` as video element so remove the need to cast source.