### PR TITLE
Upgrade to earcut 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10333,7 +10333,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/earcut": {
-      "version": "2.2.2",
+      "version": "2.2.4",
       "license": "ISC"
     },
     "node_modules/ecc-jsbn": {
@@ -25377,7 +25377,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       },
@@ -30016,7 +30016,7 @@
       "requires": {
         "@types/earcut": "^2.1.0",
         "css-color-names": "^1.0.1",
-        "earcut": "^2.2.2",
+        "earcut": "^2.2.4",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -33183,7 +33183,7 @@
       "dev": true
     },
     "earcut": {
-      "version": "2.2.2"
+      "version": "2.2.4"
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@types/earcut": "^2.1.0",
-    "earcut": "^2.2.2",
+    "earcut": "^2.2.4",
     "eventemitter3": "^3.1.0",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
> Changelog
>
> 2.2.4 (Jul 5, 2022)
>
> - Improved performance by 10–15%.
> - Fixed another rare race condition that could lead to an infinite loop.
> 
> 2.2.3 (Jul 8, 2021)
> 
> - Fixed a rare race condition that could lead to an infinite loop.

Shouldn't the latest version that matches the version constraint be automatically included before publishing? PIXI 6.4.2 was shipped with earcut 2.2.2, while 2.2.3 was already a year old and matches ^2.2.2.
