### PR TITLE
Chore: Fix the URLs for the repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ eslint, rebuild, then run the test suite.
 [fork-cli]: https://help.github.com/articles/fork-a-repo/
 [fork-gui]: https://guides.github.com/activities/forking/
 [forums]: http://www.html5gamedevs.com/forum/15-pixijs/
-[issues]: https://github.com/pixijs/pixi.js/issues
+[issues]: https://github.com/pixijs/pixijs/issues
 [jsbin]: http://jsbin.com/
 [node]: http://nodejs.org
 [pixi]: https://github.com/pixijs/pixi.js

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Thank you for reporting an issue!
 
 Before opening an issue _please_ check if a similar issue exists by
-searching existing issues (https://github.com/pixijs/pixi.js/issues).
+searching existing issues (https://github.com/pixijs/pixijs/issues).
 
 If possible, please provide code that demonstrates the problem.
 Links to a running example of the problem are best!

--- a/bundles/pixi.js-legacy/package.json
+++ b/bundles/pixi.js-legacy/package.json
@@ -31,11 +31,11 @@
     }
   },
   "homepage": "http://www.pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "files": [
     "lib",

--- a/bundles/pixi.js-node/package.json
+++ b/bundles/pixi.js-node/package.json
@@ -3,10 +3,10 @@
   "version": "7.1.0-alpha",
   "description": "Bundle for PixiJS with support for NodeJS",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "license": "MIT",
   "author": "PixiJS Team",

--- a/bundles/pixi.js-webworker/package.json
+++ b/bundles/pixi.js-webworker/package.json
@@ -3,10 +3,10 @@
   "version": "7.1.0-alpha",
   "description": "Bundle for PixiJS with support for Web Workers",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "license": "MIT",
   "author": "PixiJS Team",

--- a/bundles/pixi.js/package.json
+++ b/bundles/pixi.js/package.json
@@ -31,11 +31,11 @@
     }
   },
   "homepage": "http://www.pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "scripts": {
     "test": "floss --path test"

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -35,13 +35,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pixijs/pixi.js.git"
+    "url": "git+https://github.com/pixijs/pixijs.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/pixijs/pixi.js/issues"
+    "url": "https://github.com/pixijs/pixijs/issues"
   },
   "dependencies": {
     "@types/css-font-loading-module": "^0.0.7"

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -38,13 +38,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pixijs/pixi.js.git"
+    "url": "git+https://github.com/pixijs/pixijs.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "bugs": {
-    "url": "https://github.com/pixijs/pixi.js/issues"
+    "url": "https://github.com/pixijs/pixijs/issues"
   },
   "pixiRequirements": [
     "@pixi/assets",

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -19,11 +19,11 @@
   "description": "Canvas mixin for the text package",
   "author": "Dave Moore",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -37,14 +37,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pixijs/pixi.js.git"
+    "url": "git+https://github.com/pixijs/pixijs.git"
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1"
   },
   "sideEffects": true,
   "bugs": {
-    "url": "https://github.com/pixijs/pixi.js/issues"
+    "url": "https://github.com/pixijs/pixijs/issues"
   },
   "pixiRequirements": [
     "@pixi/assets",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -442,7 +442,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
     /**
      * Removes everything from the renderer (event listeners, spritebatch, etc...)
      * @param [removeView=false] - Removes the Canvas element from the DOM.
-     *  See: https://github.com/pixijs/pixi.js/issues/2233
+     *  See: https://github.com/pixijs/pixijs/issues/2233
      */
     destroy(removeView = false): void
     {

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -93,7 +93,7 @@ export class ImageResource extends BaseImageResource
         // FireFox 68, and possibly other versions, seems like setting the HTMLImageElement#width and #height
         // to non-zero values before its loading completes if images are in a cache.
         // Because of this, need to set the `_width` and the `_height` to zero to avoid uploading incomplete images.
-        // Please refer to the issue #5968 (https://github.com/pixijs/pixi.js/issues/5968).
+        // Please refer to the issue #5968 (https://github.com/pixijs/pixijs/issues/5968).
         if (!source.complete && !!this._width && !!this._height)
         {
             this._width = 0;

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -75,7 +75,7 @@ export class VideoResource extends BaseImageResource
         {
             const videoElement = document.createElement('video');
 
-            // workaround for https://github.com/pixijs/pixi.js/issues/5996
+            // workaround for https://github.com/pixijs/pixijs/issues/5996
             videoElement.setAttribute('preload', 'auto');
             videoElement.setAttribute('webkit-playsinline', '');
             videoElement.setAttribute('playsinline', '');

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -37,10 +37,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pixijs/pixi.js.git"
+    "url": "git+https://github.com/pixijs/pixijs.git"
   },
   "bugs": {
-    "url": "https://github.com/pixijs/pixi.js/issues"
+    "url": "https://github.com/pixijs/pixijs/issues"
   },
   "pixiRequirements": [
     "@pixi/core",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -19,11 +19,11 @@
   "description": "Installing and uninstalling extensions for PixiJS",
   "author": "Matt Karl <matt@mattkarl.com>",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -21,11 +21,11 @@
   "description": "Additional Graphics functions for drawing special shapes.",
   "author": "Matt Karl <matt@mattkarl.com>",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -24,11 +24,11 @@
     "Marcelo Alberto <malberto@killabunnies.com.ar>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "keywords": [
     "runner",

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -256,7 +256,7 @@ export const settings: ISettings = {
 
     /**
      * Default specify float precision in fragment shader.
-     * iOS is best set at highp due to https://github.com/pixijs/pixi.js/issues/3742
+     * iOS is best set at highp due to https://github.com/pixijs/pixijs/issues/3742
      * @static
      * @name PRECISION_FRAGMENT
      * @memberof PIXI.settings

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -21,11 +21,11 @@
   "description": "Adds support for environments that disallow support of new Function",
   "author": "Matt Karl <matt@mattkarl.com>",
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,11 +22,11 @@
     "Matt Karl <matt@mattkarl.com>"
   ],
   "homepage": "http://pixijs.com/",
-  "bugs": "https://github.com/pixijs/pixi.js/issues",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pixijs/pixi.js.git"
+    "url": "https://github.com/pixijs/pixijs.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Bunch of places where the repo name was the old "pixi.js" name instead of "pixijs". GitHub handles these redirects, but it would be good to make sure they are up-to-date.