### PR TITLE
Deprecate FILTER_* settings, move to Filter static members

### DIFF
--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -1,11 +1,11 @@
-import { settings } from '@pixi/settings';
 import { Program } from '../shader/Program';
 import { Shader } from '../shader/Shader';
 import { State } from '../state/State';
 import defaultFragment from './defaultFilter.frag';
 import defaultVertex from './defaultFilter.vert';
+import { MSAA_QUALITY } from '@pixi/constants';
 
-import type { MSAA_QUALITY, BLEND_MODES, CLEAR_MODES } from '@pixi/constants';
+import type { BLEND_MODES, CLEAR_MODES } from '@pixi/constants';
 import type { Dict } from '@pixi/utils';
 import type { RenderTexture } from '../renderTexture/RenderTexture';
 import type { FilterState } from './FilterState';
@@ -188,13 +188,27 @@ import type { FilterSystem } from './FilterSystem';
 export class Filter extends Shader
 {
     /**
+     * Default filter resolution for any filter.
+     * @static
+     */
+    public static resolution = 1;
+
+    /**
+     * Default filter samples for any filter.
+     * @static
+     * @type {PIXI.MSAA_QUALITY}
+     * @default PIXI.MSAA_QUALITY.NONE
+     */
+    public static multisample = MSAA_QUALITY.NONE;
+
+    /**
      * The padding of the filter. Some filters require extra space to breath such as a blur.
      * Increasing this will add extra width and height to the bounds of the object that the
      * filter is applied to.
      */
     public padding: number;
 
-    /** The samples of the filter. */
+    /** The samples override of the filter instance. */
     public multisample: MSAA_QUALITY;
 
     /** If enabled is true the filter is applied, if false it will not. */
@@ -231,8 +245,8 @@ export class Filter extends Shader
         super(program, uniforms);
 
         this.padding = 0;
-        this.resolution = settings.FILTER_RESOLUTION;
-        this.multisample = settings.FILTER_MULTISAMPLE;
+        this.resolution = Filter.resolution;
+        this.multisample = Filter.multisample;
         this.enabled = true;
         this.autoFit = true;
         this.state = new State();

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -1,5 +1,8 @@
 import { settings } from '@pixi/settings';
+import type { MSAA_QUALITY } from '@pixi/constants';
 import { ENV } from '@pixi/constants';
+import { Filter } from './filters/Filter';
+import { deprecation } from '@pixi/utils';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -31,5 +34,59 @@ settings.PREFER_ENV = ENV.WEBGL2;
  * @default false
  */
 settings.STRICT_TEXTURE_CACHE = false;
+
+// Deprecations
+Object.defineProperties(settings, {
+    /**
+     * Default filter resolution.
+     * @static
+     * @name FILTER_RESOLUTION
+     * @memberof PIXI.settings
+     * @deprecated since 7.1.0
+     * @type {number}
+     * @default 1
+     * @see PIXI.Filter.resolution
+     */
+    FILTER_RESOLUTION: {
+        get()
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.FILTER_MULTISAMPLE is deprecated, use PIXI.Filter.multisample');
+            // #endif
+
+            return Filter.resolution;
+        },
+        set(value)
+        {
+            Filter.resolution = value;
+        },
+    },
+
+    /**
+     * Default filter samples.
+     * @static
+     * @name FILTER_MULTISAMPLE
+     * @memberof PIXI.settings
+     * @deprecated since 7.1.0
+     * @type {PIXI.MSAA_QUALITY}
+     * @default PIXI.MSAA_QUALITY.NONE
+     * @see PIXI.Filter.multisample
+     */
+    FILTER_MULTISAMPLE: {
+        get()
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.FILTER_MULTISAMPLE is deprecated, use PIXI.Filter.multisample');
+            // #endif
+
+            return Filter.multisample;
+        },
+        set(value: MSAA_QUALITY)
+        {
+            Filter.multisample = value;
+        },
+    },
+
+});
 
 export { settings };

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -51,7 +51,7 @@ Object.defineProperties(settings, {
         get()
         {
             // #if _DEBUG
-            deprecation('7.1.0', 'PIXI.settings.FILTER_MULTISAMPLE is deprecated, use PIXI.Filter.multisample');
+            deprecation('7.1.0', 'PIXI.settings.FILTER_RESOLUTION is deprecated, use PIXI.Filter.resolution');
             // #endif
 
             return Filter.resolution;

--- a/packages/filter-blur/src/BlurFilter.ts
+++ b/packages/filter-blur/src/BlurFilter.ts
@@ -1,4 +1,4 @@
-import { Filter, settings, CLEAR_MODES } from '@pixi/core';
+import { Filter, CLEAR_MODES } from '@pixi/core';
 import { BlurFilterPass } from './BlurFilterPass';
 
 import type { BLEND_MODES, FilterSystem, RenderTexture } from '@pixi/core';
@@ -19,10 +19,10 @@ export class BlurFilter extends Filter
     /**
      * @param strength - The strength of the blur filter.
      * @param quality - The quality of the blur filter.
-     * @param [resolution=PIXI.settings.FILTER_RESOLUTION] - The resolution of the blur filter.
+     * @param [resolution=Filter.resolution] - The resolution of the blur filter.
      * @param kernelSize - The kernelSize of the blur filter.Options: 5, 7, 9, 11, 13, 15.
      */
-    constructor(strength = 8, quality = 4, resolution = settings.FILTER_RESOLUTION, kernelSize = 5)
+    constructor(strength = 8, quality = 4, resolution = Filter.resolution, kernelSize = 5)
     {
         super();
 

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,10 +1,10 @@
-import { GC_MODES, MIPMAP_MODES, MSAA_QUALITY, PRECISION, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
+import { GC_MODES, MIPMAP_MODES, PRECISION, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
 import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 import { isMobile } from './utils/isMobile';
 import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 
-import type { ENV } from '@pixi/constants';
+import type { ENV, MSAA_QUALITY } from '@pixi/constants';
 import type { ICanvas } from './ICanvas';
 import type { IAdapter } from './adapter';
 
@@ -31,8 +31,10 @@ export interface ISettings
     MIPMAP_TEXTURES: MIPMAP_MODES;
     ANISOTROPIC_LEVEL: number;
     RESOLUTION: number;
-    FILTER_RESOLUTION: number;
-    FILTER_MULTISAMPLE: MSAA_QUALITY;
+    /** @deprecated */
+    FILTER_RESOLUTION?: number;
+    /** @deprecated */
+    FILTER_MULTISAMPLE?: MSAA_QUALITY;
     SPRITE_MAX_TEXTURES: number;
     SPRITE_BATCH_SIZE: number;
     RENDER_OPTIONS: IRenderOptions;
@@ -113,26 +115,6 @@ export const settings: ISettings = {
      * @default 1
      */
     RESOLUTION: 1,
-
-    /**
-     * Default filter resolution.
-     * @static
-     * @name FILTER_RESOLUTION
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 1
-     */
-    FILTER_RESOLUTION: 1,
-
-    /**
-     * Default filter samples.
-     * @static
-     * @name FILTER_MULTISAMPLE
-     * @memberof PIXI.settings
-     * @type {PIXI.MSAA_QUALITY}
-     * @default PIXI.MSAA_QUALITY.NONE
-     */
-    FILTER_MULTISAMPLE: MSAA_QUALITY.NONE,
 
     /**
      * The maximum textures that this device supports.

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -18,11 +18,6 @@ describe('settings', () =>
         expect(settings.PREFER_ENV).toBeNumber();
     });
 
-    it('should have FILTER_RESOLUTION', () =>
-    {
-        expect(settings.FILTER_RESOLUTION).toBeNumber();
-    });
-
     it('should have SPRITE_MAX_TEXTURES', () =>
     {
         expect(settings.SPRITE_MAX_TEXTURES).toBeNumber();


### PR DESCRIPTION
The creation of `settings` is one of my biggest API regrets. It has become a junk-drawer for a bunch of globals and defaults. Some of these should simply be static defaults in a single class. For instance, FILTER_RESOLUTION and FILTER_MULTISAMPLE, are only used in ONE place (i.e., Filter class), and should be located there. 

### Deprecated

* Setting `settings.FILTER_RESOLUTION` becomes `Filter.resolution`
* Setting `settings.FILTER_MULTISAMPLE` becomes `Filter.multisample`

I will likely be doing several of these settings-related PRs.