### PR TITLE
Fix rounding in getOptimalTexture

### DIFF
--- a/packages/core/src/renderTexture/RenderTexturePool.ts
+++ b/packages/core/src/renderTexture/RenderTexturePool.ts
@@ -78,8 +78,8 @@ export class RenderTexturePool
     {
         let key;
 
-        minWidth = Math.ceil(minWidth * resolution);
-        minHeight = Math.ceil(minHeight * resolution);
+        minWidth = Math.ceil((minWidth * resolution) - 1e-6);
+        minHeight = Math.ceil((minHeight * resolution) - 1e-6);
 
         if (!this.enableFullScreen || minWidth !== this._pixelsWidth || minHeight !== this._pixelsHeight)
         {

--- a/packages/core/test/RenderTexturePool.tests.ts
+++ b/packages/core/test/RenderTexturePool.tests.ts
@@ -29,4 +29,37 @@ describe('RenderTexturePool', function ()
 
         renderTexturePool.clear(true);
     });
+
+    it('should create screen-sized texture with noninteger resolution', function ()
+    {
+        const resolution = 1.1;
+        const viewWidth = 1419;
+        const viewHeight = 983;
+        const screenWidth = viewWidth / resolution;
+        const screenHeight = viewHeight / resolution;
+
+        expect(screenWidth * resolution).to.equal(1419.0000000000002);
+        expect(screenHeight * resolution).to.equal(982.9999999999999);
+
+        const renderTexturePool = new RenderTexturePool();
+
+        renderTexturePool.setScreenSize({ width: viewWidth, height: viewHeight });
+
+        expect(renderTexturePool.enableFullScreen).to.be.true;
+
+        const renderTexture = renderTexturePool.getOptimalTexture(screenWidth, screenHeight, resolution);
+        const baseRenderTexture = renderTexture.baseTexture;
+
+        expect(baseRenderTexture.width).to.equal(screenWidth);
+        expect(baseRenderTexture.height).to.equal(screenHeight);
+        expect(baseRenderTexture.realWidth).to.equal(viewWidth);
+        expect(baseRenderTexture.realHeight).to.equal(viewHeight);
+        expect(renderTexturePool.texturePool[RenderTexturePool.SCREEN_KEY]?.length ?? 0).to.equal(0);
+
+        renderTexturePool.returnTexture(renderTexture);
+
+        expect(renderTexturePool.texturePool[RenderTexturePool.SCREEN_KEY]?.length ?? 0).to.equal(1);
+
+        renderTexturePool.clear(true);
+    });
 });


### PR DESCRIPTION
##### Description of change

Currently the render texture pool does not return a screen-sized render texture with some noninteger resolutions because of floating point inaccuracies. I added a small epsilon to the ceil in `getOptimalTexure` to fix that problem.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
