### PR TITLE
Remove skip in FilterSystem.roundFrame

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -590,19 +590,6 @@ export class FilterSystem implements ISystem
         transform?: Matrix
     )
     {
-        if (transform)
-        {
-            const { a, b, c, d } = transform;
-
-            // Skip if skew/rotation present in matrix, except for multiple of 90° rotation. If rotation
-            // is a multiple of 90°, then either pair of (b,c) or (a,d) will be (0,0).
-            if ((Math.abs(b) > 1e-4 || Math.abs(c) > 1e-4)
-                && (Math.abs(a) > 1e-4 || Math.abs(d) > 1e-4))
-            {
-                return;
-            }
-        }
-
         transform = transform ? tempMatrix.copyFrom(transform) : tempMatrix.identity();
 
         // Get forward transform from world space to screen space


### PR DESCRIPTION
##### Description of change

I removed the skip in `FilterSystem.roundFrame`, because if the skip conditions are met, no rounding is performed at all, which can't be right. Also passing `null` or the identity for `transform` shouldn't make a difference, but it does. So I propose that we remove the skip for now, because it's simpler than fixing it, unless @ShukantPal or someone else wants to do it.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
