### PR TITLE
Deprecate MESH_CANVAS_PADDING setting

### DIFF
--- a/packages/canvas-mesh/global.d.ts
+++ b/packages/canvas-mesh/global.d.ts
@@ -24,6 +24,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
+        /** @deprecated */
         MESH_CANVAS_PADDING: number;
     }
 }

--- a/packages/canvas-mesh/src/Mesh.ts
+++ b/packages/canvas-mesh/src/Mesh.ts
@@ -1,5 +1,4 @@
 import { Mesh } from '@pixi/mesh';
-import { settings } from './settings';
 
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 
@@ -51,16 +50,9 @@ Mesh.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRenderer):
     else if (!warned)
     {
         warned = true;
-        if (globalThis.console)
-        {
-            console.warn('Mesh with custom shaders are not supported in CanvasRenderer.');
-        }
+        globalThis.console.warn('Mesh with custom shaders are not supported in CanvasRenderer.');
     }
 };
-
-// IMPORTANT: Please do NOT use this as a precedent to use `settings` after the object is created
-// this was merely created to completely decouple canvas from the base Mesh class and we are
-// unable to add `canvasPadding` in the constructor anymore, as the case was for PixiJS v4.
 
 /**
  * Internal variable for `canvasPadding`.
@@ -72,9 +64,19 @@ Mesh.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRenderer):
 Mesh.prototype._canvasPadding = null;
 
 /**
+ * Default `canvasPadding` for canvas-based Mesh rendering.
+ * @see PIXI.Mesh.canvasPadding
+ * @static
+ * @memberof PIXI.Mesh
+ * @member {number}
+ * @default 0
+ */
+Mesh.defaultCanvasPadding = 0;
+
+/**
  * Triangles in canvas mode are automatically antialiased, use this value to force triangles
- * to overlap a bit with each other. To set the global default, set {@link PIXI.settings.MESH_CANVAS_PADDING}
- * @see PIXI.settings.MESH_CANVAS_PADDING
+ * to overlap a bit with each other. To set the global default, set {@link PIXI.Mesh.defaultCanvasPadding}
+ * @see PIXI.Mesh.defaultCanvasPadding
  * @member {number} canvasPadding
  * @memberof PIXI.Mesh
  * @default 0
@@ -82,7 +84,7 @@ Mesh.prototype._canvasPadding = null;
 Object.defineProperty(Mesh.prototype, 'canvasPadding', {
     get()
     {
-        return this._canvasPadding ?? settings.MESH_CANVAS_PADDING;
+        return this._canvasPadding ?? Mesh.defaultCanvasPadding;
     },
     set(value)
     {

--- a/packages/canvas-mesh/src/settings.ts
+++ b/packages/canvas-mesh/src/settings.ts
@@ -1,13 +1,28 @@
-import { settings } from '@pixi/core';
+import { settings, utils } from '@pixi/core';
+import { Mesh } from '@pixi/mesh';
 
-/**
- * Default `canvasPadding` for canvas-based Mesh rendering.
- * @see PIXI.Mesh.canvasPadding
- * @static
- * @memberof PIXI.settings
- * @member {number}
- * @default 0
- */
-settings.MESH_CANVAS_PADDING = 0;
+Object.defineProperties(settings, {
+    /**
+     * Default `canvasPadding` for canvas-based Mesh rendering.
+     * @see PIXI.Mesh.defaultCanvasPadding
+     * @deprecated since 7.1.0
+     * @static
+     * @memberof PIXI.settings
+     * @member {number}
+     */
+    MESH_CANVAS_PADDING: {
+        get()
+        {
+            return Mesh.defaultCanvasPadding;
+        },
+        set(value: number)
+        {
+            // #if _DEBUG
+            utils.deprecation('7.1.0', 'settings.MESH_CANVAS_PADDING is deprecated, use Mesh.defaultCanvasPadding');
+            // #endif
+            Mesh.defaultCanvasPadding = value;
+        },
+    },
+});
 
 export { settings };

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -138,7 +138,6 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @deprecated since 7.1.0
      * @type {number}
-     * @default 1
      * @see PIXI.Filter.defaultResolution
      */
     FILTER_RESOLUTION: {
@@ -163,7 +162,6 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @deprecated since 7.1.0
      * @type {PIXI.MSAA_QUALITY}
-     * @default PIXI.MSAA_QUALITY.NONE
      * @see PIXI.Filter.defaultMultisample
      */
     FILTER_MULTISAMPLE: {
@@ -260,6 +258,7 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @type {PIXI.GC_MODES}
      * @deprecated since 7.1.0
+     * @see PIXI.TextureGCSystem.defaultMode
      */
     GC_MODE: {
         get()
@@ -282,6 +281,7 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @type {number}
      * @deprecated since 7.1.0
+     * @see PIXI.TextureGCSystem.defaultMaxIdle
      */
     GC_MAX_IDLE: {
         get()
@@ -304,6 +304,7 @@ Object.defineProperties(settings, {
      * @memberof PIXI.settings
      * @type {number}
      * @deprecated since 7.1.0
+     * @see PIXI.TextureGCSystem.defaultCheckCountMax
      */
     GC_MAX_CHECK_COUNT: {
         get()

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -30,6 +30,13 @@ export interface Mesh extends GlobalMixins.Mesh {}
 export class Mesh<T extends Shader = MeshMaterial> extends Container
 {
     /**
+     * Used by the @pixi/canvas-mesh package to draw meshes using canvas.
+     * Added here because we cannot mixin a static property to Mesh type.
+     * @ignore
+     */
+    public static defaultCanvasPadding: number;
+
+    /**
      * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
      * Can be shared between multiple Mesh objects.
      * @type {PIXI.Shader|PIXI.MeshMaterial}


### PR DESCRIPTION
### Deprecated

* Removes `settings.MESH_CANVAS_PADDING` becomes `Mesh.defaultCanvasPadding`