### PR TITLE
Fixing DisplayObject destroyed flag and event

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -714,8 +714,7 @@ export abstract class DisplayObject extends EventEmitter
         {
             this.parent.removeChild(this);
         }
-        this.emit('destroyed');
-        this.removeAllListeners();
+        this._destroyed = true;
         this.transform = null;
 
         this.parent = null;
@@ -730,7 +729,8 @@ export abstract class DisplayObject extends EventEmitter
         this.interactive = false;
         this.interactiveChildren = false;
 
-        this._destroyed = true;
+        this.emit('destroyed');
+        this.removeAllListeners();
     }
 
     /**

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -410,7 +410,8 @@ export abstract class DisplayObject extends EventEmitter
      */
 
     /**
-     * Fired when this DisplayObject is destroyed.
+     * Fired when this DisplayObject is destroyed. This event is emitted once
+     * destroy is finished.
      *
      * @instance
      * @event destroyed

--- a/packages/display/test/DisplayObject.tests.ts
+++ b/packages/display/test/DisplayObject.tests.ts
@@ -247,23 +247,29 @@ describe('DisplayObject', function ()
 
     describe('destroy', function ()
     {
-        it('should trigger destroyed listeners', function ()
+        it('should trigger destroyed listeners once destruction is complete', function ()
         {
-            const listener = sinon.spy();
+            let listenerCallCount = 0;
+            let isChildDestroyed = false;
             const child = new DisplayObject();
             const container = new Container();
 
-            child.on('destroyed', listener);
+            child.on('destroyed', () =>
+            {
+                listenerCallCount++;
+                isChildDestroyed = child.destroyed;
+            });
 
             container.addChild(child);
             container.removeChild(child);
 
-            expect(listener.notCalled).to.be.true;
+            expect(listenerCallCount).to.equal(0);
 
             container.addChild(child);
             child.destroy();
 
-            expect(listener.calledOnce).to.be.true;
+            expect(listenerCallCount).to.equal(1);
+            expect(isChildDestroyed).to.be.true;
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
**What's changing**
This PR updates `DisplayObject` to set the `_destroyed` flag once destroy starts and to emit `destroyed` only once destruction is complete.

**Why**
When subscribing to the `destroyed` event on `DisplayObject` I would expect that once the callback runs `displayObject.destroyed === true`. Currently, the event is emitted towards the beginning of the `destroy()`, which means any callbacks for the event would run part way through destruction and the `destroyed` property reports as `false`.

**More specifics on our use case**
What's also important for us is that the `_destroyed` flag is set before any destructive changes begin. It seems like other places in PIXI's code follows this, for example in the [ticker](https://github.com/pixijs/pixijs/blob/dedb5c4ab9cf75dca4b8d4a3d1a5a63707d96942/packages/ticker/src/TickerListener.ts#L118) or in [resource](https://github.com/pixijs/pixijs/blob/42cc7f41bf0f76dd3c24723a264501a6ed40e7fa/packages/core/src/textures/resources/Resource.ts#L217).

We are extending from `DisplayObject` and we override setters to add additional update logic. For example, we override `set mask` so we can respond to when a mask is added or removed to a `DisplayObject`. However, a [change](https://github.com/pixijs/pixijs/commit/172b195a46e7674722b6dc04c71e9cd94c00fa7a#diff-c429f6e13dead1384160eb15715b80784269464d75f89543f9a77021aba2e618R771) in v6.2.0 updated the destroy method to call the setter instead of updating the internal variable directly. This meant our override would now be called, but we have no way of knowing that this is part of destruction, because `displayObject.destroyed` still reports as `false` at this point. This ultimately led our code to crashing because we were doing operations which were no longer valid for a partially destroyed object.

There are some other work arounds we could do, but from my understanding thus far I think this change to PIXI is the most logical solution. I hope you agree! 😄 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
