### PR TITLE
Transfer the .shiftKey property from native -> federated mouse event

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -663,6 +663,7 @@ export class EventSystem
         event.page.x = nativeEvent.pageX;
         event.page.y = nativeEvent.pageY;
         event.relatedTarget = null;
+        event.shiftKey = nativeEvent.shiftKey;
     }
 }
 


### PR DESCRIPTION
##### Description of change
I noticed that FederatedMouseEvent [does include a `shiftKey` property](https://github.com/pixijs/pixijs/blob/dev/packages/events/src/FederatedMouseEvent.ts#L31), but it doesn't seem like this property was being transferred over from the corresponding native MouseEvent.  Simple fix!

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
