### PR TITLE
Clarifying string2hex and rgb2hex examples in documentation (#8024)

### DIFF
--- a/packages/utils/src/color/hex.ts
+++ b/packages/utils/src/color/hex.ts
@@ -50,7 +50,7 @@ export function hex2string(hex: number): string
  *  - css colors: "black"
  * @example
  * import { utils } from 'pixi.js';
- * utils.string2hex("#ffffff"); // returns 0xffffff
+ * utils.string2hex("#ffffff"); // returns 0xffffff, which is 16777215 as an integer
  * @memberof PIXI.utils
  * @function string2hex
  * @param {string} string - The string color (e.g., `"#ffffff"`)
@@ -83,7 +83,7 @@ export function string2hex(string: string): number
  * Converts a color as an [R, G, B] array of normalized floats to a hexadecimal number.
  * @example
  * import { utils } from 'pixi.js';
- * utils.rgb2hex([1, 1, 1]); // returns 0xffffff
+ * utils.rgb2hex([1, 1, 1]); // returns 0xffffff, which is 16777215 as an integer
  * @memberof PIXI.utils
  * @function rgb2hex
  * @param {number[]} rgb - Array of numbers where all values are normalized floats from 0.0 to 1.0.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Clarified string2hex and rgb2hex examples in documentation, as string2hex documentation had been found confusing.

Fixes #8024.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
