### PR TITLE
BasePrepare's upload to be Promise-based

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20341,7 +20341,8 @@
         "@pixi/graphics": "6.4.2",
         "@pixi/settings": "6.4.2",
         "@pixi/text": "6.4.2",
-        "@pixi/ticker": "6.4.2"
+        "@pixi/ticker": "6.4.2",
+        "@pixi/utils": "6.4.2"
       }
     },
     "packages/runner": {

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -43,6 +43,7 @@
     "@pixi/graphics": "6.4.2",
     "@pixi/settings": "6.4.2",
     "@pixi/text": "6.4.2",
-    "@pixi/ticker": "6.4.2"
+    "@pixi/ticker": "6.4.2",
+    "@pixi/utils": "6.4.2"
   }
 }

--- a/packages/prepare/src/BasePrepare.ts
+++ b/packages/prepare/src/BasePrepare.ts
@@ -6,6 +6,7 @@ import { Text, TextStyle, TextMetrics } from '@pixi/text';
 import { CountLimiter } from './CountLimiter';
 
 import type { AbstractRenderer } from '@pixi/core';
+import { deprecation } from '@pixi/utils';
 
 interface IArrowFunction
 {
@@ -313,12 +314,35 @@ export class BasePrepare
 
     /**
      * Upload all the textures and graphics to the GPU.
-     * @param {Function|PIXI.DisplayObject|PIXI.Container|PIXI.BaseTexture|PIXI.Texture|PIXI.Graphics|PIXI.Text} item -
-     *        Either the container or display object to search for items to upload, the items to upload themselves,
-     *        or the callback function, if items have been added using `prepare.add`.
-     * @param {Function} [done] - Optional callback when all queued uploads have completed
+     * @method PIXI.BasePrepare#upload
+     * @param {PIXI.DisplayObject|PIXI.Container|PIXI.BaseTexture|PIXI.Texture|PIXI.Graphics|PIXI.Text} [item] -
+     *        Container or display object to search for items to upload or the items to upload themselves,
+     *        or optionally ommitted, if items have been added using {@link PIXI.BasePrepare#add `prepare.add`}.
      */
-    upload(item: IDisplayObjectExtended | Container | BaseTexture | Texture | (() => void), done?: () => void): void
+    upload(item?: IDisplayObjectExtended | Container | BaseTexture | Texture): Promise<void>;
+
+    /**
+     * Use the Promise-based API instead.
+     * @method PIXI.BasePrepare#upload
+     * @deprecated since version 6.5.0
+     * @param {PIXI.DisplayObject|PIXI.Container|PIXI.BaseTexture|PIXI.Texture|PIXI.Graphics|PIXI.Text} item -
+     *        Item to upload.
+     * @param {Function} [done] - Callback when completed.
+     */
+    upload(item?: IDisplayObjectExtended | Container | BaseTexture | Texture, done?: () => void): void;
+
+    /**
+     * Use the Promise-based API instead.
+     * @method PIXI.BasePrepare#upload
+     * @deprecated since version 6.5.0
+     * @param {Function} [done] - Callback when completed.
+     */
+    upload(done?: () => void): void;
+
+    /** @ignore */
+    upload(
+        item?: IDisplayObjectExtended | Container | BaseTexture | Texture | (() => void),
+        done?: () => void): Promise<void>
     {
         if (typeof item === 'function')
         {
@@ -326,31 +350,45 @@ export class BasePrepare
             item = null;
         }
 
-        // If a display object, search for items
-        // that we could upload
-        if (item)
+        // #if _DEBUG
+        if (done)
         {
-            this.add(item as IDisplayObjectExtended | Container | BaseTexture | Texture);
+            deprecation('6.5.0', 'BasePrepare.upload callback is deprecated, use the return Promise instead.');
         }
+        // #endif
 
-        // Get the items for upload from the display
-        if (this.queue.length)
+        return new Promise((resolve) =>
         {
-            if (done)
+            // If a display object, search for items
+            // that we could upload
+            if (item)
             {
-                this.completes.push(done);
+                this.add(item as IDisplayObjectExtended | Container | BaseTexture | Texture);
             }
 
-            if (!this.ticking)
+            // TODO: remove done callback and just use resolve
+            const complete = () =>
             {
-                this.ticking = true;
-                Ticker.system.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
+                done?.();
+                resolve();
+            };
+
+            // Get the items for upload from the display
+            if (this.queue.length)
+            {
+                this.completes.push(complete);
+
+                if (!this.ticking)
+                {
+                    this.ticking = true;
+                    Ticker.system.addOnce(this.tick, this, UPDATE_PRIORITY.UTILITY);
+                }
             }
-        }
-        else if (done)
-        {
-            done();
-        }
+            else
+            {
+                complete();
+            }
+        });
     }
 
     /**

--- a/packages/prepare/test/BasePrepare.tests.ts
+++ b/packages/prepare/test/BasePrepare.tests.ts
@@ -63,11 +63,10 @@ describe('BasePrepare', () =>
 
             return true;
         });
-        const complete = sinon.spy(() => { /* empty */ });
 
         prep.registerFindHook(addHook);
         prep.registerUploadHook(uploadHook);
