### PR TITLE
Fix legacy filters failing the first time they are used

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -147,7 +147,9 @@ export class FilterSystem implements ISystem
         let multisample = filters[0].multisample;
         let padding = filters[0].padding;
         let autoFit = filters[0].autoFit;
-        let legacy = filters[0].legacy;
+        // We don't know whether it's a legacy filter until it was bound for the first time,
+        // therefore we have to assume that it is if legacy is undefined.
+        let legacy = filters[0].legacy ?? true;
 
         for (let i = 1; i < filters.length; i++)
         {
@@ -166,7 +168,7 @@ export class FilterSystem implements ISystem
             // only auto fit if all filters are autofit
             autoFit = autoFit && filter.autoFit;
 
-            legacy = legacy || filter.legacy;
+            legacy = legacy || (filter.legacy ?? true);
         }
 
         if (filterStack.length === 1)


### PR DESCRIPTION
##### Description of change

This fixes legacy filters that use `filterArea`/`filterClamp` failing the first time they are used. The first time a filter is used, the `legacy` property is still undefined. This property is set after the filter is bound the first time. Until it is bound for the first time, we don't know whether it's a legacy filter, because `attributeData` isn't available yet. But we need to update the `filterArea` and `filterClamp` uniforms before that if it's a legacy filter. So the first time a filter is used we have to assume it's a legacy filter, otherwise `filterArea` and `filterClamp` are not updated, and the first render fails if it's a legacy filter.

Example that show that the glow filter fails the first time it's used: https://www.pixiplayground.com/#/edit/JprzRXPURW8S0JU3tuIQZ

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
