### PR TITLE
Add view type as a template for IRenderer, Application

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -45,7 +45,7 @@ export interface Application extends GlobalMixins.Application {}
  * @class
  * @memberof PIXI
  */
-export class Application<VIEW = ICanvas>
+export class Application<VIEW extends ICanvas = ICanvas>
 {
     /** Collection of installed plugins. */
     static _plugins: IApplicationPlugin[] = [];

--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -45,7 +45,7 @@ export interface Application extends GlobalMixins.Application {}
  * @class
  * @memberof PIXI
  */
-export class Application
+export class Application<VIEW = ICanvas>
 {
     /** Collection of installed plugins. */
     static _plugins: IApplicationPlugin[] = [];
@@ -60,7 +60,7 @@ export class Application
      * WebGL renderer if available, otherwise CanvasRenderer.
      * @member {PIXI.Renderer|PIXI.CanvasRenderer}
      */
-    public renderer: IRenderer;
+    public renderer: IRenderer<VIEW>;
 
     /**
      * @param {object} [options] - The optional renderer parameters.
@@ -104,7 +104,7 @@ export class Application
             forceCanvas: false,
         }, options);
 
-        this.renderer = autoDetectRenderer(options);
+        this.renderer = autoDetectRenderer<VIEW>(options);
 
         // install plugins here
         Application._plugins.forEach((plugin) =>
@@ -124,7 +124,7 @@ export class Application
      * @member {PIXI.ICanvas}
      * @readonly
      */
-    get view(): ICanvas
+    get view(): VIEW
     {
         return this.renderer.view;
     }

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -111,7 +111,7 @@ export interface IRendererRenderOptions
  * Starard Interface for a Pixi renderer.
  * @memberof PIXI
  */
-export interface IRenderer<VIEW = ICanvas> extends SystemManager, GlobalMixins.IRenderer
+export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager, GlobalMixins.IRenderer
 {
 
     resize(width: number, height: number): void;

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -111,7 +111,7 @@ export interface IRendererRenderOptions
  * Starard Interface for a Pixi renderer.
  * @memberof PIXI
  */
-export interface IRenderer extends SystemManager, GlobalMixins.IRenderer
+export interface IRenderer<VIEW = ICanvas> extends SystemManager, GlobalMixins.IRenderer
 {
 
     resize(width: number, height: number): void;
@@ -131,7 +131,7 @@ export interface IRenderer extends SystemManager, GlobalMixins.IRenderer
     readonly rendererLogId: string
 
     /** The canvas element that everything is drawn to.*/
-    readonly view: ICanvas
+    readonly view: VIEW
     /** Flag if we are rendering to the screen vs renderTexture */
     readonly renderingToScreen: boolean
     /** The resolution / device pixel ratio of the renderer. */

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -7,7 +7,7 @@ export interface IRendererOptionsAuto extends IRendererOptions
     forceCanvas?: boolean;
 }
 
-export interface IRendererConstructor<VIEW = ICanvas>
+export interface IRendererConstructor<VIEW extends ICanvas = ICanvas>
 {
     test(options?: IRendererOptionsAuto): boolean;
     new (options?: IRendererOptionsAuto): IRenderer<VIEW>;
@@ -17,7 +17,7 @@ export interface IRendererConstructor<VIEW = ICanvas>
  * Collection of installed Renderers.
  * @ignore
  */
-const renderers: IRendererConstructor<unknown>[] = [];
+const renderers: IRendererConstructor<ICanvas>[] = [];
 
 extensions.handleByList(ExtensionType.Renderer, renderers);
 
@@ -54,7 +54,7 @@ extensions.handleByList(ExtensionType.Renderer, renderers);
  * @param {boolean} [options.hello=false] - Logs renderer type and version.
  * @returns {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer
  */
-export function autoDetectRenderer<VIEW = ICanvas>(options?: IRendererOptionsAuto): IRenderer<VIEW>
+export function autoDetectRenderer<VIEW extends ICanvas = ICanvas>(options?: IRendererOptionsAuto): IRenderer<VIEW>
 {
     for (const RendererType of renderers)
     {

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '@pixi/extensions';
+import type { ICanvas } from '@pixi/settings';
 import type { IRenderer, IRendererOptions } from './IRenderer';
 
 export interface IRendererOptionsAuto extends IRendererOptions
@@ -53,13 +54,13 @@ extensions.handleByList(ExtensionType.Renderer, renderers);
  * @param {boolean} [options.hello=false] - Logs renderer type and version.
  * @returns {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer
  */
-export function autoDetectRenderer(options?: IRendererOptionsAuto): IRenderer
+export function autoDetectRenderer<VIEW = ICanvas>(options?: IRendererOptionsAuto): IRenderer<VIEW>
 {
     for (const RendererType of renderers)
     {
         if (RendererType.test(options))
         {
-            return new RendererType(options);
+            return new RendererType(options) as IRenderer<VIEW>;
         }
     }
 

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -7,17 +7,17 @@ export interface IRendererOptionsAuto extends IRendererOptions
     forceCanvas?: boolean;
 }
 
-export interface IRendererConstructor
+export interface IRendererConstructor<VIEW = ICanvas>
 {
     test(options?: IRendererOptionsAuto): boolean;
-    new (options?: IRendererOptionsAuto): IRenderer;
+    new (options?: IRendererOptionsAuto): IRenderer<VIEW>;
 }
 
 /**
  * Collection of installed Renderers.
  * @ignore
  */
-const renderers: IRendererConstructor[] = [];
+const renderers: IRendererConstructor<unknown>[] = [];
 
 extensions.handleByList(ExtensionType.Renderer, renderers);
 


### PR DESCRIPTION
### Current Issue

Since we are using ICanvas as a generic interface for OffscreenCanvas, HTMLCanvasElement and Node's canvas, we are getting a type error doing something pretty basic:

```ts
const app = new Application();
document.body.appendChild(app.view); // ERROR: Argument of type `ICanvas` is not assignable to type 'Node'
```

#### Workaround

Current workaround is to cast:

```ts
document.body.appendChild(app.view as HTMLCanvasElement);
```

### Fix

Use a template to specify the type of view.

```ts
const app = new Application<HTMLCanvasElement>();
document.body.appendChild(app.view);
```

```ts
const renderer = autoDetectRenderer<HTMLCanvasElement>();
document.body.appendChild(renderer.view);
```