### PR TITLE
Fix hole outlines not rendering if fill style is not visible

### DIFF
--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -390,6 +390,11 @@ export class GraphicsGeometry extends BatchGeometry
                 this.transformPoints(data.points, data.matrix);
             }
 
+            if (fillStyle.visible || lineStyle.visible)
+            {
+                this.processHoles(data.holes);
+            }
+
             for (let j = 0; j < 2; j++)
             {
                 const style = (j === 0) ? fillStyle : lineStyle;
@@ -731,8 +736,6 @@ export class GraphicsGeometry extends BatchGeometry
     {
         if (data.holes.length)
         {
-            this.processHoles(data.holes);
-
             buildPoly.triangulate(data, this);
         }
         else


### PR DESCRIPTION
Hole outlines are currently not rendered if the fill style is not visible, because `processHoles` is called in `processFill`: https://www.pixiplayground.com/#/edit/Ta76oELE3aRp8_YSQGyAp

After the change:
![image](https://user-images.githubusercontent.com/31905376/158614432-4e196c63-c047-4502-976a-0d2413379536.png)

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
