### PR TITLE
Fix svg resource test

### DIFF
--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -204,7 +204,7 @@ export class SVGResource extends BaseImageResource
         // url file extension is SVG
         return extension === 'svg'
             // source is SVG data-uri
-            || (typeof source === 'string' && (/^data:image\/svg\+xml(;(charset=utf8|utf8))?,base64/).test(source))
+            || (typeof source === 'string' && source.startsWith('data:image/svg+xml'))
             // source is SVG inline
             || (typeof source === 'string' && SVGResource.SVG_XML.test(source));
     }

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -204,7 +204,7 @@ export class SVGResource extends BaseImageResource
         // url file extension is SVG
         return extension === 'svg'
             // source is SVG data-uri
-            || (typeof source === 'string' && (/^data:image\/svg\+xml(;(charset=utf8|utf8))?;base64/).test(source))
+            || (typeof source === 'string' && (/^data:image\/svg\+xml(;(charset=utf8|utf8))?,base64/).test(source))
             // source is SVG inline
             || (typeof source === 'string' && SVGResource.SVG_XML.test(source));
     }


### PR DESCRIPTION
Demo: https://www.pixiplayground.com/#/edit/Z7ws-I72Xaa0MCMmIVAle

Test doesnt work because of semicolon. If you try  to put semicolon in string, you'll get an error, so browser really cant parse it that way.
