### PR TITLE
Fix createImageBitmap with null alphaMode

### DIFF
--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -209,7 +209,8 @@ export class ImageResource extends BaseImageResource
             .then((blob) => createImageBitmap(blob,
                 0, 0, source.width, source.height,
                 {
-                    premultiplyAlpha: this.alphaMode === ALPHA_MODES.UNPACK ? 'premultiply' : 'none',
+                    premultiplyAlpha: this.alphaMode === null || this.alphaMode === ALPHA_MODES.UNPACK
+                        ? 'premultiply' : 'none',
                 }))
             .then((bitmap: ImageBitmap) =>
             {


### PR DESCRIPTION
##### Description of change
In commit 02a186048e4cd7a24d517c4840af2e7578c68e14 `premultiplyAlpha` was changed to `alphaMode` and it broke the `createBitmap` use case when no alphaMode is specified (which is the default). Before a undefined

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
