### PR TITLE
Fix the text display becomes strange, when emoji is entered with letterSpacing specified

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -372,7 +372,13 @@ export class Text extends Sprite
             {
                 this.context.fillText(currentChar, currentPosition, y);
             }
-            currentWidth = this.context.measureText(text.substring(i + 1)).width;
+            let textStr = '';
+
+            for (let j = i + 1; j < stringArray.length; ++j)
+            {
+                textStr += stringArray[j];
+            }
+            currentWidth = this.context.measureText(textStr).width;
             currentPosition += previousWidth - currentWidth + letterSpacing;
             previousWidth = currentWidth;
         }


### PR DESCRIPTION
Fixed the problem that the text display overlaps when inputting a character string in which pictograms are mixed while the letterSpacing option of ITextStyle is specified to be other than 0.

before:
![pixijs_fixed_before](https://user-images.githubusercontent.com/97244906/148426843-346d34d5-5b25-4c01-b1c3-3c7bd110d76e.png)

after:
![pixijs_fixed_after](https://user-images.githubusercontent.com/97244906/148426848-ef442940-586f-4f5d-990e-f41ccc22e9b2.png)


<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
