### PR TITLE
Fix loadBundle progress

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -523,13 +523,17 @@ export class AssetsClass
 
         const out: Record<string, Record<string, any>> = {};
 
-        const promises = Object.keys(resolveResults).map((bundleId) =>
+        const keys = Object.keys(resolveResults);
+        let count = 0;
+        const total = keys.length;
+        const promises = keys.map((bundleId) =>
         {
             const resolveResult = resolveResults[bundleId];
 
-            return this._mapLoadToResolve(resolveResult, onProgress)
+            return this._mapLoadToResolve(resolveResult)
                 .then((resolveResult) =>
                 {
+                    if (onProgress) onProgress(++count / total);
                     out[bundleId] = resolveResult;
                 });
         });

--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -528,7 +528,7 @@ export class AssetsClass
         let total = 0;
         const _onProgress = () =>
         {
-            if (onProgress) onProgress(++count / total);
+            onProgress?.(++count / total);
         };
         const promises = keys.map((bundleId) =>
         {

--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -525,15 +525,20 @@ export class AssetsClass
 
         const keys = Object.keys(resolveResults);
         let count = 0;
-        const total = keys.length;
+        let total = 0;
+        const _onProgress = () =>
+        {
+            if (onProgress) onProgress(++count / total);
+        };
         const promises = keys.map((bundleId) =>
         {
             const resolveResult = resolveResults[bundleId];
 
-            return this._mapLoadToResolve(resolveResult)
+            total += Object.keys(resolveResult).length;
+
+            return this._mapLoadToResolve(resolveResult, _onProgress)
                 .then((resolveResult) =>
                 {
-                    if (onProgress) onProgress(++count / total);
                     out[bundleId] = resolveResult;
                 });
         });

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -137,8 +137,12 @@ describe('Assets', () =>
             manifest: 'json/asset-manifest-2.json',
         });
 
-        const assets = await Assets.loadBundle(['default', 'data']);
+        const progressMock = jest.fn();
 
+        const assets = await Assets.loadBundle(['default', 'data'], progressMock);
+
+        expect(progressMock).toHaveBeenCalledTimes(2);
+        expect(progressMock.mock.calls).toEqual([0.5, 1]);
         expect(assets.default.bunny).toBeInstanceOf(Texture);
         expect(assets.default['profile-abel']).toBeInstanceOf(Texture);
         expect(assets.default.spritesheet).toBeInstanceOf(Spritesheet);

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -141,8 +141,8 @@ describe('Assets', () =>
 
         const assets = await Assets.loadBundle(['default', 'data'], progressMock);
 
-        expect(progressMock).toHaveBeenCalledTimes(2);
-        expect(progressMock.mock.calls).toEqual([0.5, 1]);
+        expect(progressMock).toHaveBeenCalledTimes(4);
+        expect(progressMock.mock.calls).toEqual([[0.25], [0.5], [0.75], [1]]);
         expect(assets.default.bunny).toBeInstanceOf(Texture);
         expect(assets.default['profile-abel']).toBeInstanceOf(Texture);
         expect(assets.default.spritesheet).toBeInstanceOf(Spritesheet);


### PR DESCRIPTION
`loadBundle`'s `onProgress` event would fire for the individual assets per bundle, resulting in something like this when loading multiple bundles

`0.3, 0.6, 1, 0.5, 1`

~~This fix only counts when all the bundle loads and produces the expected output~~

~~`0.5, 1`~~

This fix now uses the total assets of all bundles. If 2 bundles are loaded, each containing 2 assets it produces this

`0.25, 0.5, 0.75, 1`