### PR TITLE
Clear stencil buffer in push instead of pop

### DIFF
--- a/packages/core/src/mask/StencilSystem.ts
+++ b/packages/core/src/mask/StencilSystem.ts
@@ -47,6 +47,8 @@ export class StencilSystem extends AbstractMaskSystem
         {
             // force use stencil texture in current framebuffer
             this.renderer.framebuffer.forceStencil();
+            gl.clearStencil(0);
+            gl.clear(gl.STENCIL_BUFFER_BIT);
             gl.enable(gl.STENCIL_TEST);
         }
 
@@ -78,8 +80,6 @@ export class StencilSystem extends AbstractMaskSystem
         {
             // the stack is empty!
             gl.disable(gl.STENCIL_TEST);
-            gl.clearStencil(0);
-            gl.clear(gl.STENCIL_BUFFER_BIT);
         }
         else
         {


### PR DESCRIPTION
##### Description of change

Fixes #6822.

I moved the stencil buffer clear to push out of pop so that the stencil buffer is cleared immediately after it is created and therefore cleared before it is used the first time. I assume that the stencil buffer may be in some sort of undefined state until it is cleared the first time, and that's why the stencil mask fails the first time something with a mask is rendered to the render texture. I couldn't find anything on default/initial stencil buffer (or render buffer) values, so I assume it's undefined.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
