### PR TITLE
Fix negative coords for roundPixels

### DIFF
--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -374,7 +374,7 @@ export class Mesh<T extends Shader = MeshMaterial> extends Container
 
             for (let i = 0; i < vertexData.length; ++i)
             {
-                vertexData[i] = Math.round((vertexData[i] * resolution | 0) / resolution);
+                vertexData[i] = Math.round(vertexData[i] * resolution) / resolution;
             }
         }
 

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -289,7 +289,7 @@ export class Sprite extends Container
 
             for (let i = 0; i < vertexData.length; ++i)
             {
-                vertexData[i] = Math.round((vertexData[i] * resolution | 0) / resolution);
+                vertexData[i] = Math.round(vertexData[i] * resolution) / resolution;
             }
         }
     }


### PR DESCRIPTION
How the heck we did miss it?

There are two problems in this code:

If sprite coord X < 0 it gets blurred, because rounding works differently for Left and Right parts, left is Ceil, right is Floor. Same with Y. I guess people who work with texts complained about that but we didnt understand the cause.

Second problem is that the code works only for resolution < 1, to round low-quality versions of sprites.

My suggestion is to merge this to v7, and then decide whether we want both fixes for v6 , or only remove (| 0) part, which fixes the negative values.

And Yes, `X-Files` label is back!
