### PR TITLE
Use a default object when creating a RenderTexture

### DIFF
--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -66,7 +66,7 @@ export class BaseRenderTexture extends BaseTexture
      *   of the texture being generated.
      * @param {PIXI.MSAA_QUALITY} [options.multisample=PIXI.MSAA_QUALITY.NONE] - The number of samples of the frame buffer.
      */
-    constructor(options?: IBaseTextureOptions)
+    constructor(options: IBaseTextureOptions = {})
     {
         if (typeof options === 'number')
         {


### PR DESCRIPTION
Fixes #8203

Uses a default object for constructor when creating BaseRenderTexture to keep from throwing an error when `RenderTexture.create()` is called without any arguments

Broken: https://pixiplayground.com/#/edit/WyW883F5ti4y0JuM538ap
Fixed: https://pixiplayground.com/#/edit/l2EClJqfIQW2U8aabLAcQ