### PR TITLE
Add initUIEvent in FederatedEvent

### DIFF
--- a/packages/events/src/FederatedEvent.ts
+++ b/packages/events/src/FederatedEvent.ts
@@ -140,6 +140,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
 
     /**
      * Unimplemented method included for implementing the DOM interface {@code Event}. It will throw an {@code Error}.
+     * @deprecated
      * @param _type
      * @param _bubbles
      * @param _cancelable
@@ -147,6 +148,21 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
     initEvent(_type: string, _bubbles?: boolean, _cancelable?: boolean): void
     {
         throw new Error('initEvent() is a legacy DOM API. It is not implemented in the Federated Events API.');
+    }
+
+    /**
+     * Unimplemented method included for implementing the DOM interface {@code UIEvent}. It will throw an {@code Error}.
+     * @deprecated
+     * @param _typeArg
+     * @param _bubblesArg
+     * @param _cancelableArg
+     * @param _viewArg
+     * @param _detailArg
+     */
+    initUIEvent(_typeArg: string, _bubblesArg?: boolean, _cancelableArg?: boolean, _viewArg?: Window | null,
+        _detailArg?: number): void
+    {
+        throw new Error('initUIEvent() is a legacy DOM API. It is not implemented in the Federated Events API.');
     }
 
     /** Prevent default behavior of PixiJS and the user agent. */


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

When using Pixi.js in project using TypeScript 4.4+, tsc will emit errors like this:

```
node_modules/.pnpm/registry.npmmirror.com+@pixi+events@7.0.0-alpha/node_modules/@pixi/events/index.d.ts:551:22 - error TS2420: Class 'FederatedEvent<N>' incorrectly implements interface 'UIEvent'.
  Property 'initUIEvent' is missing in type 'FederatedEvent<N>' but required in type 'UIEvent'.

551 export declare class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent {
                         ~~~~~~~~~~~~~~

  node_modules/.pnpm/registry.npmmirror.com+typescript@4.8.3/node_modules/typescript/lib/lib.dom.d.ts:14259:5
    14259     initUIEvent(typeArg: string, bubblesArg?: boolean, cancelableArg?: boolean, viewArg?: Window | null, detailArg?: number): void;
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    'initUIEvent' is declared here.
```

`PIXI.FederatedEvent` didn't implement `initUIEvent()` added in TypeScript 4.4 (although it is `@deprecated`), so in this PR I add it to make tsc happy, as mentioned in [#8458](https://github.com/pixijs/pixijs/pull/8458#issuecomment-1171423522).

Also, a `@deprecated` is added to `initEvent()` as well.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
