### PR TITLE
Chore: Cleanup action dependencies, remove Codecov

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN || '' }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || '' }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -25,27 +24,20 @@ jobs:
     - name: Install Canvas Dependencies
       run: sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
     - name: Use Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 16
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm
-      run: npm install -g npm@>=7
+      run: npm install -g npm@8
     - name: Install Dependencies
       run: npm ci
-    - name: Install Code Coverage Dependency
-      if: env.CODECOV_TOKEN != ''
-      run: npm install codecov -g
     - name: Run Unit Tests
-      uses: GabrielBB/xvfb-action@v1.0
+      uses: GabrielBB/xvfb-action@v1
       with:
         run: npm run coverage
       env:
         NODE_ENV: production
-
-    - name: Report Code Coverage
-      if: env.CODECOV_TOKEN != ''
-      run: codecov
 
     - name: Extract Branch Name
       id: branch_name
@@ -56,7 +48,7 @@ jobs:
       run: npm run dist
 
     - name: Validate Build for Distribution
-      uses: GabrielBB/xvfb-action@v1.0
+      uses: GabrielBB/xvfb-action@v1
       with:
         run: npm run dist-validate
 


### PR DESCRIPTION
### Chores

* Removes codecov, we are no longer using this and it has been breaking our builds occasionally and not reporting to codecov.io correctly.
* Change npm install to be 8 instead of `>=7` to be more future proof
* Updated any action dependencies to the latest major versions