### PR TITLE
Fix split bitmap font loading

### DIFF
--- a/bundles/pixi.js-node/src/adapter/loadNodeBitmapFont.ts
+++ b/bundles/pixi.js-node/src/adapter/loadNodeBitmapFont.ts
@@ -122,7 +122,8 @@ async function _loadBitmap(src: string, data: BitmapFontData, loader: Loader)
         textureUrls.push(url);
     }
 
-    const textures: Texture[] = Object.values(await loader.load(textureUrls));
+    const loadedTextures = await loader.load(textureUrls) as Record<string, Texture>;
+    const textures = textureUrls.map((url) => loadedTextures[url]);
 
     return BitmapFont.install(data, textures, true);
 }

--- a/packages/assets/src/loader/parsers/loadBitmapFont.ts
+++ b/packages/assets/src/loader/parsers/loadBitmapFont.ts
@@ -43,7 +43,8 @@ export const loadBitmapFont = {
             textureUrls.push(imagePath);
         }
 
-        const textures: Texture[] = Object.values(await loader.load(textureUrls));
+        const loadedTextures = await loader.load(textureUrls) as Record<string, Texture>;
+        const textures = textureUrls.map((url) => loadedTextures[url]);
 
         return BitmapFont.install(fontData, textures, true);
     },

--- a/packages/assets/test/assets/bitmap-font/split_font2.fnt
+++ b/packages/assets/test/assets/bitmap-font/split_font2.fnt
@@ -1,0 +1,16 @@
+<font>
+  <info face="split_font2" size="24" bold="0" italic="0" charset="" unicode="" stretchH="100" smooth="1" aa="1" padding="2,2,2,2" spacing="0,0" outline="0"/>
+  <common lineHeight="27" base="18" scaleW="22" scaleH="46" pages="2" packed="0"/>
+  <pages>
+    <page id="1" file="split_font_cd.png"/>
+    <page id="0" file="split_font_ab.png"/>
+  </pages>
+  <chars count="5">
+    <char id="65" x="2" y="2" width="19" height="20" xoffset="0" yoffset="0" xadvance="16" page="0" chnl="15"/>
+    <char id="66" x="2" y="24" width="15" height="20" xoffset="2" yoffset="0" xadvance="16" page="0" chnl="15"/>
+
+    <char id="67" x="2" y="2" width="18" height="20" xoffset="1" yoffset="0" xadvance="17" page="1" chnl="15"/>
+    <char id="68" x="2" y="24" width="17" height="20" xoffset="2" yoffset="0" xadvance="17" page="1" chnl="15"/>
+  </chars>
+  <kernings count="0"/>
+</font>

--- a/packages/assets/test/loader.tests.ts
+++ b/packages/assets/test/loader.tests.ts
@@ -375,9 +375,9 @@ describe('Loader', () =>
     {
         const loader = new Loader();
 
-        loader['_parsers'].push(loadJson, loadTextures, loadSpritesheet);
+        loader['_parsers'].push(loadTextures, loadBitmapFont);
 
-        const font = await loader.load(`${serverPath}bitmap-fonts/split_font2.fnt`);
+        const font = await loader.load(`${serverPath}bitmap-font/split_font2.fnt`);
 
         const charA = font.chars['A'.charCodeAt(0)];
         const charC = font.chars['C'.charCodeAt(0)];
@@ -386,7 +386,7 @@ describe('Loader', () =>
 
         expect(charA.page).toEqual(0);
         expect(charC.page).toEqual(1);
-        expect(charATexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-fonts/split_font_ab.png`);
-        expect(charCTexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-fonts/split_font_cd.png`);
+        expect(charATexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-font/split_font_ab.png`);
+        expect(charCTexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-font/split_font_cd.png`);
     });
 });

--- a/packages/assets/test/loader.tests.ts
+++ b/packages/assets/test/loader.tests.ts
@@ -1,3 +1,4 @@
+import type { ImageResource } from '@pixi/core';
 import { Texture } from '@pixi/core';
 import type { Spritesheet } from '@pixi/spritesheet';
 import { BitmapFont } from '@pixi/text-bitmap';
@@ -368,5 +369,24 @@ describe('Loader', () =>
         });
 
         expect(foundFont).toBe(false);
+    });
+
+    it('should split fonts if page IDs are in chronological order', async () =>
+    {
+        const loader = new Loader();
+
+        loader['_parsers'].push(loadJson, loadTextures, loadSpritesheet);
+
+        const font = await loader.load(`${serverPath}bitmap-fonts/split_font2.fnt`);
+
+        const charA = font.chars['A'.charCodeAt(0)];
+        const charC = font.chars['C'.charCodeAt(0)];
+        const charATexture = charA.texture as Texture<ImageResource>;
+        const charCTexture = charC.texture as Texture<ImageResource>;
+
+        expect(charA.page).toEqual(0);
+        expect(charC.page).toEqual(1);
+        expect(charATexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-fonts/split_font_ab.png`);
+        expect(charCTexture.baseTexture.resource.src).toEqual(`${serverPath}bitmap-fonts/split_font_cd.png`);
     });
 });


### PR DESCRIPTION
When loading a split bitmap font the page order is not preserved leading to textures being swapped around