### PR TITLE
Chore: refactor DOM-based side effects

### DIFF
--- a/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
+++ b/packages/compressed-textures/src/loaders/CompressedTextureLoader.ts
@@ -42,10 +42,10 @@ export type CompressedTextureExtensionRef = keyof CompressedTextureExtensions;
 export class CompressedTextureLoader
 {
     /**  Map of available texture extensions. */
-    static textureExtensions: Partial<CompressedTextureExtensions>;
+    private static _textureExtensions: Partial<CompressedTextureExtensions>;
 
     /** Map of available texture formats. */
-    static textureFormats: { [P in keyof INTERNAL_FORMATS]?: number };
+    private static _textureFormats: { [P in keyof INTERNAL_FORMATS]?: number };
 
     /**
      * Called after a compressed-textures manifest is loaded.
@@ -160,52 +160,66 @@ export class CompressedTextureLoader
         }
     }
 
-    /**
-     * Detects the available compressed texture extensions on the device.
-     * @ignore
-     */
-    static add(): void
+    /**  Map of available texture extensions. */
+    public static get textureExtensions(): Partial<CompressedTextureExtensions>
     {
-        // Auto-detect WebGL compressed-texture extensions
-        const canvas = document.createElement('canvas');
-        const gl = canvas.getContext('webgl');
-
-        if (!gl)
+        if (!CompressedTextureLoader._textureExtensions)
         {
-            // #if _DEBUG
-            console.warn('WebGL not available for compressed textures. Silently failing.');
-            // #endif
+            // Auto-detect WebGL compressed-texture extensions
+            const canvas = document.createElement('canvas');
+            const gl = canvas.getContext('webgl');
 
-            return;
-        }
-
-        const extensions = {
-            s3tc: gl.getExtension('WEBGL_compressed_texture_s3tc'),
-            s3tc_sRGB: gl.getExtension('WEBGL_compressed_texture_s3tc_srgb'), /* eslint-disable-line camelcase */
-            etc: gl.getExtension('WEBGL_compressed_texture_etc'),
-            etc1: gl.getExtension('WEBGL_compressed_texture_etc1'),
-            pvrtc: gl.getExtension('WEBGL_compressed_texture_pvrtc')
-                || gl.getExtension('WEBKIT_WEBGL_compressed_texture_pvrtc'),
-            atc: gl.getExtension('WEBGL_compressed_texture_atc'),
-            astc: gl.getExtension('WEBGL_compressed_texture_astc')
-        };
-
-        CompressedTextureLoader.textureExtensions = extensions;
-        CompressedTextureLoader.textureFormats = {};
-
-        // Assign all available compressed-texture formats
-        for (const extensionName in extensions)
-        {
-            const extension = extensions[extensionName as CompressedTextureExtensionRef];
-
-            if (!extension)
+            if (!gl)
             {
-                continue;
+                // #if _DEBUG
+                console.warn('WebGL not available for compressed textures. Silently failing.');
+                // #endif
+
+                return {};
             }
 
-            Object.assign(
-                CompressedTextureLoader.textureFormats,
-                Object.getPrototypeOf(extension));
+            const extensions = {
+                s3tc: gl.getExtension('WEBGL_compressed_texture_s3tc'),
+                s3tc_sRGB: gl.getExtension('WEBGL_compressed_texture_s3tc_srgb'), /* eslint-disable-line camelcase */
+                etc: gl.getExtension('WEBGL_compressed_texture_etc'),
+                etc1: gl.getExtension('WEBGL_compressed_texture_etc1'),
+                pvrtc: gl.getExtension('WEBGL_compressed_texture_pvrtc')
+                    || gl.getExtension('WEBKIT_WEBGL_compressed_texture_pvrtc'),
+                atc: gl.getExtension('WEBGL_compressed_texture_atc'),
+                astc: gl.getExtension('WEBGL_compressed_texture_astc')
+            };
+
+            CompressedTextureLoader._textureExtensions = extensions;
         }
+
+        return CompressedTextureLoader._textureExtensions;
+    }
+
+    /** Map of available texture formats. */
+    public static get textureFormats(): { [P in keyof INTERNAL_FORMATS]?: number }
+    {
+        if (!CompressedTextureLoader._textureFormats)
+        {
+            const extensions = CompressedTextureLoader.textureExtensions;
+
+            CompressedTextureLoader._textureFormats = {};
+
+            // Assign all available compressed-texture formats
+            for (const extensionName in extensions)
+            {
+                const extension = extensions[extensionName as CompressedTextureExtensionRef];
+
+                if (!extension)
+                {
+                    continue;
+                }
+
+                Object.assign(
+                    CompressedTextureLoader._textureFormats,
+                    Object.getPrototypeOf(extension));
+            }
+        }
+
+        return CompressedTextureLoader._textureFormats;
     }
 }

