### PR TITLE
System Extensions

### DIFF
--- a/packages/canvas-renderer/src/CanvasContextSystem.ts
+++ b/packages/canvas-renderer/src/CanvasContextSystem.ts
@@ -1,7 +1,7 @@
 import { Matrix } from '@pixi/math';
 
 import type { CanvasRenderer } from './CanvasRenderer';
-import type { ISystem } from '@pixi/core';
+import { ExtensionMetadata, ExtensionType, ISystem } from '@pixi/core';
 import { mapCanvasBlendModesToPixi } from './utils/mapCanvasBlendModesToPixi';
 import { BLEND_MODES, SCALE_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
@@ -38,6 +38,12 @@ export type SmoothingEnabledProperties =
  */
 export class CanvasContextSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type:  ExtensionType.CanvasRendererSystem,
+        name: 'canvasContext',
+    };
+
     /** A reference to the current renderer */
     private renderer: CanvasRenderer;
 

--- a/packages/canvas-renderer/src/CanvasMaskSystem.ts
+++ b/packages/canvas-renderer/src/CanvasMaskSystem.ts
@@ -2,7 +2,7 @@ import { Polygon, SHAPES } from '@pixi/math';
 
 import type { CanvasRenderer } from './CanvasRenderer';
 import type { Graphics } from '@pixi/graphics';
-import type { ISystem, MaskData } from '@pixi/core';
+import { ExtensionMetadata, ExtensionType, ISystem, MaskData } from '@pixi/core';
 import type { Container } from '@pixi/display';
 
 /**
@@ -14,6 +14,12 @@ import type { Container } from '@pixi/display';
  */
 export class CanvasMaskSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type:  ExtensionType.CanvasRendererSystem,
+        name: 'mask',
+    };
+
     /** A reference to the current renderer */
     private renderer: CanvasRenderer;
     private _foundShapes: Array<Graphics> = [];

--- a/packages/canvas-renderer/src/CanvasObjectRendererSystem.ts
+++ b/packages/canvas-renderer/src/CanvasObjectRendererSystem.ts
@@ -1,7 +1,14 @@
 import { Matrix } from '@pixi/math';
 
 import type { CanvasRenderer } from './CanvasRenderer';
-import { BaseRenderTexture, CanvasResource, IRendererRenderOptions, ISystem, RenderTexture } from '@pixi/core';
+import {
+    BaseRenderTexture,
+    CanvasResource,
+    ExtensionMetadata,
+    ExtensionType,
+    IRendererRenderOptions,
+    ISystem,
+    RenderTexture } from '@pixi/core';
 import { BLEND_MODES } from '@pixi/constants';
 import { CanvasRenderTarget, hex2string, rgb2hex } from '@pixi/utils';
 import { DisplayObject } from 'pixi.js';
@@ -14,6 +21,12 @@ import { CrossPlatformCanvasRenderingContext2D } from './CanvasContextSystem';
  */
 export class CanvasObjectRendererSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type:  ExtensionType.CanvasRendererSystem,
+        name: 'objectRenderer',
+    };
+
     /** A reference to the current renderer */
     private renderer: CanvasRenderer;
     renderingToScreen: boolean;

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -165,19 +165,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
 
         const systemConfig = {
             runners: ['init', 'destroy', 'contextChange', 'reset', 'update', 'postrender', 'prerender', 'resize'],
-            systems: {
-                // systems shared by all renderers..
-                textureGenerator: GenerateTextureSystem,
-                background: BackgroundSystem,
-                _view: ViewSystem,
-                _plugin: PluginSystem,
-                startup: StartupSystem,
-
-                // canvas systems..
-                mask: CanvasMaskSystem,
-                canvasContext: CanvasContextSystem,
-                objectRenderer: CanvasObjectRendererSystem,
-            }
+            systems: CanvasRenderer.__systems,
         };
 
         this.setup(systemConfig);
@@ -558,7 +546,11 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
         return false;
     }
 
