### PR TITLE
Fix: Jest running on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "rollup-plugin-rename-node-modules": "^1.3.1",
         "rollup-plugin-sourcemaps": "^0.4.2",
         "rollup-plugin-string": "^3.0.0",
+        "tree-kill": "^1.2.2",
         "ts-jest": "^26.0.0",
         "ts-node": "^9.0.0",
         "tsconfig-paths": "^3.10.1",
@@ -24597,6 +24598,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "dev": true,
@@ -43574,6 +43584,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
     },
     "trim-newlines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-string": "^3.0.0",
+    "tree-kill": "^1.2.2",
     "ts-jest": "^26.0.0",
     "ts-node": "^9.0.0",
     "tsconfig-paths": "^3.10.1",

--- a/test/jest-global-setup.ts
+++ b/test/jest-global-setup.ts
@@ -6,7 +6,14 @@ module.exports = async function ()
 {
     if (!process.env.GITHUB_ACTIONS)
     {
-        const httpServerProcess = spawn('http-server', ['-c-1', `${join(process.cwd(), './packages')}`]);
+        const httpServerProcess = spawn(
+            'http-server',
+            ['-c-1', `${join(process.cwd(), './packages')}`],
+            {
+                // See https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows
+                shell: process.platform === 'win32',
+            },
+        );
 
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/test/jest-global-teardown.ts
+++ b/test/jest-global-teardown.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'child_process';
+import kill from 'tree-kill';
 
 // eslint-disable-next-line func-names
 module.exports = async function ()
@@ -14,7 +15,7 @@ module.exports = async function ()
             httpServerProcess.on('close', resolve);
         });
 
-        httpServerProcess.kill();
+        kill(httpServerProcess.pid);
         await processClose;
     }
 };


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously using `npm test` on Windows will report `Error: spawn http-server ENOENT` due to the difference on the shell between Windows and other Unix-like OS. Since I usually working on Windows, I modified the Jest setup & teardown script to make it working on Windows. Package `tree-kill` is introduced to properly kill the `http-server` on Windows, since `process.kill()` will only kill the shell but not the real `http-server` process.

See https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows for more details.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
