### PR TITLE
Feat/transform feedback

### DIFF
--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -29,6 +29,7 @@ import type { ISystemConstructor } from './ISystem';
 import type { IRenderingContext } from './IRenderingContext';
 import type { IRenderableObject } from './IRenderableObject';
 import { extensions, ExtensionType } from './extensions';
+import { TransformFeedbackSystem } from './transformFeedback/transformFeedbackSystem';
 
 export interface IRendererPluginConstructor
 {
@@ -136,6 +137,12 @@ export class Renderer extends AbstractRenderer
      * @readonly
      */
     public buffer: BufferSystem;
+
+    /**
+     * TransformFeedback system instance
+     * @readonly
+     */
+    public transformFeedback: TransformFeedbackSystem;
 
     /**
      * Geometry system instance
@@ -284,6 +291,7 @@ export class Renderer extends AbstractRenderer
             .addSystem(ShaderSystem, 'shader')
             .addSystem(TextureSystem, 'texture')
             .addSystem(BufferSystem, 'buffer')
+            .addSystem(TransformFeedbackSystem, 'transformFeedback')
             .addSystem(GeometrySystem, 'geometry')
             .addSystem(FramebufferSystem, 'framebuffer')
             .addSystem(ScissorSystem, 'scissor')

--- a/packages/core/src/geometry/BufferSystem.ts
+++ b/packages/core/src/geometry/BufferSystem.ts
@@ -4,6 +4,7 @@ import type { Renderer } from '../Renderer';
 import type { IRenderingContext } from '../IRenderingContext';
 import type { Buffer } from './Buffer';
 import type { ISystem } from '../ISystem';
+import type { BUFFER_TYPE } from '@pixi/constants';
 
 /**
  * System plugin to the renderer to manage buffers.
@@ -77,6 +78,13 @@ export class BufferSystem implements ISystem
         gl.bindBuffer(buffer.type, glBuffer.buffer);
     }
 
+    unbind(type: BUFFER_TYPE): void
+    {
+        const { gl } = this;
+
+        gl.bindBuffer(type, null);
+    }
+
     /**
      * Binds an uniform buffer to at the given index.
      *
@@ -89,20 +97,6 @@ export class BufferSystem implements ISystem
         const { gl } = this;
 
         this.bindBufferBase(gl.UNIFORM_BUFFER, buffer, index);
-    }
-
-    /**
-     * Binds an transform feedback buffer to at the given index.
-     *
-     * A cache is used so a buffer will not be bound again if already bound.
-     * @param buffer - the buffer to bind
-     * @param index - the base index to bind it to.
-     */
-    bindTransformFeedbackBufferBase(buffer: Buffer, index: number): void
-    {
-        const { gl } = this;
-
-        this.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, buffer, index);
     }
 
     /**
@@ -153,7 +147,7 @@ export class BufferSystem implements ISystem
     {
         const { gl, CONTEXT_UID } = this;
 
-        const glBuffer = buffer._glBuffers[CONTEXT_UID];
+        const glBuffer = buffer._glBuffers[CONTEXT_UID] || this.createGLBuffer(buffer);
 
         if (buffer._updateID === glBuffer.updateID)
         {

--- a/packages/core/src/geometry/BufferSystem.ts
+++ b/packages/core/src/geometry/BufferSystem.ts
@@ -84,7 +84,36 @@ export class BufferSystem implements ISystem
      * @param buffer - the buffer to bind
      * @param index - the base index to bind it to.
      */
-    bindBufferBase(buffer: Buffer, index: number): void
+    bindUniformBufferBase(buffer: Buffer, index: number): void
+    {
+        const { gl } = this;
+
+        this.bindBufferBase(gl.UNIFORM_BUFFER, buffer, index);
+    }
+
+    /**
+     * Binds an transform feedback buffer to at the given index.
+     *
+     * A cache is used so a buffer will not be bound again if already bound.
+     * @param buffer - the buffer to bind
+     * @param index - the base index to bind it to.
+     */
+    bindTransformFeedbackBufferBase(buffer: Buffer, index: number): void
+    {
+        const { gl } = this;
+
+        this.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, buffer, index);
+    }
+
+    /**
+     * Binds an buffer base to at the given index.
+     *
+     * A cache is used so a buffer will not be bound again if already bound.
+     * @param target - the target to bind
+     * @param buffer - the buffer to bind
+     * @param index - the base index to bind it to.
+     */
+    protected bindBufferBase(target: number, buffer: Buffer, index: number): void
     {
         const { gl, CONTEXT_UID } = this;
 
@@ -94,7 +123,7 @@ export class BufferSystem implements ISystem
 
             this.boundBufferBases[index] = buffer;
 
-            gl.bindBufferBase(gl.UNIFORM_BUFFER, index, glBuffer.buffer);
+            gl.bindBufferBase(target, index, glBuffer.buffer);
         }
     }
 

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -1,5 +1,5 @@
 import type { GLBuffer } from './GLBuffer';
