### PR TITLE
Fix: Make NodeCanvasElement compatible with ICanvas

### DIFF
--- a/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
+++ b/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
@@ -56,7 +56,7 @@ type TempCtx = WebGLRenderingContext & {
  * @class
  * @memberof PIXI
  */
-export class NodeCanvasElement extends Canvas implements ICanvas
+export class NodeCanvasElement extends canvasModule.Canvas implements ICanvas
 {
     public style: Record<string, any>;
     private _gl: WebGLRenderingContext;

--- a/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
+++ b/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
@@ -132,6 +132,8 @@ export class NodeCanvasElement extends canvasModule.Canvas implements ICanvas
     }
 
     // @ts-expect-error - overriding getContext
+    override getContext(contextId: ContextIds, options?: any): RenderingContext | null;
+    // @ts-expect-error - overriding getContext
     override getContext(
         type: ContextIds,
         options?: NodeCanvasRenderingContext2DSettings | WebGLContextAttributes

--- a/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
+++ b/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
@@ -56,7 +56,7 @@ type TempCtx = WebGLRenderingContext & {
  * @class
  * @memberof PIXI
  */
-export class NodeCanvasElement extends canvasModule.Canvas implements ICanvas
+export class NodeCanvasElement extends Canvas implements ICanvas
 {
     public style: Record<string, any>;
     private _gl: WebGLRenderingContext;

--- a/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
+++ b/bundles/pixi.js-node/src/adapter/NodeCanvasElement.ts
@@ -7,7 +7,7 @@ import createGLContext from 'gl';
 import { utils } from '@pixi/core';
 
 import type { JpegConfig, NodeCanvasRenderingContext2DSettings, PdfConfig, PngConfig } from 'canvas';
-import type { ContextIds, ICanvas } from '@pixi/core';
+import type { ContextIds, ContextSettings, ICanvas, ICanvasRenderingContext2DSettings } from '@pixi/core';
 
 const { Canvas, CanvasRenderingContext2D, Image } = canvasModule;
 
@@ -132,11 +132,29 @@ export class NodeCanvasElement extends canvasModule.Canvas implements ICanvas
     }
 
     // @ts-expect-error - overriding getContext
-    override getContext(contextId: ContextIds, options?: any): RenderingContext | null;
+    override getContext(
+        contextId: '2d',
+        options?: ICanvasRenderingContext2DSettings | NodeCanvasRenderingContext2DSettings,
+    ): CanvasRenderingContext2D | null;
+    // @ts-expect-error - overriding getContext
+    override getContext(
+        contextId: 'bitmaprenderer',
+        options?: ImageBitmapRenderingContextSettings | NodeCanvasRenderingContext2DSettings,
+    ): null;
+    // @ts-expect-error - overriding getContext
+    override getContext(
+        contextId: 'webgl' | 'experimental-webgl',
+        options?: WebGLContextAttributes | NodeCanvasRenderingContext2DSettings,
+    ): WebGLRenderingContext | null;
+    // @ts-expect-error - overriding getContext
+    override getContext(
+        contextId: 'webgl2' | 'experimental-webgl2',
+        options?: WebGLContextAttributes | NodeCanvasRenderingContext2DSettings,
+    ): null;
     // @ts-expect-error - overriding getContext
     override getContext(
         type: ContextIds,
-        options?: NodeCanvasRenderingContext2DSettings | WebGLContextAttributes
+        options?: ContextSettings | NodeCanvasRenderingContext2DSettings,
     ): CanvasRenderingContext2D | WebGLRenderingContext | null
     {
         switch (type)

--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -4,7 +4,7 @@ import createContext from 'gl';
 import { settings, utils } from '@pixi/core';
 import { NodeCanvasElement } from './NodeCanvasElement';
 
-import type { IAdapter, ICanvas } from '@pixi/core';
+import type { IAdapter } from '@pixi/core';
 
 export const NodeAdapter = {
     /**
@@ -13,7 +13,7 @@ export const NodeAdapter = {
      * @param width - width of the canvas
      * @param height - height of the canvas
      */
-    createCanvas: (width?: number, height?: number) => new NodeCanvasElement(width, height) as unknown as ICanvas,
+    createCanvas: (width?: number, height?: number) => new NodeCanvasElement(width, height),
     /** Returns a webgl rendering context using the gl package. */
     getWebGLRenderingContext: () => createContext(1, 1) as unknown as typeof WebGLRenderingContext,
     /** Returns the fake user agent string of `node` */

--- a/bundles/pixi.js-webworker/src/adapter.ts
+++ b/bundles/pixi.js-webworker/src/adapter.ts
@@ -9,8 +9,7 @@ export const WebWorkerAdapter = {
      * @param width - width of the canvas
      * @param height - height of the canvas
      */
-    createCanvas: (width?: number, height?: number): OffscreenCanvas =>
-        new OffscreenCanvas(width | 0, height | 0),
+    createCanvas: (width?: number, height?: number) => new OffscreenCanvas(width | 0, height | 0),
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => globalThis.location.href,

--- a/packages/settings/src/ICanvas.ts
+++ b/packages/settings/src/ICanvas.ts
@@ -15,6 +15,9 @@ export interface ICanvasRenderingContext2DSettings
     willReadFrequently?: boolean;
 }
 
+export type ContextSettings =
+    ICanvasRenderingContext2DSettings | ImageBitmapRenderingContextSettings | WebGLContextAttributes;
+
 export interface ICanvasParentNode
 {
     /** Adds a node to the end of the list of children of the parent node. */
@@ -64,18 +67,29 @@ export interface ICanvas extends GlobalMixins.ICanvas, Partial<EventTarget>
     /**
      * Get rendering context of the canvas.
      * @param {ContextIds} contextId - The identifier of the type of context to create.
-     * @param {any} options - The options for creating context.
+     * @param {ContextSettings} options - The options for creating context.
      * @returns {RenderingContext | null} The created context, or null if contextId is not supported.
      */
-    getContext(contextId: '2d', options?: ICanvasRenderingContext2DSettings):
-    ICanvasRenderingContext2D | null;
-    getContext(contextId: 'bitmaprenderer', options?: ImageBitmapRenderingContextSettings):
-    ImageBitmapRenderingContext | null;
-    getContext(contextId: 'webgl' | 'experimental-webgl', options?: WebGLContextAttributes):
-    WebGLRenderingContext | null;
-    getContext(contextId: 'webgl2' | 'experimental-webgl2', options?: WebGLContextAttributes):
-    WebGL2RenderingContext | null;
-    getContext(contextId: ContextIds, options?: any): RenderingContext | null;
+    getContext(
+        contextId: '2d',
+        options?: ICanvasRenderingContext2DSettings,
+    ): ICanvasRenderingContext2D | null;
+    getContext(
+        contextId: 'bitmaprenderer',
+        options?: ImageBitmapRenderingContextSettings,
+    ): ImageBitmapRenderingContext | null;
+    getContext(
+        contextId: 'webgl' | 'experimental-webgl',
+        options?: WebGLContextAttributes,
+    ): WebGLRenderingContext | null;
+    getContext(
+        contextId: 'webgl2' | 'experimental-webgl2',
+        options?: WebGLContextAttributes,
+    ): WebGL2RenderingContext | null;
+    getContext(
+        contextId: ContextIds,
+        options?: ContextSettings,
+    ): RenderingContext | null;
 
     /**
      * Get the content of the canvas as data URL.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

- Make `NodeCanvasElement` compatible with `ICanvas`, so that `NodeCanvasElement` can be convert into `ICanvas` without `as unknown`.
    - Before: `new NodeCanvasElement(width, height) as unknown as ICanvas`
    - After: `new NodeCanvasElement(width, height) as ICanvas`
- Add `ContextSettings` as the type of `ICanvas.getContext`'s `options` argument.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
