### PR TITLE
Fix LoaderResource tests

### DIFF
--- a/packages/loaders/test/LoaderResource.tests.ts
+++ b/packages/loaders/test/LoaderResource.tests.ts
@@ -20,7 +20,6 @@ describe('LoaderResource', () =>
         {
             request = req;
         };
-        clock = sinon.useFakeTimers();
 
         image = sinon.spy(globalThis, 'Image');
     });
@@ -28,7 +27,6 @@ describe('LoaderResource', () =>
     after(() =>
     {
         xhr.restore();
-        clock.restore();
         image.restore();
     });
 
@@ -36,6 +34,12 @@ describe('LoaderResource', () =>
     {
         res = new LoaderResource(name, fixtureData.url);
         request = null;
+        clock = sinon.useFakeTimers({ global });
+    });
+
+    afterEach(() =>
+    {
+        clock.restore();
     });
 
     it('should construct properly with only a URL passed', () =>

--- a/packages/loaders/test/LoaderResource.tests.ts
+++ b/packages/loaders/test/LoaderResource.tests.ts
@@ -4,7 +4,7 @@ import { LoaderResource } from '@pixi/loaders';
 import { expect } from 'chai';
 import { fixtureData } from './fixtures/data';
 
-describe.only('LoaderResource', () =>
+describe('LoaderResource', () =>
 {
     let request: any;
     let res: LoaderResource;

--- a/packages/loaders/test/fixtures/data.ts
+++ b/packages/loaders/test/fixtures/data.ts
@@ -5,4 +5,5 @@ export const fixtureData = {
     dataUrlSvg: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSczMCcgaGVpZ2h0PSczMCc+PGNpcmNsZSBjeD0nMTUnIGN5PScxNScgcj0nMTAnIC8+PC9zdmc+', // eslint-disable-line max-len
     dataJson: '[{ "id": 12, "comment": "Hey there" }]',
     dataJsonHeaders: { 'Content-Type': 'application/json' },
+    extension: 'png',
 };


### PR DESCRIPTION
Fixes #7949 

##### Description of change

Rename LoaderResource.test.ts → LoaderResource.test**s**.ts; patch the tests that were resulting in errors because they falsely assumed they were testing XHR payloads when the fixture data was an image.