-import { ENV } from '@pixi/constants';
+import { BUFFER_TYPE, ENV } from '@pixi/constants';
 import { settings } from '../settings';
 
 import type { ISystem } from '../ISystem';
@@ -333,6 +333,7 @@ export class GeometrySystem implements ISystem
             }
         }
 
+        // @TODO: We don't know if VAO is supported.
         vao = gl.createVertexArray();
 
         gl.bindVertexArray(vao);
@@ -356,11 +357,12 @@ export class GeometrySystem implements ISystem
 
         this.activateVao(geometry, program);
 
-        this._activeVao = vao;
-
         // add it to the cache!
         vaoObjectHash[program.id] = vao;
         vaoObjectHash[signature] = vao;
+
+        gl.bindVertexArray(null);
+        bufferSystem.unbind(BUFFER_TYPE.ARRAY_BUFFER);
 
         return vao;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,4 +48,5 @@ export * from './geometry/Attribute';
 export * from './geometry/Buffer';
 export * from './geometry/Geometry';
 export * from './geometry/ViewableBuffer';
+export * from './transformFeedback/transformFeedback';
 export * from './deprecations';

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -30,6 +30,14 @@ export interface IUniformData
     name: string;
 }
 
+export interface IProgramExtraData
+{
+    transformFeedbackVaryings?: {
+        names: string[],
+        bufferMode: 'seperate' | 'interleaved'
+    }
+}
+
 /**
  * Helper class to create a shader program.
  * @memberof PIXI
@@ -54,12 +62,15 @@ export class Program
     /** Assigned when a program is first bound to the shader system. */
     uniformData: {[key: string]: IUniformData};
 
+    extra: IProgramExtraData = {};
+
     /**
      * @param vertexSrc - The source of the vertex shader.
      * @param fragmentSrc - The source of the fragment shader.
      * @param name - Name for shader
+     * @param extra - Extra data for shader
      */
-    constructor(vertexSrc?: string, fragmentSrc?: string, name = 'pixi-shader')
+    constructor(vertexSrc?: string, fragmentSrc?: string, name = 'pixi-shader', extra: IProgramExtraData = {})
     {
         this.id = UID++;
         this.vertexSrc = vertexSrc || Program.defaultVertexSrc;
@@ -67,6 +78,8 @@ export class Program
 
         this.vertexSrc = this.vertexSrc.trim();
         this.fragmentSrc = this.fragmentSrc.trim();
+
+        this.extra = extra;
 
         if (this.vertexSrc.substring(0, 8) !== '#version')
         {

--- a/packages/core/src/shader/ShaderSystem.ts
+++ b/packages/core/src/shader/ShaderSystem.ts
@@ -195,7 +195,7 @@ export class ShaderSystem implements ISystem
             );
         }
 
