### PR TITLE
Fix infinity loop in BitmapFont.from

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -414,7 +414,8 @@ export class BitmapFont
             }
 
             // Measure glyph dimensions
-            const metrics = TextMetrics.measureText(charsList[i], style, false, canvas);
+            const character = charsList[i];
+            const metrics = TextMetrics.measureText(character, style, false, canvas);
             const width = metrics.width;
             const height = Math.ceil(metrics.height);
 
@@ -427,8 +428,8 @@ export class BitmapFont
                 if (positionY === 0)
                 {
                     // We don't want user debugging an infinite loop (or do we? :)
-                    throw new Error(`[BitmapFont] textureHeight ${textureHeight}px is `
-                        + `too small for ${style.fontSize}px fonts`);
+                    throw new Error(`[BitmapFont] textureHeight ${textureHeight}px is too small `
+                        + `(fontFamily: '${style.fontFamily}', fontSize: ${style.fontSize}px, char: '${character}')`);
                 }
 
                 --i;
@@ -449,6 +450,13 @@ export class BitmapFont
             // Wrap line once full row has been rendered
             if ((textureGlyphWidth * resolution) + positionX >= lineWidth)
             {
+                if (positionX === 0)
+                {
+                    // Avoid infinite loop (There can be some very wide char like '\uFDFD'!)
+                    throw new Error(`[BitmapFont] textureWidth ${textureWidth}px is too small `
+                        + `(fontFamily: '${style.fontFamily}', fontSize: ${style.fontSize}px, char: '${character}')`);
+                }
+
                 --i;
                 positionY += maxCharHeight * resolution;
                 positionY = Math.ceil(positionY);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Avoid infinite loop caused by very wide char like '\uFDFD' (﷽) in `BitmapFont.from`, and throw detailed error information when `textureWidth` / `textureHeight` is too small.

Fixes #8755.

Example: [https://pixiplayground.com/#/edit/2sn1WkjUkZilb__5Vi9Tf](https://pixiplayground.com/#/edit/2sn1WkjUkZilb__5Vi9Tf)

Before: Page stops responding
After: Throw an error
![image](https://user-images.githubusercontent.com/8724868/196974651-2ece7cec-96a3-4a06-8c39-92bf9f6ee899.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
