### PR TITLE
Fix Geometry/Attribute stride documentation

### DIFF
--- a/packages/core/src/geometry/Attribute.ts
+++ b/packages/core/src/geometry/Attribute.ts
@@ -25,7 +25,7 @@ export class Attribute
      * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2.
      * @param {Boolean} [normalized=false] - should the data be normalized.
      * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {@link PIXI.TYPES} to see the ones available
-     * @param {Number} [stride=0] - How far apart (in floats) the start of each value is. (used for interleaving data)
+     * @param {Number} [stride=0] - How far apart the start of each value is. (used for interleaving data)
      * @param {Number} [start=0] - How far into the array to start reading values (used for interleaving data)
      */
     constructor(buffer: number, size = 0, normalized = false, type = TYPES.FLOAT, stride?: number, start?: number, instance?: boolean)
@@ -55,7 +55,7 @@ export class Attribute
      * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
      * @param {Boolean} [normalized=false] - should the data be normalized.
      * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {@link PIXI.TYPES} to see the ones available
-     * @param {Number} [stride=0] - How far apart (in floats) the start of each value is. (used for interleaving data)
+     * @param {Number} [stride=0] - How far apart the start of each value is. (used for interleaving data)
      *
      * @returns {PIXI.Attribute} A new {@link PIXI.Attribute} based on the information provided
      */

--- a/packages/core/src/geometry/Attribute.ts
+++ b/packages/core/src/geometry/Attribute.ts
@@ -25,7 +25,7 @@ export class Attribute
      * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2.
      * @param {Boolean} [normalized=false] - should the data be normalized.
      * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {@link PIXI.TYPES} to see the ones available
-     * @param {Number} [stride=0] - How far apart the start of each value is. (used for interleaving data)
+     * @param {Number} [stride=0] - How far apart, in bytes, the start of each value is. (used for interleaving data)
      * @param {Number} [start=0] - How far into the array to start reading values (used for interleaving data)
      */
     constructor(buffer: number, size = 0, normalized = false, type = TYPES.FLOAT, stride?: number, start?: number, instance?: boolean)
@@ -55,7 +55,7 @@ export class Attribute
      * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
      * @param {Boolean} [normalized=false] - should the data be normalized.
      * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {@link PIXI.TYPES} to see the ones available
-     * @param {Number} [stride=0] - How far apart the start of each value is. (used for interleaving data)
+     * @param {Number} [stride=0] - How far apart, in bytes, the start of each value is. (used for interleaving data)
      *
      * @returns {PIXI.Attribute} A new {@link PIXI.Attribute} based on the information provided
      */

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -102,7 +102,7 @@ export class Geometry
     * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
     * @param {Boolean} [normalized=false] - should the data be normalized.
     * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {PIXI.TYPES} to see the ones available
-    * @param {Number} [stride] - How far apart the start of each value is. (used for interleaving data)
+    * @param {Number} [stride] - How far apart, in bytes, the start of each value is. (used for interleaving data)
     * @param {Number} [start] - How far into the array to start reading values (used for interleaving data)
     * @param {boolean} [instance=false] - Instancing flag
     *

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -102,7 +102,7 @@ export class Geometry
     * @param {Number} [size=0] - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
     * @param {Boolean} [normalized=false] - should the data be normalized.
     * @param {PIXI.TYPES} [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {PIXI.TYPES} to see the ones available
-    * @param {Number} [stride] - How far apart (in floats) the start of each value is. (used for interleaving data)
+    * @param {Number} [stride] - How far apart the start of each value is. (used for interleaving data)
     * @param {Number} [start] - How far into the array to start reading values (used for interleaving data)
     * @param {boolean} [instance=false] - Instancing flag
     *


### PR DESCRIPTION
##### Description of change

It currently says that `stride` is in floats, but that's not true. It's bytes:

https://github.com/pixijs/pixijs/blob/bf8f1edfb5da55133d581498760017c1ab886026/packages/core/src/geometry/GeometrySystem.ts#L519-L524

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
