### PR TITLE
Chore: Automatically upload assets to release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,6 +60,14 @@ jobs:
       with:
         run: npm run dist-validate
 
+    # Append assets to releases
+    - name: Upload Assets to Release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ./dist/*
+
     # Examples:
     # 1) PR feature/acme merged into dev
     # 2) branch A merged into branch B


### PR DESCRIPTION
After each release, I was having to manually upload the assets. Finally, sorted this in GitHub Actions and it's pretty easy. 

This change automatically adds the browser builds to the release on GitHub. This means that the version on pixijs.download, npm and GitHub release are all exactly the same.