### PR TITLE
Implement test "should load texture array correctly"

### DIFF
--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -269,19 +269,14 @@ describe('Assets', () =>
             basePath,
         });
 
-        Assets.addBundle('testBundle', {
-            bunny: 'textures/bunny.{png,webp}',
-            spritesheet: 'spritesheet/spritesheet.json',
-        });
+        const pathsToLoad = ['textures/bunny.png', 'textures/profile-abel@2x.jpg'];
 
-        const assets = await Assets.loadBundle('testBundle');
+        const assets = await Assets.load(pathsToLoad);
 
-        expect(assets.bunny).toBeInstanceOf(Texture);
-        expect(assets.spritesheet).toBeInstanceOf(Spritesheet);
-
-        await Assets.unloadBundle('testBundle');
-
-        expect(assets.bunny.baseTexture).toBe(null);
+        for (const path of pathsToLoad)
+        {
+            expect(assets[path]).toBeInstanceOf(Texture);
+        }
     });
 
     it('should unload and remove from the cache correctly', async () =>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
The Assets test "should load texture array correctly" was a copy of the test "should unload bundles correctly". I've implemented the former to test Assets.load with an array of texture paths.

Existing implementation:
https://github.com/pixijs/pixijs/blob/ac965dd593f766a19ba9592e538a47f936f51739/packages/assets/test/assets.tests.ts#L266-L285 https://github.com/pixijs/pixijs/blob/ac965dd593f766a19ba9592e538a47f936f51739/packages/assets/test/assets.tests.ts#L321-L340

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
