### PR TITLE
Change "lib/node_modules" to "lib/external" with preserveModules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "rollup": "^2.75.7",
         "rollup-plugin-esbuild": "^4.9.1",
         "rollup-plugin-jscc": "^2.0.0",
+        "rollup-plugin-rename-node-modules": "^1.3.1",
         "rollup-plugin-sourcemaps": "^0.4.2",
         "rollup-plugin-string": "^3.0.0",
         "ts-jest": "^26.0.0",
@@ -5819,14 +5820,6 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
-      "version": "0.25.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "node_modules/@rollup/plugin-commonjs/node_modules/resolve": {
       "version": "1.18.1",
@@ -19443,11 +19436,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.2",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-dir": {
@@ -22906,6 +22900,25 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "node_modules/rollup-plugin-rename-node-modules": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
+      "integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^2.28.2"
+      }
+    },
+    "node_modules/rollup-plugin-rename-node-modules/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/rollup-plugin-sourcemaps": {
       "version": "0.4.2",
       "dev": true,
@@ -23558,9 +23571,10 @@
       "license": "MIT"
     },
     "node_modules/sourcemap-codec": {
-      "version": "1.4.4",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spawn-sync": {
       "version": "1.0.15",
@@ -30136,13 +30150,6 @@
         "estree-walker": {
           "version": "2.0.1",
           "dev": true
-        },
-        "magic-string": {
-          "version": "0.25.7",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
         },
         "resolve": {
           "version": "1.18.1",
@@ -39733,10 +39740,12 @@
       }
     },
     "magic-string": {
-      "version": "0.25.2",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -42130,6 +42139,24 @@
         }
       }
     },
+    "rollup-plugin-rename-node-modules": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
+      "integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
+      }
+    },
     "rollup-plugin-sourcemaps": {
       "version": "0.4.2",
       "dev": true,
@@ -42569,7 +42596,9 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.4",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-sync": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "rollup": "^2.75.7",
     "rollup-plugin-esbuild": "^4.9.1",
     "rollup-plugin-jscc": "^2.0.0",
+    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-string": "^3.0.0",
     "ts-jest": "^26.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import resolve from '@rollup/plugin-node-resolve';
+import rename from 'rollup-plugin-rename-node-modules';
 import { string } from 'rollup-plugin-string';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import esbuild from 'rollup-plugin-esbuild';
@@ -40,6 +41,7 @@ async function main()
     ];
 
     const plugins = [
+        rename(),
         jscc({ values: { _VERSION: repo.version } }),
         esbuild({ target: moduleTarget }),
         ...commonPlugins


### PR DESCRIPTION
Related issue: https://github.com/bigtimebuddy/pixi-svg/issues/33
Issue found: https://codesandbox.io/s/pixijs-examples-events-hit-test-forked-h8eog8


```
ModuleNotFoundError
Could not find module in path: '@pixi/settings/lib/node_modules/ismobilejs/esm/index.js' relative to 
'/node_modules/@pixi/settings/lib/utils/isMobile.js'
```


I believe that codesandbox is having issues with preserveModules in Rollup. Specifically, the external dependencies that are bundled (e.g. ismobilejs) are added to a folder called `node_modules`. This PR changes that folder name to be `external`. Since `node_modules` implies something very specific, I don't think it's appropriate to use that here and may be messing up patterning matching with other tools that expect `node_modules` to be _actual_ modules.

Before:
```
@pixi/settings/lib/node_modules/ismobilejs/esm/index.js
```

After:
```
@pixi/settings/lib/external/ismobilejs/esm/index.js
```

I was not able to confirm codesandbox's issue locally, but I'd like to try to do a test prerelease to validate. Either way, I still think this is a useful change.