### PR TITLE
Deprecate GC settings

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -1,10 +1,11 @@
 import { settings } from '@pixi/settings';
-import type { MSAA_QUALITY, MIPMAP_MODES, SCALE_MODES, WRAP_MODES } from '@pixi/constants';
+import type { MSAA_QUALITY, MIPMAP_MODES, SCALE_MODES, WRAP_MODES, GC_MODES } from '@pixi/constants';
 import { ENV } from '@pixi/constants';
 import { BaseTexture } from './textures/BaseTexture';
 import { Filter } from './filters/Filter';
 import { deprecation } from '@pixi/utils';
 import { BatchRenderer } from './batch/BatchRenderer';
+import { TextureGCSystem } from './systems';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -249,6 +250,72 @@ Object.defineProperties(settings, {
             deprecation('7.1.0', 'PIXI.settings.CAN_UPLOAD_SAME_BUFFER is deprecated, use PIXI.BatchRenderer.canUploadSameBuffer');
             // #endif
             BatchRenderer.canUploadSameBuffer = value;
+        },
+    },
+
+    /**
+     * Default Garbage Collection mode.
+     * @static
+     * @name GC_MODE
+     * @memberof PIXI.settings
+     * @type {PIXI.GC_MODES}
+     * @deprecated since 7.1.0
+     */
+    GC_MODE: {
+        get()
+        {
+            return TextureGCSystem.defaultMode;
+        },
+        set(value: GC_MODES)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.GC_MODE is deprecated, use TextureGCSystem.defaultMode');
+            // #endif
+            TextureGCSystem.defaultMode = value;
+        },
+    },
+
+    /**
+     * Default Garbage Collection max idle.
+     * @static
+     * @name GC_MAX_IDLE
+     * @memberof PIXI.settings
+     * @type {number}
+     * @deprecated since 7.1.0
+     */
+    GC_MAX_IDLE: {
+        get()
+        {
+            return TextureGCSystem.defaultMaxIdle;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.GC_MAX_IDLE is deprecated, use TextureGCSystem.defaultMaxIdle');
+            // #endif
+            TextureGCSystem.defaultMaxIdle = value;
+        },
+    },
+
+    /**
+     * Default Garbage Collection maximum check count.
+     * @static
+     * @name GC_MAX_CHECK_COUNT
+     * @memberof PIXI.settings
+     * @type {number}
+     * @deprecated since 7.1.0
+     */
+    GC_MAX_CHECK_COUNT: {
+        get()
+        {
+            return TextureGCSystem.defaultCheckCountMax;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.GC_MAX_CHECK_COUNT is deprecated, use TextureGCSystem.defaultCheckCountMax');
+            // #endif
+            TextureGCSystem.defaultCheckCountMax = value;
         },
     },
 });

--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -1,5 +1,4 @@
 import { GC_MODES } from '@pixi/constants';
-import { settings } from '@pixi/settings';
 
 import type { ISystem } from '../system/ISystem';
 import type { Renderer } from '../Renderer';
