### PR TITLE
Fix a problem of line alignment on CanvasRenderer

### DIFF
--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
@@ -492,6 +492,11 @@ export class CanvasGraphicsRenderer
         const xm = x + (w / 2); // x-middle
         const ym = y + (h / 2); // y-middle
 
+        if (lineStyle.alignment === 0)
+        {
+            context.save();
+        }
+
         context.beginPath();
         context.moveTo(x, ym);
         context.bezierCurveTo(x, ym - oy, xm - ox, y, xm, y);
@@ -510,6 +515,11 @@ export class CanvasGraphicsRenderer
             context.globalAlpha = fillStyle.alpha * worldAlpha;
             context.fillStyle = contextFillStyle;
             context.fill();
+        }
+        
+        if (lineStyle.alignment === 0)
+        {
+            context.restore();
         }
     }
 
@@ -540,6 +550,11 @@ export class CanvasGraphicsRenderer
 
         radius = radius > maxRadius ? maxRadius : radius;
 
+        if (lineStyle.alignment === 0)
+        {
+            context.save();
+        }
+
         context.beginPath();
         context.moveTo(rx, ry + radius);
         context.lineTo(rx, ry + height - radius);
@@ -562,6 +577,11 @@ export class CanvasGraphicsRenderer
             context.globalAlpha = fillStyle.alpha * worldAlpha;
             context.fillStyle = contextFillStyle;
             context.fill();
+        }
+        
+        if (lineStyle.alignment === 0)
+        {
+            context.restore();
         }
     }
 


### PR DESCRIPTION
##### Description of change

Fixed a drawing problem that occurred in CanvasRenderer.
When drawing roundRect and ellipse, if line alignment is set to 0, then clip will remain enabled.

Reproduction: 
https://codesandbox.io/s/pixi-linestyle-problem-with-canvasrenderer-n6d75

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
