### PR TITLE
Remove browser builds for packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build:types": "rimraf out && tsc && api-extractor-lerna-monorepo && rimraf out && ts-node-script ./scripts/injectGlobalMixins.ts",
     "watch": "rollup -cw",
     "dist": "run-s lint types build:prod build:types docs",
-    "postdist": "copyfiles -f bundles/*/dist/browser/* dist && copyfiles -f \"packages/**/dist/browser/*\" dist/packages",
+    "postdist": "copyfiles -f bundles/*/dist/browser/* dist",
     "prerelease": "run-s clean:build test",
     "postversion": "run-s lint types build:prod build:types",
     "release": "lerna version --exact --force-publish",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/accessibility.js",
   "module": "dist/esm/accessibility.mjs",
-  "bundle": "dist/browser/accessibility.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/app.js",
   "module": "dist/esm/app.mjs",
-  "bundle": "dist/browser/app.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "main": "dist/cjs/assets.js",
   "module": "dist/esm/assets.mjs",
-  "bundle": "dist/browser/assets.js",
   "types": "index.d.ts",
   "exports": {
     ".": {

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "main": "dist/cjs/basis.js",
   "module": "dist/esm/basis.mjs",
-  "bundle": "dist/browser/basis.js",
   "types": "index.d.ts",
   "exports": {
     ".": {

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Canvas mixin for the display package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-display.js",
   "module": "dist/esm/canvas-display.mjs",
-  "bundle": "dist/browser/canvas-display.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-extract.js",
   "module": "dist/esm/canvas-extract.mjs",
-  "bundle": "dist/browser/canvas-extract.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-graphics.js",
   "module": "dist/esm/canvas-graphics.mjs",
-  "bundle": "dist/browser/canvas-graphics.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-mesh.js",
   "module": "dist/esm/canvas-mesh.mjs",
-  "bundle": "dist/browser/canvas-mesh.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Canvas mixin for the particles package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-particle-container.js",
   "module": "dist/esm/canvas-particle-container.mjs",
-  "bundle": "dist/browser/canvas-particle-container.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-prepare.js",
   "module": "dist/esm/canvas-prepare.mjs",
-  "bundle": "dist/browser/canvas-prepare.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-renderer.js",
   "module": "dist/esm/canvas-renderer.mjs",
-  "bundle": "dist/browser/canvas-renderer.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Canvas mixin for the sprite-tiling package",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-sprite-tiling.js",
   "module": "dist/esm/canvas-sprite-tiling.mjs",
-  "bundle": "dist/browser/canvas-sprite-tiling.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-sprite.js",
   "module": "dist/esm/canvas-sprite.mjs",
-  "bundle": "dist/browser/canvas-sprite.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Canvas mixin for the text package",
   "author": "Dave Moore",
   "homepage": "http://pixijs.com/",

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/canvas-text.js",
   "module": "dist/esm/canvas-text.mjs",
-  "bundle": "dist/browser/canvas-text.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -31,7 +30,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -15,7 +15,6 @@
   "license": "MIT",
   "main": "dist/cjs/compressed-textures.js",
   "module": "dist/esm/compressed-textures.mjs",
-  "bundle": "dist/browser/compressed-textures.js",
   "types": "index.d.ts",
   "exports": {
     ".": {

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/constants.js",
   "module": "dist/esm/constants.mjs",
-  "bundle": "dist/browser/constants.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/core.js",
   "module": "dist/esm/core.mjs",
-  "bundle": "dist/browser/core.js",
   "types": "index.d.ts",
   "exports": {
     ".": {

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/display.js",
   "module": "dist/esm/display.mjs",
-  "bundle": "dist/browser/display.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/events.js",
   "module": "dist/esm/events.mjs",
-  "bundle": "dist/browser/events.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -30,7 +29,6 @@
   "homepage": "https://github.com/pixijs/pixi.js#readme",
   "license": "MIT",
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/extensions.js",
   "module": "dist/esm/extensions.mjs",
-  "bundle": "dist/browser/extensions.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -30,7 +29,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ]

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/extract.js",
   "module": "dist/esm/extract.mjs",
-  "bundle": "dist/browser/extract.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter that applies alpha evenly across the entire display object and any opaque elements it contains",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-alpha.js",
   "module": "dist/esm/filter-alpha.mjs",
-  "bundle": "dist/browser/filter-alpha.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-blur.js",
   "module": "dist/esm/filter-blur.mjs",
-  "bundle": "dist/browser/filter-blur.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter that blurs the display object",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter that lets you change RGBA via a 5x4 matrix transformation",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-color-matrix.js",
   "module": "dist/esm/filter-color-matrix.mjs",
-  "bundle": "dist/browser/filter-color-matrix.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter that allows offsetting of pixel values to create warping effects",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-displacement.js",
   "module": "dist/esm/filter-displacement.mjs",
-  "bundle": "dist/browser/filter-displacement.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-fxaa.js",
   "module": "dist/esm/filter-fxaa.mjs",
-  "bundle": "dist/browser/filter-fxaa.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter for fast approximate anti-aliasing",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/filter-noise.js",
   "module": "dist/esm/filter-noise.mjs",
-  "bundle": "dist/browser/filter-noise.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.filters",
   "description": "Filter that applies noise to a display object",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Additional Graphics functions for drawing special shapes.",
   "author": "Matt Karl <matt@mattkarl.com>",
   "homepage": "http://pixijs.com/",

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/graphics-extras.js",
   "module": "dist/esm/graphics-extras.mjs",
-  "bundle": "dist/browser/graphics-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -31,7 +30,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/graphics.js",
   "module": "dist/esm/graphics.mjs",
-  "bundle": "dist/browser/graphics.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/math-extras.js",
   "module": "dist/esm/math-extras.mjs",
-  "bundle": "dist/browser/math-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -35,7 +34,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Useful methods for some math structures",
   "author": "Milton Candelero",
   "contributors": [

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/math.js",
   "module": "dist/esm/math.mjs",
-  "bundle": "dist/browser/math.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ]

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/mesh-extras.js",
   "module": "dist/esm/mesh-extras.mjs",
-  "bundle": "dist/browser/mesh-extras.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/mesh.js",
   "module": "dist/esm/mesh.mjs",
-  "bundle": "dist/browser/mesh.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/mixin-cache-as-bitmap.js",
   "module": "dist/esm/mixin-cache-as-bitmap.mjs",
-  "bundle": "dist/browser/mixin-cache-as-bitmap.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Mixin to allow caching container and its children to a bitmap texture",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/mixin-get-child-by-name.js",
   "module": "dist/esm/mixin-get-child-by-name.mjs",
-  "bundle": "dist/browser/mixin-get-child-by-name.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Mixin function to find a child DisplayObject by name",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleNoExports": true,
   "description": "Mixin to find the global position of a DisplayObject",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/mixin-get-global-position.js",
   "module": "dist/esm/mixin-get-global-position.mjs",
-  "bundle": "dist/browser/mixin-get-global-position.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/particle-container.js",
   "module": "dist/esm/particle-container.mjs",
-  "bundle": "dist/browser/particle-container.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/prepare.js",
   "module": "dist/esm/prepare.mjs",
-  "bundle": "dist/browser/prepare.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/runner.js",
   "module": "dist/esm/runner.mjs",
-  "bundle": "dist/browser/runner.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -48,7 +47,6 @@
     "benchmark": "cd benchmark && npm start"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ]

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/settings.js",
   "module": "dist/esm/settings.mjs",
-  "bundle": "dist/browser/settings.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/sprite-animated.js",
   "module": "dist/esm/sprite-animated.mjs",
-  "bundle": "dist/browser/sprite-animated.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/sprite-tiling.js",
   "module": "dist/esm/sprite-tiling.mjs",
-  "bundle": "dist/browser/sprite-tiling.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/sprite.js",
   "module": "dist/esm/sprite.mjs",
-  "bundle": "dist/browser/sprite.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/spritesheet.js",
   "module": "dist/esm/spritesheet.mjs",
-  "bundle": "dist/browser/spritesheet.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/text-bitmap.js",
   "module": "dist/esm/text-bitmap.mjs",
-  "bundle": "dist/browser/text-bitmap.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/text.js",
   "module": "dist/esm/text.mjs",
-  "bundle": "dist/browser/text.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/ticker.js",
   "module": "dist/esm/ticker.mjs",
-  "bundle": "dist/browser/ticker.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -33,7 +32,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/packages/unsafe-eval/README.md
+++ b/packages/unsafe-eval/README.md
@@ -10,7 +10,7 @@ npm install @pixi/unsafe-eval
 
 ## Usage
 
-If you are using a bundler, you need to pass the core bundle into the `install` method. This function takes one arguments, either the global `PIXI` object, or the core.
+If you are using a bundler, you need to pass the core bundle into the `install` method.
 
 ```js
 import { ShaderSystem, Renderer } from '@pixi/core';
@@ -23,9 +23,3 @@ install({ ShaderSystem });
 const renderer = new Renderer();
 ```
 
-If you are including **unsafe-eval.js** direct, you do not need to do anything else:
-
-```html
-<script src="pixi.min.js"></script>
-<script src="unsafe-eval.min.js"></script>
-```

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/unsafe-eval.js",
   "module": "dist/esm/unsafe-eval.mjs",
-  "bundle": "dist/browser/unsafe-eval.js",
   "types": "index.d.ts",
   "exports": {
     ".": {

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "bundleInput": "src/bundle.ts",
   "standalone": true,
   "description": "Adds support for environments that disallow support of new Function",
   "author": "Matt Karl <matt@mattkarl.com>",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,6 @@
       }
     }
   },
-  "namespace": "PIXI.utils",
   "description": "Collection of utilities used by PixiJS",
   "author": "Mat Groves",
   "contributors": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,6 @@
   "version": "6.5.2",
   "main": "dist/cjs/utils.js",
   "module": "dist/esm/utils.mjs",
-  "bundle": "dist/browser/utils.js",
   "types": "index.d.ts",
   "exports": {
     ".": {
@@ -34,7 +33,6 @@
     "access": "public"
   },
   "files": [
-    "lib",
     "dist",
     "*.d.ts"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -110,14 +110,6 @@ async function main()
         }
     });
 
-    const namespaces = {};
-
-    // Create a map of globals to use for bundled packages
-    packages.forEach((pkg) =>
-    {
-        namespaces[pkg.name] = pkg.config.namespace || 'PIXI';
-    });
-
     packages.forEach((pkg) =>
     {
         const {
@@ -125,10 +117,6 @@ async function main()
             module,
             bundle,
             bundleModule,
-            bundleInput,
-            bundleOutput,
-            bundleNoExports,
-            standalone,
             version,
             dependencies,
             nodeDependencies,
@@ -205,56 +193,30 @@ async function main()
         // this will package all dependencies
         if (bundle)
         {
-            const input = path.join(basePath, bundleInput || 'src/index.ts');
+            const input = path.join(basePath, 'src/index.ts');
             const file = path.join(basePath, bundle);
             const moduleFile = bundleModule ? path.join(basePath, bundleModule) : '';
-            const external = standalone ? null : Object.keys(namespaces);
-            const globals = standalone ? null : namespaces;
-            const ns = namespaces[pkg.name];
-            const name = pkg.name.replace(/[^a-z]+/g, '_');
             let footer;
-            let nsBanner = banner;
-
-            // Ignore self-contained packages like unsafe-eval
-            // as well as the bundles pixi.js and pixi.js-legacy
-            if (!standalone)
-            {
-                if (bundleNoExports !== true)
-                {
-                    footer = `Object.assign(this.${ns}, ${name});`;
-                }
-
-                if (ns.includes('.'))
-                {
-                    const base = ns.split('.')[0];
-
-                    nsBanner += `\nthis.${base} = this.${base} || {};`;
-                }
-
-                nsBanner += `\nthis.${ns} = this.${ns} || {};`;
-            }
 
             results.push({
                 input,
-                external,
                 output: [
-                    Object.assign({
-                        banner: nsBanner,
+                    {
+                        name: 'PIXI',
+                        banner,
                         file,
                         format: 'iife',
                         freeze,
-                        globals,
-                        name,
                         footer,
                         sourcemap,
-                    }, bundleOutput),
-                    ...moduleFile ? [{
+                    },
+                    {
                         banner,
                         file: moduleFile,
                         format: 'esm',
                         freeze,
                         sourcemap,
-                    }] : []
+                    }
                 ],
                 treeshake: false,
                 plugins: bundlePlugins,
@@ -264,25 +226,23 @@ async function main()
             {
                 results.push({
                     input,
-                    external,
                     output: [
-                        Object.assign({
-                            banner: nsBanner,
+                        {
+                            name: 'PIXI',
+                            banner,
                             file: prodName(file),
                             format: 'iife',
                             freeze,
-                            globals,
-                            name,
                             footer,
                             sourcemap,
-                        }, bundleOutput),
-                        ...moduleFile ? [{
+                        },
+                        {
                             banner,
                             file: prodName(moduleFile),
                             format: 'esm',
                             freeze,
                             sourcemap,
-                        }] : []
+                        }
                     ],
                     treeshake: false,
                     plugins: prodBundlePlugins,


### PR DESCRIPTION
## 🔥  Breaking Change

Removes browser builds for `@pixi/*` packages. This use-case is not common enough to create a separate build for each package. The bundles (pixi.js, pixi.js-legacy, etc) will continue to have browser builds.

This change aligns with our wanting to de-emphasize `PIXI` global object, as well as looking at ways to improve tree-shaking and this package browser builds are making that effort more difficult.

This also removes a lot of edge-case complexity from the rollup.config.js.
