### PR TITLE
Chore: Resolve deprecation warnings in unit-tests

### DIFF
--- a/packages/spritesheet/test/Spritesheet.tests.ts
+++ b/packages/spritesheet/test/Spritesheet.tests.ts
@@ -14,7 +14,7 @@ describe('Spritesheet', () =>
         resources = path.join(__dirname, 'resources');
         validate = (spritesheet: Spritesheet, done) =>
         {
-            spritesheet.parse((textures) =>
+            spritesheet.parse().then((textures) =>
             {
                 const id = 'goldmine_10_5.png';
                 const width = Math.floor(spritesheet.data.frames[id].frame.w);
@@ -56,7 +56,7 @@ describe('Spritesheet', () =>
 
             const sheet = new Spritesheet(baseTexture, data);
 
-            sheet.parse(() =>
+            sheet.parse().then(() =>
             {
                 const { frame } = sheet.textures;
 

--- a/packages/text-bitmap/test/BitmapFontLoader.tests.ts
+++ b/packages/text-bitmap/test/BitmapFontLoader.tests.ts
@@ -353,7 +353,7 @@ describe('BitmapFontLoader', () =>
         const baseTexture = new BaseTexture(atlasImage);
         const spritesheet = new Spritesheet(baseTexture, atlasJSON);
 
-        spritesheet.parse(() =>
+        spritesheet.parse().then(() =>
         {
             const fontTexture  = Texture.from('resources/font.png');
             const font =  BitmapFont.install(fontXML, fontTexture);
@@ -413,7 +413,7 @@ describe('BitmapFontLoader', () =>
 
         spritesheet.resolution = 1;
 
-        spritesheet.parse(() =>
+        spritesheet.parse().then(() =>
         {
             const fontTexture  = Texture.from('resources/font.png');
             const font =  BitmapFont.install(fontXML, fontTexture);

--- a/tools/integration-tests/test/Bounds.tests.ts
+++ b/tools/integration-tests/test/Bounds.tests.ts
@@ -12,7 +12,7 @@ describe('getBounds', () =>
     it('should register correct width/height with a LOADED Sprite', () =>
     {
         const parent = new Container();
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
 
         const sprite = new Sprite(texture);
 
@@ -127,7 +127,7 @@ describe('getBounds', () =>
 
         const graphics = new Graphics().beginFill(0xFF0000).drawCircle(0, 0, 10);
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(texture);
 
         container.addChild(sprite);
@@ -198,7 +198,7 @@ describe('getBounds', () =>
     {
         const parent = new Container();
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
 
         const plane = new SimplePlane(texture);
 
@@ -234,7 +234,7 @@ describe('getBounds', () =>
 
         const graphics = new Graphics().beginFill(0xFF0000).drawCircle(0, 0, 10);
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(texture);
 
         container.addChild(sprite);
@@ -279,7 +279,7 @@ describe('getBounds', () =>
 
         const container = new Container();
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(texture);
 
         container.addChild(sprite);
@@ -305,7 +305,7 @@ describe('getBounds', () =>
 
         const graphics = new Graphics().beginFill(0xFF0000).drawRect(0, 0, 10, 10);
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(texture);
 
         container.addChild(sprite);
@@ -390,7 +390,7 @@ describe('getBounds', () =>
     it('should return a different rectangle if getting local bounds after global bounds ', () =>
     {
         const parent = new Container();
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
         const sprite = new Sprite(texture);
 
         sprite.position.x = 20;

--- a/tools/integration-tests/test/getLocalBounds.tests.ts
+++ b/tools/integration-tests/test/getLocalBounds.tests.ts
@@ -27,7 +27,7 @@ describe('getLocalBounds', () =>
     it('should register correct local-bounds with a LOADED Sprite', () =>
     {
         const parent = new Container();
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
 
         const sprite = new Sprite(texture);
 
@@ -176,7 +176,7 @@ describe('getLocalBounds', () =>
     {
         const parent = new Container();
 
-        const texture = RenderTexture.create(10, 10);
+        const texture = RenderTexture.create({ width: 10, height: 10 });
 
         const plane = new SimplePlane(texture);
 


### PR DESCRIPTION
There were a few instances in unit-tests that were throwing deprecation warnings. This upgrades these to be the most current API.