### PR TITLE
Deprecate SPRITE_* & CAN_UPLOAD_SAME_BUFFER settings, move to BatchRenderer

### DIFF
--- a/packages/core/src/batch/BatchRenderer.ts
+++ b/packages/core/src/batch/BatchRenderer.ts
@@ -8,7 +8,7 @@ import { BatchShaderGenerator } from './BatchShaderGenerator';
 import { checkMaxIfStatementsInShader } from '../shader/utils/checkMaxIfStatementsInShader';
 
 import { settings } from '@pixi/settings';
-import { premultiplyBlendMode, premultiplyTint, nextPow2, log2 } from '@pixi/utils';
+import { premultiplyBlendMode, premultiplyTint, nextPow2, log2, deprecation } from '@pixi/utils';
 import { ENV } from '@pixi/constants';
 import { BatchGeometry } from './BatchGeometry';
 
@@ -21,6 +21,7 @@ import type { Texture } from '../textures/Texture';
 import type { BLEND_MODES } from '@pixi/constants';
 import type { ExtensionMetadata } from '@pixi/extensions';
 import { extensions, ExtensionType } from '@pixi/extensions';
+import { maxRecommendedTextures } from './maxRecommendedTextures';
 
 /**
  * Interface for elements like Sprite, Mesh etc. for batching.
@@ -48,6 +49,21 @@ export interface IBatchableElement
  */
 export class BatchRenderer extends ObjectRenderer
 {
+    /**
+     * The maximum textures that this device supports.
+     * @static
+     * @default 32
+     */
+    public static maxTextures = maxRecommendedTextures(32);
+
+    /**
+     * The default sprite batch size.
+     *
+     * The default aims to balance desktop and mobile devices.
+     * @static
+     */
+    public static batchSize = 4096;
+
     /** @ignore */
     static extension: ExtensionMetadata = {
         name: 'batch',
@@ -60,7 +76,7 @@ export class BatchRenderer extends ObjectRenderer
     /**
      * The number of bufferable objects before a flush
      * occurs automatically.
-     * @default settings.SPRITE_BATCH_SIZE * 4
+     * @default PIXI.BatchRenderer.batchSize * 4
      */
     public size: number;
 
@@ -71,7 +87,7 @@ export class BatchRenderer extends ObjectRenderer
      * @see PIXI.BatchRenderer#contextChange
      * @readonly
      */
-    public MAX_TEXTURES: number;
+    public maxTextures: number;
 
     /**
      * This is used to generate a shader that can
@@ -214,7 +230,7 @@ export class BatchRenderer extends ObjectRenderer
         this.geometryClass = BatchGeometry;
         this.vertexSize = 6;
         this.state = State.for2d();
-        this.size = settings.SPRITE_BATCH_SIZE * 4;
+        this.size = BatchRenderer.batchSize * 4;
         this._vertexCount = 0;
         this._indexCount = 0;
         this._bufferedElements = [];
@@ -227,7 +243,7 @@ export class BatchRenderer extends ObjectRenderer
         this._aBuffers = {} as any;
         this._iBuffers = {} as any;
 
-        this.MAX_TEXTURES = 1;
+        this.maxTextures = 1;
 
         this.renderer.on('prerender', this.onPrerender, this);
         renderer.runners.contextChange.add(this);
@@ -238,6 +254,20 @@ export class BatchRenderer extends ObjectRenderer
         this._attributeBuffer = null;
         this._indexBuffer = null;
         this._tempBoundTextures = [];
+    }
+
+    /**
+     * @see PIXI.BatchRenderer#maxTextures
+     * @deprecated since 7.1.0
+     * @readonly
+     */
+    get MAX_TEXTURES(): number
+    {
+        // #if _DEBUG
+        deprecation('7.1.0', 'PIXI.BatchRenderer.MAX_TEXTURES renamed to PIXI.BatchRenderer.maxTextures');
+        // #endif
+
+        return this.maxTextures;
     }
 
     /**
@@ -275,7 +305,7 @@ export class BatchRenderer extends ObjectRenderer
     /**
      * Handles the `contextChange` signal.
      *
-     * It calculates `this.MAX_TEXTURES` and allocating the packed-geometry object pool.
+     * It calculates `this.maxTextures` and allocating the packed-geometry object pool.
      */
     contextChange(): void
     {
@@ -283,21 +313,21 @@ export class BatchRenderer extends ObjectRenderer
 
         if (settings.PREFER_ENV === ENV.WEBGL_LEGACY)
         {
-            this.MAX_TEXTURES = 1;
+            this.maxTextures = 1;
         }
         else
         {
             // step 1: first check max textures the GPU can handle.
-            this.MAX_TEXTURES = Math.min(
+            this.maxTextures = Math.min(
                 gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS),
-                settings.SPRITE_MAX_TEXTURES);
+                BatchRenderer.maxTextures);
 
             // step 2: check the maximum number of if statements the shader can have too..
-            this.MAX_TEXTURES = checkMaxIfStatementsInShader(
-                this.MAX_TEXTURES, gl);
+            this.maxTextures = checkMaxIfStatementsInShader(
+                this.maxTextures, gl);
         }
 
-        this._shader = this.shaderGenerator.generateShader(this.MAX_TEXTURES);
+        this._shader = this.shaderGenerator.generateShader(this.maxTextures);
 
         // we use the second shader as the first one depending on your browser
         // may omit aTextureId as it is not used by the shader so is optimized out.
@@ -320,7 +350,7 @@ export class BatchRenderer extends ObjectRenderer
         // max draw calls
         const MAX_SPRITES = this.size / 4;
         // max texture arrays
-        const MAX_TA = Math.floor(MAX_SPRITES / this.MAX_TEXTURES) + 1;
+        const MAX_TA = Math.floor(MAX_SPRITES / this.maxTextures) + 1;
 
         while (_drawCallPool.length < MAX_SPRITES)
         {
@@ -330,7 +360,7 @@ export class BatchRenderer extends ObjectRenderer
         {
             _textureArrayPool.push(new BatchTextureArray());
         }
-        for (let i = 0; i < this.MAX_TEXTURES; i++)
+        for (let i = 0; i < this.maxTextures; i++)
         {
             this._tempBoundTextures[i] = null;
         }
@@ -369,7 +399,7 @@ export class BatchRenderer extends ObjectRenderer
     {
         const {
             _bufferedTextures: textures,
-            MAX_TEXTURES,
+            maxTextures,
         } = this;
         const textureArrays = BatchRenderer._textureArrayPool;
         const batch = this.renderer.batch;
@@ -381,7 +411,7 @@ export class BatchRenderer extends ObjectRenderer
         let texArray = textureArrays[0];
         let start = 0;
 
-        batch.copyBoundTextures(boundTextures, MAX_TEXTURES);
+        batch.copyBoundTextures(boundTextures, maxTextures);
 
         for (let i = 0; i < this._bufferSize; ++i)
         {
@@ -393,9 +423,9 @@ export class BatchRenderer extends ObjectRenderer
                 continue;
             }
 
-            if (texArray.count >= MAX_TEXTURES)
+            if (texArray.count >= maxTextures)
             {
-                batch.boundArray(texArray, boundTextures, TICK, MAX_TEXTURES);
+                batch.boundArray(texArray, boundTextures, TICK, maxTextures);
                 this.buildDrawCalls(texArray, start, i);
                 start = i;
                 texArray = textureArrays[++countTexArrays];
@@ -409,7 +439,7 @@ export class BatchRenderer extends ObjectRenderer
 
         if (texArray.count > 0)
         {
-            batch.boundArray(texArray, boundTextures, TICK, MAX_TEXTURES);
+            batch.boundArray(texArray, boundTextures, TICK, maxTextures);
             this.buildDrawCalls(texArray, start, this._bufferSize);
             ++countTexArrays;
             ++TICK;
@@ -589,7 +619,7 @@ export class BatchRenderer extends ObjectRenderer
     {
         this.renderer.state.set(this.state);
 
-        this.renderer.texture.ensureSamplerType(this.MAX_TEXTURES);
+        this.renderer.texture.ensureSamplerType(this.maxTextures);
 
         this.renderer.shader.bind(this._shader);
 

--- a/packages/core/src/batch/BatchRenderer.ts
+++ b/packages/core/src/batch/BatchRenderer.ts
@@ -54,7 +54,19 @@ export class BatchRenderer extends ObjectRenderer
      * @static
      * @default 32
      */
-    public static maxTextures = maxRecommendedTextures(32);
+    public static get maxTextures(): number
+    {
+        this._maxTextures = this._maxTextures ?? maxRecommendedTextures(32);
+
+        return this._maxTextures;
+    }
+    public static set maxTextures(value: number)
+    {
+        this._maxTextures = value;
+    }
+
+    /** @ignore */
+    private static _maxTextures: number;
 
     /**
      * The default sprite batch size.

--- a/packages/core/src/batch/canUploadSameBuffer.ts
+++ b/packages/core/src/batch/canUploadSameBuffer.ts
@@ -1,4 +1,4 @@
-import { isMobile } from './isMobile';
+import { isMobile } from '@pixi/settings';
 
 /**
  * Uploading the same buffer multiple times in a single frame can cause performance issues.

--- a/packages/core/src/batch/maxRecommendedTextures.ts
+++ b/packages/core/src/batch/maxRecommendedTextures.ts
@@ -1,4 +1,4 @@
-import { isMobile } from './isMobile';
+import { isMobile, settings } from '@pixi/settings';
 
 /**
  * The maximum recommended texture units to use.
@@ -15,6 +15,7 @@ import { isMobile } from './isMobile';
 export function maxRecommendedTextures(max: number): number
 {
     let allowMax = true;
+    const navigator = settings.ADAPTER.getNavigator();
 
     if (isMobile.tablet || isMobile.phone)
     {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -227,4 +227,28 @@ Object.defineProperties(settings, {
             BatchRenderer.batchSize = value;
         },
     },
+
+    /**
+     * Can we upload the same buffer in a single frame?
+     * @static
+     * @name CAN_UPLOAD_SAME_BUFFER
+     * @memberof PIXI.settings
+     * @see PIXI.BatchRenderer.canUploadSameBuffer
+     * @deprecated since 7.1.0
+     * @type {boolean}
+     */
+    CAN_UPLOAD_SAME_BUFFER: {
+        get()
+        {
+            return BatchRenderer.canUploadSameBuffer;
+        },
+        set(value: boolean)
+        {
+            // #if _DEBUG
+            // eslint-disable-next-line max-len
+            deprecation('7.1.0', 'PIXI.settings.CAN_UPLOAD_SAME_BUFFER is deprecated, use PIXI.BatchRenderer.canUploadSameBuffer');
+            // #endif
+            BatchRenderer.canUploadSameBuffer = value;
+        },
+    },
 });

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -4,6 +4,7 @@ import { ENV } from '@pixi/constants';
 import { BaseTexture } from './textures/BaseTexture';
 import { Filter } from './filters/Filter';
 import { deprecation } from '@pixi/utils';
+import { BatchRenderer } from './batch/BatchRenderer';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -176,6 +177,54 @@ Object.defineProperties(settings, {
         set(value: MSAA_QUALITY)
         {
             Filter.multisample = value;
+        },
+    },
+
+    /**
+     * The maximum textures that this device supports.
+     * @static
+     * @name SPRITE_MAX_TEXTURES
+     * @memberof PIXI.settings
+     * @deprecated since 7.1.0
+     * @see PIXI.BatchRenderer.maxTextures
+     * @type {number}
+     */
+    SPRITE_MAX_TEXTURES: {
+        get()
+        {
+            return BatchRenderer.maxTextures;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.SPRITE_MAX_TEXTURES is deprecated, use PIXI.BatchRenderer.maxTextures');
+            // #endif
+            BatchRenderer.maxTextures = value;
+        },
+    },
+
+    /**
+     * The default sprite batch size.
+     *
+     * The default aims to balance desktop and mobile devices.
+     * @static
+     * @name SPRITE_BATCH_SIZE
+     * @memberof PIXI.settings
+     * @see PIXI.BatchRenderer.batchSize
+     * @deprecated since 7.1.0
+     * @type {number}
+     */
+    SPRITE_BATCH_SIZE: {
+        get()
+        {
+            return BatchRenderer.batchSize;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'PIXI.settings.SPRITE_BATCH_SIZE is deprecated, use PIXI.BatchRenderer.batchSize');
+            // #endif
+            BatchRenderer.batchSize = value;
         },
     },
 });

--- a/packages/core/test/BatchRenderer.tests.ts
+++ b/packages/core/test/BatchRenderer.tests.ts
@@ -61,7 +61,7 @@ describe('BatchRenderer', () =>
         {
             batchRenderer.size = 300;
             batchRenderer.contextChange();
-            batchRenderer.MAX_TEXTURES = 2;
+            batchRenderer.maxTextures = 2;
             batchRenderer.start();
             elements.forEach((element) => batchRenderer.render(element));
             expect(batchRenderer['_bufferedElements'].length).toEqual(8);
@@ -149,7 +149,7 @@ describe('BatchRenderer', () =>
         {
             batchRenderer.size = 300;
             batchRenderer.contextChange();
-            batchRenderer.MAX_TEXTURES = 2;
+            batchRenderer.maxTextures = 2;
             batchRenderer.start();
 
             const glEnable = jest.spyOn(gl, 'enable');

--- a/packages/core/test/Renderer.tests.ts
+++ b/packages/core/test/Renderer.tests.ts
@@ -6,7 +6,7 @@ import { ENV, MSAA_QUALITY } from '@pixi/constants';
 
 describe('Renderer', () =>
 {
-    it('setting option legacy should disable VAOs and SPRITE_MAX_TEXTURES', () =>
+    it('setting option legacy should disable VAOs', () =>
     {
         settings.PREFER_ENV = ENV.WEBGL_LEGACY;
         const renderer = new Renderer({ width: 1, height: 1 });

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -1007,10 +1007,10 @@ export class Graphics extends Container
             // but may be more than one plugins for graphics
             if (!DEFAULT_SHADERS[pluginName])
             {
-                const { MAX_TEXTURES } = renderer.plugins[pluginName];
-                const sampleValues = new Int32Array(MAX_TEXTURES);
+                const { maxTextures } = renderer.plugins[pluginName];
+                const sampleValues = new Int32Array(maxTextures);
 
-                for (let i = 0; i < MAX_TEXTURES; i++)
+                for (let i = 0; i < maxTextures; i++)
                 {
                     sampleValues[i] = i;
                 }

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -607,7 +607,7 @@ export class GraphicsGeometry extends BatchGeometry
             const data = this.batches[i];
 
             // TODO add some full on MAX_TEXTURE CODE..
-            const MAX_TEXTURES = 8;
+            const maxTextures = 8;
 
             // Forced cast for checking `native` without errors
             const style = data.style as LineStyle;
@@ -621,7 +621,7 @@ export class GraphicsGeometry extends BatchGeometry
 
                 // force the batch to break!
                 currentTexture = null;
-                textureCount = MAX_TEXTURES;
+                textureCount = maxTextures;
                 TICK++;
             }
 
@@ -631,7 +631,7 @@ export class GraphicsGeometry extends BatchGeometry
 
                 if (nextTexture._batchEnabled !== TICK)
                 {
-                    if (textureCount === MAX_TEXTURES)
+                    if (textureCount === maxTextures)
                     {
                         TICK++;
 

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -2,7 +2,6 @@ import { GC_MODES, PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
 import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 import { isMobile } from './utils/isMobile';
-import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 
 import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES, MSAA_QUALITY } from '@pixi/constants';
 import type { ICanvas } from './ICanvas';
@@ -39,8 +38,10 @@ export interface ISettings
     FILTER_RESOLUTION?: number;
     /** @deprecated */
     FILTER_MULTISAMPLE?: MSAA_QUALITY;
-    SPRITE_MAX_TEXTURES: number;
-    SPRITE_BATCH_SIZE: number;
+    /** @deprecated */
+    SPRITE_MAX_TEXTURES?: number;
+    /** @deprecated */
+    SPRITE_BATCH_SIZE?: number;
     RENDER_OPTIONS: IRenderOptions;
     GC_MODE: GC_MODES;
     GC_MAX_IDLE: number;
@@ -100,31 +101,6 @@ export const settings: ISettings = {
      * @default 1
      */
     RESOLUTION: 1,
-
-    /**
-     * The maximum textures that this device supports.
-     * @static
-     * @name SPRITE_MAX_TEXTURES
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 32
-     */
-    SPRITE_MAX_TEXTURES: maxRecommendedTextures(32),
-
-    // TODO: maybe change to SPRITE.BATCH_SIZE: 2000
-    // TODO: maybe add PARTICLE.BATCH_SIZE: 15000
-
-    /**
-     * The default sprite batch size.
-     *
-     * The default aims to balance desktop and mobile devices.
-     * @static
-     * @name SPRITE_BATCH_SIZE
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 4096
-     */
-    SPRITE_BATCH_SIZE: 4096,
 
     /**
      * The default render options if none are supplied to {@link PIXI.Renderer}

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,6 +1,5 @@
 import { GC_MODES, PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
-import { canUploadSameBuffer } from './utils/canUploadSameBuffer';
 import { isMobile } from './utils/isMobile';
 
 import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES, MSAA_QUALITY } from '@pixi/constants';
@@ -52,7 +51,8 @@ export interface ISettings
     SCALE_MODE?: SCALE_MODES;
     PRECISION_VERTEX: PRECISION;
     PRECISION_FRAGMENT: PRECISION;
-    CAN_UPLOAD_SAME_BUFFER: boolean;
+    /** @deprecated */
+    CAN_UPLOAD_SAME_BUFFER?: boolean;
     CREATE_IMAGE_BITMAP: boolean;
     ROUND_PIXELS: boolean;
     RETINA_PREFIX?: RegExp;
@@ -187,15 +187,6 @@ export const settings: ISettings = {
      * @default PIXI.PRECISION.MEDIUM
      */
     PRECISION_FRAGMENT: isMobile.apple.device ? PRECISION.HIGH : PRECISION.MEDIUM,
-
-    /**
-     * Can we upload the same buffer in a single frame?
-     * @static
-     * @name CAN_UPLOAD_SAME_BUFFER
-     * @memberof PIXI.settings
-     * @type {boolean}
-     */
-    CAN_UPLOAD_SAME_BUFFER: canUploadSameBuffer(),
 
     /**
      * Enables bitmap creation before image load. This feature is experimental.

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -42,9 +42,4 @@ describe('settings', () =>
     {
         expect(settings.PRECISION_FRAGMENT).toBeString();
     });
-
-    it('should have CAN_UPLOAD_SAME_BUFFER', () =>
-    {
-        expect(settings.CAN_UPLOAD_SAME_BUFFER).toBeBoolean();
-    });
 });

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -13,16 +13,6 @@ describe('settings', () =>
         expect(settings.PREFER_ENV).toBeNumber();
     });
 
-    it('should have SPRITE_MAX_TEXTURES', () =>
-    {
-        expect(settings.SPRITE_MAX_TEXTURES).toBeNumber();
-    });
-
-    it('should have SPRITE_BATCH_SIZE', () =>
-    {
-        expect(settings.SPRITE_BATCH_SIZE).toBeNumber();
-    });
-
     it('should have RENDER_OPTIONS', () =>
     {
         expect(settings.RENDER_OPTIONS).toBeObject();


### PR DESCRIPTION
Continuing progress to relocate settings that are only used in single places. This moves BatchRenderer static options.

### Deprecate

* Removes `settings.SPRITE_BATCH_SIZE` to `BatchRenderer.batchSize`
* Removes `settings.SPRITE_MAX_TEXTURES` to `BatchRenderer.maxTextures`
* Removes `settings.CAN_UPLOAD_SAME_BUFFER` to `BatchRenderer.canUploadSameBuffer`
* Removes `BatchRenderer#MAX_TEXTURES` to `BatchRenderer#maxTextures`

### Chores

* Moves `maxRecommendedTextures` to core
* Moves `canUploadSameBuffer` to core
* Replace `navigator` calls in `maxRecommendedTextures` to use the ADAPTER instead