### PR TITLE
Fixes #7272 Cubemap resources not being reuploaded on GL context loss

### DIFF
--- a/packages/core/src/textures/resources/CubeResource.ts
+++ b/packages/core/src/textures/resources/CubeResource.ts
@@ -142,7 +142,7 @@ export class CubeResource extends AbstractMultiResource
         {
             const side = this.items[i];
 
-            if (dirty[i] < side.dirtyId)
+            if (dirty[i] < side.dirtyId || glTexture.dirtyId < _baseTexture.dirtyId)
             {
                 if (side.valid && side.resource)
                 {


### PR DESCRIPTION
##### Description of change
This fixes an issue where Cubemap resources were not being reuploaded during a GL context loss, breaking those textures for any display objects relying on them. (#7272)

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
