### PR TITLE
Adds more user-friendly background option

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -82,8 +82,9 @@ export class Application
      * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present, this
      *   option only is available when using **pixi.js-legacy** or **@pixi/canvas-renderer** modules, otherwise
      *   it is ignored.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
+     * @param {number|string} [options.backgroundColor=0x000000] - The background color of the rendered area
+     *  (shown if not transparent). Also, accepts hex strings or color names (e.g., 'white').
+     * @param {number|string} [options.background] - Alias for `options.backgroundColor`.
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -175,8 +175,9 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
      *  enable this if you need to call toDataURL on the webgl context.
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *      not before the new render pass.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
+     * @param {number|string} [options.backgroundColor=0x000000] - The background color of the rendered area
+     *  (shown if not transparent). Also, accepts hex strings or color names (e.g., 'white').
+     * @param {number|string} [options.background] - Alias for `options.backgroundColor`.
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      */
     constructor(options?: IRendererOptions)
@@ -208,7 +209,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
             _plugin: CanvasRenderer.__plugins,
             background: {
                 alpha: options.backgroundAlpha,
-                color: options.backgroundColor,
+                color: options.background ?? options.backgroundColor,
                 clearBeforeRender: options.clearBeforeRender,
             },
             _view: {

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -89,7 +89,8 @@ export interface IRendererOptions extends GlobalMixins.IRendererOptions
     resolution?: number;
     preserveDrawingBuffer?: boolean;
     clearBeforeRender?: boolean;
-    backgroundColor?: number;
+    backgroundColor?: number | string;
+    background?: number | string;
     backgroundAlpha?: number;
     premultipliedAlpha?: boolean;
     powerPreference?: WebGLPowerPreference;

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -299,8 +299,9 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      *  preserveDrawingBuffer to `true`.
      * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,
      *  enable this if you need to call toDataURL on the WebGL context.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
+     * @param {number|string} [options.backgroundColor=0x000000] - The background color of the rendered area
+     *  (shown if not transparent). Also, accepts hex strings or color names (e.g., 'white').
+     * @param {number|string} [options.background] - Alias for `options.backgroundColor`.
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
      * @param {string} [options.powerPreference] - Parameter passed to WebGL context, set to "high-performance"
      *  for devices with dual graphics card.
@@ -361,7 +362,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
             _plugin: Renderer.__plugins,
             background: {
                 alpha: options.backgroundAlpha,
-                color: options.backgroundColor,
+                color: options.background ?? options.backgroundColor,
                 clearBeforeRender: options.clearBeforeRender,
             },
             _view: {

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -38,8 +38,9 @@ extensions.handleByList(ExtensionType.Renderer, renderers);
  * @param {boolean} [options.antialias=false] - sets antialias
  * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
  *  need to call toDataUrl on the webgl context
- * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
- *  (shown if not transparent).
+ * @param {number|string} [options.backgroundColor=0x000000] - The background color of the rendered area
+ *  (shown if not transparent). Also, accepts hex strings or color names (e.g., 'white').
+ * @param {number|string} [options.background] - Alias for `options.backgroundColor`.
  * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
  * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
  *   not before the new render pass.

--- a/packages/core/src/background/BackgroundSystem.ts
+++ b/packages/core/src/background/BackgroundSystem.ts
@@ -1,4 +1,4 @@
-import { hex2rgb, hex2string } from '@pixi/utils';
+import { hex2rgb, hex2string, string2hex } from '@pixi/utils';
 import type { ExtensionMetadata } from '@pixi/extensions';
 import { extensions, ExtensionType } from '@pixi/extensions';
 import type { ISystem } from '../system/ISystem';
@@ -8,7 +8,7 @@ export interface BackgroundOptions
     /** the main canvas background alpha. From 0 (fully transparent) to 1 (fully opaque). */
     alpha: number,
     /** the main canvas background color. */
-    color: number,
+    color: number | string,
     /** sets if the renderer will clear the canvas or not before the new render pass. */
     clearBeforeRender: boolean,
 }
@@ -64,7 +64,14 @@ export class BackgroundSystem implements ISystem<BackgroundOptions>
     init(options: BackgroundOptions): void
     {
         this.clearBeforeRender = options.clearBeforeRender;
-        this.color = options.color || this._backgroundColor; // run bg color setter
+
+        if (options.color)
+        {
+            this.color = typeof options.color === 'string'
+                ? string2hex(options.color)
+                : options.color;
+        }
+
         this.alpha = options.alpha;
     }
 

--- a/packages/core/test/Renderer.tests.ts
+++ b/packages/core/test/Renderer.tests.ts
@@ -139,4 +139,13 @@ describe('Renderer', () =>
 
         renderer.destroy();
     });
+
+    it('should support natural language color names', () =>
+    {
+        const renderer = new Renderer({ background: 'white' });
+
+        expect(renderer.background.color).toEqual(0xffffff);
+
+        renderer.destroy();
+    });
 });

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -13,7 +13,8 @@ export interface IRenderOptions
     view: ICanvas;
     antialias: boolean;
     autoDensity: boolean;
-    backgroundColor: number;
+    backgroundColor: number | string;
+    background?: number | string;
     backgroundAlpha: number;
     useContextAlpha: boolean | 'notMultiplied';
     clearBeforeRender: boolean;

