### PR TITLE
WIP: Added willReadFrequently to text metrics context

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -745,7 +745,7 @@ export class TextMetrics
     {
         if (!TextMetrics.__context)
         {
-            TextMetrics.__context = TextMetrics._canvas.getContext('2d');
+            TextMetrics.__context = TextMetrics._canvas.getContext('2d', { willReadFrequently: true });
         }
 
         return TextMetrics.__context;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Getting a warning from latest Chromium:

>Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

In our case the warning is triggered from `getImageData` usage in `TextMetrics`. I plan to do a write a benchmark for it, but if you already have one, it'd be awesome to use it. I checked that ios Safari doesn't crash despite not supporting it, but I'm not sure if it's enough (maybe we need to `try` and fallback like in `_canvas` getter with `OffscreenCanvas`).

I'll create an issue with repro later

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