-    static __plugins: IRendererPlugins = {};
+    /** @private */
+    static readonly __plugins: IRendererPlugins = {};
+
+    /** @private */
+    static readonly __systems: Record<string, any> = {};
 
     /**
      * Collection of installed plugins. These are included by default in PIXI, but can be excluded
@@ -577,4 +569,15 @@ extensions.handle(
     ExtensionType.CanvasRendererPlugin,
     (extension) => { CanvasRenderer.__plugins[extension.name] = extension.ref; },
     (extension) => { delete CanvasRenderer.__plugins[extension.name]; }
+);
+extensions.handle(
+    ExtensionType.CanvasRendererSystem,
+    (extension) => { CanvasRenderer.__systems[extension.name] = extension.ref; },
+    (extension) => { delete CanvasRenderer.__systems[extension.name]; }
+);
+
+extensions.add(
+    CanvasMaskSystem,
+    CanvasContextSystem,
+    CanvasObjectRendererSystem
 );

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -318,35 +318,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
 
         const systemConfig = {
             runners: ['init', 'destroy', 'contextChange', 'reset', 'update', 'postrender', 'prerender', 'resize'],
-            systems: {
-                // systems shared by all renderers..
-                textureGenerator: GenerateTextureSystem,
-                background: BackgroundSystem,
-                _view: ViewSystem,
-                _plugin: PluginSystem,
-                startup: StartupSystem,
-
-                // low level WebGL systems
-                context: ContextSystem,
-                state: StateSystem,
-                shader: ShaderSystem,
-                texture: TextureSystem,
-                buffer: BufferSystem,
-                geometry: GeometrySystem,
-                framebuffer: FramebufferSystem,
-
-                // high level pixi specific rendering
-                mask: MaskSystem,
-                scissor: ScissorSystem,
-                stencil: StencilSystem,
-                projection: ProjectionSystem,
-                textureGC: TextureGCSystem,
-                filter: FilterSystem,
-                renderTexture: RenderTextureSystem,
-                batch: BatchSystem,
-                objectRenderer: ObjectRendererSystem,
-                _multisample: MultisampleSystem,
-            }
+            systems: Renderer.__systems,
         };
 
         this.setup(systemConfig);
@@ -647,16 +619,15 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      * Collection of installed plugins. These are included by default in PIXI, but can be excluded
      * by creating a custom build. Consult the README for more information about creating custom
      * builds and excluding plugins.
-     * @readonly
-     * @property {PIXI.AccessibilityManager} accessibility Support tabbing interactive elements.
-     * @property {PIXI.Extract} extract Extract image data from renderer.
-     * @property {PIXI.InteractionManager} interaction Handles mouse, touch and pointer events.
-     * @property {PIXI.ParticleRenderer} particle Renderer for ParticleContainer objects.
-     * @property {PIXI.Prepare} prepare Pre-render display objects.
-     * @property {PIXI.BatchRenderer} batch Batching of Sprite, Graphics and Mesh objects.
-     * @property {PIXI.TilingSpriteRenderer} tilingSprite Renderer for TilingSprite objects.
+     * @private
      */
-    static __plugins: IRendererPlugins = {};
+    static readonly __plugins: IRendererPlugins = {};
+
+    /**
+     * The collection of installed systems.
+     * @private
+     */
+    static readonly __systems: Record<string, any> = {};
 }
 
 // Handle registration of extensions
@@ -664,4 +635,36 @@ extensions.handle(
     ExtensionType.RendererPlugin,
     (extension) => { Renderer.__plugins[extension.name] = extension.ref; },
     (extension) => { delete Renderer.__plugins[extension.name]; }
+);
+extensions.handle(
+    ExtensionType.RendererSystem,
+    (extension) => { Renderer.__systems[extension.name] = extension.ref; },
+    (extension) => { delete Renderer.__systems[extension.name]; }
+);
+
+extensions.add(
+    GenerateTextureSystem,
+    BackgroundSystem,
+    ViewSystem,
+    PluginSystem,
+    StartupSystem,
+    // low level WebGL systems
+    ContextSystem,
+    StateSystem,
+    ShaderSystem,
+    TextureSystem,
+    BufferSystem,
+    GeometrySystem,
+    FramebufferSystem,
+    // high level pixi specific rendering
+    MaskSystem,
+    ScissorSystem,
+    StencilSystem,
+    ProjectionSystem,
+    TextureGCSystem,
+    FilterSystem,
+    RenderTextureSystem,
+    BatchSystem,
+    ObjectRendererSystem,
+    MultisampleSystem
 );

--- a/packages/core/src/background/BackgroundSystem.ts
+++ b/packages/core/src/background/BackgroundSystem.ts
@@ -1,4 +1,5 @@
 import { hex2rgb, hex2string } from '@pixi/utils';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 import { ISystem } from '../system/ISystem';
 
 export interface BackgroundOptions
@@ -17,6 +18,15 @@ export interface BackgroundOptions
  */
 export class BackgroundSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.RendererSystem,
