### PR TITLE
Fixing CanvasSpriteRenderer behaving differently to WebGL counterpart

### DIFF
--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -113,6 +113,7 @@ export class CanvasSpriteRenderer
             dy = 0;
 
             const h = destWidth;
+
             destWidth = destHeight;
             destHeight = h;
         }

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -56,8 +56,17 @@ export class CanvasSpriteRenderer
             return;
         }
 
-        const width = texture._frame.width;
-        const height = texture._frame.height;
+        const sourceWidth = texture._frame.width;
+        const sourceHeight = texture._frame.height;
+
+        let destWidth = texture._frame.width;
+        let destHeight = texture._frame.height;
+
+        if (texture.trim)
+        {
+                destWidth = texture.trim.width;
+                destHeight = texture.trim.height;
+        }
 
         let wt = sprite.transform.worldTransform;
         let dx = 0;
@@ -102,10 +111,14 @@ export class CanvasSpriteRenderer
             // the anchor has already been applied above, so lets set it to zero
             dx = 0;
             dy = 0;
+
+            const h = destWidth;
+            destWidth = destHeight;
+            destHeight = h;
         }
 
-        dx -= width / 2;
-        dy -= height / 2;
+        dx -= destWidth / 2;
+        dy -= destHeight / 2;
 
         renderer.setContextTransform(wt, sprite.roundPixels, 1);
         // Allow for pixel rounding
@@ -145,12 +158,12 @@ export class CanvasSpriteRenderer
                 sprite._tintedCanvas,
                 0,
                 0,
-                Math.floor(width * resolution),
-                Math.floor(height * resolution),
+                Math.floor(sourceWidth * resolution),
+                Math.floor(sourceHeight * resolution),
                 Math.floor(dx * renderer.resolution),
                 Math.floor(dy * renderer.resolution),
-                Math.floor(width * renderer.resolution),
-                Math.floor(height * renderer.resolution)
+                Math.floor(destWidth * renderer.resolution),
+                Math.floor(destWidth * renderer.resolution)
             );
         }
         else
@@ -159,12 +172,12 @@ export class CanvasSpriteRenderer
                 source,
                 texture._frame.x * resolution,
                 texture._frame.y * resolution,
-                Math.floor(width * resolution),
-                Math.floor(height * resolution),
+                Math.floor(sourceWidth * resolution),
+                Math.floor(sourceHeight * resolution),
                 Math.floor(dx * renderer.resolution),
                 Math.floor(dy * renderer.resolution),
-                Math.floor(width * renderer.resolution),
-                Math.floor(height * renderer.resolution)
+                Math.floor(destWidth * renderer.resolution),
+                Math.floor(destHeight * renderer.resolution)
             );
         }
 

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -163,7 +163,7 @@ export class CanvasSpriteRenderer
                 Math.floor(dx * renderer.resolution),
                 Math.floor(dy * renderer.resolution),
                 Math.floor(destWidth * renderer.resolution),
-                Math.floor(destWidth * renderer.resolution)
+                Math.floor(destHeight * renderer.resolution)
             );
         }
         else

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -64,8 +64,8 @@ export class CanvasSpriteRenderer
 
         if (texture.trim)
         {
-                destWidth = texture.trim.width;
-                destHeight = texture.trim.height;
+            destWidth = texture.trim.width;
+            destHeight = texture.trim.height;
         }
 
         let wt = sprite.transform.worldTransform;
@@ -138,8 +138,8 @@ export class CanvasSpriteRenderer
             context.rect(
                 dx * renderer.resolution,
                 dy * renderer.resolution,
-                width * renderer.resolution,
-                height * renderer.resolution
+                destWidth * renderer.resolution,
+                destHeight * renderer.resolution
             );
             context.clip();
         }

--- a/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
+++ b/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
@@ -1,7 +1,10 @@
-import { Texture } from '@pixi/core';
+import { BaseTexture, CanvasResource, Texture } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
 import { CanvasRenderer } from '@pixi/canvas-renderer';
 import { expect } from 'chai';
+import { Container } from '@pixi/display';
+import { MIPMAP_MODES, SCALE_MODES } from '@pixi/constants';
+import { Rectangle } from '@pixi/math';
 
 describe('CanvasSpriteRenderer', () =>
 {
@@ -23,4 +26,56 @@ describe('CanvasSpriteRenderer', () =>
             renderer.destroy();
         }
     });
