### PR TITLE
Update README.md of @pixi/settings to fix the example import statement

### DIFF
--- a/packages/settings/README.md
+++ b/packages/settings/README.md
@@ -9,5 +9,5 @@ npm install @pixi/settings
 ## Usage
 
 ```js
-import * as settings from '@pixi/settings';
+import { settings } from '@pixi/settings';
 ```


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->

The example import statement on the README.md Usage of @pixi/settings 

before this commit:
```js
import * as settings from '@pixi/settings';
```

after this commit: 
```js
import { settings } from '@pixi/settings';
```

I checked it out that the latter is the right one. If someone import like the former, the changed values of pixi settings are not shared by other modules.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
