### PR TITLE
Add missing resolution setter for Renderer and CanvasRenderer

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -189,7 +189,17 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
         options = Object.assign({}, settings.RENDER_OPTIONS, options);
 
         const systemConfig = {
-            runners: ['init', 'destroy', 'contextChange', 'reset', 'update', 'postrender', 'prerender', 'resize'],
+            runners: [
+                'init',
+                'destroy',
+                'contextChange',
+                'resolutionChange',
+                'reset',
+                'update',
+                'postrender',
+                'prerender',
+                'resize'
+            ],
             systems: CanvasRenderer.__systems,
             priority: [
                 'textureGenerator',
@@ -324,6 +334,11 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
     get resolution(): number
     {
         return this._view.resolution;
+    }
+    set resolution(value: number)
+    {
+        this._view.resolution = value;
+        this.runners.resolutionChange.emit(value);
     }
 
     /** Whether CSS dimensions of canvas view should be resized to screen dimensions automatically. */

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -326,7 +326,17 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
         }, true);
 
         const systemConfig = {
-            runners: ['init', 'destroy', 'contextChange', 'reset', 'update', 'postrender', 'prerender', 'resize'],
+            runners: [
+                'init',
+                'destroy',
+                'contextChange',
+                'resolutionChange',
+                'reset',
+                'update',
+                'postrender',
+                'prerender',
+                'resize'
+            ],
             systems: Renderer.__systems,
             priority: [
                 '_view',
@@ -481,6 +491,11 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
     get resolution(): number
     {
         return this._view.resolution;
+    }
+    set resolution(value: number)
+    {
+        this._view.resolution = value;
+        this.runners.resolutionChange.emit(value);
     }
 
     /** Whether CSS dimensions of canvas view should be resized to screen dimensions automatically. */

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -130,6 +130,15 @@ export class EventSystem
         this.resolution = resolution;
     }
 
+    /**
+     * Handle changing resolution.
+     * @ignore
+     */
+    resolutionChange(resolution: number): void
+    {
+        this.resolution = resolution;
+    }
+
     /** Destroys all event listeners and detaches the renderer. */
     destroy(): void
     {

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -365,4 +365,19 @@ describe('EventSystem', () =>
             done();
         }, 800);
     });
+
+    it('should inherit resolution changes', () =>
+    {
+        const renderer = createRenderer();
+
+        renderer.resolution = 2;
+
+        expect(renderer.resolution).toEqual(2);
+        expect(renderer.events.resolution).toEqual(2);
+
+        renderer.resolution = 1;
+
+        expect(renderer.resolution).toEqual(1);
+        expect(renderer.events.resolution).toEqual(1);
+    });
 });


### PR DESCRIPTION
Closes #8792
Closes #8804

There are uses cases like automatically adjusting the resolution based on the browser zoom. This automatically adjusts the Event's resolution as well.

### :gift: Added

* Adds setter for Renderer and CanvasRenderer's `resolution`