### PR TITLE
Move UPLOADS_PER_FRAME to BasePrepare

### DIFF
--- a/packages/prepare/src/BasePrepare.ts
+++ b/packages/prepare/src/BasePrepare.ts
@@ -1,4 +1,4 @@
-import { Ticker, UPDATE_PRIORITY, settings, Texture, BaseTexture } from '@pixi/core';
+import { Ticker, UPDATE_PRIORITY, Texture, BaseTexture } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
 import { Container } from '@pixi/display';
 import { Text, TextStyle, TextMetrics } from '@pixi/text';
@@ -225,6 +225,12 @@ function findTextStyle(item: TextStyle, queue: Array<any>): boolean
 export class BasePrepare
 {
     /**
+     * The default maximum uploads per frame.
+     * @static
+     */
+    public static uploadsPerFrame = 4;
+
+    /**
      * The limiter to be used to control how quickly items are prepared.
      * @type {PIXI.CountLimiter|PIXI.TimeLimiter}
      */
@@ -277,7 +283,7 @@ export class BasePrepare
      */
     constructor(renderer: IRenderer)
     {
-        this.limiter = new CountLimiter(settings.UPLOADS_PER_FRAME);
+        this.limiter = new CountLimiter(BasePrepare.uploadsPerFrame);
         this.renderer = renderer;
         this.uploadHookHelper = null;
         this.queue = [];

--- a/packages/prepare/src/settings.ts
+++ b/packages/prepare/src/settings.ts
@@ -1,13 +1,30 @@
-import { settings } from '@pixi/core';
+import { settings, utils } from '@pixi/core';
+import { BasePrepare } from './BasePrepare';
 
-/**
- * Default number of uploads per frame using prepare plugin.
- * @static
- * @memberof PIXI.settings
- * @name UPLOADS_PER_FRAME
- * @type {number}
- * @default 4
- */
-settings.UPLOADS_PER_FRAME = 4;
+Object.defineProperties(settings, {
+    /**
+     * Default number of uploads per frame using prepare plugin.
+     * @static
+     * @memberof PIXI.settings
+     * @name UPLOADS_PER_FRAME
+     * @deprecated since 7.1.0
+     * @see PIXI.BasePrepare.uploadsPerFrame
+     * @type {number}
+     */
+    UPLOADS_PER_FRAME:
+    {
+        get()
+        {
+            return BasePrepare.uploadsPerFrame;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            utils.deprecation('7.1.0', 'settings.UPLOADS_PER_FRAME is deprecated, use prepare.BasePrepare.uploadsPerFrame');
+            // #endif
+            BasePrepare.uploadsPerFrame = value;
+        },
+    },
+});
 
 export { settings };

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -56,6 +56,7 @@ export interface ISettings
     ROUND_PIXELS: boolean;
     RETINA_PREFIX?: RegExp;
     FAIL_IF_MAJOR_PERFORMANCE_CAVEAT?: boolean;
+    /** @deprecated */
     UPLOADS_PER_FRAME?: number;
     SORTABLE_CHILDREN?: boolean;
     PREFER_ENV?: ENV;


### PR DESCRIPTION
### Deprecates

* Removes `settings.UPLOADS_PER_FRAME` to `BasePrepare.uploadsPerFrame`