### PR TITLE
Allow integer as sampler uniform value

### DIFF
--- a/packages/core/src/shader/utils/uniformParsers.ts
+++ b/packages/core/src/shader/utils/uniformParsers.ts
@@ -39,9 +39,9 @@ export const uniformParsers: IUniformParser[] = [
     },
     // handling samplers
     {
-        test: (data: any): boolean =>
-            // eslint-disable-next-line max-len
-            (data.type === 'sampler2D' || data.type === 'samplerCube' || data.type === 'sampler2DArray') && data.size === 1 && !data.isArray,
+        test: (data: any, uniform: any): boolean =>
+            // eslint-disable-next-line max-len,no-eq-null,eqeqeq
+            (data.type === 'sampler2D' || data.type === 'samplerCube' || data.type === 'sampler2DArray') && data.size === 1 && !data.isArray && (uniform == null || uniform.castToBaseTexture !== undefined),
         code: (name: string): string => `t = syncData.textureCount++;
 
             renderer.texture.bind(uv["${name}"], t);


### PR DESCRIPTION
##### Description of change

With this change it's possible to assign a texture unit to sampler uniforms.

Test: sampler uniform set to 0.
- Before: https://www.pixiplayground.com/#/edit/i4njik2hxu54d1_Q9dUaz
- After: https://www.pixiplayground.com/#/edit/AyA9fWlgnHl6EmBlHs3PQ

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
