### PR TITLE
Adjust height for single-lined stroked Text

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -153,7 +153,7 @@ export class TextMetrics
         }
 
         const lineHeight = style.lineHeight || fontProperties.fontSize + style.strokeThickness;
-        let height = Math.max(lineHeight, fontProperties.fontSize + style.strokeThickness)
+        let height = Math.max(lineHeight, fontProperties.fontSize + (style.strokeThickness * 2))
             + ((lines.length - 1) * (lineHeight + style.leading));
 
         if (style.dropShadow)


### PR DESCRIPTION
Closes #8860

**Broken**: https://jsfiddle.net/bigtimebuddy/zmfkoxe9/
**Fixed**: https://jsfiddle.net/bigtimebuddy/mh0qa1g2/

Our new lineHeight behavior didn't account for stroke with single-line text creating cut-off strokes.