### PR TITLE
Fix ISystem errors with the latest TypeScript

### DIFF
--- a/packages/core/src/background/BackgroundSystem.ts
+++ b/packages/core/src/background/BackgroundSystem.ts
@@ -17,7 +17,7 @@ export interface BackgroundOptions
  * The background system manages the background color and alpha of the main view.
  * @memberof PIXI
  */
-export class BackgroundSystem implements ISystem
+export class BackgroundSystem implements ISystem<BackgroundOptions>
 {
     /** @ignore */
     static extension: ExtensionMetadata = {

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -33,7 +33,7 @@ export interface ContextOptions
  * System plugin to the renderer to manage the context.
  * @memberof PIXI
  */
-export class ContextSystem implements ISystem
+export class ContextSystem implements ISystem<ContextOptions>
 {
     /** @ignore */
     static extension: ExtensionMetadata = {

--- a/packages/core/src/plugin/PluginSystem.ts
+++ b/packages/core/src/plugin/PluginSystem.ts
@@ -13,7 +13,7 @@ export interface IRendererPlugins extends GlobalMixins.IRendererPlugins
  * Manages the functionality that allows users to extend pixi functionality via additional plugins.
  * @memberof PIXI
  */
-export class PluginSystem implements ISystem
+export class PluginSystem implements ISystem<IRendererPlugins>
 {
     /** @ignore */
     static extension: ExtensionMetadata = {

--- a/packages/core/src/view/ViewSystem.ts
+++ b/packages/core/src/view/ViewSystem.ts
@@ -28,7 +28,7 @@ export interface ViewOptions
  * This main role is to deal with how the holding the view reference and dealing with how it is resized.
  * @memberof PIXI
  */
-export class ViewSystem implements ISystem
+export class ViewSystem implements ISystem<ViewOptions, boolean>
 {
     /** @ignore */
     static extension: ExtensionMetadata = {


### PR DESCRIPTION
The latest version of TypeScript was throwing these core errors when trying to build against v7.0.0-alpha.2.

```
node_modules/@pixi/core/index.d.ts:318:5 - error TS2416: Property 'init' in type 'BackgroundSystem' is not assignable to the same property in base type 'ISystem<null, null>'.
  Type '(options: BackgroundOptions) => void' is not assignable to type '(options?: null | undefined) => void'.
    Types of parameters 'options' and 'options' are incompatible.
      Type 'null | undefined' is not assignable to type 'BackgroundOptions'.
        Type 'undefined' is not assignable to type 'BackgroundOptions'.

318     init(options: BackgroundOptions): void;
        ~~~~

node_modules/@pixi/core/index.d.ts:1417:5 - error TS2416: Property 'init' in type 'ContextSystem' is not assignable to the same property in base type 'ISystem<null, null>'.
  Type '(options: ContextOptions) => void' is not assignable to type '(options?: null | undefined) => void'.
    Types of parameters 'options' and 'options' are incompatible.
      Type 'null | undefined' is not assignable to type 'ContextOptions'.
        Type 'undefined' is not assignable to type 'ContextOptions'.

1417     init(options: ContextOptions): void;
         ~~~~

node_modules/@pixi/core/index.d.ts:3257:5 - error TS2416: Property 'init' in type 'PluginSystem' is not assignable to the same property in base type 'ISystem<null, null>'.
  Type '(staticMap: IRendererPlugins) => void' is not assignable to type '(options?: null | undefined) => void'.
    Types of parameters 'staticMap' and 'options' are incompatible.
      Type 'null | undefined' is not assignable to type 'IRendererPlugins'.
        Type 'undefined' is not assignable to type 'IRendererPlugins'.

3257     init(staticMap: IRendererPlugins): void;
         ~~~~

node_modules/@pixi/core/index.d.ts:5576:5 - error TS2416: Property 'init' in type 'ViewSystem' is not assignable to the same property in base type 'ISystem<null, null>'.
  Type '(options: ViewOptions) => void' is not assignable to type '(options?: null | undefined) => void'.
    Types of parameters 'options' and 'options' are incompatible.
      Type 'null | undefined' is not assignable to type 'ViewOptions'.
        Type 'undefined' is not assignable to type 'ViewOptions'.

5576     init(options: ViewOptions): void;
         ~~~~

node_modules/@pixi/core/index.d.ts:5587:5 - error TS2416: Property 'destroy' in type 'ViewSystem' is not assignable to the same property in base type 'ISystem<null, null>'.
  Type '(removeView: boolean) => void' is not assignable to type '(options?: null | undefined) => void'.
    Types of parameters 'removeView' and 'options' are incompatible.
      Type 'null | undefined' is not assignable to type 'boolean'.
        Type 'undefined' is not assignable to type 'boolean'.

5587     destroy(removeView: boolean): void;
```