### PR TITLE
Fix doc formatting warnings with TransformFeedback

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,6 +62,7 @@
         "jsdoc/require-property-name": 1,
         "jsdoc/require-property-type": 1,
         "jsdoc/require-returns-description": 1,
+        "jsdoc/require-hyphen-before-param-description": 1,
         "jsdoc/tag-lines": 1,
         "jsdoc/valid-types": 1
     },

--- a/packages/core/src/transformFeedback/TransformFeedback.ts
+++ b/packages/core/src/transformFeedback/TransformFeedback.ts
@@ -24,8 +24,8 @@ export class TransformFeedback
 
     /**
      * Bind buffer to TransformFeedback
-     * @param index index to bind
-     * @param buffer buffer to bind
+     * @param index - index to bind
+     * @param buffer - buffer to bind
      */
     bindBuffer(index: number, buffer: Buffer)
     {

--- a/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
+++ b/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
@@ -46,7 +46,7 @@ export class TransformFeedbackSystem implements ISystem
 
     /**
      * Bind TransformFeedback and buffers
-     * @param transformFeedback TransformFeedback to bind
+     * @param transformFeedback - TransformFeedback to bind
      */
     bind(transformFeedback: TransformFeedback)
     {
@@ -68,8 +68,8 @@ export class TransformFeedbackSystem implements ISystem
 
     /**
      * Begin TransformFeedback
-     * @param drawMode DrawMode for TransformFeedback
-     * @param shader A Shader used by TransformFeedback. Current bound shader will be used if not provided.
+     * @param drawMode - DrawMode for TransformFeedback
+     * @param shader - A Shader used by TransformFeedback. Current bound shader will be used if not provided.
      */
     beginTransformFeedback(drawMode: DRAW_MODES, shader?: Shader)
     {
@@ -93,7 +93,7 @@ export class TransformFeedbackSystem implements ISystem
 
     /**
      * Create TransformFeedback and bind buffers
-     * @param tf TransformFeedback
+     * @param tf - TransformFeedback
      * @returns WebGLTransformFeedback
      */
     protected createGLTransformFeedback(tf: TransformFeedback)


### PR DESCRIPTION
Partially addresses formatting warnings in #8720

Adds a new lint warning to catch this in the future.

Follow-up to #8486