### PR TITLE
Fix setting precision of shader

### DIFF
--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -75,32 +75,26 @@ export class Program
         this.vertexSrc = this.vertexSrc.trim();
         this.fragmentSrc = this.fragmentSrc.trim();
 
-        const splitRegex = /^(?:.|\n|\r)*?[ \t]*#[ \t]*version[ \t].*(?:\r\n|\n|\r|$)/;
-        let vertexSrcHead = this.vertexSrc.match(splitRegex)?.[0] ?? '';
-        let vertexSrcBody = this.vertexSrc.substring(vertexSrcHead.length);
-        let fragmentSrcHead = this.fragmentSrc.match(splitRegex)?.[0] ?? '';
-        let fragmentSrcBody = this.fragmentSrc.substring(fragmentSrcHead.length);
-
-        name = name.replace(/\s+/g, '-');
-
-        if (nameCache[name])
+        if (this.vertexSrc.substring(0, 8) !== '#version')
         {
-            nameCache[name]++;
-            name += `-${nameCache[name]}`;
+            name = name.replace(/\s+/g, '-');
+
+            if (nameCache[name])
+            {
+                nameCache[name]++;
+                name += `-${nameCache[name]}`;
+            }
+            else
+            {
+                nameCache[name] = 1;
+            }
+
+            this.vertexSrc = `#define SHADER_NAME ${name}\n${this.vertexSrc}`;
+            this.fragmentSrc = `#define SHADER_NAME ${name}\n${this.fragmentSrc}`;
+
+            this.vertexSrc = setPrecision(this.vertexSrc, settings.PRECISION_VERTEX, PRECISION.HIGH);
+            this.fragmentSrc = setPrecision(this.fragmentSrc, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
         }
-        else
-        {
-            nameCache[name] = 1;
-        }
-
-        vertexSrcHead = `${vertexSrcHead}\n#define SHADER_NAME ${name}`;
-        fragmentSrcHead = `${fragmentSrcHead}\n#define SHADER_NAME ${name}`;
-
-        vertexSrcBody = setPrecision(vertexSrcBody, settings.PRECISION_VERTEX, PRECISION.HIGH);
-        fragmentSrcBody = setPrecision(fragmentSrcBody, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
-
-        this.vertexSrc = `${vertexSrcHead}\n${vertexSrcBody}`;
-        this.fragmentSrc = `${fragmentSrcHead}\n${fragmentSrcBody}`;
 
         // currently this does not extract structs only default types
         // this is where we store shader references..

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -75,26 +75,32 @@ export class Program
         this.vertexSrc = this.vertexSrc.trim();
         this.fragmentSrc = this.fragmentSrc.trim();
 
-        if (this.vertexSrc.substring(0, 8) !== '#version')
+        const splitRegex = /^(?:.|\n|\r)*?[ \t]*#[ \t]*version[ \t].*(?:\r\n|\n|\r|$)/;
+        let vertexSrcHead = this.vertexSrc.match(splitRegex)?.[0] ?? '';
+        let vertexSrcBody = this.vertexSrc.substring(vertexSrcHead.length);
+        let fragmentSrcHead = this.fragmentSrc.match(splitRegex)?.[0] ?? '';
+        let fragmentSrcBody = this.fragmentSrc.substring(fragmentSrcHead.length);
+
+        name = name.replace(/\s+/g, '-');
+
+        if (nameCache[name])
         {
-            name = name.replace(/\s+/g, '-');
-
-            if (nameCache[name])
-            {
-                nameCache[name]++;
-                name += `-${nameCache[name]}`;
-            }
-            else
-            {
-                nameCache[name] = 1;
-            }
-
-            this.vertexSrc = `#define SHADER_NAME ${name}\n${this.vertexSrc}`;
-            this.fragmentSrc = `#define SHADER_NAME ${name}\n${this.fragmentSrc}`;
-
-            this.vertexSrc = setPrecision(this.vertexSrc, settings.PRECISION_VERTEX, PRECISION.HIGH);
-            this.fragmentSrc = setPrecision(this.fragmentSrc, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
+            nameCache[name]++;
+            name += `-${nameCache[name]}`;
         }
+        else
+        {
+            nameCache[name] = 1;
+        }
+
+        vertexSrcHead = `${vertexSrcHead}\n#define SHADER_NAME ${name}`;
+        fragmentSrcHead = `${fragmentSrcHead}\n#define SHADER_NAME ${name}`;
+
+        vertexSrcBody = setPrecision(vertexSrcBody, settings.PRECISION_VERTEX, PRECISION.HIGH);
+        fragmentSrcBody = setPrecision(fragmentSrcBody, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
+
+        this.vertexSrc = `${vertexSrcHead}\n${vertexSrcBody}`;
+        this.fragmentSrc = `${fragmentSrcHead}\n${fragmentSrcBody}`;
 
         // currently this does not extract structs only default types
         // this is where we store shader references..

--- a/packages/core/src/shader/utils/setPrecision.ts
+++ b/packages/core/src/shader/utils/setPrecision.ts
@@ -13,7 +13,7 @@ import { PRECISION } from '@pixi/constants';
  */
 export function setPrecision(src: string, requestedPrecision: PRECISION, maxSupportedPrecision: PRECISION): string
 {
-    if (src.substring(0, 9) !== 'precision')
+    if (!(/^\s*precision\s+(lowp|mediump|highp)\s+float\s*;/m).test(src))
     {
         // no precision supplied, so PixiJS will add the requested level.
         let precision = requestedPrecision;
@@ -26,10 +26,10 @@ export function setPrecision(src: string, requestedPrecision: PRECISION, maxSupp
 
         return `precision ${precision} float;\n${src}`;
     }
-    else if (maxSupportedPrecision !== PRECISION.HIGH && src.substring(0, 15) === 'precision highp')
+    else if (maxSupportedPrecision !== PRECISION.HIGH)
     {
         // precision was supplied, but at a level this device does not support, so downgrading to mediump.
-        return src.replace('precision highp', 'precision mediump');
+        return src.replace(/^\s*precision\s+highp\s+float\s*;/mg, 'precision mediump float;');
     }
 
     return src;


### PR DESCRIPTION
##### Description of change

`setPrecision` always prepended a precision statement, because the shader name was prepended first. I'm not sure which statement would define the precision of the shader in this case. Also we never entered the second branch in `setPrecision`, which could leave a `highp` in there that isn't supported. So I fixed that. `setPrecision` also potentially changed highp integers to mediump in the second branch, but the documentation only mentions floats, so I changed that as well.

```glsl
precision highp float;
#define SHADER_NAME pixi-shader-3
precision lowp float;

attribute vec2 aVertexPosition;
attribute vec2 aVertexPosition2;

uniform mat3 projectionMatrix;
uniform mat3 translationMatrix;

void main() {
    gl_Position = vec4((projectionMatrix * translationMatrix * vec3(aVertexPosition + aVertexPosition2, 1.0)).xy, 0.0, 1.0);
}
```

I also improved the `#version` detection in the program constructor. I split the sources in two parts and insert the shader name and precision statement in-between. Shaders with version statement are no longer handled differently than shaders without.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
