### PR TITLE
Add OffscreenCanvas and Web Worker support

### DIFF
--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -91,7 +91,7 @@ export class AccessibilityManager
         {
             throw new Error('AccessibilityManager is only supported in browser main thread');
         }
-        if (typeof HTMLCanvasElement === 'undefined' || !(renderer.view instanceof HTMLCanvasElement))
+        if (typeof HTMLCanvasElement === 'undefined' || (renderer && !(renderer.view instanceof HTMLCanvasElement)))
         {
             throw new Error('AccessibilityManager is only supported on HTMLCanvasElement');
         }

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -2,7 +2,7 @@ import { Container } from '@pixi/display';
 import { autoDetectRenderer, extensions, ExtensionType } from '@pixi/core';
 
 import type { Rectangle } from '@pixi/math';
-import type {  IRendererOptionsAuto, IRenderer } from '@pixi/core';
+import type { ICanvas, IRenderer, IRendererOptionsAuto } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
 
 /**
@@ -67,7 +67,7 @@ export class Application
      *     options.sharedTicker to true in case that it is already started. Stop it by your own.
      * @param {number} [options.width=800] - The width of the renderers view.
      * @param {number} [options.height=600] - The height of the renderers view.
-     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
+     * @param {ICanvas} [options.view] - The canvas to use as a view, optional.
      * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
      *   canvas needs to be opaque, possibly for performance reasons on some older devices.
@@ -117,10 +117,10 @@ export class Application
 
     /**
      * Reference to the renderer's canvas element.
-     * @member {HTMLCanvasElement}
+     * @member {ICanvas}
      * @readonly
      */
-    get view(): HTMLCanvasElement
+    get view(): ICanvas
     {
         return this.renderer.view;
     }

--- a/packages/app/test/Application.tests.ts
+++ b/packages/app/test/Application.tests.ts
@@ -44,7 +44,7 @@ describe('Application', () =>
     it('should remove canvas when destroyed', () =>
     {
         const app = new Application();
-        const view = app.view;
+        const view = app.view as HTMLCanvasElement;
 
         expect(view).toBeInstanceOf(HTMLCanvasElement);
         document.body.appendChild(view);
@@ -201,11 +201,12 @@ describe('Application', () =>
                 resizeTo: div,
                 autoDensity: true,
             });
+            const view = app.view as HTMLCanvasElement;
 
-            expect(app.view.width).toEqual(200);
-            expect(app.view.height).toEqual(400);
-            expect(app.view.style.width).toEqual(div.style.width);
-            expect(app.view.style.height).toEqual(div.style.height);
+            expect(view.width).toEqual(200);
+            expect(view.height).toEqual(400);
+            expect(view.style.width).toEqual(div.style.width);
+            expect(view.style.height).toEqual(div.style.height);
             app.destroy();
         });
     });

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -1,9 +1,10 @@
 import { extensions, ExtensionType, RenderTexture } from '@pixi/core';
 import { CanvasRenderTarget } from '@pixi/utils';
 import { Rectangle } from '@pixi/math';
+
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
+import type { BaseRenderTexture, ExtensionMetadata, ICanvas, ISystem } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
-import type { BaseRenderTexture, ISystem, ExtensionMetadata } from '@pixi/core';
 
 const TEMP_RECT = new Rectangle();
 
@@ -61,7 +62,13 @@ export class CanvasExtract implements ISystem
      */
     public base64(target?: DisplayObject | RenderTexture, format?: string, quality?: number): string
     {
-        return this.canvas(target).toDataURL(format, quality);
+        const canvas = this.canvas(target);
+
+        if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement)
+        {
+            return canvas.toDataURL(format, quality);
+        }
+        throw new Error('TODO: base64 for OffscreenCanvas');
     }
 
     /**
@@ -71,7 +78,7 @@ export class CanvasExtract implements ISystem
      * @param frame - The frame the extraction is restricted to.
      * @returns A Canvas element with the texture rendered on.
      */
-    public canvas(target?: DisplayObject | RenderTexture, frame?: Rectangle): HTMLCanvasElement
+    public canvas(target?: DisplayObject | RenderTexture, frame?: Rectangle): ICanvas
     {
         const renderer = this.renderer;
         let context;

--- a/packages/canvas-graphics/src/Graphics.ts
+++ b/packages/canvas-graphics/src/Graphics.ts
@@ -44,9 +44,9 @@ Graphics.prototype.generateCanvasTexture = function generateCanvasTexture(scaleM
 
     canvasRenderer.render(this, { renderTexture: canvasBuffer, clear: true, transform: tempMatrix });
 
-    const texture = Texture.from((canvasBuffer.baseTexture as BaseRenderTexture)._canvasRenderTarget.canvas, {
-        scaleMode,
-    });
+    const texture = Texture.from(
+        (canvasBuffer.baseTexture as BaseRenderTexture)._canvasRenderTarget.canvas as HTMLCanvasElement | OffscreenCanvas,
+        { scaleMode });
 
     texture.baseTexture.setResolution(resolution);
 

--- a/packages/canvas-mesh/global.d.ts
+++ b/packages/canvas-mesh/global.d.ts
@@ -6,7 +6,7 @@ declare namespace GlobalMixins
         _canvasPadding: number;
         canvasPadding: number;
         _cachedTint: number;
-        _tintedCanvas: HTMLCanvasElement;
+        _tintedCanvas: import('@pixi/core').ICanvas;
         _cachedTexture: import('@pixi/core').Texture;
     }
 
@@ -18,7 +18,7 @@ declare namespace GlobalMixins
     interface NineSlicePlane
     {
         _cachedTint: number;
-        _tintedCanvas: HTMLCanvasElement;
+        _tintedCanvas: import('@pixi/core').ICanvas;
         _canvasUvs: number[];
     }
 }

--- a/packages/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -1,8 +1,8 @@
-import type { ExtensionMetadata } from '@pixi/core';
 import { extensions, ExtensionType, Texture } from '@pixi/core';
 import { DRAW_MODES } from '@pixi/constants';
 import { canvasUtils } from '@pixi/canvas-renderer';
 
+import type { ExtensionMetadata, ICanvas } from '@pixi/core';
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { Mesh } from '@pixi/mesh';
 
