### PR TITLE
Fix crash creating cached bitmap when filters is empty array

### DIFF
--- a/packages/mixin-cache-as-bitmap/src/index.ts
+++ b/packages/mixin-cache-as-bitmap/src/index.ts
@@ -260,7 +260,7 @@ DisplayObject.prototype._initCachedDisplayObject = function _initCachedDisplayOb
     const bounds = (this as Container).getLocalBounds(null, true).clone();
 
     // add some padding!
-    if (this.filters)
+    if (this.filters && this.filters.length)
     {
         const padding = this.filters[0].padding;
 

--- a/packages/mixin-cache-as-bitmap/test/cacheAsBitmap.tests.ts
+++ b/packages/mixin-cache-as-bitmap/test/cacheAsBitmap.tests.ts
@@ -71,6 +71,30 @@ describe('DisplayObject#cacheAsBitmap', function ()
         }
     });
 
+    it('should not throw error when filters is empty array', function ()
+    {
+        const obj = new Container();
+
+        obj.filters = [];
+        obj.cacheAsBitmap = true;
+
+        expect(function ()
+        {
+            let renderer = null;
+
+            try
+            {
+                renderer = new Renderer({ width: 50, height: 50 });
+
+                obj.render(renderer);
+            }
+            finally
+            {
+                renderer.destroy();
+            }
+        }).to.not.throw();
+    });
+
     it('should respect projection', function ()
     {
         const par = new Container();


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
In initCachedDisplayObject, it adds padding from the first filter applied to the DisplayObject if the filters property is truthy, meaning it would attempt to do so even if filters was an empty array. This change checks that's not an empty array, preventing a crash in such a scenario.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
