### PR TITLE
Denote that the geometry parameter of the Graphics constructor is optional

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -155,7 +155,7 @@ export class Graphics extends Container
     }
 
     /**
-     * @param geometry - Geometry to use, if omitted will create a new GraphicsGeometry instance.
+     * @param [geometry] - Geometry to use, if omitted will create a new GraphicsGeometry instance.
      */
     constructor(geometry: GraphicsGeometry = null)
     {


### PR DESCRIPTION
The `geometry` param of the `Graphics` constructor is currently documented as required which creates IDE warnings like the following:

![image](https://user-images.githubusercontent.com/2468703/175777627-47dd4300-67d5-4008-8c58-79f0bd573c5d.png)

This change denotes `geometry` as optional.

## Testing Done
```
npm run docs
```
![image](https://user-images.githubusercontent.com/2468703/175777656-6c56ba21-c6f6-43a8-916b-612bab93d46a.png)
