### PR TITLE
VideoResource upload fix

### DIFF
--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -85,7 +85,7 @@ export class BaseImageResource extends Resource
         }
         else if (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement)
         {
-            if (source.readyState <= 1)
+            if (source.readyState <= 1 && source.buffered.length === 0) {
             {
                 return false;
             }

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -85,7 +85,7 @@ export class BaseImageResource extends Resource
         }
         else if (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement)
         {
-            if (source.readyState <= 1 && source.buffered.length === 0) {
+            if (source.readyState <= 1 && source.buffered.length === 0)
             {
                 return false;
             }


### PR DESCRIPTION
##### Description of change
VideoResource bug fix. Ensures we upload video changes once `play` has finished. When calling `play` on the video element readyState changes from 4 to 1 once playback has ended even though all of the data is buffered. This change takes this into account and allows us to upload video changes such as `currentTime` once playback has ended. See https://codesandbox.io/s/stoic-grass-rkhxl3?file=/src/index.js for working example.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
