### PR TITLE
Deprecate BaseTexture-related settings to BaseTexture.defaultOptions

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -312,7 +312,7 @@ export enum SCALE_MODES
 /**
  * The wrap modes that are supported by pixi.
  *
- * The {@link PIXI.settings.WRAP_MODE} wrap mode affects the default wrapping mode of future operations.
+ * The wrap mode affects the default wrapping mode of future operations.
  * It can be re-assigned to either CLAMP or REPEAT, depending upon suitability.
  * If the texture is non power of two then clamp will be used regardless as WebGL can
  * only use REPEAT if the texture is po2.

--- a/packages/core/src/context/ContextSystem.ts
+++ b/packages/core/src/context/ContextSystem.ts
@@ -1,6 +1,6 @@
 import { ENV } from '@pixi/constants';
 import { extensions, ExtensionType } from '@pixi/extensions';
-import { settings } from '../settings';
+import { settings } from '@pixi/settings';
 
 import type { ExtensionMetadata } from '@pixi/extensions';
 import type { ICanvas } from '@pixi/settings';

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -1,6 +1,6 @@
 import { Rectangle } from '@pixi/math';
 import { ENV, BUFFER_BITS, MSAA_QUALITY } from '@pixi/constants';
-import { settings } from '../settings';
+import { settings } from '@pixi/settings';
 import { Framebuffer } from './Framebuffer';
 import { GLFramebuffer } from './GLFramebuffer';
 

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -1,6 +1,6 @@
 import type { GLBuffer } from './GLBuffer';
 import { BUFFER_TYPE, ENV } from '@pixi/constants';
-import { settings } from '../settings';
+import { settings } from '@pixi/settings';
 
 import type { ISystem } from '../system/ISystem';
 import type { DRAW_MODES } from '@pixi/constants';

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -1,5 +1,8 @@
 import { settings } from '@pixi/settings';
+import type { MIPMAP_MODES, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
 import { ENV } from '@pixi/constants';
+import { BaseTexture } from './textures/BaseTexture';
+import { deprecation } from '@pixi/utils';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -31,5 +34,100 @@ settings.PREFER_ENV = ENV.WEBGL2;
  * @default false
  */
 settings.STRICT_TEXTURE_CACHE = false;
+
+Object.defineProperties(settings, {
+    /**
+     * @static
+     * @name WRAP_MODE
+     * @memberof PIXI.settings
+     * @type {PIXI.WRAP_MODES}
+     * @deprecated since 7.1.0
+     * @see PIXI.BaseTexture.defaultOptions.wrapMode
+     */
+    WRAP_MODE: {
+        get()
+        {
+            return BaseTexture.defaultOptions.wrapMode;
+        },
+        set(value: WRAP_MODES)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.WRAP_MODE is deprecated, use PIXI.BaseTeture.defaultOptions.wrapMode');
+            // #endif
+            BaseTexture.defaultOptions.wrapMode = value;
+        },
+    },
+
+    /**
+     * @static
+     * @name SCALE_MODE
+     * @memberof PIXI.settings
+     * @type {PIXI.SCALE_MODES}
+     * @deprecated since 7.1.0
+     * @see PIXI.BaseTexture.defaultOptions.scaleMode
+     */
+    SCALE_MODE: {
+        get()
+        {
+            return BaseTexture.defaultOptions.scaleMode;
+        },
+        set(value: SCALE_MODES)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.SCALE_MODE is deprecated, use PIXI.BaseTeture.defaultOptions.scaleMode');
+            // #endif
+            BaseTexture.defaultOptions.scaleMode = value;
+        },
+    },
+
+    /**
+     * @static
+     * @name MIPMAP_TEXTURES
+     * @memberof PIXI.settings
+     * @type {PIXI.MIPMAP_MODES}
+     * @deprecated since 7.1.0
+     * @see PIXI.BaseTexture.defaultOptions.mipmap
+     */
+    MIPMAP_TEXTURES:
+    {
+        get()
+        {
+            return BaseTexture.defaultOptions.mipmap;
+        },
+        set(value: MIPMAP_MODES)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.MIPMAP_TEXTURES is deprecated, use PIXI.BaseTeture.defaultOptions.mipmap');
+            // #endif
+            BaseTexture.defaultOptions.mipmap = value;
+        },
+        // MIPMAP_MODES.POW2,
+    },
+
+    /**
+     * @static
+     * @name ANISOTROPIC_LEVEL
+     * @memberof PIXI.settings
+     * @type {number}
+     * @deprecated since 7.1.0
+     * @see PIXI.BaseTexture.defaultOptions.anisotropicLevel
+     */
+    ANISOTROPIC_LEVEL:
+    {
+        get()
+        {
+            return BaseTexture.defaultOptions.anisotropicLevel;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            // eslint-disable-next-line max-len
+            deprecation('7.1.0', 'PIXI.settings.ANISOTROPIC_LEVEL is deprecated, use PIXI.BaseTeture.defaultOptions.anisotropicLevel');
+            // #endif
+            BaseTexture.defaultOptions.anisotropicLevel = value;
+        },
+
+    },
+});
 
 export { settings };

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -179,5 +179,3 @@ Object.defineProperties(settings, {
         },
     },
 });
