### PR TITLE
remove add/remove parsers

### DIFF
--- a/packages/assets/src/cache/Cache.ts
+++ b/packages/assets/src/cache/Cache.ts
@@ -19,37 +19,13 @@ import type { CacheParser } from './CacheParser';
  */
 class CacheClass
 {
-    /** All loader parsers registered */
-    public parsers: CacheParser[] = [];
+    private _parsers: CacheParser[] = [];
 
     private readonly _cache: Map<string, any> = new Map();
     private readonly _cacheMap: Map<string, {
         keys: string[],
         cacheKeys: string[],
     }> = new Map();
-
-    /**
-     * Use this to add any parsers to the `cache.set` function to
-     * @param newParsers - An array of parsers to add to the cache or just a single one
-     */
-    public addParser(...newParsers: CacheParser[]): void
-    {
-        this.parsers.push(...newParsers);
-    }
-
-    /**
-     * For exceptional situations where a cache parser might be causing some trouble,
-     * @param parsersToRemove - An array of parsers to remove from the cache, or just a single one
-     */
-    public removeParser(...parsersToRemove: CacheParser[]): void
-    {
-        for (const parser of parsersToRemove)
-        {
-            const index = this.parsers.indexOf(parser);
-
-            if (index >= 0) this.parsers.splice(index, 1);
-        }
-    }
 
     /** Clear all entries. */
     public reset(): void
@@ -192,6 +168,12 @@ class CacheClass
         {
             this._cacheMap.delete(key);
         });
+    }
+
+    /** All loader parsers registered */
+    public get parsers(): CacheParser[]
+    {
+        return this._parsers;
     }
 }
 

--- a/packages/assets/src/loader/Loader.ts
+++ b/packages/assets/src/loader/Loader.ts
@@ -15,8 +15,7 @@ import type { PromiseAndParser, LoadAsset } from './types';
  */
 export class Loader
 {
-    /** All loader parsers registered */
-    public parsers: LoaderParser[] = [];
+    private _parsers: LoaderParser[] = [];
 
     /** Cache loading promises that ae currently active */
     public promiseCache: Record<string, PromiseAndParser> = {};
@@ -25,29 +24,6 @@ export class Loader
     public reset(): void
     {
         this.promiseCache = {};
-    }
-
-    /**
-     * Use this to add any parsers to the loadAssets function to use
-     * @param newParsers - An array of parsers to add to the loader, or just a single one
-     */
-    public addParser(...newParsers: LoaderParser[]): void
-    {
-        this.parsers.push(...newParsers);
-    }
-
-    /**
-     * Use this to remove any parsers you've added or any of the default ones.
-     * @param parsersToRemove - An array of parsers to remove from the loader, or just a single one
-     */
-    public removeParser(...parsersToRemove: LoaderParser[]): void
-    {
-        for (const parser of parsersToRemove)
-        {
-            const index = this.parsers.indexOf(parser);
-
-            if (index >= 0) this.parsers.splice(index, 1);
-        }
     }
 
     /**
@@ -215,5 +191,11 @@ export class Loader
         });
 
         await Promise.all(promises);
+    }
+
+    /** All loader parsers registered */
+    public get parsers(): LoaderParser[]
+    {
+        return this._parsers;
     }
 }

--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -42,7 +42,6 @@ export class Resolver
 {
     private _assetMap: Record<string, ResolveAsset[]> = {};
     private _preferredOrder: PreferOrder[] = [];
-
     private _parsers: ResolveURLParser[] = [];
 
     private _resolverHash: Record<string, ResolveAsset> = {};
@@ -100,24 +99,11 @@ export class Resolver
         return this._basePath;
     }
 
-    public get parsers(): ResolveURLParser[]
-    {
-        return this._parsers;
-    }
-
-    /** Used for testing, this resets the resolver to its initial state */
-    public reset(): void
-    {
-        this._preferredOrder = [];
-
-        this._resolverHash = {};
-        this._assetMap = {};
-        this._basePath = null;
-        this._manifest = null;
-    }
-
     /**
-     * A URL parser helps the parser to extract information and create an asset object-based on parsing the URL itself.
+     * All the active URL parsers that help the parser to extract information and create
+     * an asset object-based on parsing the URL itself.
+     *
+     * Can be added using the extensions API
      * @example
      * resolver.add('foo', [
      *    {
@@ -132,9 +118,9 @@ export class Resolver
      *    }
      * ]);
      *
-     *
      * // with a url parser the information such as resolution and file format could extracted from the url itself:
-     * resolver.addUrlParser({
+     * extensions.add({
+     *     extension: ExtensionType.ResolveParser,
      *     test: loadTextures.test, // test if url ends in an image
      *     parse: (value: string) =>
      *     ({
@@ -149,34 +135,22 @@ export class Resolver
      *    'image@2x.png'
      *    'image.png'
      * ]);
-     * @param urlParsers - The URL parser that you want to add to the resolver
+     * @
      */
