### PR TITLE
Simplify conditions for identifying playing video

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -225,7 +225,7 @@ export class VideoResource extends BaseImageResource
     {
         const source = this.source as HTMLVideoElement;
 
-        return (source.currentTime > 0 && source.paused === false && source.ended === false && source.readyState > 2);
+        return (!source.paused && !source.ended && this._isSourceReady());
     }
 
     /**
@@ -236,7 +236,7 @@ export class VideoResource extends BaseImageResource
     {
         const source = this.source as HTMLVideoElement;
 
-        return source.readyState === 3 || source.readyState === 4;
+        return source.readyState > 2;
     }
 
     /** Runs the update loop when the video is ready to play. */


### PR DESCRIPTION
Fixes #8707 

Removes the `currentTime > 0` conditional check since it's not working on Firefox with MediaStream.

### Firefox 🦊 

Broken: https://jsfiddle.net/bigtimebuddy/ah38w7y5/ (dev)
Fixed: https://jsfiddle.net/bigtimebuddy/fosvzgc0/ (this PR)


Also this seems to work fine with static video:
https://pixijs.io/examples/?v=fix-video-stream-playback#/sprite/video.js