### PR TITLE
Fix isFastRect returning true if the rectangle is rotated

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -865,6 +865,7 @@ export class Graphics extends Container
 
         return data.length === 1
             && data[0].shape.type === SHAPES.RECT
+            && !data[0].matrix
             && !data[0].holes.length
             && !(data[0].lineStyle.visible && data[0].lineStyle.width);
     }


### PR DESCRIPTION
##### Description of change

Demo of failure: https://www.pixiplayground.com/#/edit/h0Qpfm3WlcSSgJP6FAvdG

I kept the check simple, but we could also add the same check as in `ScissorSystem.isMatrixRotated` if that is preferred.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
