### PR TITLE
Fix publishing unsafe-eval package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "*.d.ts"
   ],
   "funding": {

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "files": [
-    "dist/",
+    "lib",
     "*.d.ts"
   ],
   "pixiRequirements": [

--- a/packages/unsafe-eval/src/bundle.ts
+++ b/packages/unsafe-eval/src/bundle.ts
@@ -1,8 +1,0 @@
-import { install } from './install';
-
-if (typeof (globalThis as any).PIXI === 'undefined')
-{
-    throw new Error('Global PIXI not found.');
-}
-
-install((globalThis as any).PIXI);


### PR DESCRIPTION
Closes #8791

### Fixed

* `@pixi/unsafe-eval` was missing the `lib` folder in the `files` list  of the **package.json**

### Chores

* Removes the `@pixi/unsafe-eval` bundle.ts which is no longer used
* Clean up the `@pixi/core` file list, `dist` no longer needed here