### PR TITLE
Feature: Add `Text.graphemeSegmenter` option

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -10,6 +10,27 @@ import type { IDestroyOptions } from '@pixi/display';
 import type { ICanvas, ICanvasRenderingContext2D } from '@pixi/settings';
 import type { ITextStyle } from './TextStyle';
 
+// The type for Intl.Segmenter is only available since TypeScript 4.7.2, so let's make a polyfill for it.
+interface ISegmentData
+{
+    segment: string;
+}
+interface ISegments
+{
+    [Symbol.iterator](): IterableIterator<ISegmentData>;
+}
+interface ISegmenter
+{
+    segment(input: string): ISegments;
+}
+interface IIntl
+{
+    Segmenter?: {
+        prototype: ISegmenter;
+        new(): ISegmenter;
+    };
+}
+
 const defaultDestroyOptions: IDestroyOptions = {
     texture: true,
     children: false,
@@ -73,10 +94,9 @@ export class Text extends Sprite
      */
     public static graphemeSegmenter: (s: string) => string[] = (() =>
     {
-        // TODO: Type for Intl.Segmenter
-        if (typeof (Intl as any)?.Segmenter === 'function')
+        if (typeof (Intl as IIntl)?.Segmenter === 'function')
         {
-            const segmenter = new (Intl as any).Segmenter();
+            const segmenter = new (Intl as IIntl).Segmenter();
 
             return (s: string) => [...segmenter.segment(s)].map((x) => x.segment);
         }

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -60,6 +60,30 @@ export class Text extends Sprite
      */
     public static experimentalLetterSpacing = false;
 
+    /**
+     * A Unicode "character", or "grapheme cluster", can be composed of multiple Unicode code points,
+     * such as letters with diacritical marks (e.g. `'\u0065\u0301'`, letter e with acute)
+     * or emojis with modifiers (e.g. `'\uD83E\uDDD1\u200D\uD83D\uDCBB'`, technologist).
+     * The new `Intl.Segmenter` API in ES2022 can split the string into grapheme clusters correctly. If it is not available,
+     * PixiJS will fallback to use the iterator of String, which can only spilt the string into code points.
+     * If you want to get full functionality in environments that don't support `Intl.Segmenter` (such as Firefox),
+     * you can use other libraries such as [grapheme-splitter]{@link https://www.npmjs.com/package/grapheme-splitter}
+     * or [graphemer]{@link https://www.npmjs.com/package/graphemer} to create a polyfill. Since these libraries can be
+     * relatively large in size to handle various Unicode grapheme clusters properly, PixiJS won't use them directly.
+     */
+    public static graphemeSegmenter: (s: string) => string[] = (() =>
+    {
+        // TODO: Type for Intl.Segmenter
+        if (typeof (Intl as any)?.Segmenter === 'function')
+        {
+            const segmenter = new (Intl as any).Segmenter();
+
+            return (s: string) => [...segmenter.segment(s)].map((x) => x.segment);
+        }
+
+        return (s: string) => [...s];
+    })();
+
     /** The canvas element that everything is drawn to. */
     public canvas: ICanvas;
     /** The canvas 2d context that everything is drawn with. */
@@ -353,13 +377,7 @@ export class Text extends Sprite
 
         let currentPosition = x;
 
-        // Using Array.from correctly splits characters whilst keeping emoji together.
-        // This is not supported on IE as it requires ES6, so regular text splitting occurs.
-        // This also doesn't account for emoji that are multiple emoji put together to make something else.
-        // Handling all of this would require a big library itself.
-        // https://medium.com/@giltayar/iterating-over-emoji-characters-the-es6-way-f06e4589516
-        // https://github.com/orling/grapheme-splitter
-        const stringArray = Array.from ? Array.from(text) : text.split('');
+        const stringArray = Text.graphemeSegmenter(text);
         let previousWidth = this.context.measureText(text).width;
         let currentWidth = 0;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

The `Text` used to use `Array.from` to split strings into code points, which is not enough for characters that is composed of multiple code points. Now that most of the browsers support [`Intl.Segmenter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter/Segmenter) which can split strings into grapheme cluster, we can use it to split strings properly, and fallback to `[...string]` when it is not available. The segmenter function is provided as a static field `Text.graphemeSegmenter: (s: string) => string[]`, and users can set it to their own polyfill when needed.

See https://github.com/pixijs/pixijs/issues/5571#issuecomment-1324614159 for more context.

#### Todo List

- [x] Type for `Intl.Segmenter`

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
