### PR TITLE
Convert types reference to relative path

### DIFF
--- a/scripts/fixTypes.ts
+++ b/scripts/fixTypes.ts
@@ -7,7 +7,7 @@ async function main(): Promise<void>
     const outDir = path.join(rootDir, 'out');
     const bundlesDir = path.join(outDir, 'bundles');
     const packagesDir = path.join(outDir, 'packages');
-
+    const globalMixinsPattern = /(reference) types="packages\/\w+\/(global)"/;
     const all = [
         ...(await promises.readdir(packagesDir)).map((pkg) => path.join(packagesDir, pkg)),
         ...(await promises.readdir(bundlesDir)).map((bundle) => path.join(bundlesDir, bundle))
@@ -25,7 +25,7 @@ async function main(): Promise<void>
 
         await promises.writeFile(
             path.join(libDir, 'index.d.ts'),
-            buffer.replace('reference types="packages', 'reference types="@pixi')
+            buffer.replace(globalMixinsPattern, '$1 path="../$2.d.ts"')
         );
     }
 }


### PR DESCRIPTION
Closes #8799

Output changes out from:
```ts
/// <reference types="@pixi/core/global" />
```
To:
```ts
/// <reference path="../global.d.ts" />
```

This is less confusing for TypeScript 4.7+ which is expecting a `global` exports in the package.json.