### PR TITLE
Add Rectangle.intersects to core math

### DIFF
--- a/packages/math-extras/src/rectangleExtras.ts
+++ b/packages/math-extras/src/rectangleExtras.ts
@@ -1,35 +1,6 @@
 import { Rectangle } from '@pixi/math';
 
 /**
- * Determines whether the `other` Rectangle intersects with `this` Rectangle object.
- * Returns true only if the area of the intersection is >0, this means that Rectangles
- * sharing a side are not overlapping. Another side effect is that an arealess rectangle
- * (width or height equal to zero) can't intersect any other rectangle.
- *
- * _Note: Only available with **@pixi/math-extras**._
- *
- * @method intersects
- * @memberof PIXI.Rectangle#
- * @param {Rectangle} other - The Rectangle to intersect with `this`.
- * @returns {boolean} A value of `true` if the `other` Rectangle intersects with `this`; otherwise `false`.
- */
-Rectangle.prototype.intersects = function intersects(other: Rectangle): boolean
-{
-    const x0 = this.x < other.x ? other.x : this.x;
-    const x1 = this.right > other.right ? other.right : this.right;
-
-    if (x1 <= x0)
-    {
-        return false;
-    }
-
-    const y0 = this.y < other.y ? other.y : this.y;
-    const y1 = this.bottom > other.bottom ? other.bottom : this.bottom;
-
-    return y1 > y0;
-};
-
-/**
  * Determines whether the `other` Rectangle is contained within `this` Rectangle object.
  * Rectangles that occupy the same space are considered to be containing each other.
  * Rectangles without area (width or height equal to zero) can't contain anything,

--- a/packages/math-extras/test/Rectangle.tests.ts
+++ b/packages/math-extras/test/Rectangle.tests.ts
@@ -4,61 +4,6 @@ import '@pixi/math-extras';
 
 describe('Rectangle', function ()
 {
-    describe('intersects', function ()
-    {
-        it('should return true if the area of the intersection > 0', function ()
-        {
-            /*
-            ! SHARING A SIDE IS NOT INTERSECTING !
-                +--------+--------+
-                |   A    |    B   |
-                |    +---+--+     |
-                |    |  E|  |     |
-                +----|---+--|-----+
-                |    |   |  |     |
-                |  C +---+--+ D   |
-                |        | 🄵      |
-                +--------+--------+
-            */
-            const a = new Rectangle(0, 0, 100, 100);
-            const b = new Rectangle(100, 0, 100, 100);
-            const c = new Rectangle(0, 100, 100, 100);
-            const d = new Rectangle(100, 100, 100, 100);
-            const e = new Rectangle(50, 50, 100, 100);
-            const f = new Rectangle(150, 175, 0, 0);
-
-            // e intersects a,b,c,d
-            expect(e.intersects(a)).to.equal(true);
-            expect(e.intersects(b)).to.equal(true);
-            expect(e.intersects(c)).to.equal(true);
-            expect(e.intersects(d)).to.equal(true);
-
-            // works the other way arround
-            expect(a.intersects(e)).to.equal(true);
-            expect(b.intersects(e)).to.equal(true);
-            expect(c.intersects(e)).to.equal(true);
-            expect(d.intersects(e)).to.equal(true);
-
-            // none of the other intersect (sharing a side it is NOT intersecting!)
-            expect(a.intersects(b)).to.equal(false); // share Y side
-            expect(b.intersects(d)).to.equal(false); // share X side
-            expect(c.intersects(b)).to.equal(false); // share single point
-
-            // Since F has no area, the intersection with D it's 0 so it's false.
-            expect(f.intersects(d)).to.equal(false);
-
-            // Any rectangle with area intersects itself
-            expect(a.intersects(a.clone())).to.equal(true);
-            expect(b.intersects(b.clone())).to.equal(true);
-            expect(c.intersects(c.clone())).to.equal(true);
-            expect(d.intersects(d.clone())).to.equal(true);
-            expect(e.intersects(e.clone())).to.equal(true);
-
-            // A point without area can't have an intersection, thus it can't even intersect itself
-            expect(f.intersects(f.clone())).to.equal(false);
-        });
-    });
-
     describe('containsRect', function ()
     {
         it('should return true if all four corners are inside or on the edge of the rectangle', function ()

--- a/packages/math/src/shapes/Rectangle.ts
+++ b/packages/math/src/shapes/Rectangle.ts
@@ -149,6 +149,31 @@ export class Rectangle
     }
 
     /**
+     * Determines whether the `other` Rectangle intersects with `this` Rectangle object.
+     * Returns true only if the area of the intersection is >0, this means that Rectangles
+     * sharing a side are not overlapping. Another side effect is that an arealess rectangle
+     * (width or height equal to zero) can't intersect any other rectangle.
+     *
+     * @param {Rectangle} other - The Rectangle to intersect with `this`.
+     * @returns {boolean} A value of `true` if the `other` Rectangle intersects with `this`; otherwise `false`.
+     */
+    intersects(other: Rectangle): boolean
+    {
+        const x0 = this.x < other.x ? other.x : this.x;
+        const x1 = this.right > other.right ? other.right : this.right;
+
+        if (x1 <= x0)
+        {
+            return false;
+        }
+
+        const y0 = this.y < other.y ? other.y : this.y;
+        const y1 = this.bottom > other.bottom ? other.bottom : this.bottom;
+
+        return y1 > y0;
+    }
+
+    /**
      * Pads the rectangle making it grow in all directions.
      * If paddingY is omitted, both paddingX and paddingY will be set to paddingX.
      *

--- a/packages/math/test/Rectangle.tests.ts
+++ b/packages/math/test/Rectangle.tests.ts
@@ -196,4 +196,56 @@ describe('Rectangle', function ()
         expect(rect.right).to.equal(0);
         expect(rect.bottom).to.equal(0);
     });
+
+    it('should return true if the area of the intersection > 0', function ()
+    {
+        /*
+        ! SHARING A SIDE IS NOT INTERSECTING !
+            +--------+--------+
+            |   A    |    B   |
+            |    +---+--+     |
+            |    |  E|  |     |
+            +----|---+--|-----+
+            |    |   |  |     |
+            |  C +---+--+ D   |
+            |        | 🄵      |
+            +--------+--------+
+        */
+        const a = new Rectangle(0, 0, 100, 100);
+        const b = new Rectangle(100, 0, 100, 100);
+        const c = new Rectangle(0, 100, 100, 100);
+        const d = new Rectangle(100, 100, 100, 100);
+        const e = new Rectangle(50, 50, 100, 100);
+        const f = new Rectangle(150, 175, 0, 0);
+
+        // e intersects a,b,c,d
+        expect(e.intersects(a)).to.equal(true);
+        expect(e.intersects(b)).to.equal(true);
+        expect(e.intersects(c)).to.equal(true);
+        expect(e.intersects(d)).to.equal(true);
+
+        // works the other way arround
+        expect(a.intersects(e)).to.equal(true);
+        expect(b.intersects(e)).to.equal(true);
+        expect(c.intersects(e)).to.equal(true);
+        expect(d.intersects(e)).to.equal(true);
+
+        // none of the other intersect (sharing a side it is NOT intersecting!)
+        expect(a.intersects(b)).to.equal(false); // share Y side
+        expect(b.intersects(d)).to.equal(false); // share X side
+        expect(c.intersects(b)).to.equal(false); // share single point
+
+        // Since F has no area, the intersection with D it's 0 so it's false.
+        expect(f.intersects(d)).to.equal(false);
+
+        // Any rectangle with area intersects itself
+        expect(a.intersects(a.clone())).to.equal(true);
+        expect(b.intersects(b.clone())).to.equal(true);
+        expect(c.intersects(c.clone())).to.equal(true);
+        expect(d.intersects(d.clone())).to.equal(true);
+        expect(e.intersects(e.clone())).to.equal(true);
+
+        // A point without area can't have an intersection, thus it can't even intersect itself
+        expect(f.intersects(f.clone())).to.equal(false);
+    });
 });


### PR DESCRIPTION
##### Description of change

Moves the `intersects` method from `@pixi/math-extras` to `@pixi/math`.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
