### PR TITLE
Recycle PageMeshData when BitmapText is destroyed

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -364,10 +364,7 @@ export class BitmapText extends Container
 
         const activePagesMeshData = this._activePagesMeshData;
 
-        for (let i = 0; i < activePagesMeshData.length; i++)
-        {
-            pageMeshDataPool.push(activePagesMeshData[i]);
-        }
+        pageMeshDataPool.push(...activePagesMeshData);
 
         for (let i = 0; i < lenChars; i++)
         {
@@ -898,6 +895,9 @@ export class BitmapText extends Container
         const data = BitmapFont.available[this._fontName];
         const pageMeshDataPool = data.distanceFieldType === 'none'
             ? pageMeshDataDefaultPageMeshData : pageMeshDataMSDFPageMeshData;
+
+        pageMeshDataPool.push(...this._activePagesMeshData);
+        this._activePagesMeshData = [];
 
         // Release references to any cached textures in page pool
         pageMeshDataPool


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

When `BitmapText.destroy()` is called, push the `PageMeshData` that are still in `this._activePagesMeshData` to `pageMeshDataPool`, so that more `PageMeshData` can be reused.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
