### PR TITLE
hitArea can also be null (fixing #8212)

### DIFF
--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -70,7 +70,7 @@ export interface FederatedEventTarget extends EventEmitter, EventTarget {
     interactiveChildren: boolean;
 
     /** The hit-area specifies the area for which pointer events should be captured by this event target. */
-    hitArea: IHitArea;
+    hitArea: IHitArea | null;
 }
 
 export const FederatedDisplayObject: Omit<

--- a/packages/interaction/src/interactiveTarget.ts
+++ b/packages/interaction/src/interactiveTarget.ts
@@ -44,7 +44,7 @@ export interface IHitArea {
 export interface InteractiveTarget {
     interactive: boolean;
     interactiveChildren: boolean;
-    hitArea: IHitArea;
+    hitArea: IHitArea | null;
     cursor: Cursor | string;
     buttonMode: boolean;
     trackedPointers: {[x: number]: InteractionTrackingData};


### PR DESCRIPTION
This is needed to be able to remove hitAreas again. Also, the default for hitArea is null, so this is now properly reflected in the type.

##### Description of change
Added possible type `null` to `hitArea` of `InteractiveTarget` (that is extended by `DisplayObject`).

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
