### PR TITLE
Fix culling not working with projection transforms

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -1,8 +1,10 @@
-import { MASK_TYPES, settings, utils } from '@pixi/core';
+import { MASK_TYPES, Matrix, settings, utils } from '@pixi/core';
 import { DisplayObject } from './DisplayObject';
 
-import type { MaskData, Renderer, Matrix, Rectangle } from '@pixi/core';
+import type { MaskData, Renderer, Rectangle } from '@pixi/core';
 import type { IDestroyOptions } from './DisplayObject';
+
+const tempMatrix = new Matrix();
 
 function sortChildren(a: DisplayObject, b: DisplayObject): number
 {
@@ -559,6 +561,22 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
         else if (this._render !== Container.prototype._render)
         {
             bounds = this.getBounds(true);
+        }
+
+        // Prepend the transform that is appended to the projection matrix.
+        const projectionTransform = renderer.projection.transform;
+
+        if (projectionTransform)
+        {
+            if (transform)
+            {
+                transform = tempMatrix.copyFrom(transform);
+                transform.prepend(projectionTransform);
+            }
+            else
+            {
+                transform = projectionTransform;
+            }
         }
 
         // Render the container if the source frame intersects the bounds.


### PR DESCRIPTION
Culling didn't include the projection transform in its calculation.

Test: Generate texture from red square graphics with culling enabled.
- Before: https://pixiplayground.com/#/edit/hecuI3Ahv12g4l5Gw5Pcp
- After: https://pixiplayground.com/#/edit/AyuQKXBxkN8hz00FXfH13

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
