### PR TITLE
Extending the amount of times for stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,8 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+daysUntilStale: 180
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 90
 
 # Issues with these labels will never be considered stale
 #exemptLabels:


### PR DESCRIPTION
We are being too aggressive with the Stale bot. People often make comments like "still an issue". This project doesn't get the level of activity for the default timeframes to be useful. I have extended the timeframes. If this is still an issue moving forward, I may consider removing stale all together.