### PR TITLE
Deprecate Callback for Spritesheet.parse

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -183,9 +183,20 @@ export class Spritesheet
     /**
      * Parser spritesheet from loaded data. This is done asynchronously
      * to prevent creating too many Texture within a single process.
+     * @method PIXI.Spritesheet#parse
+     */
+    public parse(): Promise<Dict<Texture>>;
+
+    /**
+     * Please use the Promise-based version of this function.
+     * @method PIXI.Spritesheet#parse
+     * @deprecated since version 6.5.0
      * @param {Function} callback - Callback when complete returns
      *        a map of the Textures for this spritesheet.
      */
+    public parse(callback?: (textures?: Dict<Texture>) => void): void;
+
+    /** @ignore */
     public parse(callback?: (textures?: Dict<Texture>) => void): Promise<Dict<Texture>>
     {
         // #if _DEBUG

--- a/packages/spritesheet/src/SpritesheetLoader.ts
+++ b/packages/spritesheet/src/SpritesheetLoader.ts
@@ -109,7 +109,7 @@ export class SpritesheetLoader
                 resource.url
             );
 
-            spritesheet.parse(() =>
+            spritesheet.parse().then(() =>
             {
                 resource.spritesheet = spritesheet;
                 resource.textures = spritesheet.textures;

--- a/packages/spritesheet/test/SpritesheetLoader.tests.ts
+++ b/packages/spritesheet/test/SpritesheetLoader.tests.ts
@@ -57,9 +57,8 @@ describe('SpritesheetLoader', () =>
         expect(res.textures).to.be.undefined;
     });
 
-    it('should load the image & create textures if json is properly formatted', () =>
+    it('should load the image & create textures if json is properly formatted', (next) =>
     {
-        const spy = sinon.spy();
         const res = createMockResource(LoaderResource.TYPE.JSON, getJsonSpritesheet());
         const loader = new Loader();
         const addStub = sinon.stub(loader, 'add');
@@ -69,33 +68,33 @@ describe('SpritesheetLoader', () =>
 
         addStub.yields(imgRes);
 
-        SpritesheetLoader.use.call(loader, res, spy);
+        SpritesheetLoader.use.call(loader, res, () =>
+        {
+            addStub.restore();
+            expect(addStub).to.have.been.calledWith(
+                `${res.name}_image`,
+                `${path.dirname(res.url)}/${res.data.meta.image}`
+            );
+            expect(res).to.have.property('textures')
+                .that.is.an('object')
+                .with.keys(Object.keys(getJsonSpritesheet().frames))
+                .and.has.property('0.png')
+                .that.is.an.instanceof(Texture);
 
-        addStub.restore();
+            expect(res.textures['0.png'].frame.x).to.equal(14);
+            expect(res.textures['0.png'].frame.y).to.equal(28);
+            expect(res.textures['0.png'].defaultAnchor.x).to.equal(0.3);
+            expect(res.textures['0.png'].defaultAnchor.y).to.equal(0.4);
+            expect(res.textures['1.png'].defaultAnchor.x).to.equal(0.0); // default of defaultAnchor is 0,0
+            expect(res.textures['1.png'].defaultAnchor.y).to.equal(0.0);
 
-        expect(spy).to.have.been.calledOnce;
-        expect(addStub).to.have.been.calledWith(
-            `${res.name}_image`,
-            `${path.dirname(res.url)}/${res.data.meta.image}`
-        );
-        expect(res).to.have.property('textures')
-            .that.is.an('object')
-            .with.keys(Object.keys(getJsonSpritesheet().frames))
-            .and.has.property('0.png')
-            .that.is.an.instanceof(Texture);
-
-        expect(res.textures['0.png'].frame.x).to.equal(14);
-        expect(res.textures['0.png'].frame.y).to.equal(28);
-        expect(res.textures['0.png'].defaultAnchor.x).to.equal(0.3);
-        expect(res.textures['0.png'].defaultAnchor.y).to.equal(0.4);
-        expect(res.textures['1.png'].defaultAnchor.x).to.equal(0.0); // default of defaultAnchor is 0,0
-        expect(res.textures['1.png'].defaultAnchor.y).to.equal(0.0);
-
-        expect(res).to.have.property('spritesheet')
-            .to.have.property('animations')
-            .to.have.property('png123');
-        expect(res.spritesheet.animations.png123.length).to.equal(3);
-        expect(res.spritesheet.animations.png123[0]).to.equal(res.textures['1.png']);
+            expect(res).to.have.property('spritesheet')
+                .to.have.property('animations')
+                .to.have.property('png123');
+            expect(res.spritesheet.animations.png123.length).to.equal(3);
+            expect(res.spritesheet.animations.png123[0]).to.equal(res.textures['1.png']);
+            next();
+        });
     });
 
     it('should not load binary images as an image loader type', (done) =>


### PR DESCRIPTION
Within the larger goal to modernize PixiJS, we'd like to remove some of the callback-style API designs and replace with Promises. Using Promises produce more readable code when used with async/await and is supported in modern browsers. 

Specifically, this change deprecates the callback on `Spritesheet.parse` and returns a Promise. This is backward compatible.

```js
// new API
await spritesheet.parse();

// deprecated API
spritesheet.parse(() => {});
```