### PR TITLE
Auto update BitmapText when its font is replaced

### DIFF
--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -137,7 +137,7 @@ export class BitmapText extends Container
      * Private tracker for the current font.
      * @private
      */
-    protected _font: BitmapFont | null;
+    protected _font?: BitmapFont;
 
     /**
      * Private tracker for the current font name.
@@ -206,7 +206,7 @@ export class BitmapText extends Container
         this._textHeight = 0;
         this._align = align;
         this._tint = tint;
-        this._font = null;
+        this._font = undefined;
         this._fontName = fontName;
         this._fontSize = fontSize;
         this.text = text;
@@ -597,6 +597,9 @@ export class BitmapText extends Container
         {
             charRenderDataPool.push(chars[i]);
         }
+
+        this._font = data;
+        this.dirty = false;
     }
 
     updateTransform(): void
@@ -664,13 +667,11 @@ export class BitmapText extends Container
         if (this._font !== font)
         {
             this.dirty = true;
-            this._font = font;
         }
 
         if (this.dirty)
         {
             this.updateText();
-            this.dirty = false;
         }
     }
 

--- a/packages/text-bitmap/test/BitmapText.tests.ts
+++ b/packages/text-bitmap/test/BitmapText.tests.ts
@@ -240,4 +240,85 @@ describe('BitmapText', () =>
 
         renderer.destroy();
     });
+
+    it('should update after font is replaced', () =>
+    {
+        BitmapFont.from('testFont');
+
+        const text = new BitmapText('123ABCabc', {
+            fontName: 'testFont',
+        });
+
+        const listener = jest.spyOn(text, 'updateText');
+
+        text.textWidth; // Should trigger updateText()
+
+        expect(listener.mock.calls).toHaveLength(1);
+
+        text.textWidth; // Should not trigger updateText()
+
+        expect(listener.mock.calls).toHaveLength(1);
+
+        BitmapFont.from('testFont'); // Replace the font
+        text.textWidth; // Should trigger updateText()
+
+        expect(listener.mock.calls).toHaveLength(2);
+    });
+
+    it('should update fontSize when font is replaced if fontSize is undefined', () =>
+    {
+        BitmapFont.from('testFont', {
+            fontSize: 12,
+        });
+
+        const text = new BitmapText('123ABCabc', {
+            fontName: 'testFont',
+        });
+
+        expect(text.fontSize).toEqual(12);
+
+        BitmapFont.from('testFont', {
+            fontSize: 24,
+        }); // Replace the font
+
+        expect(text.fontSize).toEqual(24);
+    });
+    it('should not update fontSize when font is replaced if fontSize is defined', () =>
+    {
+        BitmapFont.from('testFont', {
+            fontSize: 12,
+        });
+
+        const text = new BitmapText('123ABCabc', {
+            fontName: 'testFont',
+            fontSize: 16,
+        });
+
+        expect(text.fontSize).toEqual(16);
+
+        BitmapFont.from('testFont', {
+            fontSize: 24,
+        }); // Replace the font
+
+        expect(text.fontSize).toEqual(16);
+    });
+
+    it('should unset dirty after updateText', () =>
+    {
+        const text = new BitmapText('123ABCabc', {
+            fontName: font.font,
+        });
+
+        expect(text.dirty).toBeTrue();
+
+        text.updateText();
+
+        expect(text.dirty).toBeFalse();
+
+        text.dirty = true;
+
+        text.updateText();
+
+        expect(text.dirty).toBeFalse();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

Fixes #8758.

##### Description of change
<!-- Provide a description of the change below this comment. -->

- The `BitmapText` will trigger `updateText()` automatically when `validate()` if the `BitmapFont` it use is replaced
    - See test `should update after font is replaced`
- If `BitmapText.fontSize` is `undefined` and the `BitmapFont` it uses is replaced, it will use the new size of `BitmapFont`, instead of the old value when it is constructed
    - See test `should update fontSize when font is replaced if fontSize is undefined`
    - See test `should not update fontSize when font is replaced if fontSize is defined`
- `BitmapFont.dirty` will become `false` after `updateText()`, so that if user calls `updateText()` externally, there won't be duplicated call to `updateText()` inside `BitmapFont`
    - See test `should unset dirty after updateText`

Example: https://pixiplayground.com/#/edit/EzMFsKC9YZe8pdhMOMrwg
- Old: Broken after replacing the font; if manually call `updateText()` the font size won't change
- New: Works fine and no need to call `updateText()`
    - `bitmapText1` will change its size
    - `bitmapText2` won't change its size since its `fontSize` is specified
    - `bitmapText3` will change its family

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
