### PR TITLE
Fix app and ismobilejs typings

### DIFF
--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -1,7 +1,8 @@
-import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { ExtensionMetadata, Renderer } from '@pixi/core';
 import { ExtensionType } from '@pixi/core';
 import type { IApplicationOptions } from './Application';
+
+type ResizeableRenderer = Pick<Renderer, 'resize'>;
 
 /**
  * Middleware for for Application's resize functionality
@@ -15,7 +16,7 @@ export class ResizePlugin
 
     public static resizeTo: Window | HTMLElement;
     public static resize: () => void;
-    public static renderer: Renderer | CanvasRenderer;
+    public static renderer: ResizeableRenderer;
     public static queueResize: () => void;
     private static _resizeId: number;
     private static _resizeTo: Window | HTMLElement;

--- a/packages/settings/src/utils/isMobile.ts
+++ b/packages/settings/src/utils/isMobile.ts
@@ -1,9 +1,39 @@
-// The ESM/CJS versions of ismobilejs only
-// exports the function for executing
-// designed for Node-only environments
 import isMobileCall from 'ismobilejs';
-import type { isMobileResult } from 'ismobilejs';
 
-const isMobile: isMobileResult = isMobileCall(globalThis.navigator);
+type isMobileResult = {
+    apple: {
+        phone: boolean;
+        ipod: boolean;
+        tablet: boolean;
+        universal: boolean;
+        device: boolean;
+    };
+    amazon: {
+        phone: boolean;
+        tablet: boolean;
+        device: boolean;
+    };
+    android: {
+        phone: boolean;
+        tablet: boolean;
+        device: boolean;
+    };
+    windows: {
+        phone: boolean;
+        tablet: boolean;
+        device: boolean;
+    };
+    other: {
+        blackberry: boolean;
+        blackberry10: boolean;
+        opera: boolean;
+        firefox: boolean;
+        chrome: boolean;
+        device: boolean;
+    };
+    phone: boolean;
+    tablet: boolean;
+    any: boolean;
+};
 
-export { isMobile };
+export const isMobile: isMobileResult = isMobileCall(globalThis.navigator);


### PR DESCRIPTION
Fixes #8516

* `@pixi/app` doesn't require CanvasRenderer for the ResizePlugin
* `ismobilejs` is now embedded, manually copied the types