### PR TITLE
Fix round line join on 180 degree corner

### DIFF
--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -336,16 +336,16 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
         /* atan(0.001) ~= 0.001 rad ~= 0.057 degree */
         if (Math.abs(cross) < 0.001 * Math.abs(dot))
         {
-           verts.push(
+            verts.push(
                 x1 - (perpx * innerWeight),
                 y1 - (perpy * innerWeight));
             verts.push(
                 x1 + (perpx * outerWeight),
                 y1 + (perpy * outerWeight));
 
+            /* 180 degree corner? */
             if (dot >= 0)
             {
-
                 if (style.join === LINE_JOIN.ROUND)
                 {
                     indexCount += round(
@@ -396,17 +396,17 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
             {
                 if (clockwise) /* rotating at inner angle */
                 {
-                    verts.push(imx, imy);// inner miter point
-                    verts.push(x1 + (perpx * outerWeight), y1 + (perpy * outerWeight));// first segment's outer vertex
-                    verts.push(imx, imy);// inner miter point
-                    verts.push(x1 + (perp1x * outerWeight), y1 + (perp1y * outerWeight));// second segment's outer vertex
+                    verts.push(imx, imy); // inner miter point
+                    verts.push(x1 + (perpx * outerWeight), y1 + (perpy * outerWeight)); // first segment's outer vertex
+                    verts.push(imx, imy); // inner miter point
+                    verts.push(x1 + (perp1x * outerWeight), y1 + (perp1y * outerWeight)); // second segment's outer vertex
                 }
                 else /* rotating at outer angle */
                 {
-                    verts.push(x1 - (perpx * innerWeight), y1 - (perpy * innerWeight));// first segment's inner vertex
-                    verts.push(omx, omy);// outer miter point
-                    verts.push(x1 - (perp1x * innerWeight), y1 - (perp1y * innerWeight));// second segment's outer vertex
-                    verts.push(omx, omy);// outer miter point
+                    verts.push(x1 - (perpx * innerWeight), y1 - (perpy * innerWeight)); // first segment's inner vertex
+                    verts.push(omx, omy); // outer miter point
+                    verts.push(x1 - (perp1x * innerWeight), y1 - (perp1y * innerWeight)); // second segment's outer vertex
+                    verts.push(omx, omy); // outer miter point
                 }
 
                 indexCount += 2;

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -362,7 +362,7 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
                         x1, y1,
                         x1 - (perpx * innerWeight), y1 - (perpy * innerWeight),
                         x1 - (perp1x * innerWeight), y1 - (perp1y * innerWeight),
-                        verts, false) + 2;
+                        verts, false) + 4;
                 }
                 else
                 {

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -336,25 +336,15 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
         /* atan(0.001) ~= 0.001 rad ~= 0.057 degree */
         if (Math.abs(cross) < 0.001 * Math.abs(dot))
         {
-            if (dot < 0)
+           verts.push(
+                x1 - (perpx * innerWeight),
+                y1 - (perpy * innerWeight));
+            verts.push(
+                x1 + (perpx * outerWeight),
+                y1 + (perpy * outerWeight));
+
+            if (dot >= 0)
             {
-                // Straight line
-                verts.push(
-                    x1 - (perpx * innerWeight),
-                    y1 - (perpy * innerWeight));
-                verts.push(
-                    x1 + (perpx * outerWeight),
-                    y1 + (perpy * outerWeight));
-            }
-            else
-            {
-                // 180 degree corner
-                verts.push(
-                    x1 - (perpx * innerWeight),
-                    y1 - (perpy * innerWeight));
-                verts.push(
-                    x1 + (perpx * outerWeight),
-                    y1 + (perpy * outerWeight));
 
                 if (style.join === LINE_JOIN.ROUND)
                 {

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -326,19 +326,56 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
         const dx1 = x1 - x2;
         const dy1 = y2 - y1;
 
+        /* +ve if internal angle < 90 degree, -ve if internal angle > 90 degree. */
+        const dot = (dx0 * dx1) + (dy0 * dy1);
         /* +ve if internal angle counterclockwise, -ve if internal angle clockwise. */
         const cross = (dy0 * dx1) - (dy1 * dx0);
         const clockwise = (cross < 0);
 
-        /* Going nearly straight? */
-        if (Math.abs(cross) < 0.1)
+        /* Going nearly parallel? */
+        /* atan(0.001) ~= 0.001 rad ~= 0.057 degree */
+        if (Math.abs(cross) < 0.001 * Math.abs(dot))
         {
-            verts.push(
-                x1 - (perpx * innerWeight),
-                y1 - (perpy * innerWeight));
-            verts.push(
-                x1 + (perpx * outerWeight),
-                y1 + (perpy * outerWeight));
+            if (dot < 0)
+            {
+                // Straight line
+                verts.push(
+                    x1 - (perpx * innerWeight),
+                    y1 - (perpy * innerWeight));
+                verts.push(
+                    x1 + (perpx * outerWeight),
+                    y1 + (perpy * outerWeight));
+            }
+            else
+            {
+                // 180 degree corner
+                verts.push(
+                    x1 - (perpx * innerWeight),
+                    y1 - (perpy * innerWeight));
+                verts.push(
+                    x1 + (perpx * outerWeight),
+                    y1 + (perpy * outerWeight));
+
+                if (style.join === LINE_JOIN.ROUND)
+                {
+                    indexCount += round(
+                        x1, y1,
+                        x1 - (perpx * innerWeight), y1 - (perpy * innerWeight),
+                        x1 - (perp1x * innerWeight), y1 - (perp1y * innerWeight),
+                        verts, false) + 2;
+                }
+                else
+                {
+                    indexCount += 2;
+                }
+
+                verts.push(
+                    x1 - (perp1x * outerWeight),
+                    y1 - (perp1y * outerWeight));
+                verts.push(
+                    x1 + (perp1x * innerWeight),
+                    y1 + (perp1y * innerWeight));
+            }
 
             continue;
         }

--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -1,5 +1,5 @@
 import { Texture, BLEND_MODES, Point, Matrix, SHAPES, Polygon } from '@pixi/core';
-import { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils, LINE_CAP } from '@pixi/graphics';
+import { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils, LINE_CAP, LINE_JOIN } from '@pixi/graphics';
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 
 describe('Graphics', () =>
@@ -279,6 +279,45 @@ describe('Graphics', () =>
             graphics.lineTo(10, 0);
 
             expect(graphics.currentPath.points).toEqual([0, 0, 10, 0]);
+        });
+
+        it('should not have miter join on 180 degree corner', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics.lineStyle({ width: 1, join: LINE_JOIN.MITER });
+            graphics.moveTo(0, 0);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(0, 0);
+
+            expect(graphics.width).toBeCloseTo(10, 0.0001);
+            expect(graphics.height).toBeCloseTo(1, 0.0001);
+        });
+
+        it('should not have bevel join on 180 degree corner', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics.lineStyle({ width: 1, join: LINE_JOIN.BEVEL });
+            graphics.moveTo(0, 0);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(0, 0);
+
+            expect(graphics.width).toBeCloseTo(10, 0.0001);
+            expect(graphics.height).toBeCloseTo(1, 0.0001);
+        });
+
+        it('should have round join on 180 degree corner', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics.lineStyle({ width: 1, join: LINE_JOIN.ROUND });
+            graphics.moveTo(0, 0);
+            graphics.lineTo(10, 0);
+            graphics.lineTo(0, 0);
+
+            expect(graphics.width).toBeCloseTo(10.5, 0.0001);
+            expect(graphics.height).toBeCloseTo(1, 0.0001);
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Update the logic in `buildNonNativeLine` to deal with 180 degree or nearly 180 degree corners, and add some tests for it.

Fixes #8751.

Example: https://pixiplayground.com/#/edit/E97IvI759l-TZekre5v5J
- By row: `lineTo + lineTo`, `lineTo + bezierCurveTo`, `bezierCurveTo + bezierCurveTo`
- By column: `MITER`, `BEVEL`, `ROUND`

Before:
- `Math.PI` (Missing round join, wrong topology for `lineTo + lineTo`)
![image](https://user-images.githubusercontent.com/8724868/197350533-589b3168-efb5-45bd-9219-fc5fcea2ac30.png)
- `Math.PI + 0.001` (Missing round join for `bezierCurveTo + bezierCurveTo`)
![image](https://user-images.githubusercontent.com/8724868/197349547-af4d6e10-4ed6-4a8d-bc03-4013e2b2a5fe.png)

After:
- `Math.PI`
![image](https://user-images.githubusercontent.com/8724868/197350502-ac544d2d-b177-4f4a-adff-d08f66069a01.png)
- `Math.PI + 0.001`
![image](https://user-images.githubusercontent.com/8724868/197349505-f4bdc80b-a27b-4aee-b654-b78a98fea176.png)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
