### PR TITLE
Update asset parsers to use extensions API

### DIFF
--- a/packages/assets/src/cache/Cache.ts
+++ b/packages/assets/src/cache/Cache.ts
@@ -54,7 +54,6 @@ class CacheClass
     /** Clear all entries. */
     public reset(): void
     {
-        this.parsers.length = 0;
         this._cacheMap.clear();
         this._cache.clear();
     }

--- a/packages/assets/src/cache/CacheParser.ts
+++ b/packages/assets/src/cache/CacheParser.ts
@@ -1,3 +1,5 @@
+import type { ExtensionMetadata } from '@pixi/core';
+
 /**
  * For every asset that is cached, it will call the parsers test function
  * the flow is as follows:
@@ -10,6 +12,11 @@
  */
 export interface CacheParser<T=any>
 {
+    extension?: ExtensionMetadata;
+
+    /** A config to adjust the parser */
+    config?: Record<string, any>
+
     /**
      * Gets called by the cache when a dev caches an asset
      * @param asset - the asset to test

--- a/packages/assets/src/cache/parsers/cacheSpritesheet.ts
+++ b/packages/assets/src/cache/parsers/cacheSpritesheet.ts
@@ -1,3 +1,4 @@
+import { ExtensionType } from '@pixi/core';
 import { Spritesheet } from '@pixi/spritesheet';
 import { dirname } from '../../utils';
 import type { CacheParser } from '../CacheParser';
@@ -32,8 +33,7 @@ function getCacheableAssets(keys: string[], asset: Spritesheet, ignoreMultiPack:
 }
 
 export const cacheSpritesheet: CacheParser<Spritesheet> = {
-
+    extension: ExtensionType.CacheParser,
     test: (asset: Spritesheet) => asset instanceof Spritesheet,
-
     getCacheableAssets: (keys: string[], asset: Spritesheet) => getCacheableAssets(keys, asset, false)
 };

--- a/packages/assets/src/cache/parsers/cacheTextureArray.ts
+++ b/packages/assets/src/cache/parsers/cacheTextureArray.ts
@@ -1,7 +1,8 @@
-import { Texture } from '@pixi/core';
+import { ExtensionType, Texture } from '@pixi/core';
 import type { CacheParser } from '../CacheParser';
 
 export const cacheTextureArray: CacheParser<Texture[]> = {
+    extension: ExtensionType.CacheParser,
 
     test: (asset: any[]) => Array.isArray(asset) && asset.every((t) => t instanceof Texture),
 

--- a/packages/assets/src/loader/Loader.ts
+++ b/packages/assets/src/loader/Loader.ts
@@ -25,8 +25,6 @@ export class Loader
     public reset(): void
     {
         this.promiseCache = {};
-
-        this.parsers.length = 0;
     }
 
     /**

--- a/packages/assets/src/loader/parsers/LoaderParser.ts
+++ b/packages/assets/src/loader/parsers/LoaderParser.ts
@@ -1,3 +1,4 @@
+import type { ExtensionMetadata } from '@pixi/core';
 import type { Loader } from '../Loader';
 import type { LoadAsset } from '../types';
 
@@ -17,6 +18,10 @@ import type { LoadAsset } from '../types';
  */
 export interface LoaderParser<ASSET = any, META_DATA = any>
 {
+    extension?: ExtensionMetadata;
+
+    /** A config to adjust the parser */
+    config?: Record<string, any>
     /**
      * each URL to load will be tested here,
      * if the test is passed the assets are loaded using the load function below.

--- a/packages/assets/src/loader/parsers/loadBasis.ts
+++ b/packages/assets/src/loader/parsers/loadBasis.ts
@@ -1,4 +1,4 @@
-import { BaseTexture, Texture } from '@pixi/core';
+import { BaseTexture, ExtensionType, Texture } from '@pixi/core';
 
 import type { LoaderParser } from './LoaderParser';
 import { BasisParser, BASIS_FORMATS, BASIS_FORMAT_TO_TYPE,  TranscoderWorker } from '@pixi/basis';
@@ -7,11 +7,14 @@ import { ALPHA_MODES, FORMATS, MIPMAP_MODES } from '@pixi/constants';
 import { CompressedTextureResource } from '@pixi/compressed-textures';
 import type { LoadAsset } from '../types';
 import type { Loader } from '../Loader';
+import type { LoadTextureData } from './loadTexture';
 
 const validImages = ['basis'];
 
 /** Load BASIS textures! */
 export const loadBasis = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         const tempURL = url.split('?')[0];
@@ -72,5 +75,5 @@ export const loadBasis = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], {baseTexture: BaseTexture}>;
+} as LoaderParser<Texture | Texture[], LoadTextureData>;
 