+            ExtensionType.CanvasRendererSystem
+        ],
+        name: 'background',
+    };
+
     /**
      * This sets if the CanvasRenderer will clear the canvas or not before the new render pass.
      * If the scene is NOT transparent PixiJS will use a canvas sized fillRect operation every

--- a/packages/core/src/batch/BatchSystem.ts
+++ b/packages/core/src/batch/BatchSystem.ts
@@ -4,6 +4,7 @@ import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
 import type { BaseTexture } from '../textures/BaseTexture';
 import type { BatchTextureArray } from './BatchTextureArray';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage batching.
@@ -11,6 +12,12 @@ import type { BatchTextureArray } from './BatchTextureArray';
  */
 export class BatchSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'batch',
+    };
+
     /** An empty renderer. */
     public readonly emptyRenderer: ObjectRenderer;
 

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -5,6 +5,7 @@ import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
 import type { WebGLExtensions } from './WebGLExtensions';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 let CONTEXT_UID_COUNTER = 0;
 
@@ -33,6 +34,12 @@ export interface ContextOptions
  */
 export class ContextSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'context',
+    };
+
     /**
      * Either 1 or 2 to reflect the WebGL version being used.
      * @readonly

--- a/packages/core/src/extensions.ts
+++ b/packages/core/src/extensions.ts
@@ -10,7 +10,9 @@ enum ExtensionType
 // eslint-disable-next-line @typescript-eslint/indent
 {
     Application = 'application',
+    RendererSystem = 'renderer-webgl-system',
     RendererPlugin = 'renderer-webgl-plugin',
+    CanvasRendererSystem = 'renderer-canvas-system',
     CanvasRendererPlugin = 'renderer-canvas-plugin',
     Loader = 'loader',
 }

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -12,6 +12,7 @@ import type { IFilterTarget } from './IFilterTarget';
 import type { ISpriteMaskTarget } from './spriteMask/SpriteMaskFilter';
 import type { RenderTexture } from '../renderTexture/RenderTexture';
 import type { Renderer } from '../Renderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 const tempPoints = [new Point(), new Point(), new Point(), new Point()];
 const tempMatrix = new Matrix();
@@ -43,6 +44,12 @@ const tempMatrix = new Matrix();
  */
 export class FilterSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'filter',
+    };
+
     /**
      * List of filters for the FilterSystem
      * @member {object[]}

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -7,6 +7,7 @@ import { GLFramebuffer } from './GLFramebuffer';
 import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 const tempRectangle = new Rectangle();
 
@@ -16,6 +17,12 @@ const tempRectangle = new Rectangle();
  */
 export class FramebufferSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'framebuffer',
+    };
+
     /** A list of managed framebuffers. */
     public readonly managedFramebuffers: Array<Framebuffer>;
     public current: Framebuffer;

--- a/packages/core/src/framebuffer/MultisampleSystem.ts
+++ b/packages/core/src/framebuffer/MultisampleSystem.ts
@@ -2,6 +2,7 @@ import { MSAA_QUALITY } from '@pixi/constants';
 import { ISystem } from '../system/ISystem';
 import { Renderer } from '../Renderer';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System that manages the multisample property on the WebGL renderer
@@ -9,6 +10,12 @@ import { IRenderingContext } from '../IRenderer';
  */
 export class MultisampleSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: '_multisample',
+    };
+
     /**
      * The number of msaa samples of the canvas.
      * @readonly

--- a/packages/core/src/geometry/BufferSystem.ts
+++ b/packages/core/src/geometry/BufferSystem.ts
@@ -4,6 +4,7 @@ import type { Renderer } from '../Renderer';
 import type { Buffer } from './Buffer';
 import type { ISystem } from '../system/ISystem';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage buffers.
@@ -24,6 +25,12 @@ import { IRenderingContext } from '../IRenderer';
  */
 export class BufferSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'buffer',
+    };
+
     CONTEXT_UID: number;
     gl: IRenderingContext;
 

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -10,6 +10,7 @@ import type { Shader } from '../shader/Shader';
 import type { Program } from '../shader/Program';
 import type { Dict } from '@pixi/utils';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
 
@@ -19,6 +20,12 @@ const byteSizeMap: {[key: number]: number} = { 5126: 4, 5123: 2, 5121: 1 };
  */
 export class GeometrySystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'geometry',
