### PR TITLE
Calculate bounds of graphics geometry based on the vertices

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -854,11 +854,10 @@ export class Graphics extends Container
         this.finishPoly();
 
         const geometry = this._geometry;
-        const hasuint32 = renderer.context.supports.uint32Indices;
         // batch part..
         // batch it!
 
-        geometry.updateBatches(hasuint32);
+        geometry.updateBatches();
 
         if (geometry.batchable)
         {

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -16,7 +16,7 @@ import {
 } from '@pixi/core';
 
 import { DRAW_MODES, WRAP_MODES } from '@pixi/constants';
-import { SHAPES, Point, Matrix } from '@pixi/math';
+import { Point, Matrix } from '@pixi/math';
 import { GraphicsData } from './GraphicsData';
 import { premultiplyTint } from '@pixi/utils';
 import { Bounds } from '@pixi/display';
@@ -32,7 +32,6 @@ import type { LineStyle } from './styles/LineStyle';
 type IShape = Circle | Ellipse | Polygon | Rectangle | RoundedRectangle;
 
 const tmpPoint = new Point();
-const tmpBounds = new Bounds();
 
 /**
  * The Graphics class contains methods used to draw primitive shapes such as lines, circles and
@@ -119,9 +118,6 @@ export class GraphicsGeometry extends BatchGeometry
     /** Cached bounds. */
     protected _bounds: Bounds = new Bounds();
 
-    /** The bounds dirty flag. */
-    protected boundsDirty = -1;
-
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
     constructor()
     {
@@ -135,9 +131,9 @@ export class GraphicsGeometry extends BatchGeometry
      */
     public get bounds(): Bounds
     {
-        if (this.boundsDirty !== this.dirty)
+        if (this.validateBatching())
         {
-            this.boundsDirty = this.dirty;
+            this.updateBatches();
             this.calculateBounds();
         }
 
@@ -150,7 +146,6 @@ export class GraphicsGeometry extends BatchGeometry
      */
     protected invalidate(): void
     {
-        this.boundsDirty = -1;
         this.dirty++;
         this.batchDirty++;
         this.shapeIndex = 0;
@@ -340,10 +335,8 @@ export class GraphicsGeometry extends BatchGeometry
     /**
      * Generates intermediate batch data. Either gets converted to drawCalls
      * or used to convert to batch objects directly by the Graphics object.
-     *
-     * @param allow32Indices - Allow using 32-bit indices for preventing artifacts when more that 65535 vertices
      */
-    updateBatches(allow32Indices?: boolean): void
+    updateBatches(): void
     {
         if (!this.graphicsData.length)
         {
@@ -454,16 +447,16 @@ export class GraphicsGeometry extends BatchGeometry
             return;
         }
 
+        const need32 = attrib > 0xffff;
+
         // prevent allocation when length is same as buffer
-        if (this.indicesUint16 && this.indices.length === this.indicesUint16.length)
+        if (this.indicesUint16 && this.indices.length === this.indicesUint16.length
+            && need32 === (this.indicesUint16.BYTES_PER_ELEMENT > 2))
         {
             this.indicesUint16.set(this.indices);
         }
         else
         {
-            const need32
-                = attrib > 0xffff && allow32Indices;
-
             this.indicesUint16 = need32 ? new Uint32Array(this.indices) : new Uint16Array(this.indices);
         }
 
@@ -777,80 +770,9 @@ export class GraphicsGeometry extends BatchGeometry
     protected calculateBounds(): void
     {
         const bounds = this._bounds;
-        const sequenceBounds = tmpBounds;
-        let curMatrix = Matrix.IDENTITY;
 
-        this._bounds.clear();
-        sequenceBounds.clear();
-
-        for (let i = 0; i < this.graphicsData.length; i++)
-        {
-            const data = this.graphicsData[i];
-            const shape = data.shape;
-            const type = data.type;
-            const lineStyle = data.lineStyle;
-            const nextMatrix = data.matrix || Matrix.IDENTITY;
-            let lineWidth = 0.0;
-
-            if (lineStyle && lineStyle.visible)
-            {
-                lineWidth = lineStyle.width;
-
-                if (type !== SHAPES.POLY || data.fillStyle.visible)
-                {
-                    lineWidth *= Math.max(0, lineStyle.alignment);
-                }
-                else
-                {
-                    lineWidth *= Math.max(lineStyle.alignment, 1 - lineStyle.alignment);
-                }
-            }
-
-            if (curMatrix !== nextMatrix)
-            {
-                if (!sequenceBounds.isEmpty())
-                {
-                    bounds.addBoundsMatrix(sequenceBounds, curMatrix);
-                    sequenceBounds.clear();
-                }
-                curMatrix = nextMatrix;
-            }
-
-            if (type === SHAPES.RECT || type === SHAPES.RREC)
-            {
-                const rect = shape as Rectangle | RoundedRectangle;
-
-                sequenceBounds.addFramePad(rect.x, rect.y, rect.x + rect.width, rect.y + rect.height,
-                    lineWidth, lineWidth);
-            }
-            else if (type === SHAPES.CIRC)
-            {
-                const circle = shape as Circle;
-
-                sequenceBounds.addFramePad(circle.x, circle.y, circle.x, circle.y,
-                    circle.radius + lineWidth, circle.radius + lineWidth);
-            }
-            else if (type === SHAPES.ELIP)
-            {
-                const ellipse = shape as Ellipse;
-
-                sequenceBounds.addFramePad(ellipse.x, ellipse.y, ellipse.x, ellipse.y,
-                    ellipse.width + lineWidth, ellipse.height + lineWidth);
-            }
-            else
-            {
-                const poly = shape as Polygon;
-                // adding directly to the bounds
-
-                bounds.addVerticesMatrix(curMatrix, (poly.points as any), 0, poly.points.length, lineWidth, lineWidth);
-            }
-        }
-
-        if (!sequenceBounds.isEmpty())
-        {
-            bounds.addBoundsMatrix(sequenceBounds, curMatrix);
-        }
-
+        bounds.clear();
+        bounds.addVertexData((this.points as any), 0, this.points.length);
         bounds.pad(this.boundsPadding, this.boundsPadding);
     }
 

--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -1,5 +1,5 @@
 import { Renderer, BatchRenderer, Texture } from '@pixi/core';
-import { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils } from '@pixi/graphics';
+import { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils, LINE_CAP } from '@pixi/graphics';
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 
 import { BLEND_MODES } from '@pixi/constants';
@@ -201,7 +201,7 @@ describe('Graphics', function ()
         {
             const graphics = new Graphics();
 
-            graphics.lineStyle(1);
+            graphics.lineStyle({ width: 1, cap: LINE_CAP.SQUARE });
             graphics.moveTo(0, 0);
             graphics.lineTo(0, 10);
 
@@ -214,7 +214,7 @@ describe('Graphics', function ()
             const graphics = new Graphics();
 
             graphics.moveTo(0, 0);
-            graphics.lineStyle(1);
+            graphics.lineStyle({ width: 1, cap: LINE_CAP.SQUARE });
             graphics.lineTo(0, -10);
 
             expect(graphics.width).to.be.closeTo(1, 0.0001);
@@ -226,7 +226,7 @@ describe('Graphics', function ()
             const graphics = new Graphics();
 
             graphics.moveTo(0, 0);
-            graphics.lineStyle(1);
+            graphics.lineStyle({ width: 1, cap: LINE_CAP.SQUARE });
             graphics.lineTo(10, 0);
 
             expect(graphics.height).to.be.closeTo(1, 0.0001);
@@ -238,7 +238,7 @@ describe('Graphics', function ()
             const graphics = new Graphics();
 
             graphics.moveTo(0, 0);
-            graphics.lineStyle(1);
+            graphics.lineStyle({ width: 1, cap: LINE_CAP.SQUARE });
             graphics.lineTo(-10, 0);
 
             expect(graphics.height).to.be.closeTo(1, 0.0001);
@@ -663,7 +663,9 @@ describe('Graphics', function ()
         {
             const graphics = new Graphics();
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
 
             const spy = sinon.spy(graphics.geometry, 'calculateBounds');
 

--- a/tools/integration-tests/test/Container.tests.ts
+++ b/tools/integration-tests/test/Container.tests.ts
@@ -18,7 +18,9 @@ describe('Container', function ()
 
             parent.addChild(container);
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
             container.position.set(100, 200);
             container.updateTransform();
 
@@ -68,7 +70,9 @@ describe('Container', function ()
             const container = new Container();
             const graphics = new Graphics();
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
             container.addChild(graphics);
             container.scale.x = 2;
 
@@ -80,7 +84,9 @@ describe('Container', function ()
             const container = new Container();
             const graphics = new Graphics();
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
             container.addChild(graphics);
 
             container.width = 20;
@@ -97,7 +103,9 @@ describe('Container', function ()
             const container = new Container();
             const graphics = new Graphics();
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
             container.addChild(graphics);
             container.scale.y = 2;
 
@@ -109,7 +117,9 @@ describe('Container', function ()
             const container = new Container();
             const graphics = new Graphics();
 
+            graphics.beginFill();
             graphics.drawRect(0, 0, 10, 10);
+            graphics.endFill();
             container.addChild(graphics);
 
             container.height = 20;


### PR DESCRIPTION
##### Description of change

The bounds of graphics still have some problems. The first one that the bounds are not always tight. The second issue is that shapes with miter line-joins are potentially not completely contained inside the bounds.
- Non-tight bounds (single line with line-cap butt):
  - Before: https://www.pixiplayground.com/#/edit/9i1vRELYI48AAudWOC-_J
  - After: https://www.pixiplayground.com/#/edit/FiK6yVu79hywL0tb5YDMm
- Non-tight bounds (rotated rectangle with line-join bevel):
  - Before: https://www.pixiplayground.com/#/edit/EUWm54dJCeYHErsxaTGBT
  - After: https://www.pixiplayground.com/#/edit/RetAuLqZu8i8DeuaZDwr5
- Line alignment can create larger-than-necessary bounds:
  - Before: https://www.pixiplayground.com/#/edit/f88_wZ3belsXIbgB-lf08
  - After: https://www.pixiplayground.com/#/edit/t4IJXSstB-ZTlwy47cHHG
- Empty graphics has non-empty bounds:
  - Before: https://www.pixiplayground.com/#/edit/UpHIG5Pb19b6vJr82yS-N
  - After: https://www.pixiplayground.com/#/edit/af9CNu3dOINX1-wa_yOy5
- Miter line-join outside of bounds:
  - Before: https://www.pixiplayground.com/#/edit/5SYPCQMFXnX__9jVX2gU-
  - After: https://www.pixiplayground.com/#/edit/_Ud6Cib1SGzEVkSRlopdz

I changed it so that the bounds are calculated based on the actual vertices. This way the bounds are always tight and contain the entire graphic.

I had to remove the `allow32Indices` parameter from `updateBatches`, because we need to calculate the vertices outside of `render`. Consequently, on hardware that doesn't allow 32 bit indices the graphics is no longer rendered if the number of vertices exceeds 16 bit, and a warning is logged by the geometry system; before it would try to render the graphics, but there would be at least one artifact, because the indices buffer is too small.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
