### PR TITLE
Added safe reference to CanvasRenderingContext2D in Text

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -326,9 +326,10 @@ export class Text extends Sprite
         // Checking that we can use moddern canvas2D api
         // https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
         // note: this is unstable API, Chrome less 94 use a `textLetterSpacing`, newest use a letterSpacing
-        // eslint-disable-next-line max-len
-        const supportLetterSpacing = 'letterSpacing' in CanvasRenderingContext2D.prototype
-            || 'textLetterSpacing' in CanvasRenderingContext2D.prototype;
+        const supportLetterSpacing = window?.CanvasRenderingContext2D !== undefined
+            ? ('letterSpacing' in CanvasRenderingContext2D.prototype
+            || 'textLetterSpacing' in CanvasRenderingContext2D.prototype)
+            : false;
 
         if (letterSpacing === 0 || supportLetterSpacing)
         {


### PR DESCRIPTION
##### Description of change

Added a check for `undefined` when referencing `CanvasRenderingContext2D`.

This allows the code to continue to run in a node environment and shouldn't break anything in other environments.

Fixes #8197 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
