### PR TITLE
Fix bitmapText frag alpha

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -626,7 +626,7 @@ export class BitmapText extends Container
 
             for (const mesh of this._activePagesMeshData)
             {
-                mesh.mesh.shader.uniforms.uFWidth = Math.min(worldScale * distanceFieldRange * fontScale * resolution, 1.0);
+                mesh.mesh.shader.uniforms.uFWidth = worldScale * distanceFieldRange * fontScale * resolution;
             }
         }
 

--- a/packages/text-bitmap/src/shader/msdf.frag
+++ b/packages/text-bitmap/src/shader/msdf.frag
@@ -22,6 +22,11 @@ void main(void) {
 
   float screenPxDistance = uFWidth * (median - 0.5);
   float alpha = clamp(screenPxDistance + 0.5, 0.0, 1.0);
+  if (median < 0.01) {
+    alpha = 0.0;
+  } else if (median > 0.99) {
+    alpha = 1.0;
+  }
 
   // NPM Textures, NPM outputs
   gl_FragColor = vec4(uColor.rgb, uColor.a * alpha);


### PR DESCRIPTION
Trying to fix #8652 . 

`mipmaps dont help with SDF textures, because SDF is linear and guarantees exact result if scale > 1.0 / spread. however if its bigger then even mipmaps wont help us, there's just not enough info.`

this might be wrong. Needs testing from @insraq