### PR TITLE
Deprecated settings.TARGET_FPMS to Ticker.targetFPMS

### DIFF
--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -63,6 +63,7 @@ export interface ISettings
     PREFER_ENV?: ENV;
     STRICT_TEXTURE_CACHE?: boolean;
     MESH_CANVAS_PADDING?: number;
+    /** @deprecated */
     TARGET_FPMS?: number;
 }
 

--- a/packages/ticker/package.json
+++ b/packages/ticker/package.json
@@ -37,6 +37,7 @@
   ],
   "dependencies": {
     "@pixi/extensions": "7.1.0-alpha",
-    "@pixi/settings": "7.1.0-alpha"
+    "@pixi/settings": "7.1.0-alpha",
+    "@pixi/utils": "7.1.0-alpha"
   }
 }

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -17,7 +17,7 @@ export class Ticker
      * Target frames per millisecond.
      * @static
      */
-    public static defaultTargetFPMS = 0.06;
+    public static targetFPMS = 0.06;
 
     /** The private shared ticker instance */
     private static _shared: Ticker;
@@ -116,8 +116,8 @@ export class Ticker
     constructor()
     {
         this._head = new TickerListener(null, null, Infinity);
-        this.deltaMS = 1 / Ticker.defaultTargetFPMS;
-        this.elapsedMS = 1 / Ticker.defaultTargetFPMS;
+        this.deltaMS = 1 / Ticker.targetFPMS;
+        this.elapsedMS = 1 / Ticker.targetFPMS;
 
         this._tick = (time: number): void =>
         {
@@ -413,7 +413,7 @@ export class Ticker
             }
 
             this.deltaMS = elapsedMS;
-            this.deltaTime = this.deltaMS * Ticker.defaultTargetFPMS;
+            this.deltaTime = this.deltaMS * Ticker.targetFPMS;
 
             // Cache a local reference, in-case ticker is destroyed
             // during the emit, we can still check for head.next
@@ -460,7 +460,7 @@ export class Ticker
      * This value is used to cap {@link PIXI.Ticker#deltaTime},
      * but does not effect the measured value of {@link PIXI.Ticker#FPS}.
      * When setting this property it is clamped to a value between
-     * `0` and `Ticker.defaultTargetFPMS * 1000`.
+     * `0` and `Ticker.targetFPMS * 1000`.
      * @member {number}
      * @default 10
      */
@@ -474,8 +474,8 @@ export class Ticker
         // Minimum must be below the maxFPS
         const minFPS = Math.min(this.maxFPS, fps);
 
-        // Must be at least 0, but below 1 / Ticker.defaultTargetFPMS
-        const minFPMS = Math.min(Math.max(0, minFPS) / 1000, Ticker.defaultTargetFPMS);
+        // Must be at least 0, but below 1 / Ticker.targetFPMS
+        const minFPMS = Math.min(Math.max(0, minFPS) / 1000, Ticker.targetFPMS);
 
         this._maxElapsedMS = 1 / minFPMS;
     }

--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -1,4 +1,3 @@
-import { settings } from './settings';
 import { UPDATE_PRIORITY } from './const';
 import { TickerListener } from './TickerListener';
 
@@ -14,6 +13,12 @@ export type TickerCallback<T> = (this: T, dt: number) => any;
  */
 export class Ticker
 {
+    /**
+     * Target frames per millisecond.
+     * @static
+     */
+    public static defaultTargetFPMS = 0.06;
+
     /** The private shared ticker instance */
     private static _shared: Ticker;
     /** The private system ticker instance  */
@@ -111,8 +116,8 @@ export class Ticker
     constructor()
     {
         this._head = new TickerListener(null, null, Infinity);
-        this.deltaMS = 1 / settings.TARGET_FPMS;
-        this.elapsedMS = 1 / settings.TARGET_FPMS;
+        this.deltaMS = 1 / Ticker.defaultTargetFPMS;
+        this.elapsedMS = 1 / Ticker.defaultTargetFPMS;
 
         this._tick = (time: number): void =>
         {
@@ -408,7 +413,7 @@ export class Ticker
             }
 
             this.deltaMS = elapsedMS;
-            this.deltaTime = this.deltaMS * settings.TARGET_FPMS;
+            this.deltaTime = this.deltaMS * Ticker.defaultTargetFPMS;
 
             // Cache a local reference, in-case ticker is destroyed
             // during the emit, we can still check for head.next
@@ -455,7 +460,7 @@ export class Ticker
      * This value is used to cap {@link PIXI.Ticker#deltaTime},
      * but does not effect the measured value of {@link PIXI.Ticker#FPS}.
      * When setting this property it is clamped to a value between
-     * `0` and `PIXI.settings.TARGET_FPMS * 1000`.
+     * `0` and `Ticker.defaultTargetFPMS * 1000`.
      * @member {number}
      * @default 10
      */
@@ -469,8 +474,8 @@ export class Ticker
         // Minimum must be below the maxFPS
         const minFPS = Math.min(this.maxFPS, fps);
 
-        // Must be at least 0, but below 1 / settings.TARGET_FPMS
-        const minFPMS = Math.min(Math.max(0, minFPS) / 1000, settings.TARGET_FPMS);
+        // Must be at least 0, but below 1 / Ticker.defaultTargetFPMS
+        const minFPMS = Math.min(Math.max(0, minFPS) / 1000, Ticker.defaultTargetFPMS);
 
         this._maxElapsedMS = 1 / minFPMS;
     }

--- a/packages/ticker/src/settings.ts
+++ b/packages/ticker/src/settings.ts
@@ -10,20 +10,20 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @type {number}
      * @deprecated since 7.1.0
-     * @see PIXI.Ticker.defaultTargetFPMS
+     * @see PIXI.Ticker.targetFPMS
      */
     TARGET_FPMS: {
         get()
         {
-            return Ticker.defaultTargetFPMS;
+            return Ticker.targetFPMS;
         },
         set(value: number)
         {
             // #if _DEBUG
-            deprecation('7.1.0', 'settings.TARGET_FPMS is deprecated, use Ticker.defaultTargetFPMS');
+            deprecation('7.1.0', 'settings.TARGET_FPMS is deprecated, use Ticker.targetFPMS');
             // #endif
 
-            Ticker.defaultTargetFPMS = value;
+            Ticker.targetFPMS = value;
         },
     },
 });

--- a/packages/ticker/src/settings.ts
+++ b/packages/ticker/src/settings.ts
@@ -1,13 +1,31 @@
 import { settings } from '@pixi/settings';
+import { deprecation } from '@pixi/utils';
+import { Ticker } from './Ticker';
 
-/**
- * Target frames per millisecond.
- * @static
- * @name TARGET_FPMS
- * @memberof PIXI.settings
- * @type {number}
- * @default 0.06
- */
-settings.TARGET_FPMS = 0.06;
+Object.defineProperties(settings, {
+    /**
+     * Target frames per millisecond.
+     * @static
+     * @name TARGET_FPMS
+     * @memberof PIXI.settings
+     * @type {number}
+     * @deprecated since 7.1.0
+     * @see PIXI.Ticker.defaultTargetFPMS
+     */
+    TARGET_FPMS: {
+        get()
+        {
+            return Ticker.defaultTargetFPMS;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.TARGET_FPMS is deprecated, use Ticker.defaultTargetFPMS');
+            // #endif
+
+            Ticker.defaultTargetFPMS = value;
+        },
+    },
+});
 
 export { settings };


### PR DESCRIPTION
### Deprecated

* Remove `settings.TARGET_FPMS` becomes `Ticker.targetFPMS`

#### Notes

Decided not to name `targetFPMS` to `defaultTargetFPMS` because of how Ticker uses this property. It does not use it as a default, rather an environmental baseline for all tickers. There's currently no way to to adjust this per-Ticker.