### PR TITLE
Fix incorrect `saturate` blend mode mapping

### DIFF
--- a/packages/canvas-renderer/src/utils/mapCanvasBlendModesToPixi.ts
+++ b/packages/canvas-renderer/src/utils/mapCanvasBlendModesToPixi.ts
@@ -9,6 +9,7 @@ import { canUseNewCanvasBlendModes } from './canUseNewCanvasBlendModes';
  * @param {string[]} [array=[]] - The array to output into.
  * @returns {string[]} Mapped modes.
  */
+// TODO after upgrading to typeScript 4.6, replace `string[]` with `GlobalCompositeOperation[]`
 export function mapCanvasBlendModesToPixi(array: string[] = []): string[]
 {
     if (canUseNewCanvasBlendModes())
@@ -27,7 +28,7 @@ export function mapCanvasBlendModesToPixi(array: string[] = []): string[]
         array[BLEND_MODES.DIFFERENCE] = 'difference';
         array[BLEND_MODES.EXCLUSION] = 'exclusion';
         array[BLEND_MODES.HUE] = 'hue';
-        array[BLEND_MODES.SATURATION] = 'saturate';
+        array[BLEND_MODES.SATURATION] = 'saturation';
         array[BLEND_MODES.COLOR] = 'color';
         array[BLEND_MODES.LUMINOSITY] = 'luminosity';
     }


### PR DESCRIPTION
Fixes #8457

##### Description of change

- Replace incorrect `saturate` value for blend mode mapping with `saturation`
- ~Add `dom` lib to the `tsconfig.json` so we can use the `GlobalCompositeOperation` type to avoid this kind of error~ (needs ts 4.6+)

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
