### PR TITLE
Abandon the usage of peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25486,147 +25486,77 @@
     "packages/accessibility": {
       "name": "@pixi/accessibility",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/events": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/app": {
       "name": "@pixi/app",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/assets": {
       "name": "@pixi/assets",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/basis": {
       "name": "@pixi/basis",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "6.5.2",
-        "@pixi/compressed-textures": "6.5.2",
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-display": {
       "name": "@pixi/canvas-display",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-extract": {
       "name": "@pixi/canvas-extract",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-graphics": {
       "name": "@pixi/canvas-graphics",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-display": "6.5.2",
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/graphics": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-mesh": {
       "name": "@pixi/canvas-mesh",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-display": "6.5.2",
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/mesh": "6.5.2",
-        "@pixi/mesh-extras": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-particle-container": {
       "name": "@pixi/canvas-particle-container",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/particle-container": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-prepare": {
       "name": "@pixi/canvas-prepare",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/prepare": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-renderer": {
       "name": "@pixi/canvas-renderer",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-sprite": {
       "name": "@pixi/canvas-sprite",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-display": "6.5.2",
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-sprite-tiling": {
       "name": "@pixi/canvas-sprite-tiling",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-renderer": "6.5.2",
-        "@pixi/canvas-sprite": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/sprite-tiling": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/canvas-text": {
       "name": "@pixi/canvas-text",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/canvas-sprite": "6.5.2",
-        "@pixi/sprite": "6.5.2",
-        "@pixi/text": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/compressed-textures": {
       "name": "@pixi/compressed-textures",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "6.5.2",
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/constants": {
       "name": "@pixi/constants",
@@ -25655,19 +25585,12 @@
     "packages/display": {
       "name": "@pixi/display",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/events": {
       "name": "@pixi/events",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/extensions": {
       "name": "@pixi/extensions",
@@ -25677,77 +25600,47 @@
     "packages/extract": {
       "name": "@pixi/extract",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-alpha": {
       "name": "@pixi/filter-alpha",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-blur": {
       "name": "@pixi/filter-blur",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-color-matrix": {
       "name": "@pixi/filter-color-matrix",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-displacement": {
       "name": "@pixi/filter-displacement",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-fxaa": {
       "name": "@pixi/filter-fxaa",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/filter-noise": {
       "name": "@pixi/filter-noise",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/graphics": {
       "name": "@pixi/graphics",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/graphics-extras": {
       "name": "@pixi/graphics-extras",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/graphics": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/loaders": {
       "name": "@pixi/loaders",
@@ -25768,76 +25661,42 @@
     "packages/math-extras": {
       "name": "@pixi/math-extras",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/mesh": {
       "name": "@pixi/mesh",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/mesh-extras": {
       "name": "@pixi/mesh-extras",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/mesh": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/mixin-cache-as-bitmap": {
       "name": "@pixi/mixin-cache-as-bitmap",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/mixin-get-child-by-name": {
       "name": "@pixi/mixin-get-child-by-name",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/mixin-get-global-position": {
       "name": "@pixi/mixin-get-global-position",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/particle-container": {
       "name": "@pixi/particle-container",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/prepare": {
       "name": "@pixi/prepare",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/graphics": "6.5.2",
-        "@pixi/text": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/runner": {
       "name": "@pixi/runner",
@@ -25855,60 +25714,32 @@
     "packages/sprite": {
       "name": "@pixi/sprite",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/sprite-animated": {
       "name": "@pixi/sprite-animated",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/sprite-tiling": {
       "name": "@pixi/sprite-tiling",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/spritesheet": {
       "name": "@pixi/spritesheet",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "6.5.2",
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/text": {
       "name": "@pixi/text",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2",
-        "@pixi/sprite": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/text-bitmap": {
       "name": "@pixi/text-bitmap",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/assets": "6.5.2",
-        "@pixi/core": "6.5.2",
-        "@pixi/display": "6.5.2",
-        "@pixi/mesh": "6.5.2",
-        "@pixi/text": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/ticker": {
       "name": "@pixi/ticker",
@@ -25922,10 +25753,7 @@
     "packages/unsafe-eval": {
       "name": "@pixi/unsafe-eval",
       "version": "6.5.2",
-      "license": "MIT",
-      "peerDependencies": {
-        "@pixi/core": "6.5.2"
-      }
+      "license": "MIT"
     },
     "packages/utils": {
       "name": "@pixi/utils",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/events": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/events"
+  ]
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -44,7 +44,7 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -45,9 +45,9 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "peerDependencies": {
-    "@pixi/assets": "6.5.2",
-    "@pixi/compressed-textures": "6.5.2",
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/assets",
+    "@pixi/compressed-textures",
+    "@pixi/core"
+  ]
 }

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/display"
+  ]
 }

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-renderer",
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -37,10 +37,10 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-display": "6.5.2",
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/graphics": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-display",
+    "@pixi/canvas-renderer",
+    "@pixi/core",
+    "@pixi/graphics"
+  ]
 }

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -37,11 +37,11 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-display": "6.5.2",
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/mesh": "6.5.2",
-    "@pixi/mesh-extras": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-display",
+    "@pixi/canvas-renderer",
+    "@pixi/core",
+    "@pixi/mesh",
+    "@pixi/mesh-extras"
+  ]
 }

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/particle-container": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/particle-container"
+  ]
 }

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/prepare": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-renderer",
+    "@pixi/core",
+    "@pixi/prepare"
+  ]
 }

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -37,7 +37,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -38,10 +38,10 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/canvas-sprite": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/sprite-tiling": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-renderer",
+    "@pixi/canvas-sprite",
+    "@pixi/core",
+    "@pixi/sprite-tiling"
+  ]
 }

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -37,10 +37,10 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-display": "6.5.2",
-    "@pixi/canvas-renderer": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-display",
+    "@pixi/canvas-renderer",
+    "@pixi/core",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -35,9 +35,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/canvas-sprite": "6.5.2",
-    "@pixi/sprite": "6.5.2",
-    "@pixi/text": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/canvas-sprite",
+    "@pixi/sprite",
+    "@pixi/text"
+  ]
 }

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -47,8 +47,8 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "peerDependencies": {
-    "@pixi/assets": "6.5.2",
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/assets",
+    "@pixi/core"
+  ]
 }

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -37,7 +37,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -44,8 +44,8 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -37,7 +37,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -35,8 +35,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/graphics": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/graphics"
+  ]
 }

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -39,7 +39,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/mesh": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/mesh"
+  ]
 }

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -38,9 +38,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -38,7 +38,7 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/display"
+  ]
 }

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -38,8 +38,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -37,10 +37,10 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/graphics": "6.5.2",
-    "@pixi/text": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/graphics",
+    "@pixi/text"
+  ]
 }

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -37,9 +37,9 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/display"
+  ]
 }

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/assets": "6.5.2",
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/assets",
+    "@pixi/core"
+  ]
 }

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -37,11 +37,11 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/assets": "6.5.2",
-    "@pixi/core": "6.5.2",
-    "@pixi/display": "6.5.2",
-    "@pixi/mesh": "6.5.2",
-    "@pixi/text": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/assets",
+    "@pixi/core",
+    "@pixi/display",
+    "@pixi/mesh",
+    "@pixi/text"
+  ]
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -37,8 +37,8 @@
     "dist",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2",
