### PR TITLE
Fix rounded rectangle with zero radius

### DIFF
--- a/packages/graphics/src/utils/buildCircle.ts
+++ b/packages/graphics/src/utils/buildCircle.ts
@@ -72,6 +72,17 @@ export const buildCircle: IShapeBuildCommand = {
             return;
         }
 
+        if (n === 0)
+        {
+            points.length = 8;
+            points[0] = points[6] = x + dx;
+            points[1] = points[3] = y + dy;
+            points[2] = points[4] = x - dx;
+            points[5] = points[7] = y - dy;
+
+            return;
+        }
+
         let j1 = 0;
         let j2 = (n * 4) + (dx ? 2 : 0) + 2;
         let j3 = j2;


### PR DESCRIPTION
If the radius of a rounded rectangle is zero, the new implementation `buildCircle` produces this: 

![image](https://user-images.githubusercontent.com/31905376/159562944-49b97995-be30-41f4-b24d-a398ba42c406.png)

After the fix: 

![image](https://user-images.githubusercontent.com/31905376/159563081-ea60449a-3923-4938-8561-1b925971fa7a.png)
