### PR TITLE
Rename resolver parsers

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -15,7 +15,7 @@ import {
 import { Loader } from './loader/Loader';
 import { loadBitmapFont } from './loader/parsers/loadBitmapFont';
 import type { PreferOrder, ResolveAsset, ResolverBundle, ResolverManifest, ResolveURLParser } from './resolver';
-import { spriteSheetUrlParser, textureUrlParser } from './resolver';
+import { resolveSpriteSheetUrl, resolveTextureUrl } from './resolver';
 import { Resolver } from './resolver/Resolver';
 import { convertToList } from './utils/convertToList';
 import { detectAvif } from './utils/detections/detectAvif';
@@ -803,6 +803,6 @@ extensions.add(
     cacheTextureArray,
 
     // resolve extensions
-    textureUrlParser,
-    spriteSheetUrlParser
+    resolveTextureUrl,
+    resolveSpriteSheetUrl
 );

--- a/packages/assets/src/resolver/parsers/index.ts
+++ b/packages/assets/src/resolver/parsers/index.ts
@@ -1,2 +1,2 @@
-export * from './spriteSheetUrlParser';
-export * from './textureUrlParser';
+export * from './resolveSpriteSheetUrl';
+export * from './resolveTextureUrl';

--- a/packages/assets/src/resolver/parsers/resolveSpriteSheetUrl.ts
+++ b/packages/assets/src/resolver/parsers/resolveSpriteSheetUrl.ts
@@ -4,7 +4,7 @@ import type { ResolveAsset, ResolveURLParser } from '../types';
 
 const validImages = ['jpg', 'png', 'jpeg', 'avif', 'webp'];
 
-export const spriteSheetUrlParser = {
+export const resolveSpriteSheetUrl = {
     extension: ExtensionType.ResolveParser,
 
     test: (value: string): boolean =>

--- a/packages/assets/src/resolver/parsers/resolveTextureUrl.ts
+++ b/packages/assets/src/resolver/parsers/resolveTextureUrl.ts
@@ -4,7 +4,7 @@ import { settings } from '@pixi/settings';
 import { loadTextures } from '../../loader';
 import type { ResolveAsset, ResolveURLParser } from '../types';
 
-export const textureUrlParser = {
+export const resolveTextureUrl = {
     extension: ExtensionType.ResolveParser,
     test: loadTextures.test,
     parse: (value: string): ResolveAsset =>

--- a/packages/assets/test/resolver.tests.ts
+++ b/packages/assets/test/resolver.tests.ts
@@ -1,4 +1,4 @@
-import { spriteSheetUrlParser, textureUrlParser } from '@pixi/assets';
+import { resolveSpriteSheetUrl, resolveTextureUrl } from '@pixi/assets';
 import { Resolver } from '../src/resolver/Resolver';
 import { manifest } from './sampleManifest';
 
@@ -104,7 +104,7 @@ describe('Resolver', () =>
             },
         });
 
-        resolver.addUrlParser(textureUrlParser);
+        resolver.addUrlParser(resolveTextureUrl);
 
         resolver.add('test', [
             'profile-abel@0.5x.jpg',
@@ -277,7 +277,7 @@ describe('Resolver', () =>
             },
         });
 
-        resolver.addUrlParser(textureUrlParser);
+        resolver.addUrlParser(resolveTextureUrl);
 
         resolver.add('test', [
             'my-image@4x.webp',
@@ -452,13 +452,13 @@ describe('Resolver', () =>
             },
         ].forEach((toTest) =>
         {
-            const pass = spriteSheetUrlParser.test(toTest.url);
+            const pass = resolveSpriteSheetUrl.test(toTest.url);
 
             expect(pass).toBe(toTest.pass);
 
             if (pass)
             {
-                expect(spriteSheetUrlParser.parse(toTest.url)).toEqual(toTest.result);
+                expect(resolveSpriteSheetUrl.parse(toTest.url)).toEqual(toTest.result);
             }
         });
     });


### PR DESCRIPTION
all the other parsers have a prefix e.g. `cacheX`/`loadX`

this PR just makes the resolver parsers consistent with that convention