### PR TITLE
Fix scissor mask bugs

### DIFF
--- a/packages/core/src/mask/MaskData.ts
+++ b/packages/core/src/mask/MaskData.ts
@@ -12,7 +12,7 @@ export interface IMaskTarget extends IFilterTarget
     isSprite?: boolean;
     worldTransform: Matrix;
     isFastRect?(): boolean;
-    getBounds(skipUpdate?: boolean): Rectangle;
+    getBounds(skipUpdate?: boolean, rect?: Rectangle): Rectangle;
     render(renderer: Renderer): void;
 }
 /**

--- a/packages/core/src/mask/MaskSystem.ts
+++ b/packages/core/src/mask/MaskSystem.ts
@@ -161,7 +161,7 @@ export class MaskSystem implements ISystem
             switch (maskData.type)
             {
                 case MASK_TYPES.SCISSOR:
-                    this.renderer.scissor.pop();
+                    this.renderer.scissor.pop(maskData);
                     break;
                 case MASK_TYPES.STENCIL:
                     this.renderer.stencil.pop(maskData.maskObject);

--- a/packages/core/src/mask/ScissorSystem.ts
+++ b/packages/core/src/mask/ScissorSystem.ts
@@ -53,18 +53,13 @@ export class ScissorSystem extends AbstractMaskSystem
         const { maskObject } = maskData;
         const { renderer } = this;
         const renderTextureSystem = renderer.renderTexture;
-
-        maskObject.renderable = true;
-
-        const rect = maskObject.getBounds();
+        const rect = maskObject.getBounds(true);
 
         this.roundFrameToPixels(rect,
             renderTextureSystem.current ? renderTextureSystem.current.resolution : renderer.resolution,
             renderTextureSystem.sourceFrame,
             renderTextureSystem.destinationFrame,
             renderer.projection.transform);
-
-        maskObject.renderable = false;
 
         if (prevData)
         {

--- a/packages/core/src/mask/ScissorSystem.ts
+++ b/packages/core/src/mask/ScissorSystem.ts
@@ -5,6 +5,7 @@ import type { MaskData } from './MaskData';
 import { Matrix, Rectangle } from '@pixi/math';
 
 const tempMatrix = new Matrix();
+const rectPool: Rectangle[] = [];
 
 /**
  * System plugin to the renderer to manage scissor masking.
@@ -53,7 +54,7 @@ export class ScissorSystem extends AbstractMaskSystem
         const { maskObject } = maskData;
         const { renderer } = this;
         const renderTextureSystem = renderer.renderTexture;
-        const rect = maskObject.getBounds(true);
+        const rect = maskObject.getBounds(true, rectPool.pop() ?? new Rectangle());
 
         this.roundFrameToPixels(rect,
             renderTextureSystem.current ? renderTextureSystem.current.resolution : renderer.resolution,
@@ -174,10 +175,16 @@ export class ScissorSystem extends AbstractMaskSystem
      * last mask in the stack.
      *
      * This can also be called when you directly modify the scissor box and want to restore PixiJS state.
+     * @param maskData - The mask data.
      */
-    pop(): void
+    pop(maskData?: MaskData): void
     {
         const { gl } = this.renderer;
+
+        if (maskData)
+        {
+            rectPool.push(maskData._scissorRectLocal);
+        }
 
         if (this.getStackLength() > 0)
         {


### PR DESCRIPTION
##### Description of change

This fixes two bugs:
- `maskObject.getBounds` must skip transform updates. Same reason as #8296.
  - Before: https://www.pixiplayground.com/#/edit/b6M2O5ylXdDYqGdYfRTB5
  - After: https://www.pixiplayground.com/#/edit/KwXtA13MO-k1vDmjuvQ6z
- If the same mask is used multiple times at different levels, `_scissorRect` gets corrupted and the scissor mask is not restored properly on pop.
  - Before: https://www.pixiplayground.com/#/edit/DUNO0XixBNeJKvSVCnR8K
  - After: https://www.pixiplayground.com/#/edit/cS-ujtnS4kKpisF3mNra8
 
I also removed the two `renderable` lines. They don't seem to have any purpose. `getBounds` doesn't require the object to be renderable.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
