### PR TITLE
Allow for easier overriding of text resolution 

### DIFF
--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -81,12 +81,24 @@ export class Text extends Sprite
      * // renderer has a resolution of 1
      * const app = new Application();
      *
-     * settings.RESOLUTION = 2;
+     * Text.defaultResolution = 2;
      * Text.defaultAutoResolution = false;
      * // text has a resolution of 2
      * const text = new Text('This is a PixiJS text');
      */
     public static defaultAutoResolution = true;
+
+    /**
+     * If {@link PIXI.Text.defaultAutoResolution} is false, this will be the default resolution of the text.
+     * If not set it will default to {@link PIXI.settings.RESOLUTION}.
+     * @example
+     * Text.defaultResolution = 2;
+     * Text.defaultAutoResolution = false;
+     *
+     * // text has a resolution of 2
+     * const text = new Text('This is a PixiJS text');
+     */
+    public static defaultResolution: number;
 
     /**
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will
@@ -198,7 +210,7 @@ export class Text extends Sprite
             willReadFrequently: true,
         });
 
-        this._resolution = settings.RESOLUTION;
+        this._resolution = Text.defaultResolution ?? settings.RESOLUTION;
         this._autoResolution = Text.defaultAutoResolution;
         this._text = null;
         this._style = null;

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -10,27 +10,6 @@ import type { IDestroyOptions } from '@pixi/display';
 import type { ICanvas, ICanvasRenderingContext2D } from '@pixi/settings';
 import type { ITextStyle } from './TextStyle';
 
-// The type for Intl.Segmenter is only available since TypeScript 4.7.2, so let's make a polyfill for it.
-interface ISegmentData
-{
-    segment: string;
-}
-interface ISegments
-{
-    [Symbol.iterator](): IterableIterator<ISegmentData>;
-}
-interface ISegmenter
-{
-    segment(input: string): ISegments;
-}
-interface IIntl
-{
-    Segmenter?: {
-        prototype: ISegmenter;
-        new(): ISegmenter;
-    };
-}
-
 const defaultDestroyOptions: IDestroyOptions = {
     texture: true,
     children: false,
@@ -75,34 +54,24 @@ interface ModernContext2D extends ICanvasRenderingContext2D
 export class Text extends Sprite
 {
     /**
+     * Override whether or not the resolution of the text is automatically adjusted to match the resolution of the renderer.
+     * Setting this to false can allow you to get crisper text at lower render resolutions.
+     * @example
+     * // renderer has a resolution of 1
+     * const app = new Application();
+     *
+     * settings.RESOLUTION = 2;
+     * Text.defaultAutoResolution = false;
+     * // text has a resolution of 2
+     * const text = new Text('This is a PixiJS text');
+     */
+    public static defaultAutoResolution = true;
+    /**
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will
      * lead to more accurate letter-spacing results because it does not try to manually draw
      * each character. However, this Chrome API is experimental and may not serve all cases yet.
      */
     public static experimentalLetterSpacing = false;
-
-    /**
-     * A Unicode "character", or "grapheme cluster", can be composed of multiple Unicode code points,
-     * such as letters with diacritical marks (e.g. `'\u0065\u0301'`, letter e with acute)
-     * or emojis with modifiers (e.g. `'\uD83E\uDDD1\u200D\uD83D\uDCBB'`, technologist).
-     * The new `Intl.Segmenter` API in ES2022 can split the string into grapheme clusters correctly. If it is not available,
-     * PixiJS will fallback to use the iterator of String, which can only spilt the string into code points.
-     * If you want to get full functionality in environments that don't support `Intl.Segmenter` (such as Firefox),
-     * you can use other libraries such as [grapheme-splitter]{@link https://www.npmjs.com/package/grapheme-splitter}
-     * or [graphemer]{@link https://www.npmjs.com/package/graphemer} to create a polyfill. Since these libraries can be
-     * relatively large in size to handle various Unicode grapheme clusters properly, PixiJS won't use them directly.
-     */
-    public static graphemeSegmenter: (s: string) => string[] = (() =>
-    {
-        if (typeof (Intl as IIntl)?.Segmenter === 'function')
-        {
-            const segmenter = new (Intl as IIntl).Segmenter();
-
-            return (s: string) => [...segmenter.segment(s)].map((x) => x.segment);
-        }
-
-        return (s: string) => [...s];
-    })();
 
     /** The canvas element that everything is drawn to. */
     public canvas: ICanvas;
@@ -185,7 +154,7 @@ export class Text extends Sprite
         });
 
         this._resolution = settings.RESOLUTION;
-        this._autoResolution = true;
+        this._autoResolution = Text.defaultAutoResolution;
         this._text = null;
         this._style = null;
         this._styleListener = null;
@@ -397,7 +366,13 @@ export class Text extends Sprite
 
         let currentPosition = x;
 
-        const stringArray = Text.graphemeSegmenter(text);
+        // Using Array.from correctly splits characters whilst keeping emoji together.
+        // This is not supported on IE as it requires ES6, so regular text splitting occurs.
+        // This also doesn't account for emoji that are multiple emoji put together to make something else.
+        // Handling all of this would require a big library itself.
+        // https://medium.com/@giltayar/iterating-over-emoji-characters-the-es6-way-f06e4589516
+        // https://github.com/orling/grapheme-splitter
+        const stringArray = Array.from ? Array.from(text) : text.split('');
         let previousWidth = this.context.measureText(text).width;
         let currentWidth = 0;
 


### PR DESCRIPTION
Added a static `defaultAutoResolution` and `defaultResolution` to `Text` that allows you to more easily set the resolution of your text 

Before: 
```ts
// renderer resolution 1
const app = new Application();

settings.RESOLUTION = 2;

// resolution is still 1 because of autoResolution
const text = new Text('hi');
```

After:
```ts
// resolution 1
const app = new Application();

Text.defaultResolution = 2;
Text.defaultAutoResolution = false;

// text resolution is now 2
const text = new Text('hi');
```

Also [here](https://jsfiddle.net/d53t27bg/) is an example of how text becomes crisper when renderer resolution is 1 and text is 2
