### PR TITLE
Cleanup unused Asset.init options

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -9,7 +9,7 @@ import { isSingleItem } from './utils/isSingleItem';
 
 import type { FormatDetectionParser } from './detections';
 import type { LoadAsset, LoaderParser } from './loader';
-import type { PreferOrder, ResolveAsset, ResolveURLParser, ResolverBundle, ResolverManifest } from './resolver';
+import type { ResolveAsset, ResolverBundle, ResolverManifest } from './resolver';
 
 export type ProgressCallback = (progress: number) => void;
 
@@ -45,21 +45,6 @@ export interface AssetInitOptions
         /** custom parsers can be added here, for example something that could load a sound or a 3D model */
         parsers?: LoaderParser[];
         // more...
-    };
-    /** resolver specific options */
-    resolver?: {
-        /**
-         * a list of urlParsers, these can read the URL and pick put the various options.
-         * for example there is a texture URL parser that picks our resolution and file format.
-         * You can add custom ways to read URLs and extract information here.
-         */
-        urlParsers?: ResolveURLParser[];
-        /**
-         * a list of preferOrders that let the resolver know which asset to pick.
-         * already built-in we have a texture preferOrders that let the resolve know which asset to prefer
-         * if it has multiple assets to pick from (resolution/formats etc)
-         */
-        preferOrders?: PreferOrder[];
     };
 }
 


### PR DESCRIPTION
The resolver options in the AssetInitOptions never was used. 

The preferred way to change these things is:

* Use `extensions.add` (for `options.resolver.urlParsers`) 
* Use `Assets.resolver.prefer` (for `options.resolver.preferOrders`)