### PR TITLE
Deprecate SORTABLE_CHILDREN setting, move to Container

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -1,4 +1,4 @@
-import { MASK_TYPES, Matrix, settings, utils } from '@pixi/core';
+import { MASK_TYPES, Matrix, utils } from '@pixi/core';
 import { DisplayObject } from './DisplayObject';
 
 import type { MaskData, Renderer, Rectangle } from '@pixi/core';
@@ -50,22 +50,37 @@ export interface Container extends GlobalMixins.Container, DisplayObject {}
 export class Container<T extends DisplayObject = DisplayObject> extends DisplayObject
 {
     /**
+     * Sets the default value for the container property `sortableChildren`.
+     * If set to true, the container will sort its children by zIndex value
+     * when `updateTransform()` is called, or manually if `sortChildren()` is called.
+     *
+     * This actually changes the order of elements in the array, so should be treated
+     * as a basic solution that is not performant compared to other solutions,
+     * such as {@link https://github.com/pixijs/layers PixiJS Layers}.
+     *
+     * Also be aware of that this may not work nicely with the `addChildAt()` function,
+     * as the `zIndex` sorting may cause the child to automatically sorted to another position.
+     * @static
+     */
+    public static defaultSortableChildren = false;
+
+    /**
      * The array of children of this container.
      * @readonly
      */
     public readonly children: T[];
 
     /**
-     * If set to true, the container will sort its children by zIndex value
-     * when updateTransform() is called, or manually if sortChildren() is called.
+     * If set to true, the container will sort its children by `zIndex` value
+     * when `updateTransform()` is called, or manually if `sortChildren()` is called.
      *
      * This actually changes the order of elements in the array, so should be treated
      * as a basic solution that is not performant compared to other solutions,
-     * such as @link https://github.com/pixijs/pixi-display
+     * such as {@link https://github.com/pixijs/layers PixiJS Layers}
      *
-     * Also be aware of that this may not work nicely with the addChildAt() function,
-     * as the zIndex sorting may cause the child to automatically sorted to another position.
-     * @see PIXI.settings.SORTABLE_CHILDREN
+     * Also be aware of that this may not work nicely with the `addChildAt()` function,
+     * as the `zIndex` sorting may cause the child to automatically sorted to another position.
+     * @see PIXI.Container.defaultSortableChildren
      */
     public sortableChildren: boolean;
 
@@ -86,7 +101,7 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
         super();
 
         this.children = [];
-        this.sortableChildren = settings.SORTABLE_CHILDREN;
+        this.sortableChildren = Container.defaultSortableChildren;
         this.sortDirty = false;
 
         /**

--- a/packages/display/src/settings.ts
+++ b/packages/display/src/settings.ts
@@ -1,23 +1,30 @@
-import { settings } from '@pixi/core';
+import { settings, utils } from '@pixi/core';
+import { Container } from './Container';
 
-/**
- * Sets the default value for the container property 'sortableChildren'.
- * If set to true, the container will sort its children by zIndex value
- * when updateTransform() is called, or manually if sortChildren() is called.
- *
- * This actually changes the order of elements in the array, so should be treated
- * as a basic solution that is not performant compared to other solutions,
- * such as @link https://github.com/pixijs/pixi-display
- *
- * Also be aware of that this may not work nicely with the addChildAt() function,
- * as the zIndex sorting may cause the child to automatically sorted to another position.
- * @static
- * @constant
- * @name SORTABLE_CHILDREN
- * @memberof PIXI.settings
- * @type {boolean}
- * @default false
- */
-settings.SORTABLE_CHILDREN = false;
+Object.defineProperties(settings, {
+    /**
+     * Sets the default value for the container property 'sortableChildren'.
+     * @static
+     * @constant
+     * @name SORTABLE_CHILDREN
+     * @memberof PIXI.settings
+     * @deprecated since 7.1.0
+     * @type {boolean}
+     * @see PIXI.Container.defaultSortableChildren
+     */
+    SORTABLE_CHILDREN: {
+        get()
+        {
+            return Container.defaultSortableChildren;
+        },
+        set(value: boolean)
+        {
+            // #if _DEBUG
+            utils.deprecation('7.1.0', 'settings.SORTABLE_CHILDREN is deprecated, use Container.defaultSortableChildren');
+            // #endif
+            Container.defaultSortableChildren = value;
+        },
+    },
+});
 
 export { settings };

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -59,6 +59,7 @@ export interface ISettings
     FAIL_IF_MAJOR_PERFORMANCE_CAVEAT?: boolean;
     /** @deprecated */
     UPLOADS_PER_FRAME?: number;
+    /** @deprecated */
     SORTABLE_CHILDREN?: boolean;
     PREFER_ENV?: ENV;
     STRICT_TEXTURE_CACHE?: boolean;


### PR DESCRIPTION
### Deprecated

* Removes `settings.SORTABLE_CHILDREN` becomes `Container.defaultSortableChildren`

#### Notes

@Zyie I realized that some static member names are now matching instance members (`Container.sortableChildren` vs `Container.prototype.sortableChildren`, `BatchRenderer.maxTextures` vs `BatchRenderer.prototype.maxTextures`) is confusing and somewhat ambiguous with the docs, so I decided that static properties I'm going to prefix with `default`. Will go back and fix.