### PR TITLE
Fix generateTexture

### DIFF
--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -1,5 +1,5 @@
 import { hex2string, hex2rgb, EventEmitter, deprecation } from '@pixi/utils';
-import { Matrix, Rectangle } from '@pixi/math';
+import { Matrix, Rectangle, Transform } from '@pixi/math';
 import { MSAA_QUALITY, RENDERER_TYPE } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 import { RenderTexture } from './renderTexture/RenderTexture';
@@ -10,6 +10,7 @@ import type { IRenderingContext } from './IRenderingContext';
 import type { IRenderableContainer, IRenderableObject } from './IRenderableObject';
 
 const tempMatrix = new Matrix();
+const tempTransform = new Transform();
 
 export interface IRendererOptions extends GlobalMixins.IRendererOptions
 {
@@ -377,12 +378,16 @@ export abstract class AbstractRenderer extends EventEmitter
         tempMatrix.tx = -region.x;
         tempMatrix.ty = -region.y;
 
+        const transform = displayObject.transform;
+
+        displayObject.transform = tempTransform;
+
         this.render(displayObject, {
             renderTexture,
-            clear: false,
-            transform: tempMatrix,
-            skipUpdateTransform: !!displayObject.parent
+            transform: tempMatrix
         });
+
+        displayObject.transform = transform;
 
         return renderTexture;
     }

--- a/packages/core/src/IRenderableObject.ts
+++ b/packages/core/src/IRenderableObject.ts
@@ -1,4 +1,4 @@
-import type { Rectangle } from '@pixi/math';
+import type { Rectangle, Transform } from '@pixi/math';
 import type { Renderer } from './Renderer';
 
 /**
@@ -9,6 +9,8 @@ import type { Renderer } from './Renderer';
 interface IRenderableObject {
     /** Object must have a parent container */
     parent: IRenderableContainer;
+    /** Object must have a transform */
+    transform: Transform;
     /** Before method for transform updates */
     enableTempParent(): IRenderableContainer;
     /** Update the transforms */


### PR DESCRIPTION
##### Description of change

Fixes #8323.

- Translation:
  - Before: https://www.pixiplayground.com/#/edit/4RNT5xAO7Ib3to95keGwX
  - After: https://www.pixiplayground.com/#/edit/_skWND2rC6Vn4xQrwp4t1
- Scale:
  - Before: https://www.pixiplayground.com/#/edit/Xn7Ul6dFFCvOJurzNjEDn
  - After: https://www.pixiplayground.com/#/edit/do--rno0zbg5bfma3b5UI
- Rotation:
  - Before: https://www.pixiplayground.com/#/edit/mrpVuY-vo7yEWN-ZzaKdK
  - After: https://www.pixiplayground.com/#/edit/3hC6AWUZN0M316a2iuVrG

If the transform of the display object is anything other than the identity, the current implementation of `generateTexture` creates incorrect results. We need to temporarily change the transform of the display object to the identity, because we want to render in local space.

I also removed the `clear: false`. Don't you have to clear a new framebuffer/texture at least once before you use can it? Correct me if I'm wrong though. I'm not sure whether the spec guarantees that a framebuffer is initialized with zeros. We had the problem with stencil buffer where we used it before clearing it, and that wasn't working an some machines. That's why I'd prefer to clear: just to be safe.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
