### PR TITLE
Fix Resolver basePath setter doc saying it will append (-> prepend)

### DIFF
--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -82,7 +82,7 @@ export class Resolver
     }
 
     /**
-     * Set the base path to append to all urls when resolving
+     * Set the base path to prepend to all urls when resolving
      * @example
      * resolver.basePath = 'https://home.com/';
      * resolver.add('foo', 'bar.ong');


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
The Assets Resolver basePath is prepended, not appended. Fixed the setter docs to say "prepend" instead of "append".

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
