### PR TITLE
Fix line alignment of polygons

### DIFF
--- a/packages/graphics/src/utils/buildPoly.ts
+++ b/packages/graphics/src/utils/buildPoly.ts
@@ -3,6 +3,44 @@ import { earcut } from '@pixi/utils';
 import type { IShapeBuildCommand } from './IShapeBuildCommand';
 import type { Polygon } from '@pixi/math';
 
+function fixOrientation(points: number[], hole = false)
+{
+    const m = points.length;
+
+    if (m < 6)
+    {
+        return;
+    }
+
+    let area = 0;
+
+    for (let i = 0, x1 = points[m - 2], y1 = points[m - 1]; i < m; i += 2)
+    {
+        const x2 = points[i];
+        const y2 = points[i + 1];
+
+        area += (x2 - x1) * (y2 + y1);
+
+        x1 = x2;
+        y1 = y2;
+    }
+
+    if ((!hole && area > 0) || (hole && area <= 0))
+    {
+        const n = m / 2;
+
+        for (let i = n + (n % 2); i < m; i += 2)
+        {
+            const i1 = m - i - 2;
+            const i2 = m - i - 1;
+            const i3 = i;
+            const i4 = i + 1;
+
+            [points[i1], points[i3]] = [points[i3], points[i1]];
+            [points[i2], points[i4]] = [points[i4], points[i2]];
+        }
+    }
+}
 /**
  * Builds a polygon to draw
  *
@@ -30,12 +68,16 @@ export const buildPoly: IShapeBuildCommand = {
 
         if (points.length >= 6)
         {
+            fixOrientation(points, false);
+
             const holeArray = [];
             // Process holes..
 
             for (let i = 0; i < holes.length; i++)
             {
                 const hole = holes[i];
+
+                fixOrientation(hole.points, true);
 
                 holeArray.push(points.length / 2);
                 points = points.concat(hole.points);


### PR DESCRIPTION
##### Description of change

Line alignment of polygons currently depends on the orientation of the passed polygon/points: https://www.pixiplayground.com/#/edit/RmpbM3I1RvPlooXF8z1Kz.

The documentation says that 0 alignment is inner and 1 is outer. So the orientation of the points needs to be fixed.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