-
-export { settings };

--- a/packages/core/src/shader/utils/getTestContext.ts
+++ b/packages/core/src/shader/utils/getTestContext.ts
@@ -1,4 +1,4 @@
-import { settings } from '../../settings';
+import { settings } from '@pixi/settings';
 import { ENV } from '@pixi/constants';
 
 const unknownContext = {};

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,10 +1,10 @@
-import { GC_MODES, MSAA_QUALITY, PRECISION } from '@pixi/constants';
+import { GC_MODES, PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
 import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 import { isMobile } from './utils/isMobile';
 import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 
-import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES } from '@pixi/constants';
+import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES, MSAA_QUALITY } from '@pixi/constants';
 import type { ICanvas } from './ICanvas';
 import type { IAdapter } from './adapter';
 

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,10 +1,10 @@
-import { GC_MODES, MIPMAP_MODES, MSAA_QUALITY, PRECISION, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
+import { GC_MODES, MSAA_QUALITY, PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
 import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 import { isMobile } from './utils/isMobile';
 import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 
-import type { ENV } from '@pixi/constants';
+import type { ENV, MIPMAP_MODES, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
 import type { ICanvas } from './ICanvas';
 import type { IAdapter } from './adapter';
 
@@ -28,8 +28,10 @@ export interface IRenderOptions
 export interface ISettings
 {
     ADAPTER: IAdapter;
-    MIPMAP_TEXTURES: MIPMAP_MODES;
-    ANISOTROPIC_LEVEL: number;
+    /** @deprecated */
+    MIPMAP_TEXTURES?: MIPMAP_MODES;
+    /** @deprecated */
+    ANISOTROPIC_LEVEL?: number;
     RESOLUTION: number;
     FILTER_RESOLUTION: number;
     FILTER_MULTISAMPLE: MSAA_QUALITY;
@@ -39,8 +41,10 @@ export interface ISettings
     GC_MODE: GC_MODES;
     GC_MAX_IDLE: number;
     GC_MAX_CHECK_COUNT: number;
-    WRAP_MODE: WRAP_MODES;
-    SCALE_MODE: SCALE_MODES;
+    /** @deprecated */
+    WRAP_MODE?: WRAP_MODES;
+    /** @deprecated */
+    SCALE_MODE?: SCALE_MODES;
     PRECISION_VERTEX: PRECISION;
     PRECISION_FRAGMENT: PRECISION;
     CAN_UPLOAD_SAME_BUFFER: boolean;
@@ -82,27 +86,6 @@ export const settings: ISettings = {
      * @default PIXI.BrowserAdapter
      */
     ADAPTER: BrowserAdapter,
-
-    /**
-     * Default mipmap mode for textures.
-     * @static
-     * @name MIPMAP_TEXTURES
-     * @memberof PIXI.settings
-     * @type {PIXI.MIPMAP_MODES}
-     * @default PIXI.MIPMAP_MODES.POW2
-     */
-    MIPMAP_TEXTURES: MIPMAP_MODES.POW2,
-
-    /**
-     * Default anisotropic filtering level of textures.
-     * Usually from 0 to 16.
-     * @static
-     * @name ANISOTROPIC_LEVEL
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 0
-     */
-    ANISOTROPIC_LEVEL: 0,
 
     /**
      * Default resolution / device pixel ratio of the renderer.
@@ -223,26 +206,6 @@ export const settings: ISettings = {
      * @default 600
      */
     GC_MAX_CHECK_COUNT: 60 * 10,
-
-    /**
-     * Default wrap modes that are supported by pixi.
-     * @static
-     * @name WRAP_MODE
-     * @memberof PIXI.settings
-     * @type {PIXI.WRAP_MODES}
-     * @default PIXI.WRAP_MODES.CLAMP
-     */
-    WRAP_MODE: WRAP_MODES.CLAMP,
-
-    /**
-     * Default scale mode for textures.
-     * @static
-     * @name SCALE_MODE
-     * @memberof PIXI.settings
-     * @type {PIXI.SCALE_MODES}
-     * @default PIXI.SCALE_MODES.LINEAR
-     */
-    SCALE_MODE: SCALE_MODES.LINEAR,
 
     /**
      * Default specify float precision in vertex shader.

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -3,11 +3,6 @@ import '@pixi/core';
 
 describe('settings', () =>
 {
-    it('should have MIPMAP_TEXTURES', () =>
-    {
-        expect(settings.MIPMAP_TEXTURES).toBeNumber();
-    });
-
     it('should have RESOLUTION', () =>
     {
         expect(settings.RESOLUTION).toBeNumber();
@@ -51,16 +46,6 @@ describe('settings', () =>
     it('should have GC_MAX_CHECK_COUNT', () =>
     {
         expect(settings.GC_MAX_CHECK_COUNT).toBeNumber();
-    });
-
-    it('should have WRAP_MODE', () =>
-    {
-        expect(settings.WRAP_MODE).toBeNumber();
-    });
-
-    it('should have SCALE_MODE', () =>
-    {
-        expect(settings.SCALE_MODE).toBeNumber();
     });
 
     it('should have PRECISION_VERTEX', () =>

--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -60,25 +60,25 @@ export interface IBitmapFontOptions extends BaseOptions
      * on Power-of-Two textures. If your textureWidth or textureHeight are not power-of-two, you
      * may consider enabling mipmapping to get better quality with lower font sizes. Note:
      * for MSDF/SDF fonts, mipmapping is not supported.
-     * @default PIXI.settings.MIPMAP_TEXTURES
+     * @default PIXI.BaseTexture.defaultOptions.mipmap
      */
     mipmap?: MIPMAP_MODES;
 
     /**
      * Anisotropic filtering level of texture.
-     * @default PIXI.settings.ANISOTROPIC_LEVEL
+     * @default PIXI.BaseTexture.defaultOptions.anisotropicLevel
      */
     anisotropicLevel?: number;
 
     /**
      * Default scale mode, linear, nearest. Nearest can be helpful for bitmap-style fonts.
-     * @default PIXI.settings.SCALE_MODE
+     * @default PIXI.BaseTexture.defaultOptions.scaleMode
      */
     scaleMode?: SCALE_MODES;
 
     /**
      * Pre multiply the image alpha.  Note: for MSDF/SDF fonts, alphaMode is not supported.
-     * @default PIXI.ALPHA_MODES.UNPACK
+     * @default PIXI.BaseTexture.defaultOptions.alphaMode
      */
     alphaMode?: ALPHA_MODES;
 }


### PR DESCRIPTION
Similar to #8865. Moving a handful of settings to BaseTexture, as they are only used there:

### Deprecated

* `settings.WRAP_MODE` becomes `BaseTexture.defaultOptions.wrapMode`
* `settings.SCALE_MODE` becomes `BaseTexture.defaultOptions.scaleMode`
* `settings.MIPMAP_TEXTURES` becomes `BaseTexture.defaultOptions.mipmap`
* `settings.ANISOTROPIC_LEVEL` becomes `BaseTexture.defaultOptions.anisotropicLevel`

### Chore

* Adds BaseTexture defaults `format`, `type`, `target`, `alphaMode` to `BaseTexture.defaultOptions`

### Notes

The naming `defaultOptions` was chosen because it's already used in BitmapFont (to be consistent!)
