### PR TITLE
Fix gl.readPixels failure in tests

### DIFF
--- a/packages/core/test/RenderTexture.tests.ts
+++ b/packages/core/test/RenderTexture.tests.ts
@@ -382,17 +382,17 @@ describe('RenderTexture', () =>
 
             renderer.framebuffer.bind(textureFramebuffer);
 
-            const pixel = new Float32Array([0.3]);
+            const pixel = new Float32Array([0.1, 0.2, 0.3, 0.4]);
 
-            gl.readPixels(0, 0, 1, 1, gl.RED, gl.FLOAT, pixel);
+            gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, pixel);
 
-            expect(pixel[0]).toEqual(1.0);
+            expect(pixel).toEqual(new Float32Array([1.0, 0.0, 0.0, 1.0]));
 
-            pixel.set([0.1]);
+            pixel.set([0.1, 0.2, 0.3, 0.4]);
 
-            gl.readPixels(1, 1, 1, 1, gl.RED, gl.FLOAT, pixel);
+            gl.readPixels(1, 1, 1, 1, gl.RGBA, gl.FLOAT, pixel);
 
-            expect(pixel[0]).toEqual(0.5);
+            expect(pixel).toEqual(new Float32Array([0.5, 0.0, 0.0, 1.0]));
         });
 
         itif('should resize multisampled framebuffer with format RED / type FLOAT', () =>
@@ -425,11 +425,11 @@ describe('RenderTexture', () =>
 
             renderer.framebuffer.bind(textureFramebuffer);
 
-            const pixel = new Float32Array([0.3]);
+            const pixel = new Float32Array([0.1, 0.2, 0.3, 0.4]);
 
-            gl.readPixels(1, 1, 1, 1, gl.RED, gl.FLOAT, pixel);
+            gl.readPixels(1, 1, 1, 1, gl.RGBA, gl.FLOAT, pixel);
 
-            expect(pixel[0]).toEqual(1.0);
+            expect(pixel).toEqual(new Float32Array([1.0, 0.0, 0.0, 1.0]));
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

`gl.readPixels(gl.RED, gl.FLOAT)` may fail in some environment (jest-electron on Mac M1 Pro for example), so use `gl.readPixels(gl.RGBA, gl.FLOAT)` as a workaround.

Fixes #8761.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