-    public addUrlParser(...urlParsers: ResolveURLParser[]): void
+    public get parsers(): ResolveURLParser[]
     {
-        urlParsers.forEach((parser) =>
-        {
-            if (this._parsers.includes(parser)) return;
-
-            this._parsers.push(parser);
-        });
+        return this._parsers;
     }
 
-    /**
-     * Remove a URL parser from the resolver
-     * @param urlParsers - the URL parser that you want to remove from the resolver
-     */
-    public removeUrlParser(...urlParsers: ResolveURLParser[]): void
+    /** Used for testing, this resets the resolver to its initial state */
+    public reset(): void
     {
-        for (let i = urlParsers.length - 1; i >= 0; i--)
-        {
-            const parser = urlParsers[i];
-            const index = this._parsers.indexOf(parser);
+        this._preferredOrder = [];
 
-            if (index !== -1)
-            {
-                this._parsers.splice(index, 1);
-            }
-        }
+        this._resolverHash = {};
+        this._assetMap = {};
+        this._basePath = null;
+        this._manifest = null;
     }
 
     /**

--- a/packages/assets/test/cache.tests.ts
+++ b/packages/assets/test/cache.tests.ts
@@ -21,23 +21,12 @@ describe('Cache', () =>
     beforeEach(() =>
     {
         Cache.reset();
-        Cache.removeParser(testParser);
-    });
-
-    it('should add and remove a plugin', () =>
-    {
-        Cache.addParser(testParser);
-
-        expect(Cache.parsers).toHaveLength(3);
-
-        Cache.removeParser(testParser);
-
-        expect(Cache.parsers).toHaveLength(2);
+        Cache['_parsers'] = [];
     });
 
     it('should process a custom parsers correctly', () =>
     {
-        Cache.addParser(testParser);
+        Cache['_parsers'].push(testParser);
 
         Cache.set('test', 'hello');
 
@@ -48,7 +37,7 @@ describe('Cache', () =>
 
     it('should process multiple keys with a custom parser correctly', () =>
     {
-        Cache.addParser(testParser);
+        Cache['_parsers'].push(testParser);
 
         Cache.set(['test', 'chicken'], 'hello');
 
@@ -63,7 +52,7 @@ describe('Cache', () =>
 
     it('should remove keys with a custom parsers correctly', () =>
     {
-        Cache.addParser(testParser);
+        Cache['_parsers'].push(testParser);
 
         Cache.set('test', 'hello');
 
@@ -76,7 +65,7 @@ describe('Cache', () =>
 
     it('should remove multiple keys with a custom parser correctly', () =>
     {
-        Cache.addParser(testParser);
+        Cache['_parsers'].push(testParser);
 
         Cache.set(['test', 'chicken'], 'hello');
 

--- a/packages/assets/test/loader-compressed.tests.ts
+++ b/packages/assets/test/loader-compressed.tests.ts
@@ -8,7 +8,7 @@ describe('Compressed Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadKTX);
+        loader['_parsers'].push(loadKTX);
 
         // eslint-disable-next-line max-len
         const texture: Texture = await loader.load(`https://pixijs.io/compressed-textures-example/images/PixiJS-Logo_PNG_BC3_KTX.KTX`);
@@ -22,7 +22,7 @@ describe('Compressed Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadDDS);
+        loader['_parsers'].push(loadDDS);
 
         // eslint-disable-next-line max-len
         const texture: Texture = await loader.load(`https://pixijs.io/compressed-textures-example/images/airplane-boeing_JPG_BC3_1.DDS`);
@@ -43,7 +43,7 @@ describe('Compressed Loader', () =>
     //     //  console.log('DOING!!');
     //     const loader = new Loader();
 
-    //     loader.addParser(loadBasis);
+    //     loader['_parsers'].push(loadBasis);
 
     //     const texture: Texture = await loader.load(`https://pixijs.io/compressed-textures-example/images/kodim20.basis`);
 

--- a/packages/assets/test/loader.tests.ts
+++ b/packages/assets/test/loader.tests.ts
@@ -16,13 +16,6 @@ import {
 } from '@pixi/assets';
 import { Loader } from '../src/loader/Loader';
 
-const dummyPlugin: LoaderParser = {
-    async load(url: string): Promise<string>
-    {
-        return url;
-    },
-} as LoaderParser<string, string>;
-
 describe('Loader', () =>
 {
     const serverPath = process.env.GITHUB_ACTIONS
@@ -34,24 +27,11 @@ describe('Loader', () =>
         Cache.reset();
     });
 
-    it('should add and remove a plugin', () =>
-    {
-        const loader = new Loader();
-
-        loader.addParser(dummyPlugin);
-
-        expect(loader.parsers).toHaveLength(1);
-
-        loader.removeParser(dummyPlugin);
-
-        expect(loader.parsers).toHaveLength(0);
-    });
-
     it('should load a single image', async () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures);
+        loader['_parsers'].push(loadTextures);
 
         const texture: Texture = await loader.load(`${serverPath}textures/bunny.png`);
 
@@ -64,7 +44,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures);
+        loader['_parsers'].push(loadTextures);
 
         const texturesPromises = [];
 
@@ -87,7 +67,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures);
+        loader['_parsers'].push(loadTextures);
 
         const assetsUrls = [`${serverPath}textures/bunny.png`, `${serverPath}textures/bunny-2.png`];
 
@@ -101,7 +81,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadJson);
+        loader['_parsers'].push(loadJson);
 
         const json = await loader.load(`${serverPath}json/test.json`);
 
@@ -115,7 +95,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadJson, loadTextures, loadSpritesheet);
+        loader['_parsers'].push(loadJson, loadTextures, loadSpritesheet);
 
         const spriteSheet: Spritesheet = await loader.load(`${serverPath}spritesheet/spritesheet.json`);
 
@@ -140,9 +120,9 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        Cache.addParser(cacheSpritesheet);
+        Cache['_parsers'].push(cacheSpritesheet);
 
-        loader.addParser(loadJson, loadTextures, loadSpritesheet);
+        loader['_parsers'].push(loadJson, loadTextures, loadSpritesheet);
 
         const spritesheet = await loader.load(`${serverPath}spritesheet/multi-pack-0.json`) as Spritesheet;
 
@@ -167,7 +147,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures, loadBitmapFont);
+        loader['_parsers'].push(loadTextures, loadBitmapFont);
 
         const bitmapFont: BitmapFont = await loader.load(`${serverPath}bitmap-font/desyrel.xml`);
         const bitmapFont2: BitmapFont = await loader.load(`${serverPath}bitmap-font/font.fnt`);
@@ -180,7 +160,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTxt, loadTextures, loadBitmapFont);
+        loader['_parsers'].push(loadTxt, loadTextures, loadBitmapFont);
 
         const bitmapFont: BitmapFont = await loader.load(`${serverPath}bitmap-font/bmtxt-test.txt`);
 
@@ -191,7 +171,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures, loadBitmapFont);
+        loader['_parsers'].push(loadTextures, loadBitmapFont);
 
         const bitmapFont: BitmapFont = await loader.load(`${serverPath}bitmap-font/msdf.fnt`);
         const bitmapFont2: BitmapFont = await loader.load(`${serverPath}bitmap-font/sdf.fnt`);
@@ -206,7 +186,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures, loadBitmapFont);
+        loader['_parsers'].push(loadTextures, loadBitmapFont);
 
         const bitmapFont: BitmapFont = await loader.load(`${serverPath}bitmap-font/split_font.fnt`);
 
@@ -217,7 +197,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadWebFont);
+        loader['_parsers'].push(loadWebFont);
 
         const font = await loader.load(`${serverPath}fonts/outfit.woff2`);
 
@@ -241,7 +221,7 @@ describe('Loader', () =>
         const loader = new Loader();
 
         document.fonts.clear();
-        loader.addParser(loadWebFont);
+        loader['_parsers'].push(loadWebFont);
 
         const font = await loader.load({
             data: {
@@ -271,7 +251,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser({
+        loader['_parsers'].push({
             test: () => true,
             load: async (url, options) =>
                 url + options.data.whatever,
@@ -289,7 +269,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures);
+        loader['_parsers'].push(loadTextures);
 
         const texture: Texture = await loader.load(`${serverPath}textures/bunny.png`);
 
@@ -307,7 +287,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadJson, loadTextures, loadSpritesheet);
+        loader['_parsers'].push(loadJson, loadTextures, loadSpritesheet);
 
         const spriteSheet: Spritesheet = await loader.load(`${serverPath}spritesheet/spritesheet.json`);
 
@@ -320,7 +300,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadTextures, loadBitmapFont);
+        loader['_parsers'].push(loadTextures, loadBitmapFont);
 
         const bitmapFont: BitmapFont = await loader.load(`${serverPath}bitmap-font/desyrel.xml`);
 
@@ -335,7 +315,7 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader.addParser(loadWebFont);
+        loader['_parsers'].push(loadWebFont);
 
         await loader.load(`${serverPath}fonts/outfit.woff2`);
 

--- a/packages/assets/test/resolver.tests.ts
+++ b/packages/assets/test/resolver.tests.ts
@@ -104,7 +104,7 @@ describe('Resolver', () =>
             },
         });
 
-        resolver.addUrlParser(resolveTextureUrl);
+        resolver['_parsers'].push(resolveTextureUrl);
 
         resolver.add('test', [
             'profile-abel@0.5x.jpg',
@@ -277,7 +277,7 @@ describe('Resolver', () =>
             },
         });
 
-        resolver.addUrlParser(resolveTextureUrl);
+        resolver['_parsers'].push(resolveTextureUrl);
 
         resolver.add('test', [
             'my-image@4x.webp',


### PR DESCRIPTION
As a follow up to #8485 the add/remove parser functions have been removed

I also made all `_parser` properties private with a public getter for consistency 