### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
+++ b/packages/canvas/canvas-graphics/src/CanvasGraphicsRenderer.ts
@@ -66,7 +66,7 @@ export class CanvasGraphicsRenderer
         }
         else
         {
-            res = `#${(`00000${(tint | 0).toString(16)}`).substr(-6)}`;
+            res = `#${(`00000${(tint | 0).toString(16)}`).slice(-6)}`;
         }
 
         return res;

--- a/packages/canvas/canvas-renderer/src/canvasUtils.ts
+++ b/packages/canvas/canvas-renderer/src/canvasUtils.ts
@@ -29,7 +29,7 @@ export const canvasUtils = {
 
         color = canvasUtils.roundColor(color);
 
-        const stringColor = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
+        const stringColor = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
 
         texture.tintCache = texture.tintCache || {};
 
@@ -84,7 +84,7 @@ export const canvasUtils = {
     {
         color = canvasUtils.roundColor(color);
 
-        const stringColor = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
+        const stringColor = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
 
         texture.patternCache = texture.patternCache || {};
 
@@ -129,7 +129,7 @@ export const canvasUtils = {
         canvas.height = Math.ceil(crop.height);
 
         context.save();
-        context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
+        context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
 
         context.fillRect(0, 0, crop.width, crop.height);
 
@@ -189,7 +189,7 @@ export const canvasUtils = {
 
         context.save();
         context.globalCompositeOperation = 'copy';
-        context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).substr(-6)}`;
+        context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
         context.fillRect(0, 0, crop.width, crop.height);
 
         context.globalCompositeOperation = 'destination-atop';

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -102,7 +102,7 @@ export class VideoResource extends BaseImageResource
                 src = src || source[i] as string;
 
                 const baseSrc = src.split('?').shift().toLowerCase();
-                const ext = baseSrc.substr(baseSrc.lastIndexOf('.') + 1);
+                const ext = baseSrc.slice(baseSrc.lastIndexOf('.') + 1);
 
                 mime = mime || VideoResource.MIME_TYPES[ext] || `video/${ext}`;
 

--- a/packages/loaders/src/Loader.ts
+++ b/packages/loaders/src/Loader.ts
@@ -505,7 +505,7 @@ class Loader
         {
             const hash = rgxExtractUrlHash.exec(result)[0];
 
-            result = result.substr(0, result.length - hash.length);
+            result = result.slice(0, result.length - hash.length);
 
             if (result.indexOf('?') !== -1)
             {

--- a/packages/loaders/test/fixtures/spritesheet.ts
+++ b/packages/loaders/test/fixtures/spritesheet.ts
@@ -22,7 +22,7 @@ function dirname(path: string)
     if (dir)
     {
         // It has a dirname, strip trailing slash
-        dir = dir.substr(0, dir.length - 1);
+        dir = dir.slice(0, -1);
     }
 
     return root + dir;

--- a/packages/utils/src/color/hex.ts
+++ b/packages/utils/src/color/hex.ts
@@ -34,7 +34,7 @@ export function hex2string(hex: number): string
 {
     let hexString = hex.toString(16);
 
-    hexString = '000000'.substr(0, 6 - hexString.length) + hexString;
+    hexString = '000000'.substring(0, 6 - hexString.length) + hexString;
 
     return `#${hexString}`;
 }
@@ -62,7 +62,7 @@ export function string2hex(string: string): number
 
         if (string[0] === '#')
         {
-            string = string.substr(1);
+            string = string.slice(1);
         }
     }
 


### PR DESCRIPTION
##### Description of change

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
