### PR TITLE
Fix dereferencing textures for BitmapText

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -895,6 +895,17 @@ export class BitmapText extends Container
     destroy(options?: boolean | IDestroyOptions): void
     {
         const { _textureCache } = this;
+        const data = BitmapFont.available[this._fontName];
+        const pageMeshDataPool = data.distanceFieldType === 'none'
+            ? pageMeshDataDefaultPageMeshData : pageMeshDataMSDFPageMeshData;
+
+        // Release references to any cached textures in page pool
+        pageMeshDataPool
+            .filter((page) => _textureCache[page.mesh.texture.baseTexture.uid])
+            .forEach((page) =>
+            {
+                page.mesh.texture = Texture.EMPTY;
+            });
 
         for (const id in _textureCache)
         {


### PR DESCRIPTION
Fixes #8712

Broken: https://jsfiddle.net/bigtimebuddy/aL92zf0v/ (should see "2" and console crash)
Fixed: https://jsfiddle.net/bigtimebuddy/z8f2h7Lu/ (should see "1" and no console crash)

