### PR TITLE
Improve the data-flow for DetectionParser formats

### DIFF
--- a/packages/assets/src/detections/index.ts
+++ b/packages/assets/src/detections/index.ts
@@ -14,14 +14,14 @@ export interface FormatDetectionParser
     /**
      * Add formats (file extensions) to the existing list of formats.
      * Return an new array with added formats, do not mutate the formats argument.
-     * @return {Promise<string[]>} - Promise that resolves to the new formats array.
+     * @returns {Promise<string[]>} - Promise that resolves to the new formats array.
      */
     add: (formats: string[]) => Promise<string[]>,
     /**
      * Remove formats (file extensions) from the list of supported formats.
      * This is used when uninstalling this DetectionParser.
      * Return an new array with filtered formats, do not mutate the formats argument.
-     * @return {Promise<string[]>} - Promise that resolves to the new formats array.
+     * @returns {Promise<string[]>} - Promise that resolves to the new formats array.
      */
     remove: (formats: string[]) => Promise<string[]>,
 }

--- a/packages/assets/src/detections/index.ts
+++ b/packages/assets/src/detections/index.ts
@@ -27,4 +27,3 @@ export interface FormatDetectionParser
 }
 
 export * from './parsers';
-export * from './utils';

--- a/packages/assets/src/detections/index.ts
+++ b/packages/assets/src/detections/index.ts
@@ -1,10 +1,28 @@
 import type { ExtensionMetadata } from '@pixi/core';
 
+/**
+ * Format detection is useful for detecting feature support
+ * on the current platform.
+ * @memberof PIXI
+ */
 export interface FormatDetectionParser
 {
+    /** Should be ExtensionType.DetectionParser */
     extension?: ExtensionMetadata;
+    /** Browser/platform feature detection supported if return true  */
     test: () => Promise<boolean>,
+    /**
+     * Add formats (file extensions) to the existing list of formats.
+     * Return an new array with added formats, do not mutate the formats argument.
+     * @return {Promise<string[]>} - Promise that resolves to the new formats array.
+     */
     add: (formats: string[]) => Promise<string[]>,
+    /**
+     * Remove formats (file extensions) from the list of supported formats.
+     * This is used when uninstalling this DetectionParser.
+     * Return an new array with filtered formats, do not mutate the formats argument.
+     * @return {Promise<string[]>} - Promise that resolves to the new formats array.
+     */
     remove: (formats: string[]) => Promise<string[]>,
 }
 

--- a/packages/assets/src/detections/parsers/detectAvif.ts
+++ b/packages/assets/src/detections/parsers/detectAvif.ts
@@ -1,6 +1,5 @@
 import { settings, extensions, ExtensionType } from '@pixi/core';
 import type { FormatDetectionParser } from '..';
