### PR TITLE
Deprecate GRAPHICS_CURVES, move to Graphics.curves

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -21,7 +21,7 @@ import { GraphicsGeometry } from './GraphicsGeometry';
 import { FillStyle } from './styles/FillStyle';
 import { LineStyle } from './styles/LineStyle';
 import { Container } from '@pixi/display';
-import { LINE_JOIN, LINE_CAP } from './const';
+import { LINE_JOIN, LINE_CAP, curves } from './const';
 
 import type { IShape, IPointData, Renderer, BatchDrawCall } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
@@ -85,6 +85,19 @@ export interface Graphics extends GlobalMixins.Graphics, Container {}
  */
 export class Graphics extends Container
 {
+    /**
+     * Graphics curves resolution settings. If `adaptive` flag is set to `true`,
+     * the resolution is calculated based on the curve's length to ensure better visual quality.
+     * Adaptive draw works with `bezierCurveTo` and `quadraticCurveTo`.
+     * @static
+     * @property {boolean} [adaptive=true] - flag indicating if the resolution should be adaptive
+     * @property {number} [maxLength=10] - maximal length of a single segment of the curve (if adaptive = false, ignored)
+     * @property {number} [minSegments=8] - minimal number of segments in the curve (if adaptive = false, ignored)
+     * @property {number} [maxSegments=2048] - maximal number of segments in the curve (if adaptive = false, ignored)
+     * @property {number} [epsilon=0.0001] - precision of the curve fitting
+     */
+    public static readonly curves = curves;
+
     /**
      * Temporary point to use for containsPoint.
      * @private

--- a/packages/graphics/src/const.ts
+++ b/packages/graphics/src/const.ts
@@ -37,6 +37,7 @@ export enum LINE_CAP
     SQUARE = 'square'
 }
 
+/** @deprecated */
 export interface IGraphicsCurvesSettings
 {
     adaptive: boolean;
@@ -50,20 +51,9 @@ export interface IGraphicsCurvesSettings
 }
 
 /**
- * Graphics curves resolution settings. If `adaptive` flag is set to `true`,
- * the resolution is calculated based on the curve's length to ensure better visual quality.
- * Adaptive draw works with `bezierCurveTo` and `quadraticCurveTo`.
- * @static
- * @constant
- * @memberof PIXI
- * @name GRAPHICS_CURVES
- * @type {object}
- * @property {boolean} [adaptive=true] - flag indicating if the resolution should be adaptive
- * @property {number} [maxLength=10] - maximal length of a single segment of the curve (if adaptive = false, ignored)
- * @property {number} [minSegments=8] - minimal number of segments in the curve (if adaptive = false, ignored)
- * @property {number} [maxSegments=2048] - maximal number of segments in the curve (if adaptive = false, ignored)
+ * @private
  */
-export const GRAPHICS_CURVES: IGraphicsCurvesSettings = {
+export const curves = {
     adaptive: true,
     maxLength: 10,
     minSegments: 8,
@@ -92,3 +82,14 @@ export const GRAPHICS_CURVES: IGraphicsCurvesSettings = {
         return result;
     },
 };
+
+/**
+ * @static
+ * @constant
+ * @memberof PIXI
+ * @name GRAPHICS_CURVES
+ * @type {object}
+ * @deprecated since 7.1.0
+ * @see PIXI.Graphics.curves
+ */
+export const GRAPHICS_CURVES = curves;

--- a/packages/graphics/src/utils/ArcUtils.ts
+++ b/packages/graphics/src/utils/ArcUtils.ts
@@ -1,4 +1,4 @@
-import { GRAPHICS_CURVES } from '../const';
+import { curves } from '../const';
 import { PI_2 } from '@pixi/core';
 
 interface IArcLikeShape
@@ -98,7 +98,7 @@ export class ArcUtils
         startAngle: number, endAngle: number, _anticlockwise: boolean, points: Array<number>): void
     {
         const sweep = endAngle - startAngle;
-        const n = GRAPHICS_CURVES._segmentsCount(
+        const n = curves._segmentsCount(
             Math.abs(sweep) * radius,
             Math.ceil(Math.abs(sweep) / PI_2) * 40
         );

--- a/packages/graphics/src/utils/BezierUtils.ts
+++ b/packages/graphics/src/utils/BezierUtils.ts
@@ -1,4 +1,4 @@
-import { GRAPHICS_CURVES } from '../const';
+import { curves } from '../const';
 
 /**
  * Utilities for bezier curves
@@ -88,7 +88,7 @@ export class BezierUtils
 
         points.length -= 2;
 
-        const n = GRAPHICS_CURVES._segmentsCount(
+        const n = curves._segmentsCount(
             BezierUtils.curveLength(fromX, fromY, cpX, cpY, cpX2, cpY2, toX, toY)
         );
 

--- a/packages/graphics/src/utils/QuadraticUtils.ts
+++ b/packages/graphics/src/utils/QuadraticUtils.ts
@@ -1,4 +1,4 @@
-import { GRAPHICS_CURVES } from '../const';
+import { curves } from '../const';
 
 /**
  * Utilities for quadratic curves.
@@ -63,7 +63,7 @@ export class QuadraticUtils
         const fromX = points[points.length - 2];
         const fromY = points[points.length - 1];
 
-        const n = GRAPHICS_CURVES._segmentsCount(
+        const n = curves._segmentsCount(
             QuadraticUtils.curveLength(fromX, fromY, cpX, cpY, toX, toY)
         );
 

--- a/packages/graphics/src/utils/buildLine.ts
+++ b/packages/graphics/src/utils/buildLine.ts
@@ -3,7 +3,7 @@ import { Point, SHAPES } from '@pixi/core';
 import type { Polygon } from '@pixi/core';
 import type { GraphicsData } from '../GraphicsData';
 import type { GraphicsGeometry } from '../GraphicsGeometry';
-import { LINE_JOIN, LINE_CAP, GRAPHICS_CURVES } from '../const';
+import { LINE_JOIN, LINE_CAP, curves } from '../const';
 
 /**
  * Buffers vertices to draw a square cap.
@@ -123,7 +123,7 @@ function round(
                 angleDiff = -angleDiff;
             }
         }
-        else if (r1x >= -GRAPHICS_CURVES.epsilon)
+        else if (r1x >= -curves.epsilon)
         {
             angleDiff = -angleDiff;
         }
@@ -535,7 +535,7 @@ function buildNonNativeLine(graphicsData: GraphicsData, graphicsGeometry: Graphi
     }
 
     const indices = graphicsGeometry.indices;
-    const eps2 = GRAPHICS_CURVES.epsilon * GRAPHICS_CURVES.epsilon;
+    const eps2 = curves.epsilon * curves.epsilon;
 
     // indices.push(indexStart);
     for (let i = indexStart; i < indexCount + indexStart - 2; ++i)

--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -1,5 +1,5 @@
 import { Texture, BLEND_MODES, Point, Matrix, SHAPES, Polygon } from '@pixi/core';
-import { Graphics, GRAPHICS_CURVES, FillStyle, LineStyle, graphicsUtils, LINE_CAP, LINE_JOIN } from '@pixi/graphics';
+import { Graphics, FillStyle, LineStyle, graphicsUtils, LINE_CAP, LINE_JOIN } from '@pixi/graphics';
 const { FILL_COMMANDS, buildLine } = graphicsUtils;
 
 describe('Graphics', () =>
@@ -861,12 +861,12 @@ describe('Graphics', () =>
 
     describe('should support adaptive curves', () =>
     {
-        const defMode = GRAPHICS_CURVES.adaptive;
-        const defMaxLen = GRAPHICS_CURVES.maxLength;
-        const myMaxLen = GRAPHICS_CURVES.maxLength = 1.0;
+        const defMode = Graphics.curves.adaptive;
+        const defMaxLen = Graphics.curves.maxLength;
+        const myMaxLen = Graphics.curves.maxLength = 1.0;
         const graphics = new Graphics();
 
-        GRAPHICS_CURVES.adaptive = true;
+        Graphics.curves.adaptive = true;
 
         graphics.beginFill(0xffffff, 1.0);
         graphics.moveTo(610, 500);
@@ -879,8 +879,8 @@ describe('Graphics', () =>
 
         expect(pointsLen).toBeCloseTo(estimate, 2.0);
 
-        GRAPHICS_CURVES.adaptive = defMode;
-        GRAPHICS_CURVES.maxLength = defMaxLen;
+        Graphics.curves.adaptive = defMode;
+        Graphics.curves.maxLength = defMaxLen;
     });
 
     describe('geometry', () =>


### PR DESCRIPTION
This change is similar to my recent PRs #8868 and #8865 to relocate weirdly placed or named global settings as static members of relevant APIs. This one has been bothering me for awhile.

### Deprecated

* Moves `GRAPHICS_CURVES`  to `Graphics.curves`
* Deprecates the unnecessary `IGraphicsCurvesSettings`

### Example

Before:

```js
import { GRAPHICS_CURVES } from 'pixi.js';

GRAPHICS_CURVES.adaptive = false;
```

After:

```js
import { Graphics } from 'pixi.js';

Graphics.curves.adaptive = false;
```