+    };
+
     /**
      * `true` if we has `*_vertex_array_object` extension.
      * @readonly

--- a/packages/core/src/mask/MaskSystem.ts
+++ b/packages/core/src/mask/MaskSystem.ts
@@ -5,6 +5,7 @@ import { MASK_TYPES } from '@pixi/constants';
 import type { ISystem } from '../system/ISystem';
 import type { IMaskTarget } from './MaskData';
 import type { Renderer } from '../Renderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage masks.
@@ -31,6 +32,12 @@ import type { Renderer } from '../Renderer';
  */
 export class MaskSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'mask',
+    };
+
     /**
      * Flag to enable scissor masking.
      * @default true

--- a/packages/core/src/mask/ScissorSystem.ts
+++ b/packages/core/src/mask/ScissorSystem.ts
@@ -3,6 +3,7 @@ import { AbstractMaskSystem } from './AbstractMaskSystem';
 import type { Renderer } from '../Renderer';
 import type { MaskData } from './MaskData';
 import { Matrix, Rectangle } from '@pixi/math';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 const tempMatrix = new Matrix();
 const rectPool: Rectangle[] = [];
@@ -17,6 +18,12 @@ const rectPool: Rectangle[] = [];
  */
 export class ScissorSystem extends AbstractMaskSystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'scissor',
+    };
+
     /**
      * @param {PIXI.Renderer} renderer - The renderer this System works for.
      */

--- a/packages/core/src/mask/StencilSystem.ts
+++ b/packages/core/src/mask/StencilSystem.ts
@@ -2,6 +2,7 @@ import { AbstractMaskSystem } from './AbstractMaskSystem';
 
 import type { Renderer } from '../Renderer';
 import type { IMaskTarget, MaskData } from './MaskData';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage stencils (used for masks).
@@ -9,6 +10,12 @@ import type { IMaskTarget, MaskData } from './MaskData';
  */
 export class StencilSystem extends AbstractMaskSystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'stencil',
+    };
+
     /**
      * @param renderer - The renderer this System works for.
      */

--- a/packages/core/src/plugin/PluginSystem.ts
+++ b/packages/core/src/plugin/PluginSystem.ts
@@ -1,3 +1,4 @@
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 import { IRenderer } from '../IRenderer';
 import { Renderer } from '../Renderer';
 import { ISystem } from '../system/ISystem';
@@ -23,6 +24,15 @@ export interface IRendererPluginConstructor<R extends IRenderer = Renderer>
  */
 export class PluginSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.RendererSystem,
+            ExtensionType.CanvasRendererSystem
+        ],
+        name: '_plugin',
+    };
+
     /**
      * Collection of plugins.
      * @readonly

--- a/packages/core/src/projection/ProjectionSystem.ts
+++ b/packages/core/src/projection/ProjectionSystem.ts
@@ -3,6 +3,7 @@ import { Matrix } from '@pixi/math';
 import type { ISystem } from '../system/ISystem';
 import type { Rectangle } from '@pixi/math';
 import type { Renderer } from '../Renderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage the projection matrix.
@@ -13,6 +14,12 @@ import type { Renderer } from '../Renderer';
  */
 export class ProjectionSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'projection',
+    };
+
     /**
      * The destination frame used to calculate the current projection matrix.
      *

--- a/packages/core/src/render/ObjectRendererSystem.ts
+++ b/packages/core/src/render/ObjectRendererSystem.ts
@@ -3,6 +3,7 @@ import { IRenderableObject, IRendererRenderOptions } from '../IRenderer';
 import { ISystem } from '../system/ISystem';
 import { Renderer } from '../Renderer';
 import { RenderTexture } from '../renderTexture/RenderTexture';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * system that provides a render function that focussing on rendering Pixi Scene Graph objects
@@ -11,6 +12,12 @@ import { RenderTexture } from '../renderTexture/RenderTexture';
  */
 export class ObjectRendererSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'objectRenderer',
+    };
+
     renderer: Renderer;
 
     /**

--- a/packages/core/src/renderTexture/GenerateTextureSystem.ts
+++ b/packages/core/src/renderTexture/GenerateTextureSystem.ts
@@ -1,5 +1,6 @@
 import { MSAA_QUALITY, SCALE_MODES } from '@pixi/constants';
 import { Matrix, Rectangle, Transform } from '@pixi/math';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 import { IRenderer, IRenderableContainer, IRenderableObject } from '../IRenderer';
 import { ISystem } from '../system/ISystem';
 import { RenderTexture } from './RenderTexture';
@@ -28,6 +29,15 @@ export interface IGenerateTextureOptions
  */
 export class GenerateTextureSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.RendererSystem,
+            ExtensionType.CanvasRendererSystem
+        ],
+        name: 'textureGenerator',
+    };
+
     renderer: IRenderer;
 
     private readonly _tempMatrix: Matrix;

