### PR TITLE
Fix jest not exiting properly when killing the http server

### DIFF
--- a/test/jest-global-teardown.ts
+++ b/test/jest-global-teardown.ts
@@ -1,7 +1,20 @@
+import type { ChildProcess } from 'child_process';
+
 // eslint-disable-next-line func-names
 module.exports = async function ()
 {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    globalThis.__SERVER__?.kill();
+    const httpServerProcess = (globalThis.__SERVER__ as ChildProcess | undefined);
+
+    if (httpServerProcess)
+    {
+        const processClose = new Promise<void>((resolve) =>
+        {
+            httpServerProcess.on('close', resolve);
+        });
+
+        httpServerProcess.kill();
+        await processClose;
+    }
 };


### PR DESCRIPTION
#### Description of change

Fixes #8512

It uses `spawn` instead of `exec` so the `kill()` signal is received by the child process (looks like it's a bug on Windows, I don't have access to a native Linux distribution right now to test if this problem was present on Linux too).

I also replaced the `setTimeout` of 1sec on the setup, instead it uses the `stdout` of the child process to detect when the server is ready (which is much faster ~200ms on my laptop, and more reliable than just wait)

#### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
