### PR TITLE
add instructions for spritesheet without loader

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -43,7 +43,7 @@ export interface ISpritesheetData {
  * Utility class for maintaining reference to a collection
  * of Textures on a single Spritesheet.
  *
- * To access a sprite sheet from your code pass its JSON data file to Pixi's loader:
+ * To access a sprite sheet from your code you may pass its JSON data file to Pixi's loader:
  *
  * ```js
  * PIXI.Loader.shared.add("images/spritesheet.json").load(setup);
@@ -53,6 +53,13 @@ export interface ISpritesheetData {
  *   ...
  * }
  * ```
+ * 
+ * Alternately, you may circumvent the loader by instantiating the Spritesheet directly:
+ * ```js
+ * const sheet = new PIXI.Spritesheet(texture | baseTexture, iSpritesheetData)
+ * sheet.parse(_textures => console.log(sheet.animations))
+ * ```
+ * 
  * With the `sheet.textures` you can create Sprite objects,`sheet.animations` can be used to create an AnimatedSprite.
  *
  * Sprite sheets can be packed using tools like {@link https://codeandweb.com/texturepacker|TexturePacker},

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -53,13 +53,13 @@ export interface ISpritesheetData {
  *   ...
  * }
  * ```
- * 
+ *
  * Alternately, you may circumvent the loader by instantiating the Spritesheet directly:
  * ```js
- * const sheet = new PIXI.Spritesheet(texture | baseTexture, iSpritesheetData)
- * sheet.parse(_textures => console.log(sheet.animations))
+ * const sheet = new PIXI.Spritesheet(texture, spritesheetData);
+ * sheet.parse(() => console.log('Spritesheet ready to use!'));
  * ```
- * 
+ *
  * With the `sheet.textures` you can create Sprite objects,`sheet.animations` can be used to create an AnimatedSprite.
  *
  * Sprite sheets can be packed using tools like {@link https://codeandweb.com/texturepacker|TexturePacker},


### PR DESCRIPTION
we couldn't use the loader to develop on https://PixiTestbench.com since it's drag-n-drop with file blobs, so we needed to use the classes directly

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
