### PR TITLE
Handle URL protocols in asset path join function of loadBitmapFont parser

### DIFF
--- a/packages/assets/src/utils/path.ts
+++ b/packages/assets/src/utils/path.ts
@@ -41,13 +41,14 @@ export function extname(path: string): string
 }
 
 /**
- * Returns the extension of the path, from the last occurrence of the . (period) character to the end of
- * string in the last portion of the path.
+ * Joins together parts of a URL or file path.
  * @param parts - The path parts to join
  */
 export function join(...parts: string[]): string
 {
     let path = '';
+    let protocol = '';
+    const protocolDelim = '://';
 
     for (let i = 0; i < parts.length; i++)
     {
@@ -57,6 +58,22 @@ export function join(...parts: string[]): string
         {
             if (!path)
             {
+                if (i === 0)
+                {
+                    // if the first part of the path has a URL protocol, extract it so it's not passed
+                    // to the normalize function
+                    const protocolIndex = segment.indexOf(protocolDelim);
+
+                    if (protocolIndex !== -1)
+                    {
+                        const protocolEnd = protocolIndex + protocolDelim.length;
+
+                        protocol = segment.substring(0, protocolEnd);
+                        path += segment.substring(protocolEnd);
+
+                        continue;
+                    }
+                }
                 path += segment;
             }
             else
@@ -66,7 +83,7 @@ export function join(...parts: string[]): string
         }
     }
 
-    return normalize(path);
+    return protocol + normalize(path);
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes #8571 

The Assets parser for BitmapFonts loads the font page textures with URLs created by joining the parent directory of the font xml/fnt file's source URL with the page image filename.
https://github.com/pixijs/pixijs/blob/fdbdc45b6a95bd47145e3a7267fe2a69a1be4ebb/packages/assets/src/loader/parsers/loadBitmapFont.ts#L38-L46
The [join](https://github.com/pixijs/pixijs/blob/fdbdc45b6a95bd47145e3a7267fe2a69a1be4ebb/packages/assets/src/utils/path.ts#L48) function used did not account for protocols in the path, leading to malformed URLs like `https:/example.com/myfont.png`. These URLs are treated as valid in Chrome, however in older versions of Safari (tested on iOS 14.5), loading such a URL actually tries to load `https://example.com/example.com/myfont.png`.

In this fix, join now extracts the protocol (if present in the first part of the passed path), not passing it to the normalize function which would mangle it. I also fixed the join function's docblock to reflect what it does.

I don't think it's possible to add a new test for this as the differing behavior is platform-specific.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
