### PR TITLE
Change default value of MIPMAP_TEXTURES to ON

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -340,18 +340,19 @@ export enum WRAP_MODES
  * The {@link PIXI.settings.MIPMAP_TEXTURES} affects default texture filtering.
  * Mipmaps are generated for a baseTexture if its `mipmap` field is `ON`,
  * or its `POW2` and texture dimensions are powers of 2.
- * Due to platform restriction, `ON` option will work like `POW2` for webgl-1.
+ * Since WebGL 1 don't support mipmap for non-power-of-two textures,
+ * `ON` option will work like `POW2` for WebGL 1.
  *
  * This property only affects WebGL.
  * @name MIPMAP_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} OFF - No mipmaps
- * @property {number} POW2 - Generate mipmaps if texture dimensions are pow2
- * @property {number} ON - Always generate mipmaps
- * @property {number} ON_MANUAL - Use mipmaps, but do not auto-generate them; this is used with a resource
- *   that supports buffering each level-of-detail.
+ * @property {number} OFF - No mipmaps.
+ * @property {number} POW2 - Generate mipmaps if texture dimensions are powers of 2.
+ * @property {number} ON - Always generate mipmaps.
+ * @property {number} ON_MANUAL - Use mipmaps, but do not auto-generate them;
+ *  this is used with a resource that supports buffering each level-of-detail.
  */
 export enum MIPMAP_MODES
 // eslint-disable-next-line @typescript-eslint/indent
@@ -359,7 +360,7 @@ export enum MIPMAP_MODES
     OFF,
     POW2,
     ON,
-    ON_MANUAL
+    ON_MANUAL,
 }
 
 /**

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -69,7 +69,6 @@ export interface ISettings
  * @namespace PIXI.settings
  */
 export const settings: ISettings = {
-
     /**
      * This adapter is used to call methods that are platform dependent.
      * For example `document.createElement` only runs on the web but fails in node environments.
@@ -83,20 +82,20 @@ export const settings: ISettings = {
      * @default PIXI.BrowserAdapter
      */
     ADAPTER: BrowserAdapter,
+
     /**
-     * If set to true WebGL will attempt make textures mimpaped by default.
-     * Mipmapping will only succeed if the base texture uploaded has power of two dimensions.
+     * Default mipmap mode for textures.
      * @static
      * @name MIPMAP_TEXTURES
      * @memberof PIXI.settings
      * @type {PIXI.MIPMAP_MODES}
-     * @default PIXI.MIPMAP_MODES.POW2
+     * @default PIXI.MIPMAP_MODES.ON
      */
-    MIPMAP_TEXTURES: MIPMAP_MODES.POW2,
+    MIPMAP_TEXTURES: MIPMAP_MODES.ON,
 
     /**
      * Default anisotropic filtering level of textures.
-     * Usually from 0 to 16
+     * Usually from 0 to 16.
      * @static
      * @name ANISOTROPIC_LEVEL
      * @memberof PIXI.settings


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Change default value of `MIPMAP_TEXTURES` from `POW2` to `ON`, since PixiJS can automatically disable mipmap for NPOT textures on WebGL 1. Also some document update included.

Fixes #8775.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
