### PR TITLE
Add .mjs extension for module output

### DIFF
--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -11,7 +11,7 @@
   ],
   "standalone": true,
   "main": "dist/cjs/pixi-legacy.js",
-  "module": "dist/esm/pixi-legacy.js",
+  "module": "dist/esm/pixi-legacy.mjs",
   "bundle": "dist/browser/pixi-legacy.js",
   "bundleModule": "dist/browser/pixi-legacy.mjs",
   "bundleOutput": {
@@ -22,7 +22,7 @@
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/pixi-legacy.js"
+        "default": "./dist/esm/pixi-legacy.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -11,7 +11,7 @@
   ],
   "standalone": true,
   "main": "dist/cjs/pixi.js",
-  "module": "dist/esm/pixi.js",
+  "module": "dist/esm/pixi.mjs",
   "bundle": "dist/browser/pixi.js",
   "bundleModule": "dist/browser/pixi.mjs",
   "bundleOutput": {
@@ -22,7 +22,7 @@
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/pixi.js"
+        "default": "./dist/esm/pixi.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/accessibility",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/accessibility.js",
-  "module": "dist/esm/accessibility.js",
+  "module": "dist/esm/accessibility.mjs",
   "bundle": "dist/browser/accessibility.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/accessibility.js"
+        "default": "./dist/esm/accessibility.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/app",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/app.js",
-  "module": "dist/esm/app.js",
+  "module": "dist/esm/app.mjs",
   "bundle": "dist/browser/app.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/app.js"
+        "default": "./dist/esm/app.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/pixijs/pixi.js#readme",
   "license": "MIT",
   "main": "dist/cjs/assets.js",
-  "module": "dist/esm/assets.js",
+  "module": "dist/esm/assets.mjs",
   "bundle": "dist/browser/assets.js",
   "publishConfig": {
     "access": "public"

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -12,14 +12,14 @@
   "homepage": "https://github.com/pixijs/pixi.js#readme",
   "license": "MIT",
   "main": "dist/cjs/basis.js",
-  "module": "dist/esm/basis.js",
+  "module": "dist/esm/basis.mjs",
   "bundle": "dist/browser/basis.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/basis.js"
+        "default": "./dist/esm/basis.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-display",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-display.js",
-  "module": "dist/esm/canvas-display.js",
+  "module": "dist/esm/canvas-display.mjs",
   "bundle": "dist/browser/canvas-display.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-display.js"
+        "default": "./dist/esm/canvas-display.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-extract",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-extract.js",
-  "module": "dist/esm/canvas-extract.js",
+  "module": "dist/esm/canvas-extract.mjs",
   "bundle": "dist/browser/canvas-extract.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-extract.js"
+        "default": "./dist/esm/canvas-extract.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-graphics",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-graphics.js",
-  "module": "dist/esm/canvas-graphics.js",
+  "module": "dist/esm/canvas-graphics.mjs",
   "bundle": "dist/browser/canvas-graphics.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-graphics.js"
+        "default": "./dist/esm/canvas-graphics.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-mesh",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-mesh.js",
-  "module": "dist/esm/canvas-mesh.js",
+  "module": "dist/esm/canvas-mesh.mjs",
   "bundle": "dist/browser/canvas-mesh.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-mesh.js"
+        "default": "./dist/esm/canvas-mesh.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-particle-container",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-particle-container.js",
-  "module": "dist/esm/canvas-particle-container.js",
+  "module": "dist/esm/canvas-particle-container.mjs",
   "bundle": "dist/browser/canvas-particle-container.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-particle-container.js"
+        "default": "./dist/esm/canvas-particle-container.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-prepare",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-prepare.js",
-  "module": "dist/esm/canvas-prepare.js",
+  "module": "dist/esm/canvas-prepare.mjs",
   "bundle": "dist/browser/canvas-prepare.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-prepare.js"
+        "default": "./dist/esm/canvas-prepare.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-renderer",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-renderer.js",
-  "module": "dist/esm/canvas-renderer.js",
+  "module": "dist/esm/canvas-renderer.mjs",
   "bundle": "dist/browser/canvas-renderer.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-renderer.js"
+        "default": "./dist/esm/canvas-renderer.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-sprite-tiling",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-sprite-tiling.js",
-  "module": "dist/esm/canvas-sprite-tiling.js",
+  "module": "dist/esm/canvas-sprite-tiling.mjs",
   "bundle": "dist/browser/canvas-sprite-tiling.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-sprite-tiling.js"
+        "default": "./dist/esm/canvas-sprite-tiling.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-sprite",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-sprite.js",
-  "module": "dist/esm/canvas-sprite.js",
+  "module": "dist/esm/canvas-sprite.mjs",
   "bundle": "dist/browser/canvas-sprite.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-sprite.js"
+        "default": "./dist/esm/canvas-sprite.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/canvas-text",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/canvas-text.js",
-  "module": "dist/esm/canvas-text.js",
+  "module": "dist/esm/canvas-text.mjs",
   "bundle": "dist/browser/canvas-text.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/canvas-text.js"
+        "default": "./dist/esm/canvas-text.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -14,14 +14,14 @@
   "homepage": "https://github.com/pixijs/pixi.js#readme",
   "license": "MIT",
   "main": "dist/cjs/compressed-textures.js",
-  "module": "dist/esm/compressed-textures.js",
+  "module": "dist/esm/compressed-textures.mjs",
   "bundle": "dist/browser/compressed-textures.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/compressed-textures.js"
+        "default": "./dist/esm/compressed-textures.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/constants",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/constants.js",
-  "module": "dist/esm/constants.js",
+  "module": "dist/esm/constants.mjs",
   "bundle": "dist/browser/constants.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/constants.js"
+        "default": "./dist/esm/constants.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/core",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/core.js",
-  "module": "dist/esm/core.js",
+  "module": "dist/esm/core.mjs",
   "bundle": "dist/browser/core.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/core.js"
+        "default": "./dist/esm/core.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/display",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/display.js",
-  "module": "dist/esm/display.js",
+  "module": "dist/esm/display.mjs",
   "bundle": "dist/browser/display.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/display.js"
+        "default": "./dist/esm/display.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/events",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/events.js",
-  "module": "dist/esm/events.js",
+  "module": "dist/esm/events.mjs",
   "bundle": "dist/browser/events.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/events.js"
+        "default": "./dist/esm/events.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/extract",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/extract.js",
-  "module": "dist/esm/extract.js",
+  "module": "dist/esm/extract.mjs",
   "bundle": "dist/browser/extract.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/extract.js"
+        "default": "./dist/esm/extract.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-alpha",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-alpha.js",
-  "module": "dist/esm/filter-alpha.js",
+  "module": "dist/esm/filter-alpha.mjs",
   "bundle": "dist/browser/filter-alpha.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-alpha.js"
+        "default": "./dist/esm/filter-alpha.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-blur",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-blur.js",
-  "module": "dist/esm/filter-blur.js",
+  "module": "dist/esm/filter-blur.mjs",
   "bundle": "dist/browser/filter-blur.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-blur.js"
+        "default": "./dist/esm/filter-blur.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-color-matrix",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-color-matrix.js",
-  "module": "dist/esm/filter-color-matrix.js",
+  "module": "dist/esm/filter-color-matrix.mjs",
   "bundle": "dist/browser/filter-color-matrix.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-color-matrix.js"
+        "default": "./dist/esm/filter-color-matrix.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-displacement",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-displacement.js",
-  "module": "dist/esm/filter-displacement.js",
+  "module": "dist/esm/filter-displacement.mjs",
   "bundle": "dist/browser/filter-displacement.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-displacement.js"
+        "default": "./dist/esm/filter-displacement.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-fxaa",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-fxaa.js",
-  "module": "dist/esm/filter-fxaa.js",
+  "module": "dist/esm/filter-fxaa.mjs",
   "bundle": "dist/browser/filter-fxaa.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-fxaa.js"
+        "default": "./dist/esm/filter-fxaa.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/filter-noise",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/filter-noise.js",
-  "module": "dist/esm/filter-noise.js",
+  "module": "dist/esm/filter-noise.mjs",
   "bundle": "dist/browser/filter-noise.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/filter-noise.js"
+        "default": "./dist/esm/filter-noise.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/graphics-extras",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/graphics-extras.js",
-  "module": "dist/esm/graphics-extras.js",
+  "module": "dist/esm/graphics-extras.mjs",
   "bundle": "dist/browser/graphics-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/graphics-extras.js"
+        "default": "./dist/esm/graphics-extras.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/graphics",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/graphics.js",
-  "module": "dist/esm/graphics.js",
+  "module": "dist/esm/graphics.mjs",
   "bundle": "dist/browser/graphics.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/graphics.js"
+        "default": "./dist/esm/graphics.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/interaction",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/interaction.js",
-  "module": "dist/esm/interaction.js",
+  "module": "dist/esm/interaction.mjs",
   "bundle": "dist/browser/interaction.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/interaction.js"
+        "default": "./dist/esm/interaction.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/loaders",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/loaders.js",
-  "module": "dist/esm/loaders.js",
+  "module": "dist/esm/loaders.mjs",
   "bundle": "dist/browser/loaders.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/loaders.js"
+        "default": "./dist/esm/loaders.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/math-extras",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/math-extras.js",
-  "module": "dist/esm/math-extras.js",
+  "module": "dist/esm/math-extras.mjs",
   "bundle": "dist/browser/math-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/math-extras.js"
+        "default": "./dist/esm/math-extras.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/math",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/math.js",
-  "module": "dist/esm/math.js",
+  "module": "dist/esm/math.mjs",
   "bundle": "dist/browser/math.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/math.js"
+        "default": "./dist/esm/math.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/mesh-extras",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/mesh-extras.js",
-  "module": "dist/esm/mesh-extras.js",
+  "module": "dist/esm/mesh-extras.mjs",
   "bundle": "dist/browser/mesh-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/mesh-extras.js"
+        "default": "./dist/esm/mesh-extras.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/mesh",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/mesh.js",
-  "module": "dist/esm/mesh.js",
+  "module": "dist/esm/mesh.mjs",
   "bundle": "dist/browser/mesh.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/mesh.js"
+        "default": "./dist/esm/mesh.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/mixin-cache-as-bitmap",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/mixin-cache-as-bitmap.js",
-  "module": "dist/esm/mixin-cache-as-bitmap.js",
+  "module": "dist/esm/mixin-cache-as-bitmap.mjs",
   "bundle": "dist/browser/mixin-cache-as-bitmap.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/mixin-cache-as-bitmap.js"
+        "default": "./dist/esm/mixin-cache-as-bitmap.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/mixin-get-child-by-name",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/mixin-get-child-by-name.js",
-  "module": "dist/esm/mixin-get-child-by-name.js",
+  "module": "dist/esm/mixin-get-child-by-name.mjs",
   "bundle": "dist/browser/mixin-get-child-by-name.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/mixin-get-child-by-name.js"
+        "default": "./dist/esm/mixin-get-child-by-name.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/mixin-get-global-position",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/mixin-get-global-position.js",
-  "module": "dist/esm/mixin-get-global-position.js",
+  "module": "dist/esm/mixin-get-global-position.mjs",
   "bundle": "dist/browser/mixin-get-global-position.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/mixin-get-global-position.js"
+        "default": "./dist/esm/mixin-get-global-position.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/particle-container",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/particle-container.js",
-  "module": "dist/esm/particle-container.js",
+  "module": "dist/esm/particle-container.mjs",
   "bundle": "dist/browser/particle-container.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/particle-container.js"
+        "default": "./dist/esm/particle-container.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/polyfill/package.json
+++ b/packages/polyfill/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/polyfill",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/polyfill.js",
-  "module": "dist/esm/polyfill.js",
+  "module": "dist/esm/polyfill.mjs",
   "bundle": "dist/browser/polyfill.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/polyfill.js"
+        "default": "./dist/esm/polyfill.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/prepare",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/prepare.js",
-  "module": "dist/esm/prepare.js",
+  "module": "dist/esm/prepare.mjs",
   "bundle": "dist/browser/prepare.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/prepare.js"
+        "default": "./dist/esm/prepare.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/runner",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/runner.js",
-  "module": "dist/esm/runner.js",
+  "module": "dist/esm/runner.mjs",
   "bundle": "dist/browser/runner.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/runner.js"
+        "default": "./dist/esm/runner.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/settings",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/settings.js",
-  "module": "dist/esm/settings.js",
+  "module": "dist/esm/settings.mjs",
   "bundle": "dist/browser/settings.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/settings.js"
+        "default": "./dist/esm/settings.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/sprite-animated",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/sprite-animated.js",
-  "module": "dist/esm/sprite-animated.js",
+  "module": "dist/esm/sprite-animated.mjs",
   "bundle": "dist/browser/sprite-animated.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/sprite-animated.js"
+        "default": "./dist/esm/sprite-animated.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/sprite-tiling",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/sprite-tiling.js",
-  "module": "dist/esm/sprite-tiling.js",
+  "module": "dist/esm/sprite-tiling.mjs",
   "bundle": "dist/browser/sprite-tiling.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/sprite-tiling.js"
+        "default": "./dist/esm/sprite-tiling.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/sprite",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/sprite.js",
-  "module": "dist/esm/sprite.js",
+  "module": "dist/esm/sprite.mjs",
   "bundle": "dist/browser/sprite.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/sprite.js"
+        "default": "./dist/esm/sprite.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/spritesheet",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/spritesheet.js",
-  "module": "dist/esm/spritesheet.js",
+  "module": "dist/esm/spritesheet.mjs",
   "bundle": "dist/browser/spritesheet.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/spritesheet.js"
+        "default": "./dist/esm/spritesheet.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/text-bitmap",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/text-bitmap.js",
-  "module": "dist/esm/text-bitmap.js",
+  "module": "dist/esm/text-bitmap.mjs",
   "bundle": "dist/browser/text-bitmap.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/text-bitmap.js"
+        "default": "./dist/esm/text-bitmap.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/text",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/text.js",
-  "module": "dist/esm/text.js",
+  "module": "dist/esm/text.mjs",
   "bundle": "dist/browser/text.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/text.js"
+        "default": "./dist/esm/text.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/ticker",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/ticker.js",
-  "module": "dist/esm/ticker.js",
+  "module": "dist/esm/ticker.mjs",
   "bundle": "dist/browser/ticker.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/ticker.js"
+        "default": "./dist/esm/ticker.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/unsafe-eval",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/unsafe-eval.js",
-  "module": "dist/esm/unsafe-eval.js",
+  "module": "dist/esm/unsafe-eval.mjs",
   "bundle": "dist/browser/unsafe-eval.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/unsafe-eval.js"
+        "default": "./dist/esm/unsafe-eval.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,14 +2,14 @@
   "name": "@pixi/utils",
   "version": "6.5.0-rc.2",
   "main": "dist/cjs/utils.js",
-  "module": "dist/esm/utils.js",
+  "module": "dist/esm/utils.mjs",
   "bundle": "dist/browser/utils.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./index.d.ts",
-        "default": "./dist/esm/utils.js"
+        "default": "./dist/esm/utils.mjs"
       },
       "require": {
         "types": "./index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,7 +78,7 @@ async function main()
         alias({
             entries: [{
                 find: /^(@pixi\/([^\/]+))$/,
-                replacement: '$1/dist/esm/$2.min.js',
+                replacement: '$1/dist/esm/$2.min.mjs',
             }]
         }),
         ...prodPlugins


### PR DESCRIPTION
Partially fixes #8502

Using .mjs is required for Node.js to import as module instead of commonjs.

This change should not impact bundlers like Rollup and Webpack which all understand .mjs.