### PR TITLE
Fixing CanvasSpriteRenderer to correctly render sprites with rotated and trimmed base textures

### DIFF
--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -72,8 +72,16 @@ export class CanvasSpriteRenderer
 
         if (texture.trim)
         {
-            destWidth = texture.trim.width;
-            destHeight = texture.trim.height;
+            if (texture.rotate)
+            {
+                destWidth = texture.trim.height;
+                destHeight = texture.trim.width;
+            }
+            else
+            {
+                destWidth = texture.trim.width;
+                destHeight = texture.trim.height;
+            }
         }
 
         let wt = sprite.transform.worldTransform;

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -72,7 +72,7 @@ export class CanvasSpriteRenderer
 
         if (texture.trim)
         {
-            if (texture.rotate)
+            if (groupD8.isVertical(texture.rotate))
             {
                 destWidth = texture.trim.height;
                 destHeight = texture.trim.width;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Changes made in #8615 to fix one case of broken canvas rendering ended up breaking canvas rendering in a different way ([pixi-spine#460](https://github.com/pixijs/spine/issues/460)).

The fix I made previously didn't take into account the height/width swap required if a texture was rotated, and the fixes made in v6.5.0 were absolutely fine for this case.

I've prepared another demo site that covers all cases of the canvas rendering: https://vagabond-ambiguous-gerbera.glitch.me/

The previous red/blue atlas I used that had rotation but no trim remains, and a new purple/green atlas that has rotation and trim has been. Both were rendering correctly in v6.4, only one worked fine in 6.5.2 and 6.5.3, but both render correctly again with this fix applied.

I ran into difficulty trying to write a unit test for this, but I could spend more time in the future if that's required.

Closes #8678

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
