### PR TITLE
Fix extract pixels

### DIFF
--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -2,7 +2,8 @@ import { Sprite } from '@pixi/sprite';
 import { expect } from 'chai';
 import { skipHello } from '@pixi/utils';
 import { Texture, RenderTexture, BatchRenderer, Renderer } from '@pixi/core';
-import { Extract, PixelExtractOptions } from '@pixi/extract';
+import { Extract } from '@pixi/extract';
+import { Rectangle } from '@pixi/math';
 
 skipHello();
 
@@ -57,13 +58,13 @@ describe('Extract', () =>
         const extract = renderer.plugins.extract as Extract;
         const renderTexture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(Texture.WHITE);
-        const test: PixelExtractOptions = { x: 1, y: 2, resolution: 5, width: 10, height: 10 };
+        const frame = new Rectangle(1, 2, 5, 6);
 
         renderer.render(sprite, { renderTexture });
 
         expect(extract.canvas(renderTexture)).to.be.an.instanceof(HTMLCanvasElement);
         expect(extract.base64(renderTexture)).to.be.a('string');
-        expect(extract.pixels(renderTexture, test)).to.be.instanceOf(Uint8Array);
+        expect(extract.pixels(renderTexture, frame)).to.be.instanceOf(Uint8Array);
         expect(extract.image(renderTexture)).to.be.instanceOf(HTMLImageElement);
 
         renderer.destroy();


### PR DESCRIPTION
##### Description of change

There a multiple problems in the new extract pixels parameter:
1. `options.x`/`options.y` are never used.
2. If the target is a render texture, `options` isn't used at all.
3. Passing `resolution` with the options doesn't really make sense: the resolution is a property of the renderer / render texture.

So I made the following changes:
1. I fixed the bugs above.
2. I deprecated `PixelsExtractOptions`. The parameter is a `Rectangle` now instead.
3. I added the parameter to `extract.canvas` as well.
4. I made some changes to the rounding of the frame dimensions. They are now `round`-ed instead of `floor`-ed / cast to integer. `extract.canvas` and `extract.pixels` had different rounding before this change.

Before: https://www.pixiplayground.com/#/edit/M5ZxsbemrAs5clp0jfFSc
After: https://www.pixiplayground.com/#/edit/vBlbFzhawm26XxU1Zx9X0

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