--- a/packages/loaders/src/LoaderResource.ts
+++ b/packages/loaders/src/LoaderResource.ts
@@ -4,7 +4,7 @@ import { parseUri } from './base/parseUri';
 import type { IBaseTextureOptions, Texture } from '@pixi/core';
 
 // tests if CORS is supported in XHR, if not we need to use XDR
-const useXdr = !!((globalThis as any).XDomainRequest && !('withCredentials' in (new XMLHttpRequest())));
+let useXdr: boolean;
 let tempAnchor: any = null;
 
 // some status constants
@@ -634,6 +634,10 @@ class LoaderResource
             case LoaderResource.LOAD_TYPE.XHR:
             /* falls through */
             default:
+                if (typeof useXdr === 'undefined')
+                {
+                    useXdr = !!((globalThis as any).XDomainRequest && !('withCredentials' in (new XMLHttpRequest())));
+                }
                 if (useXdr && this.crossOrigin)
                 {
                     this._loadXdr();

--- a/packages/loaders/src/middleware/parsing.ts
+++ b/packages/loaders/src/middleware/parsing.ts
@@ -1,8 +1,6 @@
 import { LoaderResource } from '../LoaderResource';
 import { encodeBinary } from '../base/encodeBinary';
 
-const Url = self.URL || self.webkitURL;
-
 /**
  * A middleware for transforming XHR loaded Blobs into more useful objects
  *
@@ -55,6 +53,7 @@ export function parsing(resource: LoaderResource, next: (...args: any) => void):
         // if content type says this is an image, then we should transform the blob into an Image object
         else if (resource.data.type.indexOf('image') === 0)
         {
+            const Url = globalThis.URL || globalThis.webkitURL;
             const src = Url.createObjectURL(resource.data);
 
             resource.blob = resource.data;

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -56,9 +56,10 @@ export class TextMetrics
     public static BASELINE_MULTIPLIER: number;
     public static HEIGHT_MULTIPLIER: number;
 
-    // TODO: These should be protected but they're initialized outside of the class.
     private static __canvas: HTMLCanvasElement|OffscreenCanvas;
     private static __context: CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D;
+    
+    // TODO: These should be protected but they're initialized outside of the class.
     public static _fonts: { [font: string]: IFontMetrics };
     public static _newlines: number[];
     public static _breakingSpaces: number[];
@@ -717,6 +718,9 @@ export class TextMetrics
 
     /**
      * Cached canvas element for measuring text
+     * TODO: this should be private, but isn't because of backward compat, will fix later.
+     *
+     * @ignore
      */
     public static get _canvas(): HTMLCanvasElement|OffscreenCanvas
     {
@@ -748,6 +752,11 @@ export class TextMetrics
         return TextMetrics.__canvas;
     }
 
+    /**
+     * TODO: this should be private, but isn't because of backward compat, will fix later.
+     *
+     * @ignore
+     */
     public static get _context(): CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D
     {
         if (!TextMetrics.__context)

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -58,7 +58,7 @@ export class TextMetrics
 
     private static __canvas: HTMLCanvasElement|OffscreenCanvas;
     private static __context: CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D;
-    
+
     // TODO: These should be protected but they're initialized outside of the class.
     public static _fonts: { [font: string]: IFontMetrics };
     public static _newlines: number[];

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -58,7 +58,7 @@ export class TextMetrics
 
     // TODO: These should be protected but they're initialized outside of the class.
     private static __canvas: HTMLCanvasElement|OffscreenCanvas;
-    public static _context: CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D;
+    private static __context: CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D;
     public static _fonts: { [font: string]: IFontMetrics };
     public static _newlines: number[];
     public static _breakingSpaces: number[];
@@ -722,7 +722,7 @@ export class TextMetrics
     {
         if (!TextMetrics.__canvas)
         {
-            let result: HTMLCanvasElement|OffscreenCanvas;
+            let canvas: HTMLCanvasElement|OffscreenCanvas;
 
             try
             {
@@ -735,18 +735,27 @@ export class TextMetrics
                     return c;
                 }
 
-                result = document.createElement('canvas');
+                canvas = document.createElement('canvas');
             }
             catch (ex)
             {
-                result = document.createElement('canvas');
+                canvas = document.createElement('canvas');
             }
-            result.width = result.height = 10;
-            TextMetrics.__canvas = result;
-            TextMetrics._context = result.getContext('2d');
+            canvas.width = canvas.height = 10;
+            TextMetrics.__canvas = canvas;
         }
 
         return TextMetrics.__canvas;
+    }
+
+    public static get _context(): CanvasRenderingContext2D|OffscreenCanvasRenderingContext2D
+    {
+        if (!TextMetrics.__context)
+        {
+            TextMetrics.__context = TextMetrics._canvas.getContext('2d');
+        }
+
+        return TextMetrics.__context;
     }
 }
 


### PR DESCRIPTION
Fixes #6990

This change removes all the DOM calls at instantiation-time. As we work towards cleaning up the code to support Node.js rendering, this is an important first step to make sure DOM dependencies aren't called immediately. All code can now cleanly be require/import'd without barfing.
