### PR TITLE
fix node WebGLRenderingContext

### DIFF
--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -1,7 +1,7 @@
 import type { IAdapter } from '@pixi/settings';
 import { settings } from '@pixi/settings';
 import { fetch, Request, Response } from 'cross-fetch';
-import gl from 'gl';
+import createContext from 'gl';
 import { NodeCanvasElement } from './NodeCanvasElement';
 
 import fs from 'fs';
@@ -16,7 +16,7 @@ export const NodeAdapter = {
      */
     createCanvas: (width?: number, height?: number) => new NodeCanvasElement(width, height) as unknown as HTMLCanvasElement,
     /** Returns a webgl rendering context using the gl package. */
-    getWebGLRenderingContext: () => gl as unknown as typeof WebGLRenderingContext,
+    getWebGLRenderingContext: () => createContext(1, 1) as unknown as typeof WebGLRenderingContext,
     /** Returns the fake user agent string of `node` */
     getNavigator: () => ({ userAgent: 'node' }),
     /** Returns the path from which the process is being run */


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
I'm not sure if this is the approach you want to go with, but I've created this PR to highlight a bug I found with the new NodeAdapter.

The default export from the `gl` library doesn't give us a `WebGLRenderingContext`, instead it gives us a method `createContext`. You can see that [here](https://github.com/stackgl/headless-gl/blob/master/src/javascript/node-index.js#L129).
This means that in the current PIXI code, operations like [this one](https://github.com/michaeljherrmann/pixijs/blob/4975264a6ec65121751cbee2ce2cc77a80d34b9a/packages/core/src/mask/StencilSystem.ts#L28) are broken, because `STENCIL_TEST` is `undefined` (`.getWebGLRenderingContext()` is returning the function `createContext` and not an actual context).

So at first I thought we could just do `createContext()` but the dimension arguments are required (otherwise we get `null`). So I just pass 1x1 to the method. I think this is creating a "bound" context, while normally the `window.WebGLRenderingContext` is "unbound", but I think that might be okay? This is how the [docs](https://github.com/stackgl/headless-gl#example-1) in `headless-gl` demonstrate it.

Alternative:
I believe we could instead import from `gl/src/javascript/webgl-rendering-context` and just instantiate the `WebGLRenderingContext` class. It seems a bit more fragile though because I don't think that's part of the official export.

Just wanted to flag this, thanks for all of the node development! It's great!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