-import { addFormats, removeFormats } from '../utils/detectUtils';
 
 export const detectAvif: FormatDetectionParser = {
     extension: {
@@ -17,8 +16,8 @@ export const detectAvif: FormatDetectionParser = {
 
         return createImageBitmap(blob).then(() => true, () => false);
     },
-    add: addFormats('avif'),
-    remove: removeFormats('avif')
+    add: async (formats) => [...formats, 'avif'],
+    remove: async (formats) => formats.filter((f) => f !== 'avif'),
 };
 
 extensions.add(detectAvif);

--- a/packages/assets/src/detections/parsers/detectDefaults.ts
+++ b/packages/assets/src/detections/parsers/detectDefaults.ts
@@ -1,6 +1,7 @@
 import { extensions, ExtensionType } from '@pixi/core';
 import type { FormatDetectionParser } from '..';
-import { addFormats, removeFormats } from '../utils/detectUtils';
+
+const imageFormats = ['png', 'jpg', 'jpeg'];
 
 export const detectDefaults = {
     extension: {
@@ -8,8 +9,8 @@ export const detectDefaults = {
         priority: -1,
     },
     test: (): Promise<boolean> => Promise.resolve(true),
-    add: addFormats('png', 'jpg', 'jpeg'),
-    remove: removeFormats('png', 'jpg', 'jpeg')
+    add: async (formats) => [...formats, ...imageFormats],
+    remove: async (formats) => formats.filter((f) => !imageFormats.includes(f)),
 } as FormatDetectionParser;
 
 extensions.add(detectDefaults);

--- a/packages/assets/src/detections/parsers/detectWebp.ts
+++ b/packages/assets/src/detections/parsers/detectWebp.ts
@@ -1,6 +1,5 @@
 import { settings, extensions, ExtensionType } from '@pixi/core';
 import type { FormatDetectionParser } from '..';
-import { addFormats, removeFormats } from '../utils/detectUtils';
 
 export const detectWebp = {
     extension: {
@@ -16,8 +15,8 @@ export const detectWebp = {
 
         return createImageBitmap(blob).then(() => true, () => false);
     },
-    add: addFormats('webp'),
-    remove: removeFormats('webp')
+    add: async (formats) => [...formats, 'webp'],
+    remove: async (formats) => formats.filter((f) => f !== 'webp'),
 } as FormatDetectionParser;
 
 extensions.add(detectWebp);

--- a/packages/assets/src/detections/utils/detectUtils.ts
+++ b/packages/assets/src/detections/utils/detectUtils.ts
@@ -1,8 +1,0 @@
-export function addFormats(...format: string[]): (formats: string[]) => Promise<string[]>
-{
-    return async (formats: string[]) => [...formats, ...format];
-}
-export function removeFormats(...format: string[]): (formats: string[]) => Promise<string[]>
-{
-    return async (formats: string[]) => formats.filter((f) => !format.includes(f));
-}

--- a/packages/assets/src/detections/utils/detectUtils.ts
+++ b/packages/assets/src/detections/utils/detectUtils.ts
@@ -1,26 +1,8 @@
 export function addFormats(...format: string[]): (formats: string[]) => Promise<string[]>
 {
-    return async (formats: string[]) =>
-    {
-        formats.push(...format);
-
-        return formats;
-    };
+    return async (formats: string[]) => [...formats, ...format];
 }
 export function removeFormats(...format: string[]): (formats: string[]) => Promise<string[]>
 {
-    return async (formats: string[]) =>
-    {
-        for (const f of format)
-        {
-            const index = formats.indexOf(f);
-
-            if (index !== -1)
-            {
-                formats.splice(index, 1);
-            }
-        }
-
-        return formats;
-    };
+    return async (formats: string[]) => formats.filter((f) => !format.includes(f));
 }

--- a/packages/assets/src/detections/utils/index.ts
+++ b/packages/assets/src/detections/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './detectUtils';

--- a/packages/basis/src/loader/detectBasis.ts
+++ b/packages/basis/src/loader/detectBasis.ts
@@ -1,6 +1,5 @@
 import { extensions, ExtensionType } from '@pixi/core';
 import type { FormatDetectionParser } from '@pixi/assets';
-import { addFormats, removeFormats } from '@pixi/assets';
 import { BasisParser } from './BasisParser';
 
 export const detectBasis = {
@@ -9,8 +8,8 @@ export const detectBasis = {
         priority: 3,
     },
     test: async (): Promise<boolean> => !!(BasisParser.basisBinding && BasisParser.TranscoderWorker.wasmSource),
-    add: addFormats('basis'),
-    remove: removeFormats('basis')
+    add: async (formats) => [...formats, 'basis'],
+    remove: async (formats) => formats.filter((f) => f !== 'basis'),
 } as FormatDetectionParser;
 
 extensions.add(detectBasis);

--- a/packages/compressed-textures/src/loaders/detectCompressedTextures.ts
+++ b/packages/compressed-textures/src/loaders/detectCompressedTextures.ts
@@ -63,9 +63,7 @@ export const detectCompressedTextures = {
             textureFormats.push(extensionName);
         }
 
-        formats.unshift(...textureFormats);
-
-        return formats;
+        return [...textureFormats, ...formats];
     },
     remove: async (formats: string[]): Promise<string[]> =>
     {


### PR DESCRIPTION
DetectionParser was not being consistent or providing guidance about how to implement `add` and `remove` methods. This PR clarifies how developers should implement formats, which is to return a new array and not mutate the argument.

### Before Example

This _mutates_ and _returns_.

```js
{ 
  add: async (formats) => {
    formats.push('xyz');
    return formats;
  },
  remove: async(formats) => {
    formats.splice(formats.indexOf('xyz'), 1);
    return formats;
  },
}
```

### After Example

After this PR, this is much clearer.

```js
{ 
  add: async (formats) => [...formats, 'zyx'],
  remove: async(formats) => formats.filter(f => f !== 'zyx'),
}
```