### PR TITLE
Fix LoaderResource tests

### DIFF
--- a/packages/loaders/test/LoaderResource.tests.ts
+++ b/packages/loaders/test/LoaderResource.tests.ts
@@ -271,7 +271,8 @@ describe('LoaderResource', () =>
         {
             res.onComplete.add(() =>
             {
-                expect(res).to.have.property('data', fixtureData.dataJson);
+                expect(res).to.have.property('data');
+                expect(JSON.stringify(res.data)).to.equal(fixtureData.dataJson);
                 done();
             });
 

--- a/packages/loaders/test/fixtures/data.ts
+++ b/packages/loaders/test/fixtures/data.ts
@@ -1,8 +1,8 @@
 export const fixtureData = {
-    url: 'http://localhost:8126/data/hud.png',
+    url: 'http://localhost:8126/data/hud.json',
     baseUrl: 'http://localhost:8126/data',
     dataUrlGif: 'data:image/gif;base64,R0lGODlhAQABAPAAAP8REf///yH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==',
     dataUrlSvg: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMCcgaGVpZ2h0PSczMCc+PGNpcmNsZSBjeD0nMTUnIGN5PScxNScgcj0nMTAnIC8+PC9zdmc+', // eslint-disable-line max-len
-    dataJson: '[{ "id": 12, "comment": "Hey there" }]',
+    dataJson: '[{"id":12,"comment":"Hey there"}]',
     dataJsonHeaders: { 'Content-Type': 'application/json' },
 };


### PR DESCRIPTION
Fixes #7949

Most errors were caused by expecting `loadType` to be `LoaderResource.LOAD_TYPE.XHR`, but the URL in `fixtureData` was a PNG file, so it was `LoaderResource.LOAD_TYPE.IMAGE`.