### PR TITLE
fixed bitmaptext._text storing undefined values during construction

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -208,7 +208,7 @@ export class BitmapText extends Container
         this._tint = tint;
         this._fontName = fontName;
         this._fontSize = fontSize || BitmapFont.available[fontName].size;
-        this._text = text;
+        this._text = String(text === null || text === undefined ? '' : text);
         this._maxWidth = maxWidth;
         this._maxLineHeight = 0;
         this._letterSpacing = letterSpacing;

--- a/packages/text-bitmap/test/BitmapText.tests.ts
+++ b/packages/text-bitmap/test/BitmapText.tests.ts
@@ -169,4 +169,20 @@ describe('BitmapText', function ()
             }
         }
     });
+    it('should not crash if text is undefined', function ()
+    {
+        let text = new BitmapText(undefined, {
+            fontName: this.font.font,
+        });
+
+        expect(() => text.updateText()).to.not.throw();
+
+        text = new BitmapText('not undefined', {
+            fontName: this.font.font,
+        });
+
+        text.text = undefined;
+
+        expect(() => text.updateText()).to.not.throw();
+    });
 });


### PR DESCRIPTION
##### Description of change
Creating a BitmapText with an undefined text results in a crash but setting undefined after creation doesn't (it assigns an empty string)

Fixed by using the same logic for the text setter.

I did not call the setter in `.text` because that setter has other side effects that I was not comfortable triggering.

Fix to #8252 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
