### PR TITLE
Fixed README webpack link formatting

### DIFF
--- a/bundles/pixi.js-legacy/README.md
+++ b/bundles/pixi.js-legacy/README.md
@@ -21,7 +21,7 @@ This package is the same as **pixi.js**, but provides fallback support for brows
 
 ### Setup
 
-PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) to integrate with [Webpack](https://webpack.js.org/)](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](https://rollupjs.org/), [Electron](https://electron.atom.io/), [NW.js](https://nwjs.io/) or other module backed environments.
+PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) to integrate with [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](https://rollupjs.org/), [Electron](https://electron.atom.io/), [NW.js](https://nwjs.io/) or other module backed environments.
 
 #### Install
 

--- a/bundles/pixi.js/README.md
+++ b/bundles/pixi.js/README.md
@@ -17,7 +17,7 @@ hardware acceleration without prior knowledge of WebGL. Also, it's fast. Really 
 
 ### Setup
 
-PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) to integrate with [Webpack](https://webpack.js.org/)](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](https://rollupjs.org/), [Electron](https://electron.atom.io/), [NW.js](https://nwjs.io/) or other module backed environments.
+PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) to integrate with [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](https://rollupjs.org/), [Electron](https://electron.atom.io/), [NW.js](https://nwjs.io/) or other module backed environments.
 
 #### Install
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixed small formatting issue in the README.md file which is visible on NPM (how I discovered the bug).
There was a rogue `]` character, followed by a duplicate link to webpack.

| **Before** | <img width="584" alt="Screenshot 2022-09-30 at 20 06 05" src="https://user-images.githubusercontent.com/38284426/193339934-38326500-a29d-4917-8c58-b334a24daf66.png"> |
|---|---|
|  **After** ✨ | <img width="585" alt="Screenshot 2022-09-30 at 20 07 37" src="https://user-images.githubusercontent.com/38284426/193339947-39acffdf-b819-4936-b4bb-2fc8223409e0.png"> |


<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