+
+    it('should scale the base texture correctly using a trimmed rect', () =>
+    {
+        //create 2x1 texture, left pixel red, right pixel green
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+
+        canvas.width = 2;
+        canvas.height = 1;
+
+        context.fillStyle = "#ff0000";
+        context.fillRect(0, 0, 1, 1);
+
+        context.fillStyle = "#00ff00";
+        context.fillRect(1, 0, 1, 1);
+
+        const baseTexture = new BaseTexture(new CanvasResource(canvas), {
+            mipmap: MIPMAP_MODES.OFF, 
+            scaleMode: SCALE_MODES.NEAREST
+        });
+
+        //set a scale value to orig and trim rectangle to scale the texture
+        const scale = 2;
+
+        const frame = new Rectangle(0, 0, baseTexture.width,         baseTexture.height);
+        const orig  = new Rectangle(0, 0, baseTexture.width * scale, baseTexture.height * scale);
+        const trim  = new Rectangle(0, 0, baseTexture.width * scale, baseTexture.height * scale);
+
+        let testSprite = new Sprite(new Texture(baseTexture, frame, orig, trim));
+
+        let stage = new Container();
+        stage.addChild(testSprite);
+
+        let renderer = new CanvasRenderer();
+        renderer.render(stage);
+
+        let ctx = renderer.view.getContext("2d");
+
+        let pixels = ctx.getImageData(0, 0, 2 * scale, 1 * scale).data;
+
+        expect(pixels[0]).to.equal(255);
+        expect(pixels[1]).to.equal(0);
+        expect(pixels[2]).to.equal(0);
+        expect(pixels[3]).to.equal(255);
+
+        expect(pixels[8]).to.equal(0);
+        expect(pixels[9]).to.equal(255);
+        expect(pixels[10]).to.equal(0);
+        expect(pixels[11]).to.equal(255);
+
+    });
+
 });

--- a/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
+++ b/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
@@ -29,42 +29,44 @@ describe('CanvasSpriteRenderer', () =>
 
     it('should scale the base texture correctly using a trimmed rect', () =>
     {
-        //create 2x1 texture, left pixel red, right pixel green
+        // create 2x1 texture, left pixel red, right pixel green
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('2d');
 
         canvas.width = 2;
         canvas.height = 1;
 
-        context.fillStyle = "#ff0000";
+        context.fillStyle = '#ff0000';
         context.fillRect(0, 0, 1, 1);
 
-        context.fillStyle = "#00ff00";
+        context.fillStyle = '#00ff00';
         context.fillRect(1, 0, 1, 1);
 
         const baseTexture = new BaseTexture(new CanvasResource(canvas), {
-            mipmap: MIPMAP_MODES.OFF, 
+            mipmap: MIPMAP_MODES.OFF,
             scaleMode: SCALE_MODES.NEAREST
         });
 
-        //set a scale value to orig and trim rectangle to scale the texture
+        // set a scale value to orig and trim rectangle to scale the texture
         const scale = 2;
 
-        const frame = new Rectangle(0, 0, baseTexture.width,         baseTexture.height);
+        const frame = new Rectangle(0, 0, baseTexture.width, baseTexture.height);
         const orig  = new Rectangle(0, 0, baseTexture.width * scale, baseTexture.height * scale);
         const trim  = new Rectangle(0, 0, baseTexture.width * scale, baseTexture.height * scale);
 
-        let testSprite = new Sprite(new Texture(baseTexture, frame, orig, trim));
+        const testSprite = new Sprite(new Texture(baseTexture, frame, orig, trim));
 
-        let stage = new Container();
+        const stage = new Container();
+
         stage.addChild(testSprite);
 
-        let renderer = new CanvasRenderer();
+        const renderer = new CanvasRenderer();
+
         renderer.render(stage);
 
-        let ctx = renderer.view.getContext("2d");
+        const ctx = renderer.view.getContext('2d');
 
-        let pixels = ctx.getImageData(0, 0, 2 * scale, 1 * scale).data;
+        const pixels = ctx.getImageData(0, 0, 2 * scale, Number(scale)).data;
 
         expect(pixels[0]).to.equal(255);
         expect(pixels[1]).to.equal(0);
@@ -75,7 +77,5 @@ describe('CanvasSpriteRenderer', () =>
         expect(pixels[9]).to.equal(255);
         expect(pixels[10]).to.equal(0);
         expect(pixels[11]).to.equal(255);
-
     });
-
 });


### PR DESCRIPTION
##### Description of change
Fixing CanvasSpriteRenderer behaving differently to WebGL counterpart in regards to BaseTexture trimming. If a sprite's texture had custom frame, orig and trim, when using the canvas rendering, the resulting texture would have a wrong scaling. These fixes make it, that both canvas rendering and WebGL behave the same in this instance.

Bug can be reproduced here
https://www.pixiplayground.com/#/edit/8RST1GAiGaqPDUHDmKh8k

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
