### PR TITLE
Chore: Add LoaderParser Priority

### DIFF
--- a/packages/assets/src/loader/parsers/LoaderParser.ts
+++ b/packages/assets/src/loader/parsers/LoaderParser.ts
@@ -3,6 +3,22 @@ import type { Loader } from '../Loader';
 import type { LoadAsset } from '../types';
 
 /**
+ * The extension priority for loader parsers.
+ * Helpful when managing multiple parsers that share the same extension
+ * test. The higher priority parsers will be checked first.
+ */
+export enum LoaderParserPriority
+// eslint-disable-next-line @typescript-eslint/indent
+{
+    /** Generic parsers: txt, json, webfonts */
+    Low = 0,
+    /** PixiJS assets with generic extensions: spritesheets, bitmapfonts  */
+    Normal = 1,
+    /** Specific texture types: svg, png, ktx, dds, basis */
+    High = 2,
+}
+
+/**
  * All functions are optional here. The flow:
  *
  * for every asset,

--- a/packages/assets/src/loader/parsers/loadBitmapFont.ts
+++ b/packages/assets/src/loader/parsers/loadBitmapFont.ts
@@ -8,12 +8,16 @@ import { dirname, extname, join } from '../../utils/path';
 import type { Loader } from '../Loader';
 import type { LoadAsset } from '../types';
 import type { LoaderParser } from './LoaderParser';
+import { LoaderParserPriority } from './LoaderParser';
 
 const validExtensions = ['.xml', '.fnt'];
 
 /** simple loader plugin for loading in bitmap fonts! */
 export const loadBitmapFont = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.Normal,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/loadJson.ts
+++ b/packages/assets/src/loader/parsers/loadJson.ts
@@ -2,10 +2,14 @@ import { extensions, ExtensionType } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { extname } from '../../utils/path';
 import type { LoaderParser } from './LoaderParser';
+import { LoaderParserPriority } from './LoaderParser';
 
 /** simple loader plugin for loading json data */
 export const loadJson = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.Low,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/loadSpritesheet.ts
+++ b/packages/assets/src/loader/parsers/loadSpritesheet.ts
@@ -6,6 +6,7 @@ import { dirname, extname } from '../../utils/path';
 import type { Loader } from '../Loader';
 import type { LoadAsset } from '../types';
 import type { LoaderParser } from './LoaderParser';
+import { LoaderParserPriority } from './LoaderParser';
 
 interface SpriteSheetJson extends ISpritesheetData
 {
@@ -24,7 +25,10 @@ interface SpriteSheetJson extends ISpritesheetData
  * All textures in the sprite sheet are then added to the cache
  */
 export const loadSpritesheet = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.Normal,
+    },
 
     async testParse(asset: SpriteSheetJson, options: LoadAsset): Promise<boolean>
     {

--- a/packages/assets/src/loader/parsers/loadTxt.ts
+++ b/packages/assets/src/loader/parsers/loadTxt.ts
@@ -2,10 +2,14 @@ import { extensions, ExtensionType } from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { extname } from '../../utils/path';
 import type { LoaderParser } from './LoaderParser';
+import { LoaderParserPriority } from './LoaderParser';
 
 /** Simple loader plugin for loading text data */
 export const loadTxt = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.Low,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -2,6 +2,7 @@ import { extensions, ExtensionType } from '@pixi/core';
 import { basename, extname } from '../../utils/path';
 import type { LoadAsset } from '../types';
 import type { LoaderParser } from './LoaderParser';
+import { LoaderParserPriority } from './LoaderParser';
 
 const validWeights = ['normal', 'bold',
     '100', '200', '300', '400', '500', '600', '700', '800', '900',
@@ -43,7 +44,10 @@ export function getFontFamilyName(url: string): string
 
 /** Web font loader plugin */
 export const loadWebFont = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.Low,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/textures/loadBasis.ts
+++ b/packages/assets/src/loader/parsers/textures/loadBasis.ts
@@ -12,10 +12,14 @@ import { settings } from '@pixi/settings';
 import type { Loader } from '../../Loader';
 import type { LoadAsset } from '../../types';
 import type { LoaderParser } from '../LoaderParser';
+import { LoaderParserPriority } from '../LoaderParser';
 
 /** Load BASIS textures! */
 export const loadBasis = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.High,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/textures/loadDDS.ts
+++ b/packages/assets/src/loader/parsers/textures/loadDDS.ts
@@ -8,12 +8,16 @@ import { ALPHA_MODES, MIPMAP_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
 import type { LoadAsset } from '../../types';
 import type { LoaderParser } from '../LoaderParser';
+import { LoaderParserPriority } from '../LoaderParser';
 import { checkExtension } from './utils/checkExtension';
 import { createTexture } from './utils/createTexture';
 
 /** Load our DDS textures! */
 export const loadDDS: LoaderParser = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.High,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/textures/loadKTX.ts
+++ b/packages/assets/src/loader/parsers/textures/loadKTX.ts
@@ -4,6 +4,7 @@ import { BaseTexture, ExtensionType, extensions } from '@pixi/core';
 import type { Loader } from '../../Loader';
 
 import type { LoaderParser } from '../LoaderParser';
+import { LoaderParserPriority } from '../LoaderParser';
 
 import { ALPHA_MODES, MIPMAP_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
@@ -14,7 +15,10 @@ import { createTexture } from './utils/createTexture';
 
 /** Loads KTX textures! */
 export const loadKTX = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.High,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/textures/loadSVG.ts
+++ b/packages/assets/src/loader/parsers/textures/loadSVG.ts
@@ -7,12 +7,16 @@ import type { Loader } from '../../Loader';
 import type { LoadAsset } from '../../types';
 
 import type { LoaderParser } from '../LoaderParser';
+import { LoaderParserPriority } from '../LoaderParser';
 import { loadTextures } from './loadTexture';
 import { createTexture } from './utils/createTexture';
 
 /** Loads SVG's into Textures */
 export const loadSVG = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.High,
+    },
 
     test(url: string): boolean
     {

--- a/packages/assets/src/loader/parsers/textures/loadTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/loadTexture.ts
@@ -6,6 +6,7 @@ import type { Loader } from '../../Loader';
 import type { LoadAsset } from '../../types';
 
 import type { LoaderParser } from '../LoaderParser';
+import { LoaderParserPriority } from '../LoaderParser';
 import { WorkerManager } from '../WorkerManager';
 import { checkExtension } from './utils/checkExtension';
 import { createTexture } from './utils/createTexture';
@@ -34,7 +35,10 @@ export async function loadImageBitmap(url: string): Promise<ImageBitmap>
  * We can then use the ImageBitmap as a source for a Pixi Texture
  */
 export const loadTextures = {
-    extension: ExtensionType.LoadParser,
+    extension: {
+        type: ExtensionType.LoadParser,
+        priority: LoaderParserPriority.High,
+    },
 
     config: {
         preferWorkers: true,


### PR DESCRIPTION
This adds explicit priority for LoaderParsers so that generic things are always run after the more specific loaders.