-        this.renderer.buffer.bindBufferBase(group.buffer, glProgram.uniformBufferBindings[name]);
+        this.renderer.buffer.bindUniformBufferBase(group.buffer, glProgram.uniformBufferBindings[name]);
     }
 
     /**

--- a/packages/core/src/shader/utils/generateProgram.ts
+++ b/packages/core/src/shader/utils/generateProgram.ts
@@ -29,7 +29,9 @@ export function generateProgram(gl: IRenderingContext, program: Program): GLProg
     {
         if (typeof gl.transformFeedbackVaryings !== 'function')
         {
+            // #if _DEBUG
             console.warn(`TransformFeedback is not supported but TransformFeedbackVaryings are given.`);
+            // #endif
         }
         else
         {

--- a/packages/core/src/shader/utils/generateProgram.ts
+++ b/packages/core/src/shader/utils/generateProgram.ts
@@ -23,6 +23,26 @@ export function generateProgram(gl: IRenderingContext, program: Program): GLProg
     gl.attachShader(webGLProgram, glVertShader);
     gl.attachShader(webGLProgram, glFragShader);
 
+    const transformFeedbackVaryings = program.extra?.transformFeedbackVaryings;
+
+    if (transformFeedbackVaryings)
+    {
+        if (typeof gl.transformFeedbackVaryings !== 'function')
+        {
+            console.warn(`TransformFeedback is not supported but TransformFeedbackVaryings are given.`);
+        }
+        else
+        {
+            gl.transformFeedbackVaryings(
+                webGLProgram,
+                transformFeedbackVaryings.names,
+                transformFeedbackVaryings.bufferMode === 'seperate'
+                    ? gl.SEPARATE_ATTRIBS
+                    : gl.INTERLEAVED_ATTRIBS
+            );
+        }
+    }
+
     gl.linkProgram(webGLProgram);
 
     if (!gl.getProgramParameter(webGLProgram, gl.LINK_STATUS))

--- a/packages/core/src/systems.ts
+++ b/packages/core/src/systems.ts
@@ -12,3 +12,4 @@ export * from './shader/ShaderSystem';
 export * from './state/StateSystem';
 export * from './textures/TextureGCSystem';
 export * from './textures/TextureSystem';
+export * from './transformFeedback/TransformFeedbackSystem';

--- a/packages/core/src/transformFeedback/TransformFeedback.ts
+++ b/packages/core/src/transformFeedback/TransformFeedback.ts
@@ -1,0 +1,29 @@
+import { Runner } from '@pixi/runner';
+import type { Buffer } from 'pixi.js';
+
+export class TransformFeedback
+{
+    _glTransformFeedbacks: {[key: number]: WebGLTransformFeedback};
+
+    buffers: Buffer[];
+
+    disposeRunner: Runner;
+
+    constructor()
+    {
+        this._glTransformFeedbacks = {};
+        this.buffers = [];
+        this.disposeRunner = new Runner('disposeTransformFeedback');
+    }
+
+    bindBuffer(index: number, buffer: Buffer)
+    {
+        this.buffers[index] = buffer;
+    }
+
+    /** Destroy WebGL resources that are connected to this TransformFeedback. */
+    destroy(): void
+    {
+        this.disposeRunner.emit(this, false);
+    }
+}