@@ -21,6 +20,28 @@ export interface IUnloadableTexture
  */
 export class TextureGCSystem implements ISystem
 {
+    /**
+     * Default Garbage Collection mode.
+     * @static
+     * @type {PIXI.GC_MODES}
+     * @default PIXI.GC_MODES.AUTO
+     */
+    public static defaultMode = GC_MODES.AUTO;
+
+    /**
+     * Default Garbage Collection max idle.
+     * @static
+     * @default 3600
+     */
+    public static defaultMaxIdle = 60 * 60;
+
+    /**
+     * Default Garbage Collection maximum check count.
+     * @static
+     * @default 600
+     */
+    public static defaultCheckCountMax = 60 * 10;
+
     /** @ignore */
     static extension: ExtensionMetadata = {
         type: ExtensionType.RendererSystem,
@@ -41,19 +62,19 @@ export class TextureGCSystem implements ISystem
 
     /**
      * Maximum idle time, in seconds
-     * @see PIXI.settings.GC_MAX_IDLE
+     * @see PIXI.TextureGCSystem.defaultMaxIdle
      */
     public maxIdle: number;
 
     /**
      * Maximum number of item to check
-     * @see PIXI.settings.GC_MAX_CHECK_COUNT
+     * @see PIXI.TextureGCSystem.defaultCheckCountMax
      */
     public checkCountMax: number;
 
     /**
      * Current garbage collection mode
-     * @see PIXI.settings.GC_MODE
+     * @see PIXI.TextureGCSystem.defaultMode
      */
     public mode: GC_MODES;
     private renderer: Renderer;
@@ -65,9 +86,9 @@ export class TextureGCSystem implements ISystem
 
         this.count = 0;
         this.checkCount = 0;
-        this.maxIdle = settings.GC_MAX_IDLE;
-        this.checkCountMax = settings.GC_MAX_CHECK_COUNT;
-        this.mode = settings.GC_MODE;
+        this.maxIdle = TextureGCSystem.defaultMaxIdle;
+        this.checkCountMax = TextureGCSystem.defaultCheckCountMax;
+        this.mode = TextureGCSystem.defaultMode;
     }
 
     /**

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,8 +1,8 @@
-import { GC_MODES, PRECISION } from '@pixi/constants';
+import { PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
 import { isMobile } from './utils/isMobile';
 
-import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES, MSAA_QUALITY } from '@pixi/constants';
+import type { ENV, MIPMAP_MODES, WRAP_MODES, SCALE_MODES, MSAA_QUALITY, GC_MODES } from '@pixi/constants';
 import type { ICanvas } from './ICanvas';
 import type { IAdapter } from './adapter';
 
@@ -42,9 +42,12 @@ export interface ISettings
     /** @deprecated */
     SPRITE_BATCH_SIZE?: number;
     RENDER_OPTIONS: IRenderOptions;
-    GC_MODE: GC_MODES;
-    GC_MAX_IDLE: number;
-    GC_MAX_CHECK_COUNT: number;
+    /** @deprecated */
+    GC_MODE?: GC_MODES;
+    /** @deprecated */
+    GC_MAX_IDLE?: number;
+    /** @deprecated */
+    GC_MAX_CHECK_COUNT?: number;
     /** @deprecated */
     WRAP_MODE?: WRAP_MODES;
     /** @deprecated */
@@ -137,36 +140,6 @@ export const settings: ISettings = {
         legacy: false,
         hello: false,
     },
-
-    /**
-     * Default Garbage Collection mode.
-     * @static
-     * @name GC_MODE
-     * @memberof PIXI.settings
-     * @type {PIXI.GC_MODES}
-     * @default PIXI.GC_MODES.AUTO
-     */
-    GC_MODE: GC_MODES.AUTO,
-
-    /**
-     * Default Garbage Collection max idle.
-     * @static
-     * @name GC_MAX_IDLE
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 3600
-     */
-    GC_MAX_IDLE: 60 * 60,
-
-    /**
-     * Default Garbage Collection maximum check count.
-     * @static
-     * @name GC_MAX_CHECK_COUNT
-     * @memberof PIXI.settings
-     * @type {number}
-     * @default 600
-     */
-    GC_MAX_CHECK_COUNT: 60 * 10,
 
     /**
      * Default specify float precision in vertex shader.

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -18,21 +18,6 @@ describe('settings', () =>
         expect(settings.RENDER_OPTIONS).toBeObject();
     });
 
-    it('should have GC_MODE', () =>
-    {
-        expect(settings.GC_MODE).toBeNumber();
-    });
-
-    it('should have GC_MAX_IDLE', () =>
-    {
-        expect(settings.GC_MAX_IDLE).toBeNumber();
-    });
-
-    it('should have GC_MAX_CHECK_COUNT', () =>
-    {
-        expect(settings.GC_MAX_CHECK_COUNT).toBeNumber();
-    });
-
     it('should have PRECISION_VERTEX', () =>
     {
         expect(settings.PRECISION_VERTEX).toBeString();


### PR DESCRIPTION
### Deprecated

* Removes `settings.GC_MODE` becomes `TextureGCSystem.defaultMode`
* Removes `settings.GC_MAX_IDLE` becomes `TextureGCSystem.defaultMaxIdle`
* Removes `settings.GC_MAX_CHECK_COUNT` becomes `TextureGCSystem.defaultCheckCountMax`