--- a/packages/assets/src/loader/parsers/loadBitmapFont.ts
+++ b/packages/assets/src/loader/parsers/loadBitmapFont.ts
@@ -1,4 +1,5 @@
 import type { Texture } from '@pixi/core';
+import { ExtensionType } from '@pixi/core';
 import type { BitmapFontData } from '@pixi/text-bitmap';
 import { BitmapFont, TextFormat, XMLFormat, XMLStringFormat } from '@pixi/text-bitmap';
 import { dirname, extname, join } from '../../utils/path';
@@ -31,6 +32,8 @@ const validExtensions = ['.xml', '.fnt'];
 
 /** simple loader plugin for loading in bitmap fonts! */
 export const loadBitmapFont = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         return validExtensions.includes(extname(url));

--- a/packages/assets/src/loader/parsers/loadDDS.ts
+++ b/packages/assets/src/loader/parsers/loadDDS.ts
@@ -1,4 +1,4 @@
-import { BaseTexture, Texture } from '@pixi/core';
+import { BaseTexture, ExtensionType, Texture } from '@pixi/core';
 import { getResolutionOfUrl } from '@pixi/utils';
 import { parseDDS } from '@pixi/compressed-textures';
 import type { Loader } from '../Loader';
@@ -6,11 +6,14 @@ import type { Loader } from '../Loader';
 import type { LoaderParser } from './LoaderParser';
 import type { LoadAsset } from '../types';
 import { ALPHA_MODES, MIPMAP_MODES } from '@pixi/constants';
+import type { LoadTextureData } from './loadTexture';
 
 const validImages = ['dds'];
 
 /** Load our DDS textures! */
-export const loadDDS = {
+export const loadDDS: LoaderParser = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         const tempURL = url.split('?')[0];
@@ -62,5 +65,5 @@ export const loadDDS = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], {baseTexture: BaseTexture}>;
+} as LoaderParser<Texture | Texture[], LoadTextureData>;
 

--- a/packages/assets/src/loader/parsers/loadJson.ts
+++ b/packages/assets/src/loader/parsers/loadJson.ts
@@ -1,8 +1,11 @@
+import { ExtensionType } from '@pixi/core';
 import { extname } from '../../utils/path';
 import type { LoaderParser } from './LoaderParser';
 
 /** simple loader plugin for loading json data */
 export const loadJson = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         return (extname(url).includes('.json'));

--- a/packages/assets/src/loader/parsers/loadKTX.ts
+++ b/packages/assets/src/loader/parsers/loadKTX.ts
@@ -1,4 +1,4 @@
-import { BaseTexture, Texture } from '@pixi/core';
+import { BaseTexture, ExtensionType, Texture } from '@pixi/core';
 import { parseKTX } from '@pixi/compressed-textures';
 import type { Loader } from '../Loader';
 
@@ -7,11 +7,14 @@ import type { LoaderParser } from './LoaderParser';
 import { getResolutionOfUrl } from '@pixi/utils';
 import type { LoadAsset } from '../types';
 import { ALPHA_MODES, MIPMAP_MODES } from '@pixi/constants';
+import type { LoadTextureData } from './loadTexture';
 
 const validImages = ['ktx'];
 
 /** Loads KTX textures! */
 export const loadKTX = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         const tempURL = url.split('?')[0];