--- a/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
+++ b/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
@@ -1,0 +1,160 @@
+import type { ISystem, IRenderingContext, Renderer, Shader } from '@pixi/core';
+import type { DRAW_MODES } from '@pixi/constants';
+import type { TransformFeedback } from './TransformFeedback';
+
+export class TransformFeedbackSystem implements ISystem
+{
+    CONTEXT_UID: number;
+    gl: IRenderingContext;
+
+    private renderer: Renderer;
+
+    /**
+     * @param {PIXI.Renderer} renderer - The renderer this System works for.
+     */
+    constructor(renderer: Renderer)
+    {
+        this.renderer = renderer;
+    }
+
+    /** Sets up the renderer context and necessary buffers. */
+    protected contextChange(): void
+    {
+        this.gl = this.renderer.gl;
+
+        // TODO fill out...
+        this.CONTEXT_UID = this.renderer.CONTEXT_UID;
+    }
+
+    /**
+     * Bind TransformFeedback and bindBufferBase
+     * @param transformFeedback TransformFeedback to bind
+     */
+    bind(transformFeedback: TransformFeedback)
+    {
+        const { gl, CONTEXT_UID } = this;
+
+        const glTransformFeedback = transformFeedback._glTransformFeedbacks[CONTEXT_UID]
+          || this.createGLTransformFeedback(transformFeedback);
+
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, glTransformFeedback);
+    }
+
+    /** Unbind TransformFeedback */
+    unbind()
+    {
+        const { gl } = this;
+
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+    }
+
+    /**
+     * Begin TransformFeedback
+     * @param shader A Shader used by TransformFeedback
+     * @param drawMode DrawMode for TransformFeedback
+     */
+    beginTransfromFeedback(shader: Shader, drawMode: DRAW_MODES)
+    {
+        const { gl, renderer } = this;
+
+        renderer.shader.bind(shader);
+
+        gl.beginTransformFeedback(drawMode);
+    }
+
+    /** End TransformFeedback */
+    endTransformFeedback()
+    {
+        const { gl } = this;
+
+        gl.endTransformFeedback();
+    }
+
+    /**
+     * Create TransformFeedback and bind buffers
+     * @param tf TransformFeedback
+     * @returns WebGLTransformFeedback
+     */
+    protected createGLTransformFeedback(tf: TransformFeedback)
+    {
+        const { gl, renderer, CONTEXT_UID } = this;
+
+        const glTransformFeedback = gl.createTransformFeedback();
+
+        tf._glTransformFeedbacks[CONTEXT_UID] = glTransformFeedback;
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, glTransformFeedback);
+        for (let i = 0; i < tf.buffers.length; i++)
+        {
+            const buffer = tf.buffers[i];
+
+            if (!buffer) continue;
+
+            renderer.buffer.update(buffer);
+            buffer._glBuffers[CONTEXT_UID].refCount++;
+
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, i, buffer._glBuffers[CONTEXT_UID].buffer || null);
+        }
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+
+        tf.disposeRunner.add(this);
+
+        return glTransformFeedback;
+    }
+
+    /**
+     * Disposes TransfromFeedback
+     * @param {PIXI.TransformFeedback} tf - TransformFeedback
+     * @param {boolean} [contextLost=false] - If context was lost, we suppress delete TransformFeedback
+     */
+    disposeTransformFeedback(tf: TransformFeedback, contextLost?: boolean): void
+    {
+        const glTF = tf._glTransformFeedbacks[this.CONTEXT_UID];
+        const gl = this.gl;
+
+        tf.disposeRunner.remove(this);
+
+        const bufferSystem = this.renderer.buffer;
+
+        // bufferSystem may have already been destroyed..
+        // if this is the case, there is no need to destroy the geometry buffers...
+        // they already have been!
+        if (bufferSystem)
+        {
+            for (let i = 0; i < tf.buffers.length; i++)
+            {
+                const buffer = tf.buffers[i];
+
+                if (!buffer) continue;
+
+                const buf = buffer._glBuffers[this.CONTEXT_UID];
+
+                // my be null as context may have changed right before the dispose is called
+                if (buf)
+                {
+                    buf.refCount--;
+                    if (buf.refCount === 0 && !contextLost)
+                    {
+                        bufferSystem.dispose(buffer, contextLost);
+                    }
+                }
+            }
+        }
+
+        if (!glTF)
+        {
+            return;
+        }
+
+        if (!contextLost)
+        {
+            gl.deleteTransformFeedback(glTF);
+        }
+
+        delete tf._glTransformFeedbacks[this.CONTEXT_UID];
+    }
+
+    destroy(): void
+    {
+        // @TODO: Destroy managed TransformFeedbacks
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

I have enthusiasm to add GPUParticle to PixiJS world.

There're various ways to implement GPUParitlce and I choose to use TransformFeedback.

To do that, I've implemented TransformFeedbackSystem.

TransformFeedbackSystem manages stuffs related to TransformFeedback.

Then, we can make a GPUParticle with existing PIXI classes like `Mesh`, `Shader`.

```ts
class GPUParticle extends Container
{
    // Meshes to update Particle data
    particleUpdateMeshes: Mesh<Shader>[];
    // TransformFeedbacks
    transformFeedbacks: TransformFeedback[];
    // Meshes to render Particle data
    particleRenderMeshes: Mesh<Shader>[];

    inputFlag = 0;

    particleUpdateShader: Shader;
    particleRenderShader: Shader;

    constructor()
    {
        this.particleUpdateShader = new Shader(vert, frag, 'ParticleUpdate', {
            transformFeedbackVaryings: {
                names: ['out_Position', 'out_Age'],
                bufferMode: 'separate'
            }
        });

        this.particleRenderShader = new Shader(vert, frag, 'ParticleRender');
        
        // Create two particleUpdateMeshes with particleUpdateShader
        this.particleUpdateMeshes.push(this.createParticleUpdateMesh());
        this.particleUpdateMeshes.push(this.createParticleUpdateMesh());
        
        // Create two particleRenderMeshes with particleRenderShader
        this.particleRenderMeshes.push(this.createParticleRenderMesh());
        this.particleRenderMeshes.push(this.createParticleRenderMesh());

        const transformFeedback1 = new TransformFeedback();
        transformFeedback.bindBuffer(0, particleUpdateMeshes[1].geometry.getBuffer('in_Position'));
        transformFeedback.bindBuffer(1, particleUpdateMeshes[1].geometry.getBuffer('in_Age'));
        transformFeedbacks.push(transformFeedback1);

        // Create transformFeedback2
        // ....

        protected _render(renderer: Renderer): void
        {
                const inputFlag = this.inputFlag;

                const updateMesh = this.particleUpdateMeshes[inputFlag];
                const renderMesh = this.particleRenderMeshes[inputFlag];
                const transformFeedback.= this.transformFeedbacks[inputFlag];

                renderer.gl.enable(renderer.gl.RASTERIZER_DISCARD);

                // Update Particle
                renderer.transformFeedback.bind(transformFeedback);
                renderer.transformFeedback.beginTransformFeedback(updateMesh.shader, DRAW_MODES.POINTS);
                updateMesh.render(renderer);
                renderer.transformFeedback.endTransformFeedback();
                renderer.transformFeedback.unbind();

                renderer.gl.disable(renderer.gl.RASTERIZER_DISCARD);

                // Render Particle
                renderMesh.render(renderer);

                this.inputFlag = inputFlag ? 0 : 1;
        }
}
```

![Jul-14-2022 15-09-13](https://user-images.githubusercontent.com/17820596/178912314-4298bf45-b5ef-48f5-8d40-25007583e2b4.gif)



##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
