### PR TITLE
Check if image/video resource is ready for upload

### DIFF
--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -81,6 +81,21 @@ export class BaseImageResource extends Resource
 
         source = source || this.source;
 
+        if (source instanceof HTMLImageElement)
+        {
+            if (!source.complete || source.naturalWidth === 0)
+            {
+                return false;
+            }
+        }
+        else if (source instanceof HTMLVideoElement)
+        {
+            if (source.readyState <= 1)
+            {
+                return false;
+            }
+        }
+
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, baseTexture.alphaMode === ALPHA_MODES.UNPACK);
 
         if (!this.noSubImage


### PR DESCRIPTION
##### Description of change

Fixes #7457.

Don't upload to the texture if the image/video resource isn't ready.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
