### PR TITLE
chore: Add "types" and "exports" to package.json (#8368)

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -17,6 +17,19 @@
   "bundleOutput": {
     "name": "PIXI"
   },
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/pixi-legacy.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/pixi-legacy.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "homepage": "http://www.pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi.js/issues",
   "license": "MIT",

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -17,6 +17,19 @@
   "bundleOutput": {
     "name": "PIXI"
   },
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/pixi.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/pixi.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "homepage": "http://www.pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi.js/issues",
   "license": "MIT",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/accessibility.js",
   "module": "dist/esm/accessibility.js",
   "bundle": "dist/browser/accessibility.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/accessibility.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/accessibility.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Accessibility Plugin for visually impaired users",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/app.js",
   "module": "dist/esm/app.js",
   "bundle": "dist/browser/app.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/app.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/app.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Convenience class to create a new PixiJS application",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -14,6 +14,19 @@
   "main": "dist/cjs/basis.js",
   "module": "dist/esm/basis.js",
   "bundle": "dist/browser/basis.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/basis.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/basis.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/canvas/canvas-display/package.json
+++ b/packages/canvas/canvas-display/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-display.js",
   "module": "dist/esm/canvas-display.js",
   "bundle": "dist/browser/canvas-display.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-display.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-display.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Canvas mixin for the display package",
   "author": "Mat Groves",

--- a/packages/canvas/canvas-extract/package.json
+++ b/packages/canvas/canvas-extract/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-extract.js",
   "module": "dist/esm/canvas-extract.js",
   "bundle": "dist/browser/canvas-extract.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-extract.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-extract.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Canvas mixin for the extract package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-graphics/package.json
+++ b/packages/canvas/canvas-graphics/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-graphics.js",
   "module": "dist/esm/canvas-graphics.js",
   "bundle": "dist/browser/canvas-graphics.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-graphics.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-graphics.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Canvas mixin for the graphics package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-mesh/package.json
+++ b/packages/canvas/canvas-mesh/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-mesh.js",
   "module": "dist/esm/canvas-mesh.js",
   "bundle": "dist/browser/canvas-mesh.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-mesh.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-mesh.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Canvas mixin for the mesh package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-particle-container/package.json
+++ b/packages/canvas/canvas-particle-container/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-particle-container.js",
   "module": "dist/esm/canvas-particle-container.js",
   "bundle": "dist/browser/canvas-particle-container.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-particle-container.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-particle-container.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Canvas mixin for the particles package",
   "author": "Mat Groves",

--- a/packages/canvas/canvas-prepare/package.json
+++ b/packages/canvas/canvas-prepare/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-prepare.js",
   "module": "dist/esm/canvas-prepare.js",
   "bundle": "dist/browser/canvas-prepare.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-prepare.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-prepare.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Canvas mixin for the prepare package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-renderer/package.json
+++ b/packages/canvas/canvas-renderer/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-renderer.js",
   "module": "dist/esm/canvas-renderer.js",
   "bundle": "dist/browser/canvas-renderer.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-renderer.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-renderer.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Rendering using the Canvas API",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-sprite-tiling/package.json
+++ b/packages/canvas/canvas-sprite-tiling/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-sprite-tiling.js",
   "module": "dist/esm/canvas-sprite-tiling.js",
   "bundle": "dist/browser/canvas-sprite-tiling.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-sprite-tiling.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-sprite-tiling.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Canvas mixin for the sprite-tiling package",
   "author": "Mat Groves",

--- a/packages/canvas/canvas-sprite/package.json
+++ b/packages/canvas/canvas-sprite/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-sprite.js",
   "module": "dist/esm/canvas-sprite.js",
   "bundle": "dist/browser/canvas-sprite.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-sprite.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-sprite.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Canvas mixin for the sprite package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas/canvas-text/package.json
+++ b/packages/canvas/canvas-text/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/canvas-text.js",
   "module": "dist/esm/canvas-text.js",
   "bundle": "dist/browser/canvas-text.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/canvas-text.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/canvas-text.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Canvas mixin for the text package",
   "author": "Dave Moore",

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -16,6 +16,19 @@
   "main": "dist/cjs/compressed-textures.js",
   "module": "dist/esm/compressed-textures.js",
   "bundle": "dist/browser/compressed-textures.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/compressed-textures.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/compressed-textures.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/constants.js",
   "module": "dist/esm/constants.js",
   "bundle": "dist/browser/constants.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/constants.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/constants.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Constants used across PixiJS",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/core.js",
   "module": "dist/esm/core.js",
   "bundle": "dist/browser/core.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/core.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/core.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Core PixiJS",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/display.js",
   "module": "dist/esm/display.js",
   "bundle": "dist/browser/display.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/display.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/display.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Core display functionality",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/events.js",
   "module": "dist/esm/events.js",
   "bundle": "dist/browser/events.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/events.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/events.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "UI events for scene graphs",
   "keywords": [
     "interaction",

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/extract.js",
   "module": "dist/esm/extract.js",
   "bundle": "dist/browser/extract.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/extract.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/extract.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Extract raw graphics data from renderer",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filters/filter-alpha/package.json
+++ b/packages/filters/filter-alpha/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-alpha.js",
   "module": "dist/esm/filter-alpha.js",
   "bundle": "dist/browser/filter-alpha.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-alpha.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-alpha.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter that applies alpha evenly across the entire display object and any opaque elements it contains",
   "author": "Mat Groves",

--- a/packages/filters/filter-blur/package.json
+++ b/packages/filters/filter-blur/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-blur.js",
   "module": "dist/esm/filter-blur.js",
   "bundle": "dist/browser/filter-blur.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-blur.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-blur.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter that blurs the display object",
   "author": "Mat Groves",

--- a/packages/filters/filter-color-matrix/package.json
+++ b/packages/filters/filter-color-matrix/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-color-matrix.js",
   "module": "dist/esm/filter-color-matrix.js",
   "bundle": "dist/browser/filter-color-matrix.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-color-matrix.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-color-matrix.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter that lets you change RGBA via a 5x4 matrix transformation",
   "author": "Mat Groves",

--- a/packages/filters/filter-displacement/package.json
+++ b/packages/filters/filter-displacement/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-displacement.js",
   "module": "dist/esm/filter-displacement.js",
   "bundle": "dist/browser/filter-displacement.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-displacement.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-displacement.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter that allows offsetting of pixel values to create warping effects",
   "author": "Mat Groves",

--- a/packages/filters/filter-fxaa/package.json
+++ b/packages/filters/filter-fxaa/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-fxaa.js",
   "module": "dist/esm/filter-fxaa.js",
   "bundle": "dist/browser/filter-fxaa.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-fxaa.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-fxaa.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter for fast approximate anti-aliasing",
   "author": "Mat Groves",

--- a/packages/filters/filter-noise/package.json
+++ b/packages/filters/filter-noise/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/filter-noise.js",
   "module": "dist/esm/filter-noise.js",
   "bundle": "dist/browser/filter-noise.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/filter-noise.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/filter-noise.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.filters",
   "description": "Filter that applies noise to a display object",
   "author": "Mat Groves",

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/graphics-extras.js",
   "module": "dist/esm/graphics-extras.js",
   "bundle": "dist/browser/graphics-extras.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/graphics-extras.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/graphics-extras.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Additional Graphics functions for drawing special shapes.",
   "author": "Matt Karl <matt@mattkarl.com>",

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/graphics.js",
   "module": "dist/esm/graphics.js",
   "bundle": "dist/browser/graphics.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/graphics.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/graphics.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Draw primitive shapes such as lines, circles and rectangles to the display",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/interaction.js",
   "module": "dist/esm/interaction.js",
   "bundle": "dist/browser/interaction.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/interaction.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/interaction.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Plugin for handling mouse, touch and pointer events",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/loaders.js",
   "module": "dist/esm/loaders.js",
   "bundle": "dist/browser/loaders.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/loaders.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/loaders.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Load assets and resources",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/math-extras.js",
   "module": "dist/esm/math-extras.js",
   "bundle": "dist/browser/math-extras.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/math-extras.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/math-extras.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Useful methods for some math structures",
   "author": "Milton Candelero",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/math.js",
   "module": "dist/esm/math.js",
   "bundle": "dist/browser/math.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/math.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/math.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Collection of math utilities",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/mesh-extras.js",
   "module": "dist/esm/mesh-extras.js",
   "bundle": "dist/browser/mesh-extras.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/mesh-extras.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/mesh-extras.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Custom Mesh display objects, like Rope and SimplePlane",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/mesh.js",
   "module": "dist/esm/mesh.js",
   "bundle": "dist/browser/mesh.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/mesh.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/mesh.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Core Mesh functionality",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/mixin-cache-as-bitmap.js",
   "module": "dist/esm/mixin-cache-as-bitmap.js",
   "bundle": "dist/browser/mixin-cache-as-bitmap.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/mixin-cache-as-bitmap.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/mixin-cache-as-bitmap.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Mixin to allow caching container and its children to a bitmap texture",
   "author": "Mat Groves",

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/mixin-get-child-by-name.js",
   "module": "dist/esm/mixin-get-child-by-name.js",
   "bundle": "dist/browser/mixin-get-child-by-name.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/mixin-get-child-by-name.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/mixin-get-child-by-name.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Mixin function to find a child DisplayObject by name",
   "author": "Mat Groves",

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/mixin-get-global-position.js",
   "module": "dist/esm/mixin-get-global-position.js",
   "bundle": "dist/browser/mixin-get-global-position.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/mixin-get-global-position.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/mixin-get-global-position.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleNoExports": true,
   "description": "Mixin to find the global position of a DisplayObject",
   "author": "Mat Groves",

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/particle-container.js",
   "module": "dist/esm/particle-container.js",
   "bundle": "dist/browser/particle-container.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/particle-container.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/particle-container.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Render many sprite particles as efficiently as possible",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/polyfill.js",
   "module": "dist/esm/polyfill.js",
   "bundle": "dist/browser/polyfill.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/polyfill.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/polyfill.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "standalone": true,
   "description": "Support for legacy browser JavaScript environments",
   "author": "Mat Groves",

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/prepare.js",
   "module": "dist/esm/prepare.js",
   "bundle": "dist/browser/prepare.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/prepare.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/prepare.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Plugin to allow uploading textures to the GPU",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/runner.js",
   "module": "dist/esm/runner.js",
   "bundle": "dist/browser/runner.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/runner.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/runner.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "A simple alternative to events and signals with an emphasis on performance.",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/settings.js",
   "module": "dist/esm/settings.js",
   "bundle": "dist/browser/settings.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/settings.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/settings.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Collecting of user configurable settings used throughout PixiJS",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/sprite-animated.js",
   "module": "dist/esm/sprite-animated.js",
   "bundle": "dist/browser/sprite-animated.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/sprite-animated.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/sprite-animated.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Sprite Animations as depicted by playing a series of Textures",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/sprite-tiling.js",
   "module": "dist/esm/sprite-tiling.js",
   "bundle": "dist/browser/sprite-tiling.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/sprite-tiling.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/sprite-tiling.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Tiling Sprites for faster rendering a tiling image",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/sprite.js",
   "module": "dist/esm/sprite.js",
   "bundle": "dist/browser/sprite.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/sprite.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/sprite.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Base object for textured objects rendered to the screen",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/spritesheet.js",
   "module": "dist/esm/spritesheet.js",
   "bundle": "dist/browser/spritesheet.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/spritesheet.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/spritesheet.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Spritesheets maintain a collection of Textures on a single image",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/text-bitmap.js",
   "module": "dist/esm/text-bitmap.js",
   "bundle": "dist/browser/text-bitmap.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/text-bitmap.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/text-bitmap.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Text via bitmap fonts",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/text.js",
   "module": "dist/esm/text.js",
   "bundle": "dist/browser/text.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/text.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/text.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Text via the Canvas API",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/ticker.js",
   "module": "dist/esm/ticker.js",
   "bundle": "dist/browser/ticker.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/ticker.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/ticker.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "description": "Tickers are control the timings within PixiJS",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/unsafe-eval.js",
   "module": "dist/esm/unsafe-eval.js",
   "bundle": "dist/browser/unsafe-eval.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/unsafe-eval.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/unsafe-eval.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "bundleInput": "src/bundle.ts",
   "standalone": true,
   "description": "Adds support for environments that disallow support of new Function",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,19 @@
   "main": "dist/cjs/utils.js",
   "module": "dist/esm/utils.js",
   "bundle": "dist/browser/utils.js",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+          "default": "./dist/cjs/utils.js",
+          "types": "./index.d.ts"
+      },
+      "require": {
+          "default": "./dist/esm/utils.js",
+          "types": "./index.d.ts"
+      }
+    }
+  },
   "namespace": "PIXI.utils",
   "description": "Collection of utilities used by PixiJS",
   "author": "Mat Groves",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
This CR adjusts the `package.json` to make PIXI easier to use in an ESM environment with TypeScript.

TypeScript 4.7 introduces official (albeit beta) support for ESM in TypeScript. In connection with modern bundling tools such as Vite, it presents an exciting opportunity for front-end development. Unfortunately, the current version of PIXI packages do not behave properly in an ESM environment due to adjustments in how TypeScript resolves packages and types.

To be more specific, when running TS in ESM mode against the current version of PIXI, it resolves the code to the CJS bundle and the types to a non-existent index file in the CJS directory. To get it to correctly resolve both the types and the entrypoint, the `package.json` needs to include an `"exports"` key that specifies both types and entrypoint for ESM and CJS. 

For more details on this feature, see [they TypeScript 4.7 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing) or [the node.js documentation](https://nodejs.org/api/packages.html#packages_exports). Additionally, for fallback reasons, it's recommend to explicitly include the `"types"` field which specifies exactly where the types are located in the package.
 
This PR adds both of those keys to the 50 applicable PIXI packages, as well as the 2 associated bundle packages. 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
