### PR TITLE
Chore: Add build:types to dist workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:dev": "rollup -c",
     "build:types": "rimraf out && tsc && api-extractor-lerna-monorepo && rimraf out && ts-node-script ./scripts/injectGlobalMixins.ts",
     "watch": "rollup -cw",
-    "dist": "run-s lint:src types build:prod docs",
+    "dist": "run-s lint:src types build:prod build:types docs",
     "postdist": "copyfiles -f bundles/*/dist/browser/* dist && copyfiles -f \"packages/**/dist/browser/*\" dist/packages",
     "prerelease": "run-s clean:build test",
     "postversion": "run-s lint:src types build:prod build:types",


### PR DESCRIPTION
#8274 passed the build even though `build:types` failed locally. This should prevent such a regression.