### PR TITLE
Fix building types twice when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "postversion": "run-s lint types build:prod build:types",
     "release": "lerna version --exact --force-publish",
     "version": "ts-node scripts/fixPeerVersions.ts && npx --yes npm@7.20.2 i --package-lock-only && git add package-lock.json",
-    "prepublish-ci": "run-s build:types",
     "publish-ci": "lerna publish from-package --yes --no-verify-access",
     "webdoc": "webdoc"
   },


### PR DESCRIPTION
I noticed that when we publish on GitHub Actions, types are generated _twice_. This is unnecessary as generating types is now part of the standard `npm run dist` action. There's no need to run it again. Pre-publishing types is a holdover before `build:types` was including with every action.