### PR TITLE
Skip rounding in FilterSystem.roundFrame if frame or bindingSourceFrame is empty

### DIFF
--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -592,6 +592,11 @@ export class FilterSystem implements ISystem
         transform?: Matrix
     )
     {
+        if (frame.width <= 0 || frame.height <= 0 || bindingSourceFrame.width <= 0 || bindingSourceFrame.height <= 0)
+        {
+            return;
+        }
+
         if (transform)
         {
             const { a, b, c, d } = transform;


### PR DESCRIPTION
##### Description of change

It's a tiny optimization, but more importantly: we cannot allow `roundFrame` to continue with an empty `bindingSourceFrame`, because `frame` is NaN at the end otherwise, and that can't be good.
```js
        transform
            .translate(-bindingSourceFrame.x, -bindingSourceFrame.y)
            .scale(
                bindingDestinationFrame.width / bindingSourceFrame.width,   // <====
                bindingDestinationFrame.height / bindingSourceFrame.height) // <====
            .translate(bindingDestinationFrame.x, bindingDestinationFrame.y);
```

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