--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -7,6 +7,7 @@ import type { RenderTexture } from './RenderTexture';
 import type { BaseRenderTexture } from './BaseRenderTexture';
 import type { MaskData } from '../mask/MaskData';
 import type { ISize } from '@pixi/math';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 // Temporary rectangle for assigned sourceFrame or destinationFrame
 const tempRect = new Rectangle();
@@ -34,7 +35,13 @@ const tempRect2 = new Rectangle();
  */
 export class RenderTextureSystem implements ISystem
 {
-/* eslint-enable max-len */
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'renderTexture',
+    };
+
+    /* eslint-enable max-len */
 
     /**
      * List of masks for the {@link PIXI.StencilSystem}.

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -12,6 +12,7 @@ import { generateUniformBufferSync } from './utils/generateUniformBufferSync';
 
 import { generateProgram } from './utils/generateProgram';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 let UID = 0;
 // default sync data so we don't create a new one each time!
@@ -23,6 +24,12 @@ const defaultSyncData = { textureCount: 0, uboCount: 0 };
  */
 export class ShaderSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'shader',
+    };
+
     /**
      * The current WebGL rendering context.
      * @member {WebGLRenderingContext}

--- a/packages/core/src/startup/StartupSystem.ts
+++ b/packages/core/src/startup/StartupSystem.ts
@@ -5,6 +5,7 @@ import type { IRendererPlugins } from '../plugin/PluginSystem';
 import { IRenderer } from '../IRenderer';
 import { ISystem } from '../system/ISystem';
 import { ContextOptions } from '../systems';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 // TODO this can be infered by good use of generics in the future..
 export interface StartupOptions extends Record<string, unknown>
@@ -20,6 +21,15 @@ export interface StartupOptions extends Record<string, unknown>
  * @memberof PIXI
  */export class StartupSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.RendererSystem,
+            ExtensionType.CanvasRendererSystem
+        ],
+        name: 'startup',
+    };
+
     readonly renderer: IRenderer;
 
     constructor(renderer: IRenderer)

--- a/packages/core/src/state/StateSystem.ts
+++ b/packages/core/src/state/StateSystem.ts
@@ -4,6 +4,7 @@ import { BLEND_MODES } from '@pixi/constants';
 
 import type { ISystem } from '../system/ISystem';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 const BLEND = 0;
 const OFFSET = 1;
@@ -18,6 +19,12 @@ const DEPTH_MASK = 5;
  */
 export class StateSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'state',
+    };
+
     /**
      * State ID
      * @readonly

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -5,6 +5,7 @@ import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
 import type { Texture } from './Texture';
 import type { RenderTexture } from '../renderTexture/RenderTexture';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 export interface IUnloadableTexture
 {
@@ -19,6 +20,12 @@ export interface IUnloadableTexture
  */
 export class TextureGCSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'textureGC',
+    };
+
     /**
      * Count
      * @readonly

--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -9,6 +9,7 @@ import type { Texture } from './Texture';
 
 import type { Renderer } from '../Renderer';
 import { IRenderingContext } from '../IRenderer';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 
 /**
  * System plugin to the renderer to manage textures.
@@ -16,6 +17,12 @@ import { IRenderingContext } from '../IRenderer';
  */
 export class TextureSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: ExtensionType.RendererSystem,
+        name: 'texture',
+    };
+
     /**
      * Bound textures.
      * @readonly

--- a/packages/core/src/view/ViewSystem.ts
+++ b/packages/core/src/view/ViewSystem.ts
@@ -1,5 +1,6 @@
 import { Rectangle } from '@pixi/math';
 import { settings } from '@pixi/settings';
+import { ExtensionMetadata, ExtensionType } from '../extensions';
 import { IRenderer } from '../IRenderer';
 import { ISystem } from '../system/ISystem';
 
@@ -28,6 +29,15 @@ export interface ViewOptions
  */
 export class ViewSystem implements ISystem
 {
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.RendererSystem,
+            ExtensionType.CanvasRendererSystem
+        ],
+        name: '_view',
+    };
+
     private renderer: IRenderer;
 
     /**


### PR DESCRIPTION
Converts systems for Renderer and CanvasRenderer into extensions. Systems are now installed statically which helps unblock a handful of fixes. 

## Future Changes Unblocked

* Make EventSystem something that can be automatically installed in the bundle
* Fully deprecate interaction package
* Convert accessibility, extract, canvas-extract, prepare, canvas-prepare into systems