### PR TITLE
Fix attribute location

### DIFF
--- a/packages/core/src/shader/utils/generateProgram.ts
+++ b/packages/core/src/shader/utils/generateProgram.ts
@@ -34,6 +34,25 @@ export function generateProgram(gl: IRenderingContext, program: Program): GLProg
     program.attributeData = getAttributeData(webGLProgram, gl);
     program.uniformData = getUniformData(webGLProgram, gl);
 
+    // GLSL 1.00: bind attributes sorted by name in ascending order
+    // GLSL 3.00: don't change the attribute locations that where chosen by the compiler
+    //            or assigned by the layout specifier in the shader source code
+    if (!(/^[ \t]*#[ \t]*version[ \t]+300[ \t]+es[ \t]*$/m).test(program.vertexSrc))
+    {
+        const keys = Object.keys(program.attributeData);
+
+        keys.sort((a, b) => (a > b) ? 1 : -1); // eslint-disable-line no-confusing-arrow
+
+        for (let i = 0; i < keys.length; i++)
+        {
+            program.attributeData[keys[i]].location = i;
+
+            gl.bindAttribLocation(webGLProgram, i, keys[i]);
+        }
+
+        gl.linkProgram(webGLProgram);
+    }
+
     gl.deleteShader(glVertShader);
     gl.deleteShader(glFragShader);
 

--- a/packages/core/src/shader/utils/generateProgram.ts
+++ b/packages/core/src/shader/utils/generateProgram.ts
@@ -34,19 +34,6 @@ export function generateProgram(gl: IRenderingContext, program: Program): GLProg
     program.attributeData = getAttributeData(webGLProgram, gl);
     program.uniformData = getUniformData(webGLProgram, gl);
 
-    const keys = Object.keys(program.attributeData);
-
-    keys.sort((a, b) => (a > b) ? 1 : -1); // eslint-disable-line no-confusing-arrow
-
-    for (let i = 0; i < keys.length; i++)
-    {
-        program.attributeData[keys[i]].location = i;
-
-        gl.bindAttribLocation(webGLProgram, i, keys[i]);
-    }
-
-    gl.linkProgram(webGLProgram);
-
     gl.deleteShader(glVertShader);
     gl.deleteShader(glFragShader);
 

--- a/packages/core/src/shader/utils/getAttributeData.ts
+++ b/packages/core/src/shader/utils/getAttributeData.ts
@@ -31,7 +31,7 @@ export function getAttributeData(program: WebGLProgram, gl: WebGLRenderingContex
             type,
             name: attribData.name,
             size: mapSize(type),
-            location: i,
+            location: gl.getAttribLocation(program, attribData.name),
         };
 
         attributes[attribData.name] = data;


### PR DESCRIPTION
##### Description of change

Not sure why the attribute location are manually bound instead of using the locations the compiler/linker chose (`getAttribLocation`). Shaders with layout location specifiers do not work because of this (layout location specifiers cannot be overridden): https://www.pixiplayground.com/#/edit/GleYmYB2SrVtbDyw5Tlhv.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
