### PR TITLE
feat: [7877] Allow loading SVG with viewBox only

### DIFF
--- a/packages/core/test/SVGResource.tests.ts
+++ b/packages/core/test/SVGResource.tests.ts
@@ -191,6 +191,36 @@ describe('SVGResource', function ()
             expect(Object.keys(svgSize).length)
                 .to.equal(0);
         });
+
+        it('should get size from viewBox', function ()
+        {
+            const url = path.join(this.resources, 'viewBoxOnly.svg');
+            const svgString = fs.readFileSync(url, 'utf8');
+            const svgSize = SVGResource.parseWidthHeightFromViewBox(svgString);
+
+            expect(svgString.includes('viewBox')).to.equal(true);
+            expect(svgSize.width).to.equal(8);
+            expect(svgSize.height).to.equal(11);
+        });
+
+        it('should get scaled size from viewBox', function ()
+        {
+            const url = path.join(this.resources, 'viewBoxOnly.svg');
+            const svgString = fs.readFileSync(url, 'utf8');
+            let scale = { width: 16, height: 100 };
+            let svgSize = SVGResource.parseWidthHeightFromViewBox(svgString, scale);
+
+            expect(svgString.includes('viewBox')).to.equal(true);
+            expect(svgSize.width).to.equal(16);
+            expect(svgSize.height).to.equal(22);
+
+            scale = { width: 100, height: 33 };
+            svgSize = SVGResource.parseWidthHeightFromViewBox(svgString, scale);
+
+            expect(svgString.includes('viewBox')).to.equal(true);
+            expect(svgSize.width).to.equal(24);
+            expect(svgSize.height).to.equal(33);
+        });
     });
 
     describe('test', function ()

--- a/packages/core/test/resources/viewBoxOnly.svg
+++ b/packages/core/test/resources/viewBoxOnly.svg
@@ -1,0 +1,13 @@
+<svg 
+  id="numbers" 
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 11">
+  <defs>
+    <style>.cls-1,.cls-2{fill:none;stroke:#231f20;stroke-width:1.01px;}.cls-2{stroke-linecap:round;stroke-linejoin:round;}</style>
+  </defs>
+  <title>9</title>
+    <path 
+      class="cls-1" 
+      d="M717.59,551c-0.1-1.37,1.18-2.89,2.93-3.36,2.41-.65,3.48.51,3.64,1.52,0.23,1.49-1.42,3.25-3.25,3.52S717.68,552.22,717.59,551Z" transform="translate(-717.08 -546.91)"/><path class="cls-2" d="M717.77,556.64a8.92,8.92,0,0,0,4.64-2.81,11.12,11.12,0,0,0,1.68-3.85" 
+      transform="translate(-717.08 -546.91)"
+    />
+</svg>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
- Update width/height `SVGResource`'s error handler.
- Instead of reporting 0 and abort, fallback to parse the base64 and get `viewBox`'s width and height
- If viewBox is also not available, then abort.
- Added 2 unit test
  - Get size from `SVGResource.parseWidthHeightFromViewBox(svgString)` 
  - Get scaled size from `SVGResource.parseWidthHeightFromViewBox(svgString, size)` 
![image](https://user-images.githubusercontent.com/10471270/137561301-2d8041dc-d86f-47d7-aaed-f215f74fe1d4.png)


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
