### PR TITLE
Annotate Extract.pixels parameter as optional

### DIFF
--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -181,7 +181,7 @@ export class Extract implements IRendererPlugin
      *  to convert. If left empty will use the main renderer
      * @return {Uint8Array} One-dimensional array containing the pixel data of the entire texture
      */
-    public pixels(target: DisplayObject|RenderTexture): Uint8Array
+    public pixels(target?: DisplayObject|RenderTexture): Uint8Array
     {
         const renderer = this.renderer;
         let resolution;


### PR DESCRIPTION
##### Description of change

Hi there -- just a one-character fix for the type of `Extract.pixels` to align it with the documented parameter (according to the description it should be optional).

Unsure if there are applicable lints or tests -- unfortunately I'm just evaluating whether Pixi is a viable option so I don't have time to clone and run tests as noted in the checklist below. Hope your CI covers these cases!

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
