### PR TITLE
Fix import issue in canvas-renderer

### DIFF
--- a/packages/canvas-display/global.d.ts
+++ b/packages/canvas-display/global.d.ts
@@ -1,5 +1,10 @@
 declare namespace GlobalMixins
 {
+    interface DisplayObject
+    {
+        renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
+    }
+
     interface Container
     {
         _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;

--- a/packages/canvas-renderer/global.d.ts
+++ b/packages/canvas-renderer/global.d.ts
@@ -21,11 +21,6 @@ declare namespace GlobalMixins
         tintId?: number;
     }
 
-    interface DisplayObject
-    {
-        renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
-    }
-
     interface IRendererOptions
     {
         forceCanvas?: boolean;
@@ -35,6 +30,11 @@ declare namespace GlobalMixins
     interface CanvasRenderer
     {
 
+    }
+
+    interface IRenderableObject
+    {
+        renderCanvas?(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }
 

--- a/packages/canvas-renderer/src/CanvasObjectRendererSystem.ts
+++ b/packages/canvas-renderer/src/CanvasObjectRendererSystem.ts
@@ -6,13 +6,13 @@ import type {
     ExtensionMetadata,
     IRendererRenderOptions,
     ISystem,
+    IRenderableObject,
     RenderTexture } from '@pixi/core';
 import {
     CanvasResource,
     ExtensionType } from '@pixi/core';
 import { BLEND_MODES } from '@pixi/constants';
 import { CanvasRenderTarget, hex2string, rgb2hex } from '@pixi/utils';
-import type { DisplayObject } from 'pixi.js';
 import type { CrossPlatformCanvasRenderingContext2D } from './CanvasContextSystem';
 
 /**
@@ -31,7 +31,7 @@ export class CanvasObjectRendererSystem implements ISystem
     /** A reference to the current renderer */
     private renderer: CanvasRenderer;
     renderingToScreen: boolean;
-    lastObjectRendered: DisplayObject;
+    lastObjectRendered: IRenderableObject;
 
     /** @param renderer - A reference to the current renderer */
     constructor(renderer: CanvasRenderer)
@@ -44,7 +44,7 @@ export class CanvasObjectRendererSystem implements ISystem
      * @param displayObject - The object to be rendered.
      * @param options - the options to be passed to the renderer
      */
-    public render(displayObject: DisplayObject, options?: IRendererRenderOptions): void
+    public render(displayObject: IRenderableObject, options?: IRendererRenderOptions): void
     {
         const renderer = this.renderer;
 

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -25,6 +25,12 @@ declare namespace GlobalMixins
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IRenderableObject
+    {
+
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface Renderer
     {
 

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -10,7 +10,7 @@ import type { SystemManager } from './system/SystemManager';
  * The minimum APIs needed to implement a renderable object.
  * @memberof PIXI
  */
-export interface IRenderableObject
+export interface IRenderableObject extends GlobalMixins.IRenderableObject
 {
     /** Object must have a parent container */
     parent: IRenderableContainer;


### PR DESCRIPTION
Cleanup a few issues related to package boundaries and removed the import from `pixi.js`