### PR TITLE
Fix Sprite.getLocalBounds corrupting bounds

### DIFF
--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -1,6 +1,6 @@
 import { BLEND_MODES } from '@pixi/constants';
 import { Texture } from '@pixi/core';
-import { Container } from '@pixi/display';
+import { Bounds, Container } from '@pixi/display';
 import { ObservablePoint, Point, Rectangle } from '@pixi/math';
 import { settings } from '@pixi/settings';
 import { sign } from '@pixi/utils';
@@ -417,10 +417,15 @@ export class Sprite extends Container
         // we can do a fast local bounds if the sprite has no children!
         if (this.children.length === 0)
         {
-            this._bounds.minX = this._texture.orig.width * -this._anchor._x;
-            this._bounds.minY = this._texture.orig.height * -this._anchor._y;
-            this._bounds.maxX = this._texture.orig.width * (1 - this._anchor._x);
-            this._bounds.maxY = this._texture.orig.height * (1 - this._anchor._y);
+            if (!this._localBounds)
+            {
+                this._localBounds = new Bounds();
+            }
+
+            this._localBounds.minX = this._texture.orig.width * -this._anchor._x;
+            this._localBounds.minY = this._texture.orig.height * -this._anchor._y;
+            this._localBounds.maxX = this._texture.orig.width * (1 - this._anchor._x);
+            this._localBounds.maxY = this._texture.orig.height * (1 - this._anchor._y);
 
             if (!rect)
             {
@@ -432,7 +437,7 @@ export class Sprite extends Container
                 rect = this._localBoundsRect;
             }
 
-            return this._bounds.getRectangle(rect);
+            return this._localBounds.getRectangle(rect);
         }
 
         return super.getLocalBounds.call(this, rect);

--- a/packages/sprite/test/Sprite.tests.ts
+++ b/packages/sprite/test/Sprite.tests.ts
@@ -111,6 +111,36 @@ describe('Sprite', function ()
             expect(bounds.width).to.equal(20);
             expect(bounds.height).to.equal(30);
         });
+
+        it('should not corrupt bounds', function ()
+        {
+            const texture = RenderTexture.create({ width: 20, height: 30 });
+            const sprite = new Sprite(texture);
+
+            sprite.scale.x = 2;
+            sprite.y = -5;
+
+            let bounds = sprite.getBounds(false);
+
+            expect(bounds.x).to.equal(0);
+            expect(bounds.y).to.equal(-5);
+            expect(bounds.width).to.equal(40);
+            expect(bounds.height).to.equal(30);
+
+            bounds = sprite.getLocalBounds();
+
+            expect(bounds.x).to.equal(0);
+            expect(bounds.y).to.equal(0);
+            expect(bounds.width).to.equal(20);
+            expect(bounds.height).to.equal(30);
+
+            bounds = sprite.getBounds(true);
+
+            expect(bounds.x).to.equal(0);
+            expect(bounds.y).to.equal(-5);
+            expect(bounds.width).to.equal(40);
+            expect(bounds.height).to.equal(30);
+        });
     });
 
     describe('containsPoint', function ()


### PR DESCRIPTION
##### Description of change

Currently `getLocalBounds` modifies and corrupts the `_bounds` of the sprite so that subsequent `getBounds(true)` calls return the local bounds instead of the global bounds. This PR fixes that.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