@@ -125,7 +125,7 @@ export class CanvasMeshRenderer
                 mesh._tintedCanvas = canvasUtils.getTintedCanvas(
                     { texture: mesh._cachedTexture },
                     mesh.tint
-                ) as HTMLCanvasElement;
+                ) as ICanvas;
             }
         }
 
@@ -223,7 +223,7 @@ export class CanvasMeshRenderer
         );
 
         context.drawImage(
-            textureSource,
+            textureSource as CanvasImageSource,
             0,
             0,
             textureWidth * base.resolution,

--- a/packages/canvas-mesh/src/Mesh.ts
+++ b/packages/canvas-mesh/src/Mesh.ts
@@ -16,7 +16,7 @@ Mesh.prototype._cachedTint = 0xFFFFFF;
 /**
  * Cached tinted texture.
  * @memberof PIXI.Mesh#
- * @member {HTMLCanvasElement} _tintedCanvas
+ * @member {PIXI.ICanvas} _tintedCanvas
  * @protected
  */
 Mesh.prototype._tintedCanvas = null;

--- a/packages/canvas-mesh/src/NineSlicePlane.ts
+++ b/packages/canvas-mesh/src/NineSlicePlane.ts
@@ -14,7 +14,7 @@ NineSlicePlane.prototype._cachedTint = 0xFFFFFF;
 /**
  * Cached tinted texture.
  * @memberof PIXI.NineSlicePlane#
- * @member {HTMLCanvasElement} _tintedCanvas
+ * @member {PIXI.ICanvas} _tintedCanvas
  * @protected
  */
 NineSlicePlane.prototype._tintedCanvas = null;
@@ -101,7 +101,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer: Canvas
             const dw = Math.max(1, vertices[ind + 10] - vertices[ind]);
             const dh = Math.max(1, vertices[ind + 11] - vertices[ind + 1]);
 
-            context.drawImage(textureSource, uvs[col], uvs[row + 4], sw, sh,
+            context.drawImage(textureSource as CanvasImageSource, uvs[col], uvs[row + 4], sw, sh,
                 vertices[ind], vertices[ind + 1], dw, dh);
         }
     }

--- a/packages/canvas-prepare/src/CanvasPrepare.ts
+++ b/packages/canvas-prepare/src/CanvasPrepare.ts
@@ -2,7 +2,7 @@ import { BaseTexture, extensions, ExtensionType } from '@pixi/core';
 import { BasePrepare } from '@pixi/prepare';
 import { settings } from '@pixi/settings';
 
-import type { ISystem, ExtensionMetadata, IRenderer } from '@pixi/core';
+import type { ExtensionMetadata, ICanvas, IRenderer, ISystem } from '@pixi/core';
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { IDisplayObjectExtended } from '@pixi/prepare';
 
@@ -66,12 +66,12 @@ export class CanvasPrepare extends BasePrepare implements ISystem
      * An offline canvas to render textures to
      * @internal
      */
-    canvas: HTMLCanvasElement;
+    canvas: ICanvas;
     /**
      * The context to the canvas
      * @internal
      */
