### PR TITLE
Fix Assets missing types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@rollup/plugin-commonjs": "^15.1.0",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^9.0.0",
-        "@types/css-font-loading-module": "^0.0.7",
         "@types/jest": "^26.0.0",
         "@webdoc/cli": "^2.0.0",
         "copyfiles": "^2.1.0",
@@ -6116,8 +6115,7 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "dev": true
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
     },
     "node_modules/@types/earcut": {
       "version": "2.1.1",
@@ -25496,7 +25494,10 @@
     "packages/assets": {
       "name": "@pixi/assets",
       "version": "7.0.0-alpha",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@types/css-font-loading-module": "^0.0.7"
+      }
     },
     "packages/basis": {
       "name": "@pixi/basis",
@@ -29560,7 +29561,10 @@
       "version": "file:packages/app"
     },
     "@pixi/assets": {
-      "version": "file:packages/assets"
+      "version": "file:packages/assets",
+      "requires": {
+        "@types/css-font-loading-module": "^0.0.7"
+      }
     },
     "@pixi/basis": {
       "version": "file:packages/basis"
@@ -30090,8 +30094,7 @@
     "@types/css-font-loading-module": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
-      "dev": true
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
     },
     "@types/earcut": {
       "version": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@types/css-font-loading-module": "^0.0.7",
     "@types/jest": "^26.0.0",
     "@webdoc/cli": "^2.0.0",
     "copyfiles": "^2.1.0",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -43,6 +43,9 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixi.js/issues"
   },
+  "dependencies": {
+    "@types/css-font-loading-module": "^0.0.7"
+  },
   "pixiRequirements": [
     "@pixi/core"
   ]

--- a/packages/assets/src/loader/types.ts
+++ b/packages/assets/src/loader/types.ts
@@ -4,6 +4,8 @@ export interface LoadAsset<T=any>
 {
     src: string;
     data?: T;
+    alias?: string[];
+    format?: string;
 }
 
 export interface PromiseAndParser


### PR DESCRIPTION
fixes #8646 and missing `alias` and `format` form `LoadAssets`