### PR TITLE
TilingSpriteRenderer should self-install

### DIFF
--- a/packages/sprite-tiling/src/TilingSpriteRenderer.ts
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.ts
@@ -1,4 +1,4 @@
-import { ObjectRenderer, Shader, State, QuadUv, ExtensionType, WRAP_MODES, Matrix, utils } from '@pixi/core';
+import { ObjectRenderer, Shader, State, QuadUv, ExtensionType, WRAP_MODES, Matrix, utils, extensions } from '@pixi/core';
 
 import fragmentSimpleSrc from './sprite-tiling-simple.frag';
 import gl1VertexSrc from './sprite-tiling-fallback.vert';
@@ -162,3 +162,5 @@ export class TilingSpriteRenderer extends ObjectRenderer
         renderer.geometry.draw(this.renderer.gl.TRIANGLES, 6, 0);
     }
 }
+
+extensions.add(TilingSpriteRenderer);


### PR DESCRIPTION
The TilingSpriteRenderer was not getting installed resulting in the following error when trying to render a TilingSprite object:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'start')
    at BatchSystem.setObjectRenderer (core.mjs:2406:26)
    at TilingSprite._render (sprite-tiling.mjs:54:20)
    at TilingSprite.render (display.mjs:777:12)
    at Container.renderAdvanced (display.mjs:812:26)
    at Container.render (display.mjs:773:12)
    at Container.render (display.mjs:779:26)
    at ObjectRendererSystem.render (core.mjs:6870:19)
    at _Renderer.render (core.mjs:6120:25)
```