-    ctx: CanvasRenderingContext2D;
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 
     /**
      * @param renderer - A reference to the current renderer

--- a/packages/canvas-renderer/global.d.ts
+++ b/packages/canvas-renderer/global.d.ts
@@ -8,7 +8,7 @@ declare namespace GlobalMixins
     interface Texture
     {
         patternCache?: { [key: string]: CanvasPattern };
-        tintCache?: { [key: string]: HTMLCanvasElement | HTMLImageElement };
+        tintCache?: { [key: string]: import('@pixi/core').ICanvas | HTMLImageElement };
     }
 
     interface BaseRenderTexture
@@ -45,7 +45,7 @@ declare interface CanvasPattern extends GlobalMixins.GlobalTintable
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-declare interface HTMLCanvasElement extends GlobalMixins.GlobalTintable
+declare interface ICanvas extends GlobalMixins.GlobalTintable
 {
 
 }

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -158,7 +158,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
      * @param options - The optional renderer parameters
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+     * @param {PIXI.ICanvas} [options.view] - the canvas to use as a view, optional
      * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
      *   canvas needs to be opaque, possibly for performance reasons on some older devices.

--- a/packages/canvas-renderer/src/canvasUtils.ts
+++ b/packages/canvas-renderer/src/canvasUtils.ts
@@ -1,8 +1,8 @@
-import { hex2rgb, rgb2hex } from '@pixi/utils';
+import { environment, hex2rgb, rgb2hex } from '@pixi/utils';
 import { settings } from '@pixi/settings';
 import { canUseNewCanvasBlendModes } from './utils/canUseNewCanvasBlendModes';
 
-import type { Texture } from '@pixi/core';
+import type { ICanvas, Texture } from '@pixi/core';
 
 /**
  * Utility methods for Sprite/Texture tinting.
@@ -13,7 +13,7 @@ import type { Texture } from '@pixi/core';
  * @memberof PIXI
  */
 export const canvasUtils = {
-    canvas: null as HTMLCanvasElement,
+    canvas: null as ICanvas,
 
     /**
      * Basically this method just needs a sprite and a color and tints the sprite with the given color.
@@ -21,9 +21,9 @@ export const canvasUtils = {
      * @param {PIXI.Sprite} sprite - the sprite to tint
      * @param sprite.texture
      * @param {number} color - the color to use to tint the sprite with
-     * @returns {HTMLCanvasElement} The tinted canvas
+     * @returns {ICanvas|HTMLImageElement} The tinted canvas
      */
-    getTintedCanvas: (sprite: { texture: Texture }, color: number): HTMLCanvasElement | HTMLImageElement =>
+    getTintedCanvas: (sprite: { texture: Texture }, color: number): ICanvas | HTMLImageElement =>
     {
         const texture = sprite.texture;
 
@@ -35,16 +35,16 @@ export const canvasUtils = {
 
         const cachedCanvas = texture.tintCache[stringColor];
 
-        let canvas: HTMLCanvasElement;
+        let canvas: ICanvas;
 
         if (cachedCanvas)
         {
-            if (cachedCanvas.tintId === texture._updateID)
+            if ((cachedCanvas as GlobalMixins.GlobalTintable).tintId === texture._updateID)
             {
                 return texture.tintCache[stringColor];
             }
 
-            canvas = texture.tintCache[stringColor] as HTMLCanvasElement;
+            canvas = texture.tintCache[stringColor] as ICanvas;
         }
         else
         {
@@ -53,14 +53,26 @@ export const canvasUtils = {
 
         canvasUtils.tintMethod(texture, color, canvas);
 
-        canvas.tintId = texture._updateID;
+        (canvas as GlobalMixins.GlobalTintable).tintId = texture._updateID;
 
         if (canvasUtils.convertTintToImage)
         {
+            if (environment.webworker)
+            {
+                throw Error('TODO: Convert tint to Image in Web Worker');
+            }
+
             // is this better?
             const tintImage = new Image();
 
-            tintImage.src = (canvas as HTMLCanvasElement).toDataURL();
+            if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement)
+            {
+                tintImage.src = (canvas as HTMLCanvasElement).toDataURL();
+            }
+            else
+            {
+                throw Error('TODO: Convert OffscreenCanvas to Image');
+            }
 
             texture.tintCache[stringColor] = tintImage;
         }
@@ -77,7 +89,7 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @param {PIXI.Texture} texture - the sprite to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @returns {HTMLCanvasElement} The tinted canvas
+     * @returns {CanvasPattern} The tinted canvas
      */
     getTintedPattern: (texture: Texture, color: number): CanvasPattern =>
     {
@@ -98,7 +110,7 @@ export const canvasUtils = {
             canvasUtils.canvas = settings.ADAPTER.createCanvas();
         }
         canvasUtils.tintMethod(texture, color, canvasUtils.canvas);
-        pattern = canvasUtils.canvas.getContext('2d').createPattern(canvasUtils.canvas, 'repeat');
+        pattern = canvasUtils.canvas.getContext('2d').createPattern(canvasUtils.canvas as CanvasImageSource, 'repeat');
         pattern.tintId = texture._updateID;
         texture.patternCache[stringColor] = pattern;
 
@@ -110,9 +122,9 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {ICanvas} canvas - the current canvas
      */
-    tintWithMultiply: (texture: Texture, color: number, canvas: HTMLCanvasElement): void =>
+    tintWithMultiply: (texture: Texture, color: number, canvas: ICanvas): void =>
     {
         const context = canvas.getContext('2d');
         const crop = texture._frame.clone();
@@ -168,9 +180,9 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {ICanvas} canvas - the current canvas
      */
-    tintWithOverlay: (texture: Texture, color: number, canvas: HTMLCanvasElement): void =>
+    tintWithOverlay: (texture: Texture, color: number, canvas: ICanvas): void =>
     {
         const context = canvas.getContext('2d');
         const crop = texture._frame.clone();
@@ -211,9 +223,9 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @param {PIXI.Texture} texture - the texture to tint
      * @param {number} color - the color to use to tint the sprite with
-     * @param {HTMLCanvasElement} canvas - the current canvas
+     * @param {ICanvas} canvas - the current canvas
      */
-    tintWithPerPixel: (texture: Texture, color: number, canvas: HTMLCanvasElement): void =>
+    tintWithPerPixel: (texture: Texture, color: number, canvas: ICanvas): void =>
     {
         const context = canvas.getContext('2d');
         const crop = texture._frame.clone();
@@ -306,7 +318,7 @@ export const canvasUtils = {
      * @memberof PIXI.canvasUtils
      * @type {Function}
      */
-    tintMethod: null as (texture: Texture, color: number, canvas: HTMLCanvasElement) => void,
+    tintMethod: null as (texture: Texture, color: number, canvas: ICanvas) => void,
 };
 
 canvasUtils.tintMethod = canvasUtils.canUseMultiply ? canvasUtils.tintWithMultiply : canvasUtils.tintWithPerPixel;

--- a/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
+++ b/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
@@ -1,12 +1,14 @@
 import { settings } from '@pixi/settings';
 
+import type { ICanvas } from '@pixi/core';
+
 /**
  * Creates a little colored canvas
  * @ignore
  * @param {string} color - The color to make the canvas
- * @returns {HTMLCanvasElement} a small canvas element
+ * @returns {ICanvas} a small canvas element
  */
-function createColoredCanvas(color: string): HTMLCanvasElement
+function createColoredCanvas(color: string): ICanvas
 {
     const canvas = settings.ADAPTER.createCanvas(6, 1);
     const context = canvas.getContext('2d');
@@ -36,8 +38,8 @@ export function canUseNewCanvasBlendModes(): boolean
     const context = canvas.getContext('2d');
 
     context.globalCompositeOperation = 'multiply';
-    context.drawImage(magenta, 0, 0);
-    context.drawImage(yellow, 2, 0);
+    context.drawImage(magenta as CanvasImageSource, 0, 0);
+    context.drawImage(yellow as CanvasImageSource, 2, 0);
 
     const imageData = context.getImageData(2, 0, 1, 1);
 

--- a/packages/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas-sprite-tiling/src/TilingSprite.ts
@@ -4,6 +4,7 @@ import { CanvasRenderTarget } from '@pixi/utils';
 import { Matrix, Point } from '@pixi/math';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
+import type { ICanvas } from '@pixi/core';
 
 const worldMatrix = new Matrix();
 const patternMatrix = new Matrix();
@@ -43,8 +44,8 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
         // Tint the tiling sprite
         if (this.tint !== 0xFFFFFF)
         {
-            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tint) as HTMLCanvasElement;
-            tempCanvas.context.drawImage(this._tintedCanvas, 0, 0);
+            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tint) as ICanvas;
+            tempCanvas.context.drawImage(this._tintedCanvas as CanvasImageSource, 0, 0);
         }
         else
         {
@@ -52,7 +53,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
                 -texture._frame.x * baseTextureResolution, -texture._frame.y * baseTextureResolution);
         }
         this._cachedTint = this.tint;
-        this._canvasPattern = tempCanvas.context.createPattern(tempCanvas.canvas, 'repeat');
+        this._canvasPattern = tempCanvas.context.createPattern(tempCanvas.canvas as CanvasImageSource, 'repeat');
     }
 
     // set context state..

--- a/packages/canvas-sprite/global.d.ts
+++ b/packages/canvas-sprite/global.d.ts
@@ -2,7 +2,7 @@ declare namespace GlobalMixins
 {
     interface Sprite
     {
-        _tintedCanvas: HTMLCanvasElement | HTMLImageElement;
+        _tintedCanvas: import('@pixi/core').ICanvas | HTMLImageElement;
         _renderCanvas(renderer: import('@pixi/canvas-renderer').CanvasRenderer): void;
     }
 }

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -10,7 +10,7 @@ const canvasRenderWorldTransform = new Matrix();
 
 /**
  * Types that can be passed to drawImage
- * @typedef {HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap} ICanvasImageSource
+ * @typedef {HTMLImageElement | HTMLVideoElement | HTMLCanvasElement | OffscreenCanvas | ImageBitmap} ICanvasImageSource
  * @memberof PIXI
  */
 
@@ -153,7 +153,8 @@ export class CanvasSpriteRenderer
 
         if (sprite.tint !== 0xFFFFFF)
         {
-            if (sprite._cachedTint !== sprite.tint || sprite._tintedCanvas.tintId !== sprite._texture._updateID)
+            if (sprite._cachedTint !== sprite.tint
+                || (sprite._tintedCanvas as GlobalMixins.GlobalTintable).tintId !== sprite._texture._updateID)
             {
                 sprite._cachedTint = sprite.tint;
 
@@ -162,7 +163,7 @@ export class CanvasSpriteRenderer
             }
 
             context.drawImage(
-                sprite._tintedCanvas,
+                sprite._tintedCanvas as CanvasImageSource,
                 0,
                 0,
                 Math.floor(sourceWidth * resolution),

--- a/packages/canvas-sprite/src/Sprite.ts
+++ b/packages/canvas-sprite/src/Sprite.ts
@@ -4,7 +4,7 @@ import type { CanvasRenderer } from '@pixi/canvas-renderer';
 /**
  * Cached tinted texture.
  * @memberof PIXI.Sprite#
- * @member {HTMLCanvasElement} _tintedCanvas
+ * @member {PIXI.ICanvas} _tintedCanvas
  * @protected
  */
 Sprite.prototype._tintedCanvas = null;

--- a/packages/core/src/ICanvas.ts
+++ b/packages/core/src/ICanvas.ts
@@ -1,0 +1,1 @@
+export type { ICanvas } from '@pixi/settings';

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -277,7 +277,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      * @param [options] - The optional renderer parameters.
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.
-     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
+     * @param {PIXI.ICanvas} [options.view] - The canvas to use as a view, optional.
      * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
      *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
      *   canvas needs to be opaque, possibly for performance reasons on some older devices.

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -29,7 +29,7 @@ extensions.handleByList(ExtensionType.Renderer, renderers);
  * @param {object} [options] - The optional renderer parameters
  * @param {number} [options.width=800] - the width of the renderers view
  * @param {number} [options.height=600] - the height of the renderers view
- * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
+ * @param {PIXI.ICanvas} [options.view] - the canvas to use as a view, optional
  * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
  *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
  *   canvas needs to be opaque, possibly for performance reasons on some older devices.

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -1,6 +1,7 @@
 import { ENV } from '@pixi/constants';
 import { settings } from '../settings';
 
+import type { ICanvas } from '../ICanvas';
 import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
 import type { WebGLExtensions } from './WebGLExtensions';
@@ -194,7 +195,7 @@ export class ContextSystem implements ISystem
      * @see https://developer.mozilla.org/en/docs/Web/API/HTMLCanvasElement/getContext
      * @returns {WebGLRenderingContext} the WebGL context
      */
-    createContext(canvas: HTMLCanvasElement, options: WebGLContextAttributes): IRenderingContext
+    createContext(canvas: ICanvas, options: WebGLContextAttributes): IRenderingContext
     {
         let gl;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,8 +13,8 @@ export const VERSION = '$_VERSION';
 export * from '@pixi/extensions';
 export * from './textures/resources';
 export * from './systems';
+export * from './ICanvas';
 export * from './IRenderer';
-
 export * from './autoDetectRenderer';
 export * from './fragments';
 export * from './system/ISystem';

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -15,7 +15,7 @@ const defaultBufferOptions = {
     alphaMode: ALPHA_MODES.NPM,
 };
 
-export type ImageSource = HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap;
+export type ImageSource = HTMLImageElement | HTMLVideoElement | HTMLCanvasElement | OffscreenCanvas | ImageBitmap;
 
 export interface IBaseTextureOptions<RO = any>
 {
@@ -197,7 +197,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
     private _wrapMode?: WRAP_MODES;
 
     /**
-     * @param {PIXI.Resource|string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} [resource=null] -
+     * @param {PIXI.Resource|string|HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas} [resource=null] -
      *        The current resource to use, for things that aren't Resource objects, will be converted
      *        into a Resource.
      * @param options - Collection of options
@@ -582,7 +582,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
      * source is an image url or an image element and not in the base texture
      * cache, it will be created and loaded.
      * @static
-     * @param {string|string[]|HTMLImageElement|HTMLCanvasElement|SVGElement|HTMLVideoElement} source - The
+     * @param {string|string[]|HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|SVGElement} source - The
      *        source to create base texture from.
      * @param options - See {@link PIXI.BaseTexture}'s constructor for options.
      * @param {string} [options.pixiIdPrefix=pixiid] - If a source has no id, this is the prefix of the generated id

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -331,7 +331,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
     /**
      * Helper function that creates a new Texture based on the source you provide.
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
-     * @param {string|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|PIXI.BaseTexture} source -
+     * @param {string|HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|PIXI.BaseTexture} source -
      *        Source or array of sources to create texture from
      * @param options - See {@link PIXI.BaseTexture}'s constructor for options.
      * @param {string} [options.pixiIdPrefix=pixiid] - If a source has no id, this is the prefix of the generated id
@@ -448,14 +448,14 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
 
     /**
      * Create a texture from a source and add to the cache.
-     * @param {HTMLImageElement|HTMLCanvasElement|string} source - The input source.
+     * @param {HTMLImageElement|HTMLCanvasElement|OffscreenCanvas|string} source - The input source.
      * @param imageUrl - File name of texture, for cache and resolving resolution.
      * @param name - Human readable name for the texture cache. If no name is
      *        specified, only `imageUrl` will be used as the cache ID.
      * @param options
      * @returns - Output texture
      */
-    static fromLoader<R extends Resource = Resource>(source: HTMLImageElement | HTMLCanvasElement | string,
+    static fromLoader<R extends Resource = Resource>(source: HTMLImageElement | HTMLCanvasElement | OffscreenCanvas | string,
         imageUrl: string, name?: string, options?: IBaseTextureOptions): Promise<Texture<R>>
     {
         const baseTexture = new BaseTexture<R>(source, Object.assign({
@@ -689,7 +689,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
             context.fillStyle = 'white';
             context.fillRect(0, 0, 16, 16);
 
-            Texture._WHITE = new Texture(BaseTexture.from(canvas));
+            Texture._WHITE = new Texture(BaseTexture.from(canvas as ImageSource));
             removeAllHandlers(Texture._WHITE);
             removeAllHandlers(Texture._WHITE.baseTexture);
         }

--- a/packages/core/src/textures/resources/ArrayResource.ts
+++ b/packages/core/src/textures/resources/ArrayResource.ts
@@ -125,7 +125,7 @@ export class ArrayResource extends AbstractMultiResource
                         1,
                         texture.format,
                         glTexture.type,
-                        (item.resource as BaseImageResource).source
+                        (item.resource as BaseImageResource).source as TexImageSource | OffscreenCanvas
                     );
                 }
             }

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -14,7 +14,7 @@ export class BaseImageResource extends Resource
 {
     /**
      * The source element.
-     * @member {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|SVGElement}
+     * @member {HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|SVGElement}
      * @readonly
      */
     public source: ImageSource;
@@ -28,7 +28,7 @@ export class BaseImageResource extends Resource
     public noSubImage: boolean;
 
     /**
-     * @param {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|SVGElement} source
+     * @param {HTMLImageElement|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas|SVGElement} source
      */
     constructor(source: ImageSource)
     {
@@ -76,14 +76,14 @@ export class BaseImageResource extends Resource
 
         source = source || this.source;
 
-        if (source instanceof HTMLImageElement)
+        if (typeof HTMLImageElement !== 'undefined' && source instanceof HTMLImageElement)
         {
             if (!source.complete || source.naturalWidth === 0)
             {
                 return false;
             }
         }
-        else if (source instanceof HTMLVideoElement)
+        else if (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement)
         {
             if (source.readyState <= 1)
             {
@@ -98,14 +98,16 @@ export class BaseImageResource extends Resource
             && glTexture.width === width
             && glTexture.height === height)
         {
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, baseTexture.format, glTexture.type, source);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, baseTexture.format, glTexture.type,
+                source as TexImageSource | OffscreenCanvas);
         }
         else
         {
             glTexture.width = width;
             glTexture.height = height;
 
-            gl.texImage2D(baseTexture.target, 0, glTexture.internalFormat, baseTexture.format, glTexture.type, source);
+            gl.texImage2D(baseTexture.target, 0, glTexture.internalFormat, baseTexture.format, glTexture.type,
+                source as TexImageSource | OffscreenCanvas);
         }
 
         return true;

--- a/packages/core/src/textures/resources/CanvasResource.ts
+++ b/packages/core/src/textures/resources/CanvasResource.ts
@@ -1,11 +1,14 @@
 import { BaseImageResource } from './BaseImageResource';
 
+import type { ImageSource } from './../BaseTexture';
+import type { ICanvas } from '../../ICanvas';
+
 /**
  * @interface OffscreenCanvas
  */
 
 /**
- * Resource type for HTMLCanvasElement.
+ * Resource type for HTMLCanvasElement and OffscreenCanvas.
  * @memberof PIXI
  */
 export class CanvasResource extends BaseImageResource
@@ -14,9 +17,9 @@ export class CanvasResource extends BaseImageResource
      * @param source - Canvas element to use
      */
     // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(source: HTMLCanvasElement)
+    constructor(source: ICanvas)
     {
-        super(source);
+        super(source as ImageSource);
     }
 
     /**

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -78,7 +78,7 @@ export class ImageResource extends BaseImageResource
     {
         options = options || {};
 
-        if (!(source instanceof HTMLImageElement))
+        if (typeof source === 'string')
         {
             const imageElement = new Image();
 

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -3,6 +3,7 @@ import { BaseImageResource } from './BaseImageResource';
 import { settings } from '@pixi/settings';
 
 import type { ISize } from '@pixi/math';
+import type { ImageSource } from '../BaseTexture';
 
 export interface ISVGResourceOptions
 {
@@ -52,7 +53,7 @@ export class SVGResource extends BaseImageResource
     {
         options = options || {};
 
-        super(settings.ADAPTER.createCanvas());
+        super(settings.ADAPTER.createCanvas() as ImageSource);
         this._width = 0;
         this._height = 0;
 

--- a/packages/core/src/view/ViewSystem.ts
+++ b/packages/core/src/view/ViewSystem.ts
@@ -81,7 +81,7 @@ export class ViewSystem implements ISystem
     {
         this.screen = new Rectangle(0, 0, options.width, options.height);
 
-        this.element = options.view || settings.ADAPTER.createCanvas();
+        this.element = options.view || settings.ADAPTER.createCanvas() as HTMLCanvasElement;
 
         this.resolution = options.resolution || settings.RESOLUTION;
 

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -4,7 +4,7 @@ import { FederatedPointerEvent } from './FederatedPointerEvent';
 import { FederatedWheelEvent } from './FederatedWheelEvent';
 import { extensions, ExtensionType } from '@pixi/core';
 
-import type { IRenderableObject, ExtensionMetadata } from '@pixi/core';
+import type { ExtensionMetadata, ICanvas, IRenderableObject } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
 import type { IPointData } from '@pixi/math';
 
@@ -20,7 +20,7 @@ const TOUCH_TO_POINTER: Record<string, string> = {
 interface Renderer
 {
     lastObjectRendered: IRenderableObject;
-    view: HTMLCanvasElement;
+    view: ICanvas;
     resolution: number;
     plugins: Record<string, any>;
 }
@@ -127,7 +127,7 @@ export class EventSystem
     {
         const { view, resolution } = this.renderer;
 
-        this.setTargetElement(view);
+        this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
     }
 

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -152,7 +152,7 @@ describe('EventSystem', () =>
                         changedTouches: [
                             new Touch({
                                 identifier: 0,
-                                target: renderer.view,
+                                target: renderer.view as HTMLCanvasElement,
                                 clientX,
                                 clientY,
                             }),
@@ -175,6 +175,7 @@ describe('EventSystem', () =>
     {
         const renderer = createRenderer();
         const [stage, graphics] = createScene();
+        const view = renderer.view as HTMLCanvasElement;
 
         renderer.render(stage);
         graphics.cursor = 'copy';
@@ -187,7 +188,7 @@ describe('EventSystem', () =>
             })
         );
 
-        expect(renderer.view.style.cursor).toEqual('copy');
+        expect(view.style.cursor).toEqual('copy');
 
         const eventSpy = jest.fn();
 
@@ -201,7 +202,7 @@ describe('EventSystem', () =>
         );
 
         expect(eventSpy).not.toBeCalled();
-        expect(renderer.view.style.cursor).toEqual('inherit');
+        expect(view.style.cursor).toEqual('inherit');
     });
 
     it('should dispatch synthetic over/out events on pointermove', () =>

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -2,7 +2,7 @@ import { CanvasRenderTarget } from '@pixi/utils';
 import { Rectangle } from '@pixi/math';
 import { extensions, ExtensionType, RenderTexture } from '@pixi/core';
 
-import type { Renderer, ISystem, ExtensionMetadata } from '@pixi/core';
+import type { ICanvas, ISystem, ExtensionMetadata, Renderer } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
 
 const TEMP_RECT = new Rectangle();
@@ -75,7 +75,13 @@ export class Extract implements ISystem
      */
     public base64(target: DisplayObject | RenderTexture, format?: string, quality?: number): string
     {
-        return this.canvas(target).toDataURL(format, quality);
+        const canvas = this.canvas(target);
+
+        if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement)
+        {
+            return canvas.toDataURL(format, quality);
+        }
+        throw new Error('TODO: base64 for OffscreenCanvas');
     }
 
     /**
@@ -85,7 +91,7 @@ export class Extract implements ISystem
      * @param frame - The frame the extraction is restricted to.
      * @returns - A Canvas element with the texture rendered on.
      */
-    public canvas(target: DisplayObject | RenderTexture, frame?: Rectangle): HTMLCanvasElement
+    public canvas(target: DisplayObject | RenderTexture, frame?: Rectangle): ICanvas
     {
         const renderer = this.renderer;
         let resolution;
@@ -163,7 +169,7 @@ export class Extract implements ISystem
             target.context.scale(1, -1);
 
             // we can't render to itself because we should be empty before render.
-            target.context.drawImage(canvasBuffer.canvas, 0, -height);
+            target.context.drawImage(canvasBuffer.canvas as CanvasImageSource, 0, -height);
 
             canvasBuffer.destroy();
             canvasBuffer = target;

--- a/packages/settings/src/adapter.ts
+++ b/packages/settings/src/adapter.ts
@@ -1,3 +1,5 @@
+import type { ICanvas } from './canvas';
+
 export type ContextIds = '2d' | 'webgl' | 'experimental-webgl' | 'webgl2';
 
 /**
@@ -8,7 +10,7 @@ export type ContextIds = '2d' | 'webgl' | 'experimental-webgl' | 'webgl2';
 export interface IAdapter
 {
     /** Returns a canvas object that can be used to create a webgl context. */
-    createCanvas: (width?: number, height?: number) => HTMLCanvasElement;
+    createCanvas: (width?: number, height?: number) => ICanvas;
     /** Returns a webgl rendering context. */
     getWebGLRenderingContext: () => typeof WebGLRenderingContext;
     /** Returns a partial implementation of the browsers window.navigator */
@@ -37,5 +39,20 @@ export const BrowserAdapter = {
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI ?? window.location.href),
+    fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
+} as IAdapter;
+
+export const WebWorkerAdapter = {
+    /**
+     * Creates a canvas element of the given size.
+     * This canvas is created using the browser's OffscreenCanvas.
+     * @param width - width of the canvas
+     * @param height - height of the canvas
+     */
+    createCanvas: (width: number, height: number): OffscreenCanvas =>
+        new OffscreenCanvas(width || 0, height || 0),
+    getWebGLRenderingContext: () => WebGLRenderingContext,
+    getNavigator: () => navigator,
+    getBaseUrl: () => self.location.href,
     fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
 } as IAdapter;

--- a/packages/settings/src/canvas.ts
+++ b/packages/settings/src/canvas.ts
@@ -1,0 +1,16 @@
+type RenderingContext2D = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+type RenderingContext = RenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext | WebGL2RenderingContext;
+
+/** Common interface for HTMLCanvasElement and OffscreenCanvas */
+export interface ICanvas
+{
+    width: number;
+    height: number;
+
+    getContext(contextId: '2d', options?: CanvasRenderingContext2DSettings): RenderingContext2D | null;
+    getContext(contextId: 'bitmaprenderer', options?: ImageBitmapRenderingContextSettings):
+    ImageBitmapRenderingContext | null;
+    getContext(contextId: 'webgl', options?: WebGLContextAttributes): WebGLRenderingContext | null;
+    getContext(contextId: 'webgl2', options?: WebGLContextAttributes): WebGL2RenderingContext | null;
+    getContext(contextId: string, options?: any): RenderingContext | null;
+}

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -1,3 +1,5 @@
 export * from './settings';
+export * from './utils/environment';
 export * from './utils/isMobile';
 export * from './adapter';
+export * from './canvas';

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,14 +1,17 @@
-import type { ENV } from '@pixi/constants';
 import { GC_MODES, MIPMAP_MODES, MSAA_QUALITY, PRECISION, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
-import type { IAdapter } from './adapter';
-import { BrowserAdapter } from './adapter';
+import { BrowserAdapter, WebWorkerAdapter } from './adapter';
 import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
+import { environment } from './utils/environment';
 import { isMobile } from './utils/isMobile';
 import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 
+import type { ENV } from '@pixi/constants';
+import type { ICanvas } from '@pixi/core';
+import type { IAdapter } from './adapter';
+
 export interface IRenderOptions
 {
-    view: HTMLCanvasElement;
+    view: ICanvas;
     antialias: boolean;
     autoDensity: boolean;
     backgroundColor: number;
@@ -76,9 +79,9 @@ export const settings: ISettings = {
      * @name ADAPTER
      * @memberof PIXI.settings
      * @type {PIXI.IAdapter}
-     * @default PIXI.BrowserAdapter
+     * @default PIXI.BrowserAdapter for browser main thread, PIXI.WebWorkerAdapter for worker thread
      */
-    ADAPTER: BrowserAdapter,
+    ADAPTER: environment.webworker ? WebWorkerAdapter : BrowserAdapter,
     /**
      * If set to true WebGL will attempt make textures mimpaped by default.
      * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
@@ -163,7 +166,7 @@ export const settings: ISettings = {
      * @name RENDER_OPTIONS
      * @memberof PIXI.settings
      * @type {object}
-     * @property {HTMLCanvasElement} [view=null] -
+     * @property {ICanvas} [view=null] -
      * @property {boolean} [antialias=false] -
      * @property {boolean} [autoDensity=false] -
      * @property {boolean} [useContextAlpha=true]  -

--- a/packages/settings/src/utils/environment.ts
+++ b/packages/settings/src/utils/environment.ts
@@ -1,0 +1,5 @@
+export const environment = {
+    browser: typeof window === 'object',
+    webworker: typeof importScripts === 'function',
+    node: typeof process === 'object',
+};

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -488,7 +488,7 @@ export class Sprite extends Container
     /**
      * Helper function that creates a new sprite based on the source you provide.
      * The source can be - frame id, image url, video url, canvas element, video element, base texture
-     * @param {string|PIXI.Texture|HTMLCanvasElement|HTMLVideoElement} source - Source to create texture from
+     * @param {string|PIXI.Texture|HTMLVideoElement|HTMLCanvasElement|OffscreenCanvas} source - Source to create texture from
      * @param {object} [options] - See {@link PIXI.BaseTexture}'s constructor for options.
      * @returns The newly created sprite
      */

--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -1,15 +1,16 @@
-import { getResolutionOfUrl } from '@pixi/utils';
-import { Rectangle } from '@pixi/math';
 import { Texture, BaseTexture } from '@pixi/core';
+import { Rectangle } from '@pixi/math';
 import { TextStyle, TextMetrics } from '@pixi/text';
+import { getResolutionOfUrl } from '@pixi/utils';
 import { autoDetectFormat } from './formats';
 import { BitmapFontData } from './BitmapFontData';
 import { resolveCharacters, drawGlyph, extractCharCode } from './utils';
 
-import type { Dict } from '@pixi/utils';
-import type { ITextStyle } from '@pixi/text';
+import type { ICanvas } from '@pixi/core';
 import { ALPHA_MODES } from '@pixi/constants';
 import { settings } from '@pixi/settings';
+import type { ITextStyle } from '@pixi/text';
+import type { Dict } from '@pixi/utils';
 
 export interface IBitmapFontCharacter
 {
@@ -387,8 +388,8 @@ export class BitmapFont
         let positionX = 0;
         let positionY = 0;
 
-        let canvas: HTMLCanvasElement;
-        let context: CanvasRenderingContext2D;
+        let canvas: ICanvas;
+        let context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
         let baseTexture: BaseTexture;
         let maxCharHeight = 0;
         const baseTextures: BaseTexture[] = [];

--- a/packages/text-bitmap/src/utils/drawGlyph.ts
+++ b/packages/text-bitmap/src/utils/drawGlyph.ts
@@ -1,5 +1,7 @@
-import { generateFillStyle } from './generateFillStyle';
 import { hex2rgb, string2hex } from '@pixi/utils';
+import { generateFillStyle } from './generateFillStyle';
+
+import type { ICanvas } from '@pixi/core';
 import type { TextMetrics, TextStyle } from '@pixi/text';
 
 // TODO: Prevent code duplication b/w drawGlyph & Text#updateText
@@ -9,7 +11,7 @@ import type { TextMetrics, TextStyle } from '@pixi/text';
  *
  * Ignored because not directly exposed.
  * @ignore
- * @param {HTMLCanvasElement} canvas
+ * @param {ICanvas} canvas
  * @param {CanvasRenderingContext2D} context
  * @param {TextMetrics} metrics
  * @param {number} x
@@ -18,8 +20,8 @@ import type { TextMetrics, TextStyle } from '@pixi/text';
  * @param {TextStyle} style
  */
 export function drawGlyph(
-    canvas: HTMLCanvasElement,
-    context: CanvasRenderingContext2D,
+    canvas: ICanvas,
+    context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     metrics: TextMetrics,
     x: number,
     y: number,

--- a/packages/text-bitmap/src/utils/generateFillStyle.ts
+++ b/packages/text-bitmap/src/utils/generateFillStyle.ts
@@ -1,5 +1,7 @@
-import type { TextStyle, TextMetrics } from '@pixi/text';
 import { TEXT_GRADIENT } from '@pixi/text';
+
+import type { ICanvas } from '@pixi/core';
+import type { TextStyle, TextMetrics } from '@pixi/text';
 
 // TODO: Prevent code duplication b/w generateFillStyle & Text#generateFillStyle
 
@@ -15,8 +17,8 @@ import { TEXT_GRADIENT } from '@pixi/text';
  * @returns {string|number|CanvasGradient} The fill style
  */
 export function generateFillStyle(
-    canvas: HTMLCanvasElement,
-    context: CanvasRenderingContext2D,
+    canvas: ICanvas,
+    context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     style: TextStyle,
     resolution: number,
     lines: string[],

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -1,15 +1,15 @@
 /* eslint max-depth: [2, 8] */
-import { Sprite } from '@pixi/sprite';
-import { Texture  } from '@pixi/core';
-import { settings } from '@pixi/settings';
+import { Texture } from '@pixi/core';
 import { Rectangle } from '@pixi/math';
+import { settings } from '@pixi/settings';
+import { Sprite } from '@pixi/sprite';
 import { sign, trimCanvas, hex2rgb, string2hex } from '@pixi/utils';
 import { TEXT_GRADIENT } from './const';
 import { TextStyle } from './TextStyle';
 import { TextMetrics } from './TextMetrics';
 
+import type { ICanvas, ImageSource, Renderer } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
-import type { Renderer } from '@pixi/core';
 import type { ITextStyle } from './TextStyle';
 
 const defaultDestroyOptions: IDestroyOptions = {
@@ -58,7 +58,7 @@ export class Text extends Sprite
     public static experimentalLetterSpacing = false;
 
     /** The canvas element that everything is drawn to. */
-    public canvas: HTMLCanvasElement;
+    public canvas: ICanvas;
     /** The canvas 2d context that everything is drawn with. */
     public context: ModernContext2D;
     public localStyleID: number;
@@ -110,7 +110,7 @@ export class Text extends Sprite
      * @param {object|PIXI.TextStyle} [style] - The style parameters
      * @param canvas - The canvas element for drawing text
      */
-    constructor(text?: string | number, style?: Partial<ITextStyle> | TextStyle, canvas?: HTMLCanvasElement)
+    constructor(text?: string | number, style?: Partial<ITextStyle> | TextStyle, canvas?: ICanvas)
     {
         let ownCanvas = false;
 
@@ -123,7 +123,7 @@ export class Text extends Sprite
         canvas.width = 3;
         canvas.height = 3;
 
-        const texture = Texture.from(canvas);
+        const texture = Texture.from(canvas as ImageSource);
 
         texture.orig = new Rectangle();
         texture.trim = new Rectangle();

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -1,4 +1,6 @@
 import { settings } from '@pixi/settings';
+
+import type { ICanvas } from '@pixi/core';
 import type { TextStyle, TextStyleWhiteSpace } from './TextStyle';
 
 interface IFontMetrics
@@ -56,7 +58,7 @@ export class TextMetrics
     public static BASELINE_MULTIPLIER: number;
     public static HEIGHT_MULTIPLIER: number;
 
-    private static __canvas: HTMLCanvasElement | OffscreenCanvas;
+    private static __canvas: ICanvas;
     private static __context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 
     // TODO: These should be protected but they're initialized outside of the class.
@@ -101,7 +103,7 @@ export class TextMetrics
         text: string,
         style: TextStyle,
         wordWrap?: boolean,
-        canvas: HTMLCanvasElement | OffscreenCanvas = TextMetrics._canvas
+        canvas: ICanvas = TextMetrics._canvas
     ): TextMetrics
     {
         wordWrap = (wordWrap === undefined || wordWrap === null) ? style.wordWrap : wordWrap;
@@ -172,7 +174,7 @@ export class TextMetrics
     private static wordWrap(
         text: string,
         style: TextStyle,
-        canvas: HTMLCanvasElement | OffscreenCanvas = TextMetrics._canvas
+        canvas: ICanvas = TextMetrics._canvas
     ): string
     {
         const context = canvas.getContext('2d');
@@ -705,11 +707,11 @@ export class TextMetrics
      * TODO: this should be private, but isn't because of backward compat, will fix later.
      * @ignore
      */
-    public static get _canvas(): HTMLCanvasElement | OffscreenCanvas
+    public static get _canvas(): ICanvas
     {
         if (!TextMetrics.__canvas)
         {
-            let canvas: HTMLCanvasElement | OffscreenCanvas;
+            let canvas: ICanvas;
 
             try
             {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -46,6 +46,17 @@
  */
 export { isMobile } from '@pixi/settings';
 
+/**
+ * Execution environment detection.
+ * @memberof PIXI.utils
+ * @name environment
+ * @member {object}
+ * @property {boolean} browser - `true` if current environment is browser main thread
+ * @property {boolean} webworker - `true` if current environment is browser worker thread
+ * @property {boolean} phone - `true` if current environment is Node.js
+ */
+export { environment } from '@pixi/settings';
+
 import EventEmitter from 'eventemitter3';
 
 /**

--- a/packages/utils/src/media/CanvasRenderTarget.ts
+++ b/packages/utils/src/media/CanvasRenderTarget.ts
@@ -1,5 +1,7 @@
 import { settings } from '@pixi/settings';
 
+import type { ICanvas } from '@pixi/core';
+
 /**
  * Creates a Canvas element of the given size to be used as a target for rendering to.
  * @class
@@ -8,10 +10,10 @@ import { settings } from '@pixi/settings';
 export class CanvasRenderTarget
 {
     /** The Canvas object that belongs to this CanvasRenderTarget. */
-    public canvas: HTMLCanvasElement;
+    public canvas: ICanvas;
 
     /** A CanvasRenderingContext2D object representing a two-dimensional rendering context. */
-    public context: CanvasRenderingContext2D;
+    public context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 
     /**
      * The resolution / device pixel ratio of the canvas

--- a/packages/utils/src/media/trimCanvas.ts
+++ b/packages/utils/src/media/trimCanvas.ts
@@ -1,3 +1,5 @@
+import type { ICanvas } from '@pixi/core';
+
 interface Inset
 {
     top?: number;
@@ -10,10 +12,10 @@ interface Inset
  * Trim transparent borders from a canvas
  * @memberof PIXI.utils
  * @function trimCanvas
- * @param {HTMLCanvasElement} canvas - the canvas to trim
+ * @param {ICanvas} canvas - the canvas to trim
  * @returns {object} Trim data
  */
-export function trimCanvas(canvas: HTMLCanvasElement): {width: number; height: number; data?: ImageData}
+export function trimCanvas(canvas: ICanvas): {width: number; height: number; data?: ImageData}
 {
     // https://gist.github.com/remy/784508
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

This PR attempts to add OffscreenCanvas and Web Worker support to Pixi.js.

This should fix #7123.


##### Description of change
<!-- Provide a description of the change below this comment. -->

- New interface [PIXI.ICanvas](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/settings/src/canvas.ts), the common interface for HTMLCanvasElement and OffscreenCanvas
    - Change many usages of HTMLCanvasElement to PIXI.ICanvas, such as PIXI.Renderer.view
- ~~New [PIXI.environment](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/settings/src/utils/environment.ts) for environment detection~~
    - ~~[PIXI.AccessibilityManager](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/accessibility/src/AccessibilityManager.ts) now only added to extensions in browser main thread, not in worker thread~~
- ~~New [PIXI.WebWorkerAdapter](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/settings/src/adapter.ts) for Web Worker~~
    - ~~Default value for [PIXI.settings.ADAPTER](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/settings/src/settings.ts) will be PIXI.WebWorkerAdapter in worker thread~~
- Other small changes to make things work for OffscreenCanvas / Web Worker


##### Todo List

There are still some small things to do (see Todo List), so I made this PR in draft state for everyone's opinion. :wink:

- [ ] Implement base64 for OffscreenCanvas in [PIXI.CanvasExtract](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/canvas-extract/src/CanvasExtract.ts) and [PIXI.Extract](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/extract/src/Extract.ts)
- [ ] Implement convertTintToImage for OffscreenCanvas / Web Worker in [PIXI.canvasUtils](https://github.com/SuperSodaSea/pixijs/blob/web-worker/packages/canvas-renderer/src/canvasUtils.ts)
- [ ] Add tests for OffscreenCanvas / Web Worker


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
