### PR TITLE
Chore: Cleanup useContextAlpha deprecation

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -70,9 +70,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      * @param {number} [options.width=800] - The width of the renderers view.
      * @param {number} [options.height=600] - The height of the renderers view.
      * @param {PIXI.ICanvas} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
+     * @param {boolean} [options.premultipliedAlpha=true] - Set to `false` to disable premultipliedAlpha.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -164,9 +164,6 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
      * @param {number} [options.width=800] - the width of the screen
      * @param {number} [options.height=600] - the height of the screen
      * @param {PIXI.ICanvas} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1
      * @param {boolean} [options.antialias=false] - sets antialias
@@ -214,6 +211,14 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
         };
 
         this.setup(systemConfig);
+
+        if ('useContextAlpha' in options)
+        {
+            // #if _DEBUG
+            deprecation('7.0.0', 'options.useContextAlpha is deprecated, use options.backgroundAlpha instead');
+            // #endif
+            options.backgroundAlpha = options.useContextAlpha === false ? 1 : options.backgroundAlpha;
+        }
 
         // convert our big blob of options into system specific ones..
         const startupOptions: StartupOptions = {

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -554,7 +554,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
     {
         // #if _DEBUG
         // eslint-disable-next-line max-len
-        deprecation('7.0.0', 'renderer.useContextAlpha has been deprecated, please use renderer.background.clearBeforeRender instead.');
+        deprecation('7.0.0', 'renderer.clearBeforeRender has been deprecated, please use renderer.background.clearBeforeRender instead.');
         // #endif
 
         return this.background.clearBeforeRender;
@@ -570,7 +570,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
     {
         // #if _DEBUG
         // eslint-disable-next-line max-len
-        deprecation('7.0.0', 'Renderer#useContextAlpha has been deprecated, please use Renderer#context.premultipliedAlpha instead.');
+        deprecation('7.0.0', 'renderer.useContextAlpha has been deprecated, please use renderer.context.premultipliedAlpha instead.');
         // #endif
 
         return this.context.useContextAlpha;

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -286,9 +286,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      * @param {number} [options.width=800] - The width of the screen.
      * @param {number} [options.height=600] - The height of the screen.
      * @param {PIXI.ICanvas} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
+     * @param {boolean} [options.premultipliedAlpha=true] - Set to `false` to disable premultipliedAlpha.
      * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
      *   resolutions other than 1.
      * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
@@ -368,6 +366,16 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
 
         this.setup(systemConfig);
 
+        if ('useContextAlpha' in options)
+        {
+            // #if _DEBUG
+            // eslint-disable-next-line max-len
+            deprecation('7.0.0', 'options.useContextAlpha is deprecated, use options.premultipliedAlpha and options.backgroundAlpha instead');
+            // #endif
+            options.premultipliedAlpha = options.useContextAlpha && options.useContextAlpha !== 'notMultiplied';
+            options.backgroundAlpha = options.useContextAlpha === false ? 1 : options.backgroundAlpha;
+        }
+
         // new options!
         const startupOptions: StartupOptions = {
             hello: options.hello,
@@ -388,8 +396,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
                 antialias: options.antialias,
                 context: options.context,
                 powerPreference: options.powerPreference,
-                premultipliedAlpha: options.premultipliedAlpha
-                ?? (options.useContextAlpha && options.useContextAlpha !== 'notMultiplied'),
+                premultipliedAlpha: options.premultipliedAlpha,
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
             },
         };

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -134,7 +134,7 @@ export class ContextSystem implements ISystem<ContextOptions>
         else
         {
             const alpha = this.renderer.background.alpha < 1;
-            const premultipliedAlpha =  options.premultipliedAlpha ?? true;
+            const premultipliedAlpha =  options.premultipliedAlpha;
 
             this.preserveDrawingBuffer = options.preserveDrawingBuffer;
             this.useContextAlpha = options.useContextAlpha;

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -16,7 +16,9 @@ export interface IRenderOptions
     backgroundColor: number | string;
     background?: number | string;
     backgroundAlpha: number;
-    useContextAlpha: boolean | 'notMultiplied';
+    premultipliedAlpha: boolean;
+    /** @deprecated */
+    useContextAlpha?: boolean | 'notMultiplied';
     clearBeforeRender: boolean;
     preserveDrawingBuffer: boolean;
     width: number;
@@ -169,7 +171,7 @@ export const settings: ISettings = {
      * @property {PIXI.ICanvas} [view=null] -
      * @property {boolean} [antialias=false] -
      * @property {boolean} [autoDensity=false] -
-     * @property {boolean} [useContextAlpha=true]  -
+     * @property {boolean} [premultipliedAlpha=true]  -
      * @property {number} [backgroundColor=0x000000] -
      * @property {number} [backgroundAlpha=1] -
      * @property {boolean} [clearBeforeRender=true] -
@@ -185,7 +187,7 @@ export const settings: ISettings = {
         autoDensity: false,
         backgroundColor: 0x000000,
         backgroundAlpha: 1,
-        useContextAlpha: true,
+        premultipliedAlpha: true,
         clearBeforeRender: true,
         preserveDrawingBuffer: false,
         width: 800,


### PR DESCRIPTION
Closes #8861

### Changed

* Removes `useContextAlpha` from the Application, CanvasRenderer and Renderer options documentation
* Add deprecation flag to `useContextAlpha` in IRenderOptions
* Always set a default for `premultipliedAlpha` as this is now a required field
* Add deprecation warnings and fallback behavior for `useContextAlpha` with constructor arguments