### PR TITLE
Fix Interactivity in ShadowDOM

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -258,7 +258,15 @@ export class EventSystem
         // if we support touch events, then only use those for touch events, not pointer events
         if (this.supportsTouchEvents && (nativeEvent as PointerEvent).pointerType === 'touch') return;
 
-        const outside = nativeEvent.target !== this.domElement ? 'outside' : '';
+        let target = nativeEvent.target;
+
+        // if in shadow DOM use composedPath to access target
+        if (nativeEvent.composedPath && nativeEvent.composedPath().length > 0)
+        {
+            target = nativeEvent.composedPath()[0];
+        }
+
+        const outside = target !== this.domElement ? 'outside' : '';
         const normalizedEvents = this.normalizeToPointerData(nativeEvent);
 
         for (let i = 0, j = normalizedEvents.length; i < j; i++)

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1224,7 +1224,9 @@ export class InteractionManager extends EventEmitter
 
         // if the event wasn't targeting our canvas, then consider it to be pointerupoutside
         // in all cases (unless it was a pointercancel)
-        const eventAppend = originalEvent.target !== this.interactionDOMElement ? 'outside' : '';
+        // for shadow dom use composedPath()
+        const target = originalEvent.composedPath() ? originalEvent.composedPath()[0] : originalEvent.target;
+        const eventAppend = target !== this.interactionDOMElement ? 'outside' : '';
 
         for (let i = 0; i < eventLen; i++)
         {

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1224,7 +1224,6 @@ export class InteractionManager extends EventEmitter
 
         // if the event wasn't targeting our canvas, then consider it to be pointerupoutside
         // in all cases (unless it was a pointercancel)
-        // for shadow dom use composedPath()
         const target = originalEvent.composedPath() ? originalEvent.composedPath()[0] : originalEvent.target;
         const eventAppend = target !== this.interactionDOMElement ? 'outside' : '';
 

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1224,7 +1224,14 @@ export class InteractionManager extends EventEmitter
 
         // if the event wasn't targeting our canvas, then consider it to be pointerupoutside
         // in all cases (unless it was a pointercancel)
-        const target = originalEvent.composedPath() ? originalEvent.composedPath()[0] : originalEvent.target;
+        let target = originalEvent.target;
+
+        // if in shadow DOM use composedPath to access target
+        if (originalEvent.composedPath && originalEvent.composedPath().length > 0)
+        {
+            target = originalEvent.composedPath()[0];
+        }
+
         const eventAppend = target !== this.interactionDOMElement ? 'outside' : '';
 
         for (let i = 0; i < eventLen; i++)


### PR DESCRIPTION

##### Description of change
This is a small change to access the event target even if inside a shadowDOM context.  Before this 'click' and 'pointerup' events would not trigger inside a web component.  See relevant issues listed below.  The fix is implemented by accessing the first entry of `composedPath()` if it is available.  Otherwise it defaults to the previous implementation of `originalEvent.target`.  I didn't add tests to this as I'm unsure how to add a web component test case given the current test set up, but if you have any suggestions or recommendations as to how to create a test I would be happy to do so.

https://github.com/pixijs/pixijs/issues/8281
https://github.com/pixijs/pixijs/issues/7165

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
