### PR TITLE
typescript add DisplayObject.interactive

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -215,6 +215,7 @@ export abstract class DisplayObject extends EventEmitter
     public renderable: boolean;
     public filterArea: Rectangle;
     public filters: Filter[] | null;
+    public interactive: boolean;
     public isSprite: boolean;
     public isMask: boolean;
     public _lastSortedIndex: number;
@@ -353,6 +354,12 @@ export abstract class DisplayObject extends EventEmitter
          * @member {?PIXI.Filter[]}
          */
         this.filters = null;
+
+        /**
+         * Enable interaction events for the DisplayObject.
+         * Touch, pointer and mouse events will not be emitted unless `interactive` is set to `true`.
+         */
+        this.interactive = false;
 
         /**
          * Currently enabled filters


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
add typescript type to DisplayObject.interactive ([exist in documentation](https://pixijs.download/release/docs/PIXI.DisplayObject.html#interactive) but does not exist on use with typescript

I copied the documentation text in the comment of interactive to conform with it.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
