### PR TITLE
Event emitter types improvements

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -13,12 +13,12 @@ export interface IDestroyOptions
 
 export interface DisplayObjectEvents extends GlobalMixins.DisplayObjectEvents
 {
-    added: [Container];
-    childAdded: [DisplayObject, Container, number];
-    childRemoved: [DisplayObject, Container, number];
+    added: [container: Container];
+    childAdded: [child: DisplayObject, container: Container, index: number];
+    childRemoved: [child: DisplayObject, container: Container, index: number];
     destroyed: [];
-    removed: [Container];
-    removedFrom: [DisplayObject, Container, number];
+    removed: [container: Container];
+    removedFrom: [child: DisplayObject, container: Container, index: number];
 }
 
 export interface DisplayObject

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -18,7 +18,6 @@ export interface DisplayObjectEvents extends GlobalMixins.DisplayObjectEvents
     childRemoved: [child: DisplayObject, container: Container, index: number];
     destroyed: [];
     removed: [container: Container];
-    removedFrom: [child: DisplayObject, container: Container, index: number];
 }
 
 export interface DisplayObject

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -34,5 +34,5 @@ export type FederatedEventMap = {
     wheel: FederatedWheelEvent;
 };
 export type FederatedEventEmitterTypes = {
-    [K in keyof FederatedEventMap]: [FederatedEventMap[K]];
+    [K in keyof FederatedEventMap]: [event: FederatedEventMap[K]];
 };

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -34,5 +34,5 @@ export type FederatedEventMap = {
     wheel: FederatedWheelEvent;
 };
 export type FederatedEventEmitterTypes = {
-    [K in keyof FederatedEventMap]: [event: FederatedEventMap[K]];
+    [K in keyof FederatedEventMap as K | `${K}capture`]: [event: FederatedEventMap[K]];
 };


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Hello,

these are just very minor changes to slightly improve DX:

1. Use labeled tuples
    * A very minor improvement in DX:
![Bildschirm­foto 2022-11-06 um 09 51 35](https://user-images.githubusercontent.com/11465247/200162205-f5b8d10c-619a-43f6-9b3f-ade3af73b70b.png)
    Before the signature of fn was `fn: (args_0: PIXI.FederatedPointerEvent) => void`
    * The syntax used requires TypeScript 4.1. If that's a problem I can replace it by just writing out the events by hand.

    
2. Add types for `*capture` events
    * These seemed to be missing, I hope this wasn't intentional?

**Note**: The event `removedFrom` doesn't seem to be used anywhere (haven't found it in the docs and neither anywhere in the code). Shall I remove this from the types?

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
