### PR TITLE
Fix JSDoc of PIXI.DisplayObject#childRemoved

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -105,9 +105,9 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
 
         /**
          * Fired when a DisplayObject is removed from this Container.
-         * @event PIXI.DisplayObject#removedFrom
+         * @event PIXI.DisplayObject#childRemoved
          * @param {PIXI.DisplayObject} child - The child removed from the Container.
-         * @param {PIXI.Container} container - The container that removed removed the child.
+         * @param {PIXI.Container} container - The container that removed the child.
          * @param {number} index - The former children's index of the removed child
          */
     }


### PR DESCRIPTION
##### Description of change
I fixed JSDoc of PIXI.DisplayObject#childRemoved. (The event was introduced by https://github.com/pixijs/pixijs/pull/5472)

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)