### PR TITLE
Fix window paths on Node and add root relative pathing support

### DIFF
--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -6,7 +6,6 @@ import { NodeCanvasElement } from './NodeCanvasElement';
 
 import fs from 'fs';
 import path from 'path';
-import { isAbsoluteUrl } from '@pixi/assets';
 
 export const NodeAdapter = {
     /**
@@ -20,8 +19,9 @@ export const NodeAdapter = {
     getWebGLRenderingContext: () => gl as unknown as typeof WebGLRenderingContext,
     /** Returns the fake user agent string of `node` */
     getNavigator: () => ({ userAgent: 'node' }),
-    /** Returns an empty base url */
-    getBaseUrl: () => '',
+    /** Returns the path from which the process is being run */
+    getBaseUrl: () => process.cwd(),
+    /** Returns the root of the path from which the process is being run */
     getRootUrl: () =>
     {
         if (process.platform === 'win32')
@@ -35,7 +35,8 @@ export const NodeAdapter = {
     {
         const request = new Request(url, options);
 
-        if (isAbsoluteUrl(request.url))
+        // check if urls starts with http(s) as only these are supported by node-fetch
+        if ((/^http(s)*:/).test(request.url))
         {
             return fetch(url, request);
         }

--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -36,7 +36,7 @@ export const NodeAdapter = {
         const request = new Request(url, options);
 
         // check if urls starts with http(s) as only these are supported by node-fetch
-        if ((/^http(s)*:/).test(request.url))
+        if ((/^https?:/).test(request.url))
         {
             return fetch(url, request);
         }

--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -1,7 +1,7 @@
 import { convertToList } from '../utils/convertToList';
 import { createStringVariations } from '../utils/createStringVariations';
 import { isSingleItem } from '../utils/isSingleItem';
-import { getBaseUrl, makeAbsoluteUrl } from '../utils/url/makeAbsoluteUrl';
+import { convertToBaseUrl, makeAbsoluteUrl } from '../utils/url/makeAbsoluteUrl';
 import type { ResolveAsset, PreferOrder, ResolveURLParser, ResolverManifest, ResolverBundle } from './types';
 
 /**
@@ -91,7 +91,7 @@ export class Resolver
      */
     public set basePath(basePath: string)
     {
-        this._basePath = getBaseUrl(basePath);
+        this._basePath = convertToBaseUrl(basePath);
     }
 
     public get basePath(): string

--- a/packages/assets/src/utils/url/isAbsoluteUrl.ts
+++ b/packages/assets/src/utils/url/isAbsoluteUrl.ts
@@ -10,7 +10,7 @@
 export function isAbsoluteUrl(url: string): boolean
 {
     // Don't match Windows paths `c:\`
-    if ((/^[a-zA-Z]:\\/).test(url))
+    if ((/^[a-zA-Z]:(\\|\/)/).test(url))
     {
         return false;
     }

--- a/packages/assets/src/utils/url/isAbsoluteUrl.ts
+++ b/packages/assets/src/utils/url/isAbsoluteUrl.ts
@@ -1,18 +1,22 @@
+import { settings } from '@pixi/settings';
+
 /**
  * Used to check whether the given URL is an absolute URL or not.
  * An absolute URL is defined as a URL that contains the complete details needed to locate a file
  *
- * Taken directly from here: https://github.com/sindresorhus/is-absolute-url/blob/master/index.js
+ * Adapted from here: https://github.com/sindresorhus/is-absolute-url/blob/master/index.js
  *
  * returns true if the URL is absolute, false if relative.
  * @param url - The URL to test
  */
 export function isAbsoluteUrl(url: string): boolean
 {
-    // Don't match Windows paths `c:\`
-    if ((/^[a-zA-Z]:(\\|\/)/).test(url))
+    // If running in node then an absolute URL will start will either a `/` on unix or disk drive on windows
+    if (settings.ADAPTER.getNavigator().userAgent === 'node')
     {
-        return false;
+        if (process.platform === 'win32') return (/^[a-zA-Z]:(\\|\/)/).test(url);
+
+        return url.startsWith('/');
     }
 
     // Scheme: https://tools.ietf.org/html/rfc3986#section-3.1

--- a/packages/assets/src/utils/url/makeAbsoluteUrl.ts
+++ b/packages/assets/src/utils/url/makeAbsoluteUrl.ts
@@ -2,7 +2,7 @@ import { settings } from '@pixi/settings';
 import { isAbsoluteUrl } from './isAbsoluteUrl';
 import { urlJoin } from './urlJoin';
 
-export function convertToBaseUrl(url: string): string
+export function removeUrlParams(url: string): string
 {
     if (url.length === 0) return url;
     const re = new RegExp(/^.*\//);
@@ -11,6 +11,7 @@ export function convertToBaseUrl(url: string): string
 }
 
 let baseUrl: string;
+let rootUrl: string;
 
 /**
  * Converts URL to an absolute path.
@@ -19,20 +20,25 @@ let baseUrl: string;
  * If it's not, we convert it
  * @param url - The URL to test
  * @param customBaseUrl - The base URL to use
+ * @param customRootUrl - The root URL to use
  */
-export function makeAbsoluteUrl(url: string, customBaseUrl?: string): string
+export function makeAbsoluteUrl(url: string, customBaseUrl?: string, customRootUrl?: string): string
 {
     if (!baseUrl)
     {
-        baseUrl = convertToBaseUrl(settings.ADAPTER.getBaseUrl());
+        baseUrl = removeUrlParams(settings.ADAPTER.getBaseUrl());
+    }
+    if (!rootUrl)
+    {
+        rootUrl = removeUrlParams(settings.ADAPTER.getRootUrl());
     }
 
     if (url.startsWith('/'))
     {
-        return settings.ADAPTER.getBaseUrl() + url;
+        return (customRootUrl ? customRootUrl : rootUrl) + url;
     }
 
-    const base = customBaseUrl !== undefined ? convertToBaseUrl(customBaseUrl) : baseUrl;
+    const base = customBaseUrl !== undefined ? removeUrlParams(customBaseUrl) : baseUrl;
     const absolutePath = isAbsoluteUrl(url) ? url : urlJoin(base, url);
 
     return absolutePath;

--- a/packages/assets/src/utils/url/makeAbsoluteUrl.ts
+++ b/packages/assets/src/utils/url/makeAbsoluteUrl.ts
@@ -2,8 +2,9 @@ import { settings } from '@pixi/settings';
 import { isAbsoluteUrl } from './isAbsoluteUrl';
 import { urlJoin } from './urlJoin';
 
-export function getBaseUrl(url: string): string
+export function convertToBaseUrl(url: string): string
 {
+    if (url.length === 0) return url;
     const re = new RegExp(/^.*\//);
 
     return re.exec(url.split('?')[0])[0].replace(new RegExp(/#\/|#/), '');
@@ -23,10 +24,15 @@ export function makeAbsoluteUrl(url: string, customBaseUrl?: string): string
 {
     if (!baseUrl)
     {
-        baseUrl = getBaseUrl(settings.ADAPTER.getBaseUrl());
+        baseUrl = convertToBaseUrl(settings.ADAPTER.getBaseUrl());
     }
 
-    const base = customBaseUrl !== undefined ? getBaseUrl(customBaseUrl) : baseUrl;
+    if (url.startsWith('/'))
+    {
+        return settings.ADAPTER.getBaseUrl() + url;
+    }
+
+    const base = customBaseUrl !== undefined ? convertToBaseUrl(customBaseUrl) : baseUrl;
     const absolutePath = isAbsoluteUrl(url) ? url : urlJoin(base, url);
 
     return absolutePath;

--- a/packages/assets/test/utils.tests.ts
+++ b/packages/assets/test/utils.tests.ts
@@ -1,4 +1,4 @@
-import { createStringVariations } from '@pixi/assets';
+import { createStringVariations, makeAbsoluteUrl, removeUrlParams } from '@pixi/assets';
 
 describe('Utils', () =>
 {
@@ -31,5 +31,26 @@ describe('Utils', () =>
         expect(out3).toEqual([
             'hell@2x.png',
         ]);
+    });
+
+    it('should create absolute urls', () =>
+    {
+        const b1 = 'http://example.com/page-1/';
+        const b2 = 'https://example.com/page-1/';
+        const b3 = 'http://example.com';
+        const b4 = 'https://example.com';
+
+        expect(makeAbsoluteUrl('browser.png', b1, b3)).toEqual(`${b1}browser.png`);
+        expect(makeAbsoluteUrl('browser.png', b2, b3)).toEqual(`${b2}browser.png`);
+        expect(makeAbsoluteUrl('/browser.png', b1, b3)).toEqual(`${b3}/browser.png`);
+        expect(makeAbsoluteUrl('/browser.png', b2, b4)).toEqual(`${b4}/browser.png`);
+
+        // url is already absolute
+        expect(makeAbsoluteUrl('http://examples.com/browser.png', b2, b4)).toEqual(`http://examples.com/browser.png`);
+    });
+
+    it('should strip away url params', () =>
+    {
+        expect(removeUrlParams('http://example.com/page-1/index.html?a=1&b=2')).toEqual('http://example.com/page-1/');
     });
 });

--- a/packages/settings/src/adapter.ts
+++ b/packages/settings/src/adapter.ts
@@ -15,6 +15,7 @@ export interface IAdapter
     getNavigator: () => { userAgent: string };
     /** Returns the current base URL For browser environments this is either the document.baseURI or window.location.href */
     getBaseUrl: () => string;
+    getRootUrl: () => string;
     fetch: (url: RequestInfo, options?: RequestInit) => Promise<Response>;
 }
 
@@ -36,6 +37,7 @@ export const BrowserAdapter = {
     },
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
-    getBaseUrl: () => document.baseURI ?? window.location.href,
+    getBaseUrl: () => (document.baseURI || window.location.href),
+    getRootUrl: () => `${window.location.origin}`,
     fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
 } as IAdapter;

--- a/packages/settings/src/adapter.ts
+++ b/packages/settings/src/adapter.ts
@@ -38,6 +38,6 @@ export const BrowserAdapter = {
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI || window.location.href),
-    getRootUrl: () => `${window.location.origin}`,
+    getRootUrl: () => window.location.origin,
     fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
 } as IAdapter;


### PR DESCRIPTION
This PR fixes 2 issues:

- #8566
- #8564

For root-relative paths I added a new options to the adapter called `getRootPath` as these will be different for different adapters.
For windows paths I changed the checks being made for check if a path is absolute or not.

Previous Behaviour:

- Windows Node: 
  - `basePath` = `/`
  - `rootPath` = N/A
- Unix Node: 
  - `basePath` = `/`
  - `rootPath` = N/A
- Browser: 
  - `basePath` = `document.baseURI || window.location.href`
  - `rootPath` = N/A

New Behaviour:

- Windows Node: 
  - `basePath` = `process.cwd()` e.g. `C:\\Users\\foo\\bar`
  - `rootPath` = `C:\\`
- Unix Node: 
  - `basePath` = `process.cwd()` e.g. `/Users/foo/bar`
  - `rootPath` = `''`
- Browser: 
  - `basePath` = `document.baseURI || window.location.href`
  - `rootPath` = `window.location.origin`

This change to `basePath` in node would be a breaking change but makes more sense now that `rootPath` is being used.

I do think this is a band-aid fix as I think that all path code should be split out of assets but that is a bigger change that could be done in a separate PR?