### PR TITLE
add script to clean types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "run-s watch",
     "clean:build": "rimraf \"{bundles,packages,out}/*/dist\"",
+    "clean:types": "rimraf \"{bundles,packages}/*/index.d.ts\"",
     "clean:dist": "rimraf dist/*",
     "clean:modules": "lerna clean --yes",
     "clean": "run-s clean:*",


### PR DESCRIPTION
when running `npm run types` or `npm run build:types` if there was issues in the `d.ts` files it would block it

this just adds a little clean script to remove them