### PR TITLE
Fix MSDF gray squares

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -1,4 +1,4 @@
-import { ALPHA_MODES, settings, Texture, BaseTexture, Rectangle, utils } from '@pixi/core';
+import { ALPHA_MODES, MIPMAP_MODES, settings, Texture, BaseTexture, Rectangle, utils } from '@pixi/core';
 import { TextStyle, TextMetrics } from '@pixi/text';
 import { autoDetectFormat } from './formats';
 import { BitmapFontData } from './BitmapFontData';
@@ -163,6 +163,7 @@ export class BitmapFont
             if (distanceField?.fieldType && distanceField.fieldType !== 'none')
             {
                 pageTextures[id].baseTexture.alphaMode = ALPHA_MODES.NO_PREMULTIPLIED_ALPHA;
+                pageTextures[id].baseTexture.mipmap = MIPMAP_MODES.OFF;
             }
         }
 

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -626,7 +626,7 @@ export class BitmapText extends Container
 
             for (const mesh of this._activePagesMeshData)
             {
-                mesh.mesh.shader.uniforms.uFWidth = worldScale * distanceFieldRange * fontScale * resolution;
+                mesh.mesh.shader.uniforms.uFWidth = Math.min(worldScale * distanceFieldRange * fontScale * resolution, 1.0);
             }
         }
 


### PR DESCRIPTION
Bug: https://codesandbox.io/s/pixi-v6-bitmap-text-gray-square-rsp91x

Fixed: https://codesandbox.io/s/pixi-v6-bitmap-text-gray-square-fix-bf5k4l

Zoom out, see how gray squares appear

Two lines fix:
1. uFWidth should be 1.0 minimum, because if median is 0 then result should be 0 and not >0
2. mipmaps dont help with SDF textures, because SDF is linear and guarantees exact result if `scale > 1.0 / spread`. however if its bigger then even mipmaps wont help us, there's just not enough info.