### PR TITLE
Fix BitmapText crash problem

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -897,6 +897,10 @@ export class BitmapText extends Container
             ? pageMeshDataDefaultPageMeshData : pageMeshDataMSDFPageMeshData;
 
         pageMeshDataPool.push(...this._activePagesMeshData);
+        for (const data of this._activePagesMeshData)
+        {
+            this.removeChild(data.mesh);
+        }
         this._activePagesMeshData = [];
 
         // Release references to any cached textures in page pool


### PR DESCRIPTION
Remove all `activePagesMeshData[...].mesh` from the `BitmapText`'s children in `destroy()`, so that they won't be accidentally destroyed by `Container.destroy({ chilren: true })`.

Fixes #8732.