### PR TITLE
Fix `fromBuffer`

### DIFF
--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -652,7 +652,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
         const resource = new BufferResource(buffer, { width, height });
         const type = buffer instanceof Float32Array ? TYPES.FLOAT : TYPES.UNSIGNED_BYTE;
 
-        return new BaseTexture(resource, Object.assign(defaultBufferOptions, options || { width, height, type }));
+        return new BaseTexture(resource, Object.assign({}, defaultBufferOptions, options || { width, height, type }));
     }
 
     /**


### PR DESCRIPTION
`Object.assign` modifies `defaultBufferOptions`: https://pixiplayground.com/#/edit/TFeCVbqcd1xDhZ1_RtL1j