### PR TITLE
Fix for 'attributes is null' exception on mobile (fixes #8216)

### DIFF
--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -280,7 +280,7 @@ export class ContextSystem implements ISystem
         }
 
         // this is going to be fairly simple for now.. but at least we have room to grow!
-        if (!attributes.stencil)
+        if (attributes && !attributes.stencil)
         {
             /* eslint-disable max-len, no-console */
             console.warn('Provided WebGL context does not have a stencil buffer, masks may not render correctly');


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
When context is lost in some scenarios (e.g. re-rendering canvas in a react component), `gl.getContextAttributes()` can return null, causing an exception while checking the `stencil` attribute to log this warning. This only occurs on some mobile environments (it can be reproduced in desktop browser "Responsive Design Mode" however).

This change adds an additional check to make sure `context` is defined before checking the `stencil` attribute. If context is lost it simply doesn't log the warning as the warning wouldn't necessarily be accurate.


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
