### PR TITLE
Add isImageBitmapSupported in WorkerManager

### DIFF
--- a/packages/assets/src/loader/parsers/textures/loadTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/loadTexture.ts
@@ -20,6 +20,13 @@ const validImages = ['.jpg', '.png', '.jpeg', '.avif', '.webp'];
 export async function loadImageBitmap(url: string): Promise<ImageBitmap>
 {
     const response = await settings.ADAPTER.fetch(url);
+
+    if (!response.ok)
+    {
+        throw new Error(`[loadImageBitmap] Failed to fetch ${url}: `
+            + `${response.status} ${response.statusText}`);
+    }
+
     const imageBlob = await response.blob();
     const imageBitmap = await createImageBitmap(imageBlob);
 
@@ -64,7 +71,14 @@ export const loadTextures = {
 
         if (globalThis.createImageBitmap)
         {
-            src = this.config.preferWorkers ? await WorkerManager.loadImageBitmap(url) : await loadImageBitmap(url);
+            if (this.config.preferWorkers && await WorkerManager.isImageBitmapSupported())
+            {
+                src = await WorkerManager.loadImageBitmap(url);
+            }
+            else
+            {
+                src = await loadImageBitmap(url);
+            }
         }
         else
         {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

Add `isImageBitmapSupported` method in `WorkerManager`, so that the `loadTextures.load()` won't fail on browser that support `createImageBitmap` in main thread but not worker threads.

Fixes #8738.

##### Description of change
<!-- Provide a description of the change below this comment. -->

- Add `isImageBitmapSupported` method in `WorkerManager`
- `WorkerManager.loadImageBitmap` will `reject(e)` if error happens, instead of silently `resolve(null)`
- Check `response.ok` after `fetch()` and throw Error in order to get better error information
    - Before
    ![image](https://user-images.githubusercontent.com/8724868/196056884-109a0305-a861-4114-9da4-fbc1a3a92c0b.png)
    - After
    ![image](https://user-images.githubusercontent.com/8724868/196056934-e95c8384-ae55-4376-9007-d93c9345d7cd.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
