### PR TITLE
Add overload signatures for Assets

### DIFF
--- a/bundles/pixi.js-node/src/adapter/loadNodeBitmapFont.ts
+++ b/bundles/pixi.js-node/src/adapter/loadNodeBitmapFont.ts
@@ -1,9 +1,10 @@
+import { parseStringPromise } from 'xml2js';
+import { extensions, ExtensionType, settings, utils } from '@pixi/core';
+import { BitmapFont, BitmapFontData, TextFormat, XMLStringFormat } from '@pixi/text-bitmap';
+
 import type { LoadAsset, Loader, LoaderParser } from '@pixi/assets';
 import type { Texture } from '@pixi/core';
-import { extensions, ExtensionType, settings, utils } from '@pixi/core';
 import type { IBitmapFontRawData } from '@pixi/text-bitmap';
-import { BitmapFont, BitmapFontData, TextFormat, XMLStringFormat } from '@pixi/text-bitmap';
-import { parseStringPromise } from 'xml2js';
 
 interface XMLRawJson
 {
@@ -120,7 +121,7 @@ async function _loadBitmap(src: string, data: BitmapFontData, loader: Loader)
         textureUrls.push(url);
     }
 
-    const loadedTextures = await loader.load(textureUrls) as Record<string, Texture>;
+    const loadedTextures = await loader.load<Texture>(textureUrls);
     const textures = textureUrls.map((url) => loadedTextures[url]);
 
     return BitmapFont.install(data, textures, true);

--- a/packages/assets/src/loader/Loader.ts
+++ b/packages/assets/src/loader/Loader.ts
@@ -1,7 +1,8 @@
 import { utils } from '@pixi/core';
 import { convertToList, isSingleItem } from '../utils';
+
 import type { LoaderParser } from './parsers/LoaderParser';
-import type { PromiseAndParser, LoadAsset } from './types';
+import type { LoadAsset, PromiseAndParser } from './types';
 
 /**
  * The Loader is responsible for loading all assets, such as images, spritesheets, audio files, etc.
@@ -102,10 +103,18 @@ export class Loader
      * @param assetsToLoadIn - urls that you want to load, or a single one!
      * @param onProgress - a function that gets called when the progress changes
      */
-    public async load(
+    public async load<T = any>(
+        assetsToLoadIn: string | LoadAsset,
+        onProgress?: (progress: number) => void,
+    ): Promise<T>;
+    public async load<T = any>(
+        assetsToLoadIn: string[] | LoadAsset[],
+        onProgress?: (progress: number) => void,
+    ): Promise<Record<string, T>>;
+    public async load<T = any>(
         assetsToLoadIn: string | string[] | LoadAsset | LoadAsset[],
         onProgress?: (progress: number) => void,
-    ): Promise<{[key: string]: any} | any>
+    ): Promise<T | Record<string, T>>
     {
         let count = 0;
 

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -1,7 +1,6 @@
+import { Assets } from '@pixi/assets';
 import { BaseTexture, Texture } from '@pixi/core';
 import { Spritesheet } from '@pixi/spritesheet';
-
-import { Assets } from '@pixi/assets';
 
 function wait(value = 500)
 {
@@ -252,13 +251,13 @@ describe('Assets', () =>
             basePath,
         });
 
-        const bunny = await Assets.load('textures/bunny.png') as Texture;
+        const bunny = await Assets.load<Texture>('textures/bunny.png');
 
         bunny.destroy(true);
 
         expect(bunny.baseTexture).toBe(null);
 
-        const bunnyReloaded = await Assets.load('textures/bunny.png') as Texture;
+        const bunnyReloaded = await Assets.load<Texture>('textures/bunny.png');
 
         expect(bunnyReloaded.baseTexture).toBeInstanceOf(BaseTexture);
     });
@@ -306,7 +305,7 @@ describe('Assets', () =>
             basePath,
         });
 
