### PR TITLE
TreeSearch findHit void function return value used - InteractionManager hit is never set

### DIFF
--- a/packages/interaction/src/TreeSearch.ts
+++ b/packages/interaction/src/TreeSearch.ts
@@ -193,8 +193,8 @@ export class TreeSearch
      */
     public findHit(interactionEvent: InteractionEvent, displayObject: DisplayObject,
         func?: InteractionCallback, hitTest?: boolean
-    ): void
+    ): boolean
     {
-        this.recursiveFindHit(interactionEvent, displayObject, func, hitTest, false);
+        return this.recursiveFindHit(interactionEvent, displayObject, func, hitTest, false);
     }
 }


### PR DESCRIPTION
It appears that a void function return value is used.  

`hit` is never set because `findHit()` returns nothing - it does not return `recursiveFindHit()` 

`InteractionManager` function `processInteractive()` is setting `hit` to `TreeSearch` class `findHit()` function

![image](https://user-images.githubusercontent.com/1213591/153121305-f667a369-da9e-4f51-b294-59b4cdcf13fa.png)


However, `TreeSearch` class `findHit()` specifies `void` and returns nothing, despite docs specifying a return

![image](https://user-images.githubusercontent.com/1213591/153121669-a76cedec-c71f-4917-81de-af6ab3592ec3.png)

Note that the `recursiveFindHit()` function returns a `boolean`

```ts
    /**
     * @return - Returns true if the displayObject hit the point
     */
    public recursiveFindHit(interactionEvent: InteractionEvent, displayObject: DisplayObject,
        func?: InteractionCallback, hitTest?: boolean, interactive?: boolean
    ): boolean
    {
        let hit = false;
        // ...
        return hit;
    }
```

