### PR TITLE
Bundle ismobilejs into settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13953,6 +13953,7 @@
     },
     "node_modules/ismobilejs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isobject": {
@@ -25140,7 +25141,7 @@
       "name": "@pixi/settings",
       "version": "6.5.0-rc.2",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "ismobilejs": "^1.1.0"
       }
     },
@@ -34741,7 +34742,8 @@
       "version": "2.0.0"
     },
     "ismobilejs": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -37,7 +37,7 @@
     "dist",
     "*.d.ts"
   ],
-  "dependencies": {
+  "devDependencies": {
     "ismobilejs": "^1.1.0"
   }
 }


### PR DESCRIPTION
Partially fixes #8502 

This bundles the `ismobilejs` dependency, which avoids import issues because of the non-Node.js nature of the package. Honestly, bundling this into settings it's a bad idea because it's 1) very small and 2) is stable for our purposes.