### PR TITLE
Add @pixi/webworker bundle

### DIFF
--- a/bundles/pixi.js-legacy/README.md
+++ b/bundles/pixi.js-legacy/README.md
@@ -36,7 +36,7 @@ import * as PIXI from 'pixi.js-legacy'
 ### Basic Usage Example
 
 ```js
-import { Application, Sprite, Assets } from 'pixi.js-legacy';
+import { Application, Assets, Sprite } from 'pixi.js-legacy';
 
 // The application will create a renderer using WebGL, if possible,
 // with a fallback to a canvas render. It will also setup the ticker

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -42,7 +42,7 @@ For non-mac users, please refer to the [canvas installation guide](https://www.n
 ## Basic Usage Example
 
 ```js
-import { Application, Sprite, Assets } from '@pixi/node';
+import { Application, Assets, Sprite } from '@pixi/node';
 import path from 'path';
 import { writeFileSync } from 'fs';
 

--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -21,6 +21,7 @@ export const NodeAdapter = {
     getNavigator: () => ({ userAgent: 'node' }),
     /** Returns the path from which the process is being run */
     getBaseUrl: () => process.cwd(),
+    getFontFaceSet: () => null,
     fetch: (url: RequestInfo, options?: RequestInit) =>
     {
         const request = new Request(url, options);

--- a/bundles/pixi.js-webworker/LICENSE
+++ b/bundles/pixi.js-webworker/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2013-2017 Mathew Groves, Chad Engler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/bundles/pixi.js-webworker/README.md
+++ b/bundles/pixi.js-webworker/README.md
@@ -1,0 +1,92 @@
+@pixi/webworker
+=============
+
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+
+The aim of this project is to provide a fast lightweight 2D library that works
+across all devices. The PixiJS renderer allows everyone to enjoy the power of
+hardware acceleration without prior knowledge of WebGL. Also, it's fast. Really fast.
+
+**We are now a part of the [Open Collective](https://opencollective.com/pixijs) and with your support you can help us make PixiJS even better. To make a donation, simply click the button below and we'll love you forever!**
+
+<div align="center">
+  <a href="https://opencollective.com/pixijs/donate" target="_blank">
+    <img src="https://opencollective.com/pixijs/donate/button@2x.png?color=blue" width=250 />
+  </a>
+</div>
+
+### Setup
+
+PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-is-npm) to integrate with [Webpack](https://webpack.js.org/), [Browserify](http://browserify.org/), [Rollup](https://rollupjs.org/), [Electron](https://electron.atom.io/), [NW.js](https://nwjs.io/) or other module backed environments.
+
+#### Install
+
+```
+npm install @pixi/webworker
+```
+There is no default export. The correct way to import PixiJS is:
+
+```js
+import * as PIXI from '@pixi/webworker'
+```
+### Basic Usage Example
+
+In `index.js`:
+```js
+// Create a canvas element and insert it into DOM
+const width = 800, height = 600;
+const resolution = window.devicePixelRatio;
+const canvas = document.createElement('canvas');
+canvas.style.width = `${ width }px`;
+canvas.style.height = `${ height }px`;
+document.body.appendChild(canvas);
+
+// Create the worker
+const worker = new Worker('worker.js', { type: 'module' });
+// Transfer canvas to the worker
+const view = canvas.transferControlToOffscreen();
+worker.postMessage({ width, height, resolution, view }, [view]);
+
+```
+
+In `worker.js`:
+```js
+import { Application, Assets, Sprite } from '@pixi/webworker';
+
+self.onmessage = async e => {
+    // Recieve OffscreenCanvas from index.js
+    const { width, height, resolution, view } = e.data;
+    
+    // The application will create a renderer using WebGL, if possible,
+    // with a fallback to a canvas render. It will also setup the ticker
+    // and the root stage PIXI.Container
+    const app = new Application({ width, height, resolution, view });
+
+    // load the texture we need
+    const texture = await Assets.load('assets/bunny.png');
+
+    // This creates a texture from a 'bunny.png' image
+    const bunny = new Sprite(texture);
+
+    // Setup the position of the bunny
+    bunny.x = app.renderer.width / 2;
+    bunny.y = app.renderer.height / 2;
+
+    // Rotate around the center
+    bunny.anchor.x = 0.5;
+    bunny.anchor.y = 0.5;
+
+    // Add the bunny to the scene we are building
+    app.stage.addChild(bunny);
+
+    // Listen for frame updates
+    app.ticker.add(() => {
+        // each frame we spin the bunny around a bit
+        bunny.rotation += 0.01;
+    });
+}
+```
+
+### License
+
+This content is released under the (http://opensource.org/licenses/MIT) MIT License.

--- a/bundles/pixi.js-webworker/package.json
+++ b/bundles/pixi.js-webworker/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@pixi/webworker",
+  "version": "7.0.0-alpha.3",
+  "description": "Bundle for PixiJS with support for Web Workers",
+  "homepage": "http://pixijs.com/",
+  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/pixi.js.git"
+  },
+  "license": "MIT",
+  "author": "PixiJS Team",
+  "main": "dist/cjs/webworker.cjs",
+  "module": "dist/esm/webworker.mjs",
+  "bundle": "dist/browser/webworker.js",
+  "bundleModule": "dist/browser/webworker.mjs",
+  "bundleOutput": {
+    "name": "PIXI"
+  },
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./dist/esm/webworker.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./dist/cjs/webworker.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "*.d.ts"
+  ],
+  "dependencies": {
+    "@pixi/app": "7.0.0-alpha.3",
+    "@pixi/assets": "7.0.0-alpha.3",
+    "@pixi/compressed-textures": "7.0.0-alpha.3",
+    "@pixi/core": "7.0.0-alpha.3",
+    "@pixi/display": "7.0.0-alpha.3",
+    "@pixi/extensions": "7.0.0-alpha.3",
+    "@pixi/extract": "7.0.0-alpha.3",
+    "@pixi/filter-alpha": "7.0.0-alpha.3",
+    "@pixi/filter-blur": "7.0.0-alpha.3",
+    "@pixi/filter-color-matrix": "7.0.0-alpha.3",
+    "@pixi/filter-displacement": "7.0.0-alpha.3",
+    "@pixi/filter-fxaa": "7.0.0-alpha.3",
+    "@pixi/filter-noise": "7.0.0-alpha.3",
+    "@pixi/graphics": "7.0.0-alpha.3",
+    "@pixi/mesh": "7.0.0-alpha.3",
+    "@pixi/mesh-extras": "7.0.0-alpha.3",
+    "@pixi/mixin-cache-as-bitmap": "7.0.0-alpha.3",
+    "@pixi/mixin-get-child-by-name": "7.0.0-alpha.3",
+    "@pixi/mixin-get-global-position": "7.0.0-alpha.3",
+    "@pixi/particle-container": "7.0.0-alpha.3",
+    "@pixi/prepare": "7.0.0-alpha.3",
+    "@pixi/sprite": "7.0.0-alpha.3",
+    "@pixi/sprite-animated": "7.0.0-alpha.3",
+    "@pixi/sprite-tiling": "7.0.0-alpha.3",
+    "@pixi/spritesheet": "7.0.0-alpha.3",
+    "@pixi/text": "7.0.0-alpha.3",
+    "@pixi/text-bitmap": "7.0.0-alpha.3"
+  }
+}

--- a/bundles/pixi.js-webworker/src/adapter.ts
+++ b/bundles/pixi.js-webworker/src/adapter.ts
@@ -1,6 +1,6 @@
-import { settings } from '@pixi/settings';
+import { settings } from '@pixi/core';
 
-import type { IAdapter } from '@pixi/settings';
+import type { IAdapter } from '@pixi/core';
 
 export const WebWorkerAdapter = {
     /**

--- a/bundles/pixi.js-webworker/src/adapter.ts
+++ b/bundles/pixi.js-webworker/src/adapter.ts
@@ -1,0 +1,23 @@
+import { settings } from '@pixi/settings';
+
+import type { IAdapter } from '@pixi/settings';
+
+export const WebWorkerAdapter = {
+    /**
+     * Creates a canvas element of the given size.
+     * This canvas is created using the browser's native canvas element.
+     * @param width - width of the canvas
+     * @param height - height of the canvas
+     */
+    createCanvas: (width?: number, height?: number): OffscreenCanvas =>
+        new OffscreenCanvas(width | 0, height | 0),
+    getWebGLRenderingContext: () => WebGLRenderingContext,
+    getNavigator: () => navigator,
+    getBaseUrl: () => globalThis.location.href,
+    getFontFaceSet: () => (globalThis as unknown as WorkerGlobalScope).fonts,
+    fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
+} as IAdapter;
+
+settings.ADAPTER = WebWorkerAdapter;
+
+export { settings };

--- a/bundles/pixi.js-webworker/src/index.ts
+++ b/bundles/pixi.js-webworker/src/index.ts
@@ -1,6 +1,3 @@
-import './adapter';
-
-import { extensions, INSTALLED } from '@pixi/core';
 import { AlphaFilter } from '@pixi/filter-alpha';
 import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
 import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
@@ -10,23 +7,6 @@ import { NoiseFilter } from '@pixi/filter-noise';
 import '@pixi/mixin-cache-as-bitmap';
 import '@pixi/mixin-get-child-by-name';
 import '@pixi/mixin-get-global-position';
-// eslint-disable-next-line @typescript-eslint/no-duplicate-imports
-import { NodeCanvasResource } from './adapter';
-import { loadTextures, loadWebFont } from '@pixi/assets';
-import { ResizePlugin } from '@pixi/app';
-import { loadBitmapFont } from '@pixi/text-bitmap';
-
-// Remove the default loader plugins
-extensions.remove(
-    loadTextures,
-    loadWebFont,
-    loadBitmapFont,
-    ResizePlugin
-);
-
-// reset installed resources and remove resize plugin from Application
-INSTALLED.length = 0;
-INSTALLED.push(NodeCanvasResource);
 
 export const filters = {
     AlphaFilter,
@@ -40,8 +20,8 @@ export const filters = {
 
 // Export ES for those importing specifically by name,
 export * from '@pixi/app';
-export * from './adapter';
 export * from '@pixi/assets';
+export * from '@pixi/compressed-textures';
 export * from '@pixi/core';
 export * from '@pixi/display';
 export * from '@pixi/extract';
@@ -51,8 +31,10 @@ export * from '@pixi/mesh-extras';
 export * from '@pixi/particle-container';
 export * from '@pixi/prepare';
 export * from '@pixi/sprite';
+export * from '@pixi/spritesheet';
 export * from '@pixi/sprite-animated';
 export * from '@pixi/sprite-tiling';
-export * from '@pixi/spritesheet';
 export * from '@pixi/text';
 export * from '@pixi/text-bitmap';
+
+export * from './adapter';

--- a/bundles/pixi.js/README.md
+++ b/bundles/pixi.js/README.md
@@ -32,7 +32,7 @@ import * as PIXI from 'pixi.js'
 ### Basic Usage Example
 
 ```js
-import { Application, Sprite } from 'pixi.js';
+import { Application, Assets, Sprite } from 'pixi.js';
 
 // The application will create a renderer using WebGL, if possible,
 // with a fallback to a canvas render. It will also setup the ticker

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,40 @@
         "node": ">=16"
       }
     },
+    "bundles/pixi.js-webworker": {
+      "name": "@pixi/webworker",
+      "version": "7.0.0-alpha.3",
+      "license": "MIT",
+      "dependencies": {
+        "@pixi/app": "7.0.0-alpha.3",
+        "@pixi/assets": "7.0.0-alpha.3",
+        "@pixi/compressed-textures": "7.0.0-alpha.3",
+        "@pixi/core": "7.0.0-alpha.3",
+        "@pixi/display": "7.0.0-alpha.3",
+        "@pixi/extensions": "7.0.0-alpha.3",
+        "@pixi/extract": "7.0.0-alpha.3",
+        "@pixi/filter-alpha": "7.0.0-alpha.3",
+        "@pixi/filter-blur": "7.0.0-alpha.3",
+        "@pixi/filter-color-matrix": "7.0.0-alpha.3",
+        "@pixi/filter-displacement": "7.0.0-alpha.3",
+        "@pixi/filter-fxaa": "7.0.0-alpha.3",
+        "@pixi/filter-noise": "7.0.0-alpha.3",
+        "@pixi/graphics": "7.0.0-alpha.3",
+        "@pixi/mesh": "7.0.0-alpha.3",
+        "@pixi/mesh-extras": "7.0.0-alpha.3",
+        "@pixi/mixin-cache-as-bitmap": "7.0.0-alpha.3",
+        "@pixi/mixin-get-child-by-name": "7.0.0-alpha.3",
+        "@pixi/mixin-get-global-position": "7.0.0-alpha.3",
+        "@pixi/particle-container": "7.0.0-alpha.3",
+        "@pixi/prepare": "7.0.0-alpha.3",
+        "@pixi/sprite": "7.0.0-alpha.3",
+        "@pixi/sprite-animated": "7.0.0-alpha.3",
+        "@pixi/sprite-tiling": "7.0.0-alpha.3",
+        "@pixi/spritesheet": "7.0.0-alpha.3",
+        "@pixi/text": "7.0.0-alpha.3",
+        "@pixi/text-bitmap": "7.0.0-alpha.3"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -5725,6 +5759,10 @@
         "@webdoc/model": "^1.2.1",
         "@webdoc/template-library": "^1.2.1"
       }
+    },
+    "node_modules/@pixi/webworker": {
+      "resolved": "bundles/pixi.js-webworker",
+      "link": true
     },
     "node_modules/@rollup/plugin-alias": {
       "version": "3.1.1",
@@ -29790,6 +29828,38 @@
         "missionlog": "^1.6.0",
         "open-sans-fonts": "^1.6.2",
         "taffydb": "^2.7.3"
+      }
+    },
+    "@pixi/webworker": {
+      "version": "file:bundles/pixi.js-webworker",
+      "requires": {
+        "@pixi/app": "7.0.0-alpha.3",
+        "@pixi/assets": "7.0.0-alpha.3",
+        "@pixi/compressed-textures": "7.0.0-alpha.3",
+        "@pixi/core": "7.0.0-alpha.3",
+        "@pixi/display": "7.0.0-alpha.3",
+        "@pixi/extensions": "7.0.0-alpha.3",
+        "@pixi/extract": "7.0.0-alpha.3",
+        "@pixi/filter-alpha": "7.0.0-alpha.3",
+        "@pixi/filter-blur": "7.0.0-alpha.3",
+        "@pixi/filter-color-matrix": "7.0.0-alpha.3",
+        "@pixi/filter-displacement": "7.0.0-alpha.3",
+        "@pixi/filter-fxaa": "7.0.0-alpha.3",
+        "@pixi/filter-noise": "7.0.0-alpha.3",
+        "@pixi/graphics": "7.0.0-alpha.3",
+        "@pixi/mesh": "7.0.0-alpha.3",
+        "@pixi/mesh-extras": "7.0.0-alpha.3",
+        "@pixi/mixin-cache-as-bitmap": "7.0.0-alpha.3",
+        "@pixi/mixin-get-child-by-name": "7.0.0-alpha.3",
+        "@pixi/mixin-get-global-position": "7.0.0-alpha.3",
+        "@pixi/particle-container": "7.0.0-alpha.3",
+        "@pixi/prepare": "7.0.0-alpha.3",
+        "@pixi/sprite": "7.0.0-alpha.3",
+        "@pixi/sprite-animated": "7.0.0-alpha.3",
+        "@pixi/sprite-tiling": "7.0.0-alpha.3",
+        "@pixi/spritesheet": "7.0.0-alpha.3",
+        "@pixi/text": "7.0.0-alpha.3",
+        "@pixi/text-bitmap": "7.0.0-alpha.3"
       }
     },
     "@rollup/plugin-alias": {

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -1,5 +1,5 @@
 import { extensions, ExtensionType, utils } from '@pixi/core';
-import { settings } from '@pixi/settings';
+import { settings } from '@pixi/core';
 import { LoaderParserPriority } from './LoaderParser';
 
 import type { LoadAsset } from '../types';

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -1,7 +1,9 @@
 import { extensions, ExtensionType, utils } from '@pixi/core';
+import { settings } from '@pixi/settings';
+import { LoaderParserPriority } from './LoaderParser';
+
 import type { LoadAsset } from '../types';
 import type { LoaderParser } from './LoaderParser';
-import { LoaderParserPriority } from './LoaderParser';
 
 const validWeights = ['normal', 'bold',
     '100', '200', '300', '400', '500', '600', '700', '800', '900',
@@ -59,12 +61,14 @@ export const loadWebFont = {
     async load(url: string, options?: LoadAsset<LoadFontData>): Promise<FontFace | FontFace[]>
     {
         // Prevent loading font if navigator is not online
-        if (!window.navigator.onLine)
+        if (!globalThis.navigator.onLine)
         {
             throw new Error('[loadWebFont] Cannot load font - navigator is offline');
         }
 
-        if ('FontFace' in window)
+        const fonts = settings.ADAPTER.getFontFaceSet();
+
+        if (fonts)
         {
             const fontFaces: FontFace[] = [];
             const name = options.data?.family ?? getFontFamilyName(url);
@@ -82,7 +86,7 @@ export const loadWebFont = {
 
                 await font.load();
 
-                document.fonts.add(font);
+                fonts.add(font);
 
                 fontFaces.push(font);
             }
@@ -100,7 +104,7 @@ export const loadWebFont = {
     unload(font: FontFace | FontFace[]): void
     {
         (Array.isArray(font) ? font : [font])
-            .forEach((t) => document.fonts.delete(t));
+            .forEach((t) => settings.ADAPTER.getFontFaceSet().delete(t));
     }
 } as LoaderParser<FontFace | FontFace[]>;
 

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -1,5 +1,4 @@
-import { extensions, ExtensionType, utils } from '@pixi/core';
-import { settings } from '@pixi/core';
+import { extensions, ExtensionType, settings, utils } from '@pixi/core';
 import { LoaderParserPriority } from './LoaderParser';
 
 import type { LoadAsset } from '../types';

--- a/packages/assets/src/loader/parsers/textures/loadTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/loadTexture.ts
@@ -1,12 +1,12 @@
 import { BaseTexture, extensions, ExtensionType, settings, utils } from '@pixi/core';
-import type { Loader } from '../../Loader';
-import type { LoadAsset } from '../../types';
 import { LoaderParserPriority } from '../LoaderParser';
 import { WorkerManager } from '../WorkerManager';
 import { checkExtension } from './utils/checkExtension';
 import { createTexture } from './utils/createTexture';
 
 import type { IBaseTextureOptions, Texture } from '@pixi/core';
+import type { Loader } from '../../Loader';
+import type { LoadAsset } from '../../types';
 import type { LoaderParser } from '../LoaderParser';
 
 const validImages = ['.jpg', '.png', '.jpeg', '.avif', '.webp'];
@@ -62,7 +62,7 @@ export const loadTextures = {
     {
         let src: any = null;
 
-        if (window.createImageBitmap)
+        if (globalThis.createImageBitmap)
         {
             src = this.config.preferWorkers ? await WorkerManager.loadImageBitmap(url) : await loadImageBitmap(url);
         }

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -68,7 +68,7 @@ export class BaseImageResource extends Resource
      * @param {HTMLImageElement|HTMLVideoElement|ImageBitmap|PIXI.ICanvas} [source] - (optional)
      * @returns - true is success
      */
-    upload(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture, source?: ImageSource): boolean
+    override upload(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture, source?: ImageSource): boolean
     {
         const gl = renderer.gl;
         const width = baseTexture.realWidth;
@@ -115,7 +115,7 @@ export class BaseImageResource extends Resource
      * Checks if source width/height was changed, resize can cause extra baseTexture update.
      * Triggers one update in any case.
      */
-    update(): void
+    override update(): void
     {
         if (this.destroyed)
         {
@@ -133,7 +133,7 @@ export class BaseImageResource extends Resource
     }
 
     /** Destroy this {@link BaseImageResource} */
-    dispose(): void
+    override dispose(): void
     {
         this.source = null;
     }

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -61,7 +61,7 @@ export class ImageBitmapResource extends BaseImageResource
 
         if (typeof source === 'string')
         {
-            super(ImageBitmapResource._DUMMY);
+            super(ImageBitmapResource.EMPTY);
 
             this.url = source;
         }
@@ -183,14 +183,21 @@ export class ImageBitmapResource extends BaseImageResource
             && (typeof source === 'string' || source instanceof ImageBitmap);
     }
 
-    private static __DUMMY: ICanvas;
+    /**
+     * Cached empty placeholder canvas.
+     * @see EMPTY
+     */
+    private static _EMPTY: ICanvas;
 
-    private static get _DUMMY(): ICanvas
+    /**
+     * ImageBitmap cannot be created synchronously, so a empty placeholder canvas is needed when loading from URLs.
+     * Only for internal usage.
+     * @returns The cached placeholder canvas.
+     */
+    private static get EMPTY(): ICanvas
     {
-        if (ImageBitmapResource.__DUMMY) return ImageBitmapResource.__DUMMY;
+        ImageBitmapResource._EMPTY = ImageBitmapResource._EMPTY ?? settings.ADAPTER.createCanvas(0, 0);
 
-        ImageBitmapResource.__DUMMY = settings.ADAPTER.createCanvas(0, 0);
-
-        return ImageBitmapResource.__DUMMY;
+        return ImageBitmapResource._EMPTY;
     }
 }

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -1,5 +1,4 @@
-import { ALPHA_MODES } from '@pixi/constants';
-import { settings } from '@pixi/settings';
+import { ALPHA_MODES, settings } from '@pixi/core';
 import { BaseImageResource } from './BaseImageResource';
 
 import type { ICanvas } from '@pixi/settings';

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -1,4 +1,23 @@
+import { ALPHA_MODES } from '@pixi/constants';
+import { settings } from '@pixi/settings';
 import { BaseImageResource } from './BaseImageResource';
+
+import type { ICanvas } from '@pixi/settings';
+import type { Renderer } from '../../Renderer';
+import type { BaseTexture } from '../BaseTexture';
+import type { GLTexture } from '../GLTexture';
+
+export interface IImageBitmapResourceOptions
+{
+    /** Start loading process automatically when constructed. */
+    autoLoad?: boolean;
+
+    /** Load image using cross origin. */
+    crossOrigin?: boolean;
+
+    /** Alpha mode used when creating the ImageBitmap. */
+    alphaMode?: ALPHA_MODES;
+}
 
 /**
  * Resource type for ImageBitmap.
@@ -6,22 +25,172 @@ import { BaseImageResource } from './BaseImageResource';
  */
 export class ImageBitmapResource extends BaseImageResource
 {
+    /** URL of the image source. */
+    url: string | null;
+
     /**
-     * @param source - Image element to use
+     * Load image using cross origin.
+     * @default false
      */
-    // eslint-disable-next-line @typescript-eslint/no-useless-constructor
-    constructor(source: ImageBitmap)
+    crossOrigin: boolean;
+
+    /**
+     * Controls texture alphaMode field
+     * Copies from options
+     * Default is `null`, copies option from baseTexture
+     * @readonly
+     */
+    alphaMode: ALPHA_MODES | null;
+
+    /**
+     * Promise when loading.
+     * @default null
+     */
+    private _load: Promise<ImageBitmapResource>;
+
+    /**
+     * @param source - ImageBitmap or URL to use
+     * @param options
+     * @param {boolean} [options.autoLoad=true] - Start loading process automatically when constructed.
+     * @param {boolean} [options.crossOrigin=true] - Load image using cross origin.
+     * @param {PIXI.ALPHA_MODES} [options.alphaMode=null] - Alpha mode used when creating the ImageBitmap.
+     */
+    constructor(source: ImageBitmap | string, options?: IImageBitmapResourceOptions)
     {
-        super(source);
+        options = options || {};
+
+        if (typeof source === 'string')
+        {
+            super(ImageBitmapResource._DUMMY);
+
+            this.url = source;
+        }
+        else
+        {
+            super(source);
+
+            this.url = null;
+        }
+
+        this.crossOrigin = options.crossOrigin ?? true;
+        this.alphaMode = typeof options.alphaMode === 'number' ? options.alphaMode : null;
+
+        this._load = null;
+
+        if (options.autoLoad !== false)
+        {
+            this.load();
+        }
+    }
+
+    load(): Promise<ImageBitmapResource>
+    {
+        if (this._load)
+        {
+            return this._load;
+        }
+
+        this._load = new Promise(async (resolve, reject) =>
+        {
+            if (this.url === null)
+            {
+                resolve(this);
+
+                return;
+            }
+
+            try
+            {
+                const response = await settings.ADAPTER.fetch(this.url, {
+                    mode: this.crossOrigin ? 'cors' : 'no-cors'
+                });
+
+                if (this.destroyed) return;
+
+                const imageBlob = await response.blob();
+
+                if (this.destroyed) return;
+
+                const imageBitmap = await createImageBitmap(imageBlob, {
+                    premultiplyAlpha: this.alphaMode === null || this.alphaMode === ALPHA_MODES.UNPACK
+                        ? 'premultiply' : 'none',
+                });
+
+                if (this.destroyed) return;
+
+                this.source = imageBitmap;
+                this.update();
+
+                resolve(this);
+            }
+            catch (e)
+            {
+                if (this.destroyed) return;
+
+                reject(e);
+                this.onError.emit(e);
+            }
+        });
+
+        return this._load;
+    }
+
+    /**
+     * Upload the image bitmap resource to GPU.
+     * @param renderer - Renderer to upload to
+     * @param baseTexture - BaseTexture for this resource
+     * @param glTexture - GLTexture to use
+     * @returns {boolean} true is success
+     */
+    override upload(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture): boolean
+    {
+        if (!(this.source instanceof ImageBitmap))
+        {
+            this.load();
+
+            return false;
+        }
+
+        if (typeof this.alphaMode === 'number')
+        {
+            baseTexture.alphaMode = this.alphaMode;
+        }
+
+        return super.upload(renderer, baseTexture, glTexture);
+    }
+
+    /** Destroys this resource. */
+    override dispose(): void
+    {
+        if (this.source instanceof ImageBitmap)
+        {
+            this.source.close();
+        }
+
+        super.dispose();
+
+        this._load = null;
     }
 
     /**
      * Used to auto-detect the type of resource.
      * @param {*} source - The source object
-     * @returns {boolean} `true` if source is an ImageBitmap
+     * @returns {boolean} `true` if current environment support ImageBitmap, and source is string or ImageBitmap
      */
-    static test(source: unknown): source is ImageBitmap
+    static override test(source: unknown): source is string | ImageBitmap
     {
-        return !!globalThis.createImageBitmap && typeof ImageBitmap !== 'undefined' && source instanceof ImageBitmap;
+        return !!globalThis.createImageBitmap && typeof ImageBitmap !== 'undefined'
+            && (typeof source === 'string' || source instanceof ImageBitmap);
+    }
+
+    private static __DUMMY: ICanvas;
+
+    private static get _DUMMY(): ICanvas
+    {
+        if (ImageBitmapResource.__DUMMY) return ImageBitmapResource.__DUMMY;
+
+        ImageBitmapResource.__DUMMY = settings.ADAPTER.createCanvas(0, 0);
+
+        return ImageBitmapResource.__DUMMY;
     }
 }

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -1,4 +1,5 @@
-import { ALPHA_MODES, settings } from '@pixi/core';
+import { ALPHA_MODES } from '@pixi/constants';
+import { settings } from '@pixi/settings';
 import { BaseImageResource } from './BaseImageResource';
 
 import type { ICanvas } from '@pixi/settings';

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -1,4 +1,5 @@
-import { ALPHA_MODES, settings } from '@pixi/core';
+import { ALPHA_MODES } from '@pixi/constants';
+import { settings } from '@pixi/settings';
 import { BaseImageResource } from './BaseImageResource';
 
 import type { Renderer } from '../../Renderer';

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -1,14 +1,14 @@
-import { BaseImageResource } from './BaseImageResource';
-import { settings } from '@pixi/settings';
 import { ALPHA_MODES } from '@pixi/constants';
+import { settings } from '@pixi/settings';
+import { BaseImageResource } from './BaseImageResource';
 
-import type { BaseTexture } from '../BaseTexture';
 import type { Renderer } from '../../Renderer';
+import type { BaseTexture } from '../BaseTexture';
 import type { GLTexture } from '../GLTexture';
 
 export interface IImageResourceOptions
 {
-    /** Start loading process */
+    /** Start loading process automatically when constructed. */
     autoLoad?: boolean;
 
     /** Whether its required to create a bitmap before upload. */
@@ -234,7 +234,7 @@ export class ImageResource extends BaseImageResource
      * @param glTexture - GLTexture to use
      * @returns {boolean} true is success
      */
-    upload(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture): boolean
+    override upload(renderer: Renderer, baseTexture: BaseTexture, glTexture: GLTexture): boolean
     {
         if (typeof this.alphaMode === 'number')
         {
@@ -293,7 +293,7 @@ export class ImageResource extends BaseImageResource
     }
 
     /** Destroys this resource. */
-    dispose(): void
+    override dispose(): void
     {
         (this.source as HTMLImageElement).onload = null;
         (this.source as HTMLImageElement).onerror = null;
@@ -312,10 +312,10 @@ export class ImageResource extends BaseImageResource
     /**
      * Used to auto-detect the type of resource.
      * @param {*} source - The source object
-     * @returns {boolean} `true` if source is string or HTMLImageElement
+     * @returns {boolean} `true` if current environment support HTMLImageElement, and source is string or HTMLImageElement
      */
-    static test(source: unknown): source is string | HTMLImageElement
+    static override test(source: unknown): source is string | HTMLImageElement
     {
-        return typeof source === 'string' || source instanceof HTMLImageElement;
+        return typeof HTMLImageElement !== 'undefined' && (typeof source === 'string' || source instanceof HTMLImageElement);
     }
 }

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -1,5 +1,4 @@
-import { ALPHA_MODES } from '@pixi/constants';
-import { settings } from '@pixi/settings';
+import { ALPHA_MODES, settings } from '@pixi/core';
 import { BaseImageResource } from './BaseImageResource';
 
 import type { Renderer } from '../../Renderer';

--- a/packages/core/src/textures/resources/index.ts
+++ b/packages/core/src/textures/resources/index.ts
@@ -12,8 +12,8 @@ export * from './Resource';
 export * from './BaseImageResource';
 
 INSTALLED.push(
-    ImageResource,
     ImageBitmapResource,
+    ImageResource,
     CanvasResource,
     VideoResource,
     SVGResource,

--- a/packages/settings/src/adapter.ts
+++ b/packages/settings/src/adapter.ts
@@ -16,6 +16,7 @@ export interface IAdapter
     getNavigator: () => { userAgent: string };
     /** Returns the current base URL For browser environments this is either the document.baseURI or window.location.href */
     getBaseUrl: () => string;
+    getFontFaceSet: () => FontFaceSet | null;
     fetch: (url: RequestInfo, options?: RequestInit) => Promise<Response>;
 }
 
@@ -38,5 +39,6 @@ export const BrowserAdapter = {
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI ?? window.location.href),
+    getFontFaceSet: () => document.fonts,
     fetch: (url: RequestInfo, options?: RequestInit) => fetch(url, options),
 } as IAdapter;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

This PR adds `@pixi/webworker` bundle for Web Workers. This bundle is basicly `pixijs` with `@pixi/accessibility` & `@pixi/events` removed and `WebWorkerAdapter` added, enough for running small demos in Web Workers.

See also https://github.com/pixijs/examples/pull/158.

Related Issue: https://github.com/pixijs/pixijs/issues/7123

##### Description of change
<!-- Provide a description of the change below this comment. -->

- Add `@pixi/webworker` bundle
- Add `IAdapter.getFontFaceSet()` to cover the difference between main thread and worker thread (`document.fonts` for main thread, `globalThis.fonts` for worker thread)
- `ImageBitmapResource` now recieve `string` in constructor, in order to support `Texture.from(url)` in Web Workers
- Other minor changes to make basic things work in Web Workers

##### Todo List

- [x] (Fixed) `Texture.from(url)` not working (It use `ImageResource`, which is not working since HTMLImageElement is not available in Web Workers. Perhaps we can make `ImageBitmapResource` recieve `string`). Using `await Assets.load(url)` is OK.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
