### PR TITLE
fix: Resolves issue where "exports" broke webpack (#8379)

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -21,12 +21,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/pixi-legacy.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/pixi-legacy.js"
       },
       "require": {
-        "default": "./dist/esm/pixi-legacy.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/pixi-legacy.js"
       }
     }
   },

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -21,12 +21,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/pixi.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/pixi.js"
       },
       "require": {
-        "default": "./dist/esm/pixi.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/pixi.js"
       }
     }
   },

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/accessibility.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/accessibility.js"
       },
       "require": {
-        "default": "./dist/esm/accessibility.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/accessibility.js"
       }
     }
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/app.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/app.js"
       },
       "require": {
-        "default": "./dist/esm/app.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/app.js"
       }
     }
   },

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -18,12 +18,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/basis.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/basis.js"
       },
       "require": {
-        "default": "./dist/esm/basis.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/basis.js"
       }
     }
   },

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-display.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-display.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-display.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-display.js"
       }
     }
   },

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-extract.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-extract.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-extract.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-extract.js"
       }
     }
   },

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-graphics.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-graphics.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-graphics.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-graphics.js"
       }
     }
   },

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-mesh.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-mesh.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-mesh.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-mesh.js"
       }
     }
   },

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-particle-container.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-particle-container.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-particle-container.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-particle-container.js"
       }
     }
   },

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-prepare.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-prepare.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-prepare.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-prepare.js"
       }
     }
   },

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-renderer.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-renderer.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-renderer.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-renderer.js"
       }
     }
   },

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-sprite-tiling.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-sprite-tiling.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-sprite-tiling.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-sprite-tiling.js"
       }
     }
   },

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-sprite.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-sprite.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-sprite.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-sprite.js"
       }
     }
   },

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/canvas-text.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/canvas-text.js"
       },
       "require": {
-        "default": "./dist/esm/canvas-text.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/canvas-text.js"
       }
     }
   },

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -20,12 +20,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/compressed-textures.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/compressed-textures.js"
       },
       "require": {
-        "default": "./dist/esm/compressed-textures.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/compressed-textures.js"
       }
     }
   },

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/constants.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/constants.js"
       },
       "require": {
-        "default": "./dist/esm/constants.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/constants.js"
       }
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/core.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/core.js"
       },
       "require": {
-        "default": "./dist/esm/core.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/core.js"
       }
     }
   },

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/display.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/display.js"
       },
       "require": {
-        "default": "./dist/esm/display.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/display.js"
       }
     }
   },

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/events.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/events.js"
       },
       "require": {
-        "default": "./dist/esm/events.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/events.js"
       }
     }
   },

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/extract.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/extract.js"
       },
       "require": {
-        "default": "./dist/esm/extract.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/extract.js"
       }
     }
   },

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-alpha.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-alpha.js"
       },
       "require": {
-        "default": "./dist/esm/filter-alpha.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-alpha.js"
       }
     }
   },

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-blur.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-blur.js"
       },
       "require": {
-        "default": "./dist/esm/filter-blur.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-blur.js"
       }
     }
   },

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-color-matrix.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-color-matrix.js"
       },
       "require": {
-        "default": "./dist/esm/filter-color-matrix.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-color-matrix.js"
       }
     }
   },

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-displacement.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-displacement.js"
       },
       "require": {
-        "default": "./dist/esm/filter-displacement.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-displacement.js"
       }
     }
   },

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-fxaa.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-fxaa.js"
       },
       "require": {
-        "default": "./dist/esm/filter-fxaa.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-fxaa.js"
       }
     }
   },

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/filter-noise.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/filter-noise.js"
       },
       "require": {
-        "default": "./dist/esm/filter-noise.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/filter-noise.js"
       }
     }
   },

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/graphics-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/graphics-extras.js"
       },
       "require": {
-        "default": "./dist/esm/graphics-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/graphics-extras.js"
       }
     }
   },

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/graphics.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/graphics.js"
       },
       "require": {
-        "default": "./dist/esm/graphics.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/graphics.js"
       }
     }
   },

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/interaction.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/interaction.js"
       },
       "require": {
-        "default": "./dist/esm/interaction.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/interaction.js"
       }
     }
   },

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/loaders.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/loaders.js"
       },
       "require": {
-        "default": "./dist/esm/loaders.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/loaders.js"
       }
     }
   },

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/math-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/math-extras.js"
       },
       "require": {
-        "default": "./dist/esm/math-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/math-extras.js"
       }
     }
   },

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/math.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/math.js"
       },
       "require": {
-        "default": "./dist/esm/math.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/math.js"
       }
     }
   },

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/mesh-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/mesh-extras.js"
       },
       "require": {
-        "default": "./dist/esm/mesh-extras.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/mesh-extras.js"
       }
     }
   },

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/mesh.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/mesh.js"
       },
       "require": {
-        "default": "./dist/esm/mesh.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/mesh.js"
       }
     }
   },

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/mixin-cache-as-bitmap.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/mixin-cache-as-bitmap.js"
       },
       "require": {
-        "default": "./dist/esm/mixin-cache-as-bitmap.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/mixin-cache-as-bitmap.js"
       }
     }
   },

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/mixin-get-child-by-name.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/mixin-get-child-by-name.js"
       },
       "require": {
-        "default": "./dist/esm/mixin-get-child-by-name.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/mixin-get-child-by-name.js"
       }
     }
   },

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/mixin-get-global-position.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/mixin-get-global-position.js"
       },
       "require": {
-        "default": "./dist/esm/mixin-get-global-position.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/mixin-get-global-position.js"
       }
     }
   },

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/particle-container.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/particle-container.js"
       },
       "require": {
-        "default": "./dist/esm/particle-container.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/particle-container.js"
       }
     }
   },

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/polyfill.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/polyfill.js"
       },
       "require": {
-        "default": "./dist/esm/polyfill.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/polyfill.js"
       }
     }
   },

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/prepare.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/prepare.js"
       },
       "require": {
-        "default": "./dist/esm/prepare.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/prepare.js"
       }
     }
   },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/runner.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/runner.js"
       },
       "require": {
-        "default": "./dist/esm/runner.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/runner.js"
       }
     }
   },

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/settings.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/settings.js"
       },
       "require": {
-        "default": "./dist/esm/settings.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/settings.js"
       }
     }
   },

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/sprite-animated.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/sprite-animated.js"
       },
       "require": {
-        "default": "./dist/esm/sprite-animated.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/sprite-animated.js"
       }
     }
   },

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/sprite-tiling.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/sprite-tiling.js"
       },
       "require": {
-        "default": "./dist/esm/sprite-tiling.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/sprite-tiling.js"
       }
     }
   },

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/sprite.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/sprite.js"
       },
       "require": {
-        "default": "./dist/esm/sprite.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/sprite.js"
       }
     }
   },

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/spritesheet.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/spritesheet.js"
       },
       "require": {
-        "default": "./dist/esm/spritesheet.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/spritesheet.js"
       }
     }
   },

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/text-bitmap.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/text-bitmap.js"
       },
       "require": {
-        "default": "./dist/esm/text-bitmap.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/text-bitmap.js"
       }
     }
   },

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/text.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/text.js"
       },
       "require": {
-        "default": "./dist/esm/text.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/text.js"
       }
     }
   },

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/ticker.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/ticker.js"
       },
       "require": {
-        "default": "./dist/esm/ticker.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/ticker.js"
       }
     }
   },

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/unsafe-eval.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/unsafe-eval.js"
       },
       "require": {
-        "default": "./dist/esm/unsafe-eval.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/unsafe-eval.js"
       }
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,12 +8,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/cjs/utils.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/esm/utils.js"
       },
       "require": {
-        "default": "./dist/esm/utils.js",
-        "types": "./index.d.ts"
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/utils.js"
       }
     }
   },


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes the bug reported in #8379 and introduced in #8371 

General idea, as within the second-level of the "exports" key (where "import" and "require" are specified), the third level (where "types" and "default" are specified) is expected to be sorted in order of specificity, with "default" coming last. Although not all tools enforce this, webpack does and will refuse to compile if this is improperly managed. 

The fix swaps the order of these to prevent such issues. 

Embarrassingly enough, while resolving this I noticed that in the original version of this CR, I had additionally swapped the order the "esm" and "cjs" references. As part of this fix, I also resolved that issue. 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Additionally, I linked this against a local webpack project and was able to get past the initial resolution stage.