-        const bunny = await Assets.load('textures/bunny.png') as Texture;
+        const bunny = await Assets.load<Texture>('textures/bunny.png');
 
         await Assets.unload('textures/bunny.png');
 

--- a/packages/assets/test/loader.tests.ts
+++ b/packages/assets/test/loader.tests.ts
@@ -1,8 +1,8 @@
+import { Cache, loadJson, loadSVG, loadTextures, loadWebFont } from '@pixi/assets';
 import { Texture } from '@pixi/core';
+import { Loader } from '../src/loader/Loader';
 
 import type { LoaderParser } from '@pixi/assets';
-import { Cache, loadJson, loadSVG, loadTextures, loadWebFont } from '@pixi/assets';
-import { Loader } from '../src/loader/Loader';
 
 describe('Loader', () =>
 {
@@ -21,7 +21,7 @@ describe('Loader', () =>
 
         loader['_parsers'].push(loadTextures);
 
-        const texture: Texture = await loader.load(`${serverPath}textures/bunny.png`);
+        const texture = await loader.load<Texture>(`${serverPath}textures/bunny.png`);
 
         expect(texture.baseTexture.valid).toBe(true);
         expect(texture.width).toBe(26);
@@ -34,7 +34,7 @@ describe('Loader', () =>
 
         loader['_parsers'].push(loadSVG);
 
-        const texture: Texture = await loader.load(`${serverPath}svg/logo.svg`);
+        const texture = await loader.load<Texture>(`${serverPath}svg/logo.svg`);
 
         expect(texture.baseTexture.valid).toBe(true);
         expect(texture.width).toBe(512);
@@ -47,7 +47,7 @@ describe('Loader', () =>
 
         loader['_parsers'].push(loadSVG);
 
-        const texture: Texture = await loader.load({
+        const texture = await loader.load<Texture>({
             data: {
                 resourceOptions: {
                     width: 128,
@@ -73,7 +73,7 @@ describe('Loader', () =>
 
         for (let i = 0; i < 10; i++)
         {
-            texturesPromises.push(loader.load(`${serverPath}textures/bunny.png`));
+            texturesPromises.push(loader.load<Texture>(`${serverPath}textures/bunny.png`));
         }
 
         const textures = await Promise.all(texturesPromises);
@@ -94,7 +94,7 @@ describe('Loader', () =>
 
         const assetsUrls = [`${serverPath}textures/bunny.png`, `${serverPath}textures/bunny-2.png`];
 
-        const textures = await loader.load(assetsUrls);
+        const textures = await loader.load<Texture>(assetsUrls);
 
         expect(textures[`${serverPath}textures/bunny.png`]).toBeInstanceOf(Texture);
         expect(textures[`${serverPath}textures/bunny-2.png`]).toBeInstanceOf(Texture);
@@ -120,7 +120,7 @@ describe('Loader', () =>
 
         loader['_parsers'].push(loadWebFont);
 
-        const font = await loader.load(`${serverPath}fonts/outfit.woff2`);
+        const font = await loader.load<FontFace>(`${serverPath}fonts/outfit.woff2`);
 
         let foundFont = false;
 
@@ -144,7 +144,7 @@ describe('Loader', () =>
         document.fonts.clear();
         loader['_parsers'].push(loadWebFont);
 
-        const font = await loader.load({
+        const font = await loader.load<FontFace>({
             data: {
                 family: 'Overridden',
                 style: 'italic',
@@ -178,7 +178,7 @@ describe('Loader', () =>
                 url + options.data.whatever,
         } as LoaderParser<string>);
 
-        const sillyID: string = await loader.load({
+        const sillyID = await loader.load<string>({
             src: `${serverPath}textures/bunny.png`,
             data: { whatever: 23 },
         });
@@ -192,7 +192,7 @@ describe('Loader', () =>
 
         loader['_parsers'].push(loadTextures);
 
-        const texture: Texture = await loader.load(`${serverPath}textures/bunny.png`);
+        const texture = await loader.load<Texture>(`${serverPath}textures/bunny.png`);
 
         expect(texture.baseTexture.destroyed).toBe(false);
 

--- a/packages/compressed-textures/test/compressed-textures.tests.ts
+++ b/packages/compressed-textures/test/compressed-textures.tests.ts
@@ -1,8 +1,9 @@
 import { Assets } from '@pixi/assets';
-import type { Texture } from '@pixi/core';
 import { Loader } from '../../assets/src/loader/Loader';
 import { Resolver } from '../../assets/src/resolver/Resolver';
 import { detectCompressedTextures, loadDDS, loadKTX, resolveCompressedTextureUrl } from '../src/loaders';
+
+import type { Texture } from '@pixi/core';
 
 describe('Compressed Loader', () =>
 {
@@ -15,7 +16,7 @@ describe('Compressed Loader', () =>
         loader['_parsers'].push(loadKTX);
 
         // eslint-disable-next-line max-len
-        const texture: Texture = await loader.load(`https://pixijs.io/compressed-textures-example/images/PixiJS-Logo_PNG_BC3_KTX.KTX`);
+        const texture = await loader.load<Texture>(`https://pixijs.io/compressed-textures-example/images/PixiJS-Logo_PNG_BC3_KTX.KTX`);
 
         expect(texture.baseTexture.valid).toBe(true);
         expect(texture.width).toBe(898);
@@ -29,7 +30,7 @@ describe('Compressed Loader', () =>
         loader['_parsers'].push(loadDDS);
 
         // eslint-disable-next-line max-len
-        const texture: Texture = await loader.load(`https://pixijs.io/compressed-textures-example/images/airplane-boeing_JPG_BC3_1.DDS`);
+        const texture = await loader.load<Texture>(`https://pixijs.io/compressed-textures-example/images/airplane-boeing_JPG_BC3_1.DDS`);
 
         expect(texture.baseTexture.valid).toBe(true);
         expect(texture.width).toBe(1000);

--- a/packages/mesh-extras/test/SimplePlane.tests.ts
+++ b/packages/mesh-extras/test/SimplePlane.tests.ts
@@ -1,6 +1,6 @@
-import { SimplePlane } from '@pixi/mesh-extras';
-import { Point, Renderer, RenderTexture, Texture } from '@pixi/core';
 import { Cache, loadTextures } from '@pixi/assets';
+import { Point, Renderer, RenderTexture, Texture } from '@pixi/core';
+import { SimplePlane } from '@pixi/mesh-extras';
 import { Loader } from '../../assets/src/loader/Loader';
 
 import type { PlaneGeometry } from '@pixi/mesh-extras';
@@ -26,7 +26,7 @@ describe('SimplePlane', () =>
 
     it('should create a plane from an external image', async () =>
     {
-        const texture = await loader.load(`${serverPath}bitmap-1.png`);
+        const texture = await loader.load<Texture>(`${serverPath}bitmap-1.png`);
 
         const plane = new SimplePlane(texture, 100, 100);
 

--- a/packages/mesh-extras/test/SimpleRope.tests.ts
+++ b/packages/mesh-extras/test/SimpleRope.tests.ts
@@ -1,5 +1,5 @@
 import { Cache, loadTextures } from '@pixi/assets';
-import { Renderer, Texture, Point } from '@pixi/core';
+import { Point, Renderer, Texture } from '@pixi/core';
 import { SimpleRope } from '@pixi/mesh-extras';
 import { Loader } from '../../assets/src/loader/Loader';
 
@@ -23,7 +23,7 @@ describe('SimpleRope', () =>
     });
     it('should create a rope from an external image', async () =>
     {
-        const texture = await loader.load(`${serverPath}bitmap-1.png`);
+        const texture = await loader.load<Texture>(`${serverPath}bitmap-1.png`);
         const rope = new SimpleRope(texture, [new Point(0, 0), new Point(0, 1)]);
 
         expect(rope).toBeInstanceOf(SimpleRope);

--- a/packages/text-bitmap/src/loadBitmapFont.ts
+++ b/packages/text-bitmap/src/loadBitmapFont.ts
@@ -1,11 +1,11 @@
-import type { Texture } from '@pixi/core';
-import { settings, utils, extensions, ExtensionType } from '@pixi/core';
+import { LoaderParserPriority } from '@pixi/assets';
+import { extensions, ExtensionType, settings, utils } from '@pixi/core';
+import { BitmapFont } from './BitmapFont';
+import { TextFormat, XMLStringFormat } from './formats';
 
 import type { LoadAsset, Loader, LoaderParser } from '@pixi/assets';
-import { LoaderParserPriority } from '@pixi/assets';
-import { BitmapFont } from './BitmapFont';
+import type { Texture } from '@pixi/core';
 import type { BitmapFontData } from './BitmapFontData';
-import { TextFormat, XMLStringFormat } from './formats';
 
 const validExtensions = ['.xml', '.fnt'];
 
@@ -44,7 +44,7 @@ export const loadBitmapFont = {
             textureUrls.push(imagePath);
         }
 
-        const loadedTextures = await loader.load(textureUrls) as Record<string, Texture>;
+        const loadedTextures = await loader.load<Texture>(textureUrls);
         const textures = textureUrls.map((url) => loadedTextures[url]);
 
         return BitmapFont.install(fontData, textures, true);

--- a/packages/text-bitmap/test/BitmapFontLoader.tests.ts
+++ b/packages/text-bitmap/test/BitmapFontLoader.tests.ts
@@ -1,8 +1,9 @@
 import { Cache, loadTextures, loadTxt } from '@pixi/assets';
-import type { ImageResource, Texture } from '@pixi/core';
+import { utils } from '@pixi/core';
 import { BitmapFont, loadBitmapFont } from '@pixi/text-bitmap';
-import { BaseTextureCache, TextureCache } from '@pixi/utils';
 import { Loader } from '../../assets/src/loader/Loader';
+
+import type { ImageResource, Texture } from '@pixi/core';
 
 describe('BitmapFontLoader', () =>
 {
@@ -23,13 +24,13 @@ describe('BitmapFontLoader', () =>
         {
             delete BitmapFont.available[font];
         }
-        for (const baseTexture in BaseTextureCache)
+        for (const baseTexture in utils.BaseTextureCache)
         {
-            delete BaseTextureCache[baseTexture];
+            delete utils.BaseTextureCache[baseTexture];
         }
-        for (const texture in TextureCache)
+        for (const texture in utils.TextureCache)
         {
-            delete TextureCache[texture];
+            delete utils.TextureCache[texture];
         }
     });
 
@@ -57,7 +58,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register bitmap font', async () =>
     {
-        const font = await loader.load(`${serverPath}font.fnt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}font.fnt`);
 
         expect(font).toBeObject();
         expect(BitmapFont.available.font).toEqual(font);
@@ -105,7 +106,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register bitmap font based on txt data', async () =>
     {
-        const font = await loader.load(`${serverPath}bmtxt-test.txt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}bmtxt-test.txt`);
 
         expect(font).toBeObject();
         expect(font).toHaveProperty('chars');
@@ -154,7 +155,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register bitmap font based on text format', async () =>
     {
-        const font = await loader.load(`${serverPath}font-text.fnt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}font-text.fnt`);
 
         expect(font).toBeObject();
         expect(BitmapFont.available.fontText).toEqual(font);
@@ -202,7 +203,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register SCALED bitmap font', async () =>
     {
-        const font = await loader.load(`${serverPath}font@0.5x.fnt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}font@0.5x.fnt`);
 
         expect(font).toBeObject();
         expect(BitmapFont.available.font).toEqual(font);
@@ -250,7 +251,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register bitmap font having more than one texture', async () =>
     {
-        const font = await loader.load(`${serverPath}split_font.fnt`) as BitmapFont;
+        const font = await loader.load<BitmapFont>(`${serverPath}split_font.fnt`);
 
         expect(font).toBeObject();
         expect(BitmapFont.available.split_font).toEqual(font);
@@ -310,7 +311,7 @@ describe('BitmapFontLoader', () =>
 
     it('should split fonts if page IDs are in chronological order', async () =>
     {
-        const font = await loader.load(`${serverPath}split_font2.fnt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}split_font2.fnt`);
 
         const charA = font.chars['A'.charCodeAt(0)];
         const charC = font.chars['C'.charCodeAt(0)];
@@ -325,9 +326,9 @@ describe('BitmapFontLoader', () =>
 
     it('should set the texture to NPM on SDF fonts', async () =>
     {
-        const sdfFont = await loader.load(`${serverPath}sdf.fnt`);
-        const msdfFont = await loader.load(`${serverPath}msdf.fnt`);
-        const regularFont = await loader.load(`${serverPath}font-text.fnt`);
+        const sdfFont = await loader.load<BitmapFont>(`${serverPath}sdf.fnt`);
+        const msdfFont = await loader.load<BitmapFont>(`${serverPath}msdf.fnt`);
+        const regularFont = await loader.load<BitmapFont>(`${serverPath}font-text.fnt`);
 
         expect(sdfFont.chars['A'.charCodeAt(0)].texture.baseTexture.alphaMode).toEqual(0);
         expect(msdfFont.chars['A'.charCodeAt(0)].texture.baseTexture.alphaMode).toEqual(0);
@@ -336,9 +337,9 @@ describe('BitmapFontLoader', () =>
 
     it('should set the distanceFieldType correctly', async () =>
     {
-        const sdfFont = await loader.load(`${serverPath}sdf.fnt`);
-        const msdfFont = await loader.load(`${serverPath}msdf.fnt`);
-        const regularFont = await loader.load(`${serverPath}font-text.fnt`);
+        const sdfFont = await loader.load<BitmapFont>(`${serverPath}sdf.fnt`);
+        const msdfFont = await loader.load<BitmapFont>(`${serverPath}msdf.fnt`);
+        const regularFont = await loader.load<BitmapFont>(`${serverPath}font-text.fnt`);
 
         expect(sdfFont.distanceFieldType).toEqual('sdf');
         expect(msdfFont.distanceFieldType).toEqual('msdf');
@@ -347,7 +348,7 @@ describe('BitmapFontLoader', () =>
 
     it('should properly register bitmap font with random placed arguments into info tag', async () =>
     {
-        const font = await loader.load(`${serverPath}font-random-args.fnt`);
+        const font = await loader.load<BitmapFont>(`${serverPath}font-random-args.fnt`);
 
         expect(font).toBeObject();
         expect(BitmapFont.available.font).toEqual(font);
@@ -369,7 +370,7 @@ describe('BitmapFontLoader', () =>
 
         loader['_parsers'].push(loadTextures, loadBitmapFont);
 
-        const bitmapFont: BitmapFont = await loader.load(`${serverPath}desyrel.xml`);
+        const bitmapFont = await loader.load<BitmapFont>(`${serverPath}desyrel.xml`);
 
         expect(bitmapFont).toBeInstanceOf(BitmapFont);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

The `Assets.load`, `Assets.get` and `Loader.load` used to return `Promise<T | Record<string, T>>` regardless of the type of the argument is `string` or `string[]`, this caused me to perform extra cast on the return value when using them. So I add overload signatures to these methods, now they will return a more exact type.

Old:
```ts
const texture = await Assets.load('textures/bunny.png') as Texture;
// type of `await Assets.load<Texture>('textures/bunny.png')` is Texture | Record<string, Texture>
```

New:
```ts
const texture = await Assets.load<Texture>('textures/bunny.png');
// type of `await Assets.load<Texture>('textures/bunny.png')` is Texture
```

The tests that use `Assets` or `Loader` are modified. Also some `import` arrangements are included.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
