### PR TITLE
Fix uniforms sync generation of inactive null uniform

### DIFF
--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -211,7 +211,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>
 
         if (!data)
         {
-            if (group.uniforms[i].group)
+            if (group.uniforms[i]?.group)
             {
                 if (group.uniforms[i].ubo)
                 {


### PR DESCRIPTION
##### Description of change

Fixes inactive `null`/`undefined` uniforms breaking uniforms sync generation.

Playground: https://www.pixiplayground.com/#/edit/HGD9TE6ISB-5ePVIvQOF8

`test` is an inactive uniform that is assigned `null`, which breaks the uniforms sync generation:

```
Uncaught TypeError: group.uniforms[i] is null
    generateUniformsSync core.js:6941
    createSyncGroups core.js:9230
    syncUniforms core.js:9224
    syncUniformGroup core.js:9214
    bind core.js:9189
```

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
