### PR TITLE
Fix radius documentation for `PIXI.Circle`

### DIFF
--- a/packages/math/src/shapes/Circle.ts
+++ b/packages/math/src/shapes/Circle.ts
@@ -14,7 +14,7 @@ export class Circle
     /** @default 0 */
     public y: number;
 
-    /** @default 1 */
+    /** @default 0 */
     public radius: number;
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixed the documentation for radius member of `PIXI.Circle`. It said the default value of `radius` is `1` but it is actually `0`. If it's the other way round, that the documentation is correct and the default value is supposed to be `1` instead of `0` then I can make that change in a different PR.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
