### PR TITLE
Add missing events to FederatedEventMap

### DIFF
--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -4,8 +4,8 @@ import type { FederatedWheelEvent } from './FederatedWheelEvent';
 export type FederatedEventMap = {
     click: FederatedPointerEvent;
     mousedown: FederatedPointerEvent;
-    mouseenter: FederatedPointerEvent
-    mouseleave: FederatedPointerEvent
+    mouseenter: FederatedPointerEvent;
+    mouseleave: FederatedPointerEvent;
     mousemove: FederatedPointerEvent;
     mouseout: FederatedPointerEvent;
     mouseover: FederatedPointerEvent;

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -16,6 +16,7 @@ export type FederatedEventMap = {
     pointertap: FederatedPointerEvent;
     pointerup: FederatedPointerEvent;
     pointerupoutside: FederatedPointerEvent;
+    pointercancel: FederatedPointerEvent;
     rightclick: FederatedPointerEvent;
     rightdown: FederatedPointerEvent;
     rightup: FederatedPointerEvent;

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -4,19 +4,23 @@ import type { FederatedWheelEvent } from './FederatedWheelEvent';
 export type FederatedEventMap = {
     click: FederatedPointerEvent;
     mousedown: FederatedPointerEvent;
+    mouseenter: FederatedPointerEvent
+    mouseleave: FederatedPointerEvent
     mousemove: FederatedPointerEvent;
     mouseout: FederatedPointerEvent;
     mouseover: FederatedPointerEvent;
     mouseup: FederatedPointerEvent;
     mouseupoutside: FederatedPointerEvent;
+    pointercancel: FederatedPointerEvent;
     pointerdown: FederatedPointerEvent;
+    pointerenter: FederatedPointerEvent;
+    pointerleave: FederatedPointerEvent;
     pointermove: FederatedPointerEvent;
     pointerout: FederatedPointerEvent;
     pointerover: FederatedPointerEvent;
     pointertap: FederatedPointerEvent;
     pointerup: FederatedPointerEvent;
     pointerupoutside: FederatedPointerEvent;
-    pointercancel: FederatedPointerEvent;
     rightclick: FederatedPointerEvent;
     rightdown: FederatedPointerEvent;
     rightup: FederatedPointerEvent;


### PR DESCRIPTION
##### Description of change
Adds the pointercancel event. https://developer.mozilla.org/en-US/docs/Web/API/Element/pointercancel_event 
Because touchcancel exists, it seems like pointercancel should be there.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
