### PR TITLE
pointer over broken on touch devices

### DIFF
--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1596,6 +1596,8 @@ export class InteractionManager extends EventEmitter
      */
     private onPointerOver(originalEvent: InteractivePointerEvent): void
     {
+        if (this.supportsTouchEvents && (originalEvent as PointerEvent).pointerType === 'touch') return;
+
         const events = this.normalizeToPointerData(originalEvent);
 
         // Only mouse and pointer can call onPointerOver, so events will always be length 1


### PR DESCRIPTION
##### Description of change
prevent pointer over firing on touch pointers as pointerOut doesn't fire on touch, this leads to the activeInteractionData filling up every time you touch the screen

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)