-    "@pixi/sprite": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core",
+    "@pixi/sprite"
+  ]
 }

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -35,7 +35,7 @@
     "dist/",
     "*.d.ts"
   ],
-  "peerDependencies": {
-    "@pixi/core": "6.5.2"
-  }
+  "pixiRequirements": [
+    "@pixi/core"
+  ]
 }


### PR DESCRIPTION
### Context

The usage of `peerDependencies` have been a huge problem plaguing PixiJS v6. Different package managers resolve them differently causing lots of double-installed packages, especially when upgrading or using 3rd-party PixiJS plugins. Also, our packages use peers in a somewhat complex graph way making debugging this difficult. Here are some examples how this manifests for users: #8621, #8186, #8545 or #7816. We even had to make this [wiki](https://github.com/pixijs/pixijs/wiki/Upgrading-PixiJS) about how to upgrade.

### Overview

This change abandons `peerDependencies` completely in describing the relationships between packages.

For our bundles (`pixi.js`, `pixi.js-legacy` and `@pixi/node`) this change will not impact users. If anything, it will make doing upgrades much simpler and with fewer headaches.

For those using _individual packages_, it's important that you install the complete set of requirements. For this we will also update https://pixijs.io/customize as well as add `pixiRequirements` field in the **package.json** to be able to script resolution (maybe we can create a simple CLI in core to do this check, e.g., `pixi-doctor`).

The consequence of missing a package, is that build-tools or runtime fail at a missing package. This is _much_ easier for a user to understand. For instance, compare the above linked issues to a TypeScript error like this:

```
error TS2307: Cannot find module '@pixi/graphics' or its corresponding type declarations.
```

The solution here is easy: `yarn add @pixi/graphics` or `npm install @pixi/graphics`. 

This change isn't perfect and I wish we could get peers to work, but this approach is easier for users to self-debug and has fewer mysterious double-install side effects (missing types, missing runtime plugins, etc). Also, it's a change that we can continue to build upon to make the ecosystem work with all package managers more gracefully.
