### PR TITLE
Fixing CanvasSpriteRenderer to correctly render sprites with rotated base textures

### DIFF
--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -119,11 +119,6 @@ export class CanvasSpriteRenderer
             // the anchor has already been applied above, so lets set it to zero
             dx = 0;
             dy = 0;
-
-            const h = destWidth;
-
-            destWidth = destHeight;
-            destHeight = h;
         }
 
         dx -= destWidth / 2;

--- a/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
+++ b/packages/canvas-sprite/test/CanvasSpriteRenderer.tests.ts
@@ -82,4 +82,70 @@ describe('CanvasSpriteRenderer', () =>
         expect(pixels[10]).toEqual(0);
         expect(pixels[11]).toEqual(255);
     });
+
+    it('should render a sprite with a rotated base texture correctly', () =>
+    {
+        // create a 4x2 texture, left 2x2 red, right 2x2 green
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+
+        canvas.width = 4;
+        canvas.height = 2;
+
+        context.fillStyle = '#ff0000';
+        context.fillRect(0, 0, 2, 2);
+
+        context.fillStyle = '#00ff00';
+        context.fillRect(2, 0, 2, 2);
+
+        const baseTexture = new BaseTexture(new CanvasResource(canvas), {
+            mipmap: MIPMAP_MODES.OFF,
+            scaleMode: SCALE_MODES.NEAREST
+        });
+
+        const frame = new Rectangle(0, 0, 4, 2);
+        const orig  = new Rectangle(0, 0, 2, 4);
+
+        // create a sprite with a texture that treats this base texture as rotated
+        // (now a 2x4 texture with the top 2x2 green, bottom 2x2 red)
+        const testSprite = new Sprite(new Texture(baseTexture, frame, orig, null, 2));
+
+        const stage = new Container();
+
+        stage.addChild(testSprite);
+
+        const renderer = new CanvasRenderer();
+
+        renderer.render(stage);
+
+        const ctx = renderer.view.getContext('2d');
+
+        // grab 2x2 pixels from corner where the two 2x2s meet on the right edge,
+        // so we can check nothing is rendering wider than it should
+        const pixels = ctx.getImageData(1, 1, 2, 2).data;
+
+        // the top left pixel should be green
+        expect(pixels[0]).toEqual(0);
+        expect(pixels[1]).toEqual(255);
+        expect(pixels[2]).toEqual(0);
+        expect(pixels[3]).toEqual(255);
+
+        // the top right pixel should be black (not being rendered to)
+        expect(pixels[4]).toEqual(0);
+        expect(pixels[5]).toEqual(0);
+        expect(pixels[6]).toEqual(0);
+        expect(pixels[7]).toEqual(255);
+
+        // the bottom left pixel should be red
+        expect(pixels[8]).toEqual(255);
+        expect(pixels[9]).toEqual(0);
+        expect(pixels[10]).toEqual(0);
+        expect(pixels[11]).toEqual(255);
+
+        // the bottom right pixel should also black (not being rendered to)
+        expect(pixels[12]).toEqual(0);
+        expect(pixels[13]).toEqual(0);
+        expect(pixels[14]).toEqual(0);
+        expect(pixels[15]).toEqual(255);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
During an update to the PIXI.js versions in use where I work, we observed newly broken canvas renderer rendering for textures where the `BaseTexture` is rotated - for example, if some textures were atlassed in a spritesheet and the texture packer decided to rotate a texture for whatever reason.

For example, this is screenshot from a canvas renderer running v6.5.2, where the red check pattern is taller than it is wide, the blue pattern is wider than it is tall, but they're [in a texture atlas where the blue pattern has been rotated](https://cdn.glitch.global/b31e8b57-49fc-4abc-8e9a-011e8602fd1f/canvas-atlas.png?v=1661423801783).

![image](https://user-images.githubusercontent.com/32482581/186731113-9de5b5ff-72c3-493f-90c1-f9f6b4cce2b5.png)

Prior to #8408 (v.6.5.0), this was not an issue.

I've prepared a demo website showing the issue in detail over here: https://living-checker-skull.glitch.me/

The `destWidth`/`destHeight` swapping in the `if (texture.rotate)` appears to be unneeded, as the `width`/`height` from the `frame` is still accurate. Removing the swap (as this PR does) fixes the rendering back to the pre-#8408 behaviour for this case.

The added unit test pass in a cherry picked 6.4.2 (with the `toEquals` replaced with `to.equals` anyhow), and fail against v6.5.2, but pass with the code change applied.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