@@ -77,5 +80,5 @@ export const loadKTX = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], {baseTexture: BaseTexture}>;
+} as LoaderParser<Texture | Texture[], LoadTextureData>;
 

--- a/packages/assets/src/loader/parsers/loadSpritesheet.ts
+++ b/packages/assets/src/loader/parsers/loadSpritesheet.ts
@@ -1,4 +1,5 @@
 import type { Texture } from '@pixi/core';
+import { ExtensionType } from '@pixi/core';
 import type { ISpritesheetData } from '@pixi/spritesheet';
 import { Spritesheet } from '@pixi/spritesheet';
 
@@ -25,6 +26,8 @@ interface SpriteSheetJson extends ISpritesheetData
  * All textures in the sprite sheet are then added to the cache
  */
 export const loadSpritesheet = {
+    extension: ExtensionType.LoadParser,
+
     testParse(asset: SpriteSheetJson, options: LoadAsset): boolean
     {
         return (extname(options.src).includes('.json') && !!asset.frames);

--- a/packages/assets/src/loader/parsers/loadTxt.ts
+++ b/packages/assets/src/loader/parsers/loadTxt.ts
@@ -1,8 +1,11 @@
+import { ExtensionType } from '@pixi/core';
 import { extname } from '../../utils/path';
 import type { LoaderParser } from './LoaderParser';
 
 /** Simple loader plugin for loading text data */
 export const loadTxt = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         return (extname(url).includes('.txt'));

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -1,3 +1,4 @@
+import { ExtensionType } from '@pixi/core';
 import { basename, extname } from '../../utils/path';
 import type { LoadAsset } from '../types';
 import type { LoaderParser } from './LoaderParser';
@@ -42,6 +43,8 @@ export function getFontFamilyName(url: string): string
 
 /** Web font loader plugin */
 export const loadWebFont = {
+    extension: ExtensionType.LoadParser,
+
     test(url: string): boolean
     {
         const tempURL = url.split('?')[0];

--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -103,7 +103,6 @@ export class Resolver
     /** Used for testing, this resets the resolver to its initial state */
     public reset(): void
     {
-        this._parsers = [];
         this._preferredOrder = [];
 
         this._resolverHash = {};

--- a/packages/assets/src/resolver/parsers/spriteSheetUrlParser.ts
+++ b/packages/assets/src/resolver/parsers/spriteSheetUrlParser.ts
@@ -1,9 +1,12 @@
+import { ExtensionType } from '@pixi/core';
 import { settings } from '@pixi/settings';
-import type { ResolveAsset } from '../types';
+import type { ResolveAsset, ResolveURLParser } from '../types';
 
 const validImages = ['jpg', 'png', 'jpeg', 'avif', 'webp'];
 
 export const spriteSheetUrlParser = {
+    extension: ExtensionType.ResolveParser,
+
     test: (value: string): boolean =>
     {
         const tempURL = value.split('?')[0];
@@ -25,4 +28,4 @@ export const spriteSheetUrlParser = {
             src: value,
         };
     },
-};
+} as ResolveURLParser;

--- a/packages/assets/src/resolver/parsers/textureUrlParser.ts
+++ b/packages/assets/src/resolver/parsers/textureUrlParser.ts
@@ -1,9 +1,11 @@
+import { ExtensionType } from '@pixi/core';
 import { settings } from '@pixi/settings';
 
 import { loadTextures } from '../../loader';
-import type { ResolveAsset } from '../types';
+import type { ResolveAsset, ResolveURLParser } from '../types';
 
 export const textureUrlParser = {
+    extension: ExtensionType.ResolveParser,
     test: loadTextures.test,
     parse: (value: string): ResolveAsset =>
         ({
@@ -11,4 +13,4 @@ export const textureUrlParser = {
             format: value.split('.').pop(),
             src: value,
         }),
-};
+} as ResolveURLParser;

--- a/packages/assets/src/resolver/types.ts
+++ b/packages/assets/src/resolver/types.ts
@@ -1,3 +1,5 @@
+import type { ExtensionMetadata } from '@pixi/core';
+
 /**
  * A prefer order lets the resolver know which assets to prefere depending on the various parameters passed to it.
  * @memberof PIXI
@@ -6,7 +8,6 @@ export interface PreferOrder
 {
     /** the importance order of the params */
     priority?: string[];
-    // TODO @bigtimebuddy -need a better name than prepare..
     params: {
         [key: string]: any;
     };
@@ -55,6 +56,9 @@ export type ResolverManifest = {
  */
 export interface ResolveURLParser
 {
+    extension?: ExtensionMetadata;
+    /** A config to adjust the parser */
+    config?: Record<string, any>
     /** the test to perform on the url to determin if it should be parsed */
     test: (url: string) => boolean;
     /** the function that will convert the url into an object */

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -137,7 +137,6 @@ describe('Assets', () =>
             manifest: 'json/asset-manifest-2.json',
         });
 
-        // TODO if its an array of one.. return the single object
         const assets = await Assets.loadBundle(['default', 'data']);
 
         expect(assets.default.bunny).toBeInstanceOf(Texture);
@@ -189,9 +188,6 @@ describe('Assets', () =>
 
         await Assets.load('textures/bunny.png');
 
-        // TODO - this src will be added in the future..
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         expect(bunny.baseTexture.resource.src).toBe(`${basePath}textures/bunny.png`);
     });
 
@@ -208,9 +204,6 @@ describe('Assets', () =>
 
         await Assets.load('textures/bunny.png');
 
-        // TODO - this src will be added in the future..
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         expect(bunny.baseTexture.resource.src).toBe(`${basePath}textures/bunny.png`);
     });
 
@@ -228,9 +221,6 @@ describe('Assets', () =>
         const asset = await Assets.loader.promiseCache[`${basePath}textures/bunny.png`].promise;
 
         expect(asset).toBeInstanceOf(Texture);
-        // TODO - this src will be added in the future..
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         expect(asset.baseTexture.resource.src).toBe(`${basePath}textures/bunny.png`);
     });
 

--- a/packages/assets/test/cache.tests.ts
+++ b/packages/assets/test/cache.tests.ts
@@ -21,17 +21,18 @@ describe('Cache', () =>
     beforeEach(() =>
     {
         Cache.reset();
+        Cache.removeParser(testParser);
     });
 
     it('should add and remove a plugin', () =>
     {
         Cache.addParser(testParser);
 
-        expect(Cache.parsers).toHaveLength(1);
+        expect(Cache.parsers).toHaveLength(3);
 
         Cache.removeParser(testParser);
 
-        expect(Cache.parsers).toHaveLength(0);
+        expect(Cache.parsers).toHaveLength(2);
     });
 
     it('should process a custom parsers correctly', () =>

--- a/packages/core/src/extensions.ts
+++ b/packages/core/src/extensions.ts
@@ -13,6 +13,9 @@ enum ExtensionType
     RendererPlugin = 'renderer-webgl-plugin',
     CanvasRendererPlugin = 'renderer-canvas-plugin',
     Loader = 'loader',
+    LoadParser = 'load-parser',
+    ResolveParser = 'resolve-parser',
+    CacheParser = 'cache-parser',
 }
 
 interface ExtensionMetadataDetails
@@ -57,8 +60,8 @@ type ExtensionHandler = (extension: ExtensionFormat) => void;
  */
 const normalizeExtension = (ext: ExtensionFormatLoose | any): ExtensionFormat =>
 {
-    // Class submission, use extension object
-    if (typeof ext === 'function')
+    // Class/Object submission, use extension object
+    if (typeof ext === 'function' || (typeof ext === 'object' && ext.extension))
     {
         // #if _DEBUG
         if (!ext.extension)


### PR DESCRIPTION
Converts the parsers to use the new extensions API

Also adds a `config` option to each parser in case you want some customizability. e.g. `preferWorker` in the `loadTexture` parser 