--- a/packages/utils/src/color/hex.ts
+++ b/packages/utils/src/color/hex.ts
@@ -60,6 +60,14 @@ export function string2hex(string: string): number
         if (string[0] === '#')
         {
             string = string.slice(1);
+
+            // Add support for shorthand hex colors
+            if (string.length === 3)
+            {
+                const [r, g, b] = string;
+
+                string = r + r + g + g + b + b;
+            }
         }
     }
 

--- a/packages/utils/src/color/hex.ts
+++ b/packages/utils/src/color/hex.ts
@@ -40,10 +40,12 @@ export function hex2string(hex: number): string
 /**
  * Converts a string to a hexadecimal color number.
  * It can handle:
- *  hex strings starting with #: "#ffffff"
- *  hex strings starting with 0x: "0xffffff"
- *  hex strings without prefix: "ffffff"
- *  css colors: "black"
+ *  - hex strings starting with #: "#ffffff"
+ *  - hex strings starting with 0x: "0xffffff"
+ *  - hex strings without prefix: "ffffff"
+ *  - hex strings (3 characters) with #: "#fff"
+ *  - hex strings (3 characters) without prefix: "fff"
+ *  - css colors: "black"
  * @example
  * PIXI.utils.string2hex("#ffffff"); // returns 0xffffff
  * @memberof PIXI.utils
@@ -60,14 +62,14 @@ export function string2hex(string: string): number
         if (string[0] === '#')
         {
             string = string.slice(1);
+        }
 
-            // Add support for shorthand hex colors
-            if (string.length === 3)
-            {
-                const [r, g, b] = string;
+        // Add support for shorthand hex colors
+        if (string.length === 3)
+        {
+            const [r, g, b] = string;
 
-                string = r + r + g + g + b + b;
-            }
+            string = r + r + g + g + b + b;
         }
     }
 

--- a/packages/utils/test/utils.tests.ts
+++ b/packages/utils/test/utils.tests.ts
@@ -71,6 +71,27 @@ describe('utils', () =>
         // it('should properly convert rgb array to hex color string');
     });
 
+    describe('string2hex', () =>
+    {
+        it('should handle short-hand colors', () =>
+        {
+            expect(utils.string2hex('#fff')).toEqual(0xffffff);
+            expect(utils.string2hex('#000')).toEqual(0);
+        });
+
+        it('should handle color names', () =>
+        {
+            expect(utils.string2hex('white')).toEqual(0xffffff);
+            expect(utils.string2hex('black')).toEqual(0);
+        });
+
+        it('should handle color names', () =>
+        {
+            expect(utils.string2hex('#ffffff')).toEqual(0xffffff);
+            expect(utils.string2hex('#000000')).toEqual(0);
+        });
+    });
+
     describe('getResolutionOfUrl', () =>
     {
         it('should exist', () =>

--- a/packages/utils/test/utils.tests.ts
+++ b/packages/utils/test/utils.tests.ts
@@ -73,22 +73,46 @@ describe('utils', () =>
 
     describe('string2hex', () =>
     {
-        it('should handle short-hand colors', () =>
+        it('should handle short-hand hex colors', () =>
+        {
+            expect(utils.string2hex('fff')).toEqual(0xffffff);
+            expect(utils.string2hex('f00')).toEqual(0xff0000);
+            expect(utils.string2hex('000')).toEqual(0);
+        });
+
+        it('should handle short-hand hex colors with hash', () =>
         {
             expect(utils.string2hex('#fff')).toEqual(0xffffff);
+            expect(utils.string2hex('#f00')).toEqual(0xff0000);
             expect(utils.string2hex('#000')).toEqual(0);
         });
 
         it('should handle color names', () =>
         {
             expect(utils.string2hex('white')).toEqual(0xffffff);
+            expect(utils.string2hex('red')).toEqual(0xff0000);
             expect(utils.string2hex('black')).toEqual(0);
         });
 
-        it('should handle color names', () =>
+        it('should handle hex colors with hash prefix', () =>
         {
             expect(utils.string2hex('#ffffff')).toEqual(0xffffff);
+            expect(utils.string2hex('#ff0000')).toEqual(0xff0000);
             expect(utils.string2hex('#000000')).toEqual(0);
+        });
+
+        it('should handle hex colors', () =>
+        {
+            expect(utils.string2hex('ffffff')).toEqual(0xffffff);
+            expect(utils.string2hex('ff0000')).toEqual(0xff0000);
+            expect(utils.string2hex('000000')).toEqual(0);
+        });
+
+        it('should handle hex with hexadecimal prefix', () =>
+        {
+            expect(utils.string2hex('0xffffff')).toEqual(0xffffff);
+            expect(utils.string2hex('0xff0000')).toEqual(0xff0000);
+            expect(utils.string2hex('0x000000')).toEqual(0);
         });
     });
 


### PR DESCRIPTION
### Added

* Adds `background` shorter alias for `backgroundColor` option in Renderer, CanvasRenderer, and Application
* Supports hex strings (e.g., "#ff0000")
* Supports color names (e.g., "red")
* Supports short-hand hex strings (e.g. "#f00")

```ts
const renderer = new Renderer({ background: 'red' });
const renderer = new Renderer({ background: '#f00' });
const renderer = new Renderer({ background: 'f00' });
const renderer = new Renderer({ background: '#ff0000' });
const renderer = new Renderer({ background: 0xff0000 });
```