### PR TITLE
Render Immediate After Resize

### DIFF
--- a/packages/app/src/ResizePlugin.ts
+++ b/packages/app/src/ResizePlugin.ts
@@ -18,6 +18,7 @@ export class ResizePlugin
     public static resize: () => void;
     public static renderer: ResizeableRenderer;
     public static queueResize: () => void;
+    public static render: () => void;
     private static _resizeId: number;
     private static _resizeTo: Window | HTMLElement;
     private static cancelResize: () => void;
@@ -126,6 +127,7 @@ export class ResizePlugin
             }
 
             this.renderer.resize(width, height);
+            this.render();
         };
 
         // On resize


### PR DESCRIPTION
Closes #8629 

Adds a render call immediately after resizing Application to avoid a frame flicker.

**Before:** https://codesandbox.io/s/resizeto-flickering-kv1w2r
**After:** https://codesandbox.io/s/resizeto-flickering-forked-syxlbw