### PR TITLE
Chore: Remove Renderer cast in Accessibility

### DIFF
--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -6,7 +6,7 @@ import type { Rectangle } from '@pixi/math';
 import type { Container } from '@pixi/display';
 import { ExtensionType } from '@pixi/core';
 import type { IAccessibleHTMLElement } from './accessibleTarget';
-import type { IRenderer, ExtensionMetadata, Renderer } from '@pixi/core';
+import type { IRenderer, ExtensionMetadata } from '@pixi/core';
 import { FederatedEvent } from '@pixi/events';
 
 // add some extra variables to the container..
@@ -504,7 +504,7 @@ export class AccessibilityManager
     private _dispatchEvent(e: UIEvent, type: string[]): void
     {
         const { displayObject: target } = e.target as IAccessibleHTMLElement;
-        const boundry = (this.renderer as Renderer).events.rootBoundary;
+        const boundry = this.renderer.events.rootBoundary;
         const event: FederatedEvent = Object.assign(new FederatedEvent(boundry), { target });
 
         boundry.rootTarget = this.renderer.lastObjectRendered as DisplayObject;

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -37,6 +37,12 @@ declare namespace GlobalMixins
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IRenderer
+    {
+
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
     interface IRendererPlugins
     {
 

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -78,7 +78,7 @@ export interface IRendererRenderOptions
  * Starard Interface for a Pixi renderer.
  * @memberof PIXI
  */
-export interface IRenderer extends SystemManager
+export interface IRenderer extends SystemManager, GlobalMixins.IRenderer
 {
 
     resize(width: number, height: number): void;

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -7,6 +7,11 @@ declare namespace GlobalMixins
 
     }
 
+    interface IRenderer
+    {
+        readonly events: import('@pixi/events').EventSystem;
+    }
+
     interface Renderer
     {
         readonly events: import('@pixi/events').EventSystem;


### PR DESCRIPTION
Removes the need to cast as Renderer in accessibility by adding the EventSystem as an IRenderer member.