### PR TITLE
Fix Rollup warning, ignore used node dependencies

### DIFF
--- a/bundles/pixi.js-node/package.json
+++ b/bundles/pixi.js-node/package.json
@@ -71,6 +71,7 @@
     "gl": "^5.0.0",
     "xml2js": "^0.4.23"
   },
+  "nodeDependencies": ["fs", "path"],
   "publishConfig": {
     "access": "public"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -119,6 +119,7 @@ async function main()
             standalone,
             version,
             dependencies,
+            nodeDependencies,
             peerDependencies,
             // TODO: remove this in v7, along with the declaration in the package.json
             // This is a temporary fix to skip transpiling on the @pixi/node package
@@ -137,7 +138,8 @@ async function main()
 
         // Check for bundle folder
         const external = Object.keys(dependencies || [])
-            .concat(Object.keys(peerDependencies || []));
+            .concat(Object.keys(peerDependencies || []))
+            .concat(nodeDependencies || []);
         const basePath = path.relative(__dirname, pkg.dir);
         const input = path.join(basePath, 'src/index.ts');
         const freeze = false;


### PR DESCRIPTION
Added simple change to the build steps to ignore a Rollup warning for node dependencies.