### PR TITLE
Include DEBUG statements in module output

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,7 @@ async function main()
 
     const plugins = [
         rename(),
-        jscc({ values: { _VERSION: repo.version } }),
+        jscc({ values: { _VERSION: repo.version, _DEBUG: true } }),
         esbuild({ target: moduleTarget }),
         ...commonPlugins
     ];


### PR DESCRIPTION
Close #8874 

Deprecation warnings should be included when building with a bundler.

Users can use plugins (e.g., [@rollup/plugin-strip](https://www.npmjs.com/package/@rollup/plugin-strip)) for removing deprecations warnings, console logs and asserts.
