### PR TITLE
Fix blitFramebuffer

### DIFF
--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -573,8 +573,9 @@ export class FramebufferSystem implements ISystem
 
         this.bind(framebuffer);
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo.framebuffer);
-        gl.blitFramebuffer(sourcePixels.x, sourcePixels.y, sourcePixels.width, sourcePixels.height,
-            destPixels.x, destPixels.y, destPixels.width, destPixels.height,
+        gl.blitFramebuffer(
+            sourcePixels.left, sourcePixels.top, sourcePixels.right, sourcePixels.bottom,
+            destPixels.left, destPixels.top, destPixels.right, destPixels.bottom,
             gl.COLOR_BUFFER_BIT, sameSize ? gl.NEAREST : gl.LINEAR
         );
     }


### PR DESCRIPTION
`gl.blitFramebuffer` are passed incorrect arguments: the source/destination rectangles are defined by two points and not x, y, width, height.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
