### PR TITLE
Add OffscreenCanvas types as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5829,6 +5829,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.6.4",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -20060,6 +20065,9 @@
       "name": "@pixi/core",
       "version": "6.2.1",
       "license": "MIT",
+      "dependencies": {
+        "@types/offscreencanvas": "^2019.6.4"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/pixijs"
@@ -24325,7 +24333,9 @@
     },
     "@pixi/core": {
       "version": "file:packages/core",
-      "requires": {}
+      "requires": {
+        "@types/offscreencanvas": "^2019.6.4"
+      }
     },
     "@pixi/display": {
       "version": "file:packages/display",
@@ -24862,6 +24872,11 @@
     "@types/object-assign": {
       "version": "4.0.30",
       "dev": true
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.6.4",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.6.4.tgz",
+      "integrity": "sha512-u8SAgdZ8ROtkTF+mfZGOscl0or6BSj9A4g37e6nvxDc+YB/oDut0wHkK2PBBiC2bNR8TS0CPV+1gAk4fNisr1Q=="
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,9 @@
     "type": "opencollective",
     "url": "https://opencollective.com/pixijs"
   },
+  "dependencies": {
+    "@types/offscreencanvas": "^2019.6.4"
+  },
   "peerDependencies": {
     "@pixi/constants": "6.2.1",
     "@pixi/math": "6.2.1",


### PR DESCRIPTION
Adds `@types/offscreencanvas` dependency in the core package

OffscreenCanvas is referenced in the following packages:
* `@pixi/core`
* `@pixi/events`
* `@pixi/interaction`
* `@pixi/text`

Fixes #8174 