-        prep.upload(uploadItem, complete);
+        prep.upload(uploadItem);
 
         expect(prep['queue']).to.contain(uploadItem);
 
@@ -75,12 +74,11 @@ describe('BasePrepare', () =>
 
         expect(addHook.calledOnce).to.be.true;
         expect(uploadHook.calledOnce).to.be.true;
-        expect(complete.calledOnce).to.be.true;
 
         prep.destroy();
     });
 
-    it('should call complete if no queue', () =>
+    it('should call complete if no queue', async () =>
     {
         const renderer = {} as AbstractRenderer;
         const prep = new BasePrepare(renderer);
@@ -92,7 +90,7 @@ describe('BasePrepare', () =>
         const complete = sinon.spy(() => { /* empty */ });
 
         prep.registerFindHook(addHook);
-        prep.upload({} as DisplayObject, complete);
+        await prep.upload({} as DisplayObject).then(complete);
 
         expect(complete.calledOnce).to.be.true;
 
@@ -112,11 +110,10 @@ describe('BasePrepare', () =>
         });
         const uploadHook = sinon.spy(() =>
             false);
-        const complete = sinon.spy(() => { /* empty */ });
 
         prep.registerFindHook(addHook);
         prep.registerUploadHook(uploadHook);
-        prep.upload({} as DisplayObject, complete);
+        prep.upload({} as DisplayObject);
 
         expect(prep['queue']).to.have.lengthOf(1);
 
@@ -125,7 +122,6 @@ describe('BasePrepare', () =>
         expect(prep['queue']).to.be.empty;
         expect(addHook.calledOnce).to.be.true;
         expect(uploadHook.calledOnce).to.be.true;
-        expect(complete.calledOnce).to.be.true;
 
         prep.destroy();
     });
@@ -143,13 +139,12 @@ describe('BasePrepare', () =>
         });
         const uploadHook = sinon.spy(() =>
             false);
-        const complete = sinon.spy(() => { /* empty */ });
 
         prep.registerFindHook(addHook);
         prep.registerUploadHook(uploadHook);
         const item = {} as DisplayObject;
 
-        prep.upload(item, complete);
+        prep.upload(item);
 
         expect(prep['queue']).to.have.lengthOf(1);
 
@@ -159,12 +154,11 @@ describe('BasePrepare', () =>
         expect(prep['queue']).to.be.empty;
         expect(addHook.calledOnce).to.be.true;
         expect(uploadHook.called).to.be.false;
-        expect(complete.calledOnce).to.be.true;
 
         prep.destroy();
     });
 
-    it('should attach to the system ticker', (done) =>
+    it('should attach to the system ticker', async () =>
     {
         const renderer = {} as AbstractRenderer;
         const prep = new BasePrepare(renderer);
@@ -177,24 +171,14 @@ describe('BasePrepare', () =>
         });
         const uploadHook = sinon.spy(() => true);
 
-        const complete = sinon.spy(() =>
-        {
-            expect(prep['queue']).to.be.empty;
-            expect(addHook.calledOnce).to.be.true;
-            expect(uploadHook.calledOnce).to.be.true;
-
-            prep.destroy();
-
-            done();
-        });
-
         prep.registerFindHook(addHook);
         prep.registerUploadHook(uploadHook);
-        prep.upload({} as DisplayObject, complete);
+        await prep.upload({} as DisplayObject);
 
-        expect(prep['queue']).to.have.lengthOf(1);
-        expect(addHook.called).to.be.true;
-        expect(uploadHook.called).to.be.false;
-        expect(complete.called).to.not.be.ok;
+        expect(prep['queue']).to.be.empty;
+        expect(addHook.calledOnce).to.be.true;
+        expect(uploadHook.calledOnce).to.be.true;
+
+        prep.destroy();
     });
 });


### PR DESCRIPTION
The BasePrepare plugin had a callback for knowing when items had finished uploading/preparing. Changed this to a Promise-based API.

```js
// deprecated callback
renderer.plugins.prepare.upload(stage, () => {});

// new Promise-based api
await renderer.plugins.prepare.upload(stage);
```
