### PR TITLE
Deprecate precision settings to Program

### DIFF
--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -68,6 +68,10 @@ declare namespace GlobalMixins
         SCALE_MODE: import('@pixi/constants').SCALE_MODES;
         /** @deprecated */
         CAN_UPLOAD_SAME_BUFFER: boolean;
+        /** @deprecated */
+        PRECISION_VERTEX: import('@pixi/constants').PRECISION,
+        /** @deprecated */
+        PRECISION_FRAGMENT: import('@pixi/constants').PRECISION,
 
         STRICT_TEXTURE_CACHE: boolean;
         PREFER_ENV: import('@pixi/constants').ENV;

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -1,11 +1,12 @@
 import { settings } from '@pixi/settings';
-import type { MSAA_QUALITY, MIPMAP_MODES, SCALE_MODES, WRAP_MODES, GC_MODES } from '@pixi/constants';
+import type { MSAA_QUALITY, MIPMAP_MODES, SCALE_MODES, WRAP_MODES, GC_MODES, PRECISION } from '@pixi/constants';
 import { ENV } from '@pixi/constants';
 import { BaseTexture } from './textures/BaseTexture';
 import { Filter } from './filters/Filter';
 import { deprecation } from '@pixi/utils';
 import { BatchRenderer } from './batch/BatchRenderer';
 import { TextureGCSystem } from './systems';
+import { Program } from './shader/Program';
 
 /**
  * The maximum support for using WebGL. If a device does not
@@ -317,6 +318,52 @@ Object.defineProperties(settings, {
             deprecation('7.1.0', 'settings.GC_MAX_CHECK_COUNT is deprecated, use TextureGCSystem.defaultCheckCountMax');
             // #endif
             TextureGCSystem.defaultCheckCountMax = value;
+        },
+    },
+
+    /**
+     * Default specify float precision in vertex shader.
+     * @static
+     * @name PRECISION_VERTEX
+     * @memberof PIXI.settings
+     * @type {PIXI.PRECISION}
+     * @deprecated since 7.1.0
+     * @see PIXI.Program.defaultVertexPrecision
+     */
+    PRECISION_VERTEX: {
+        get()
+        {
+            return Program.defaultVertexPrecision;
+        },
+        set(value: PRECISION)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.PRECISION_VERTEX is deprecated, use Program.defaultVertexPrecision');
+            // #endif
+            Program.defaultVertexPrecision = value;
+        },
+    },
+
+    /**
+     * Default specify float precision in fragment shader.
+     * @static
+     * @name PRECISION_FRAGMENT
+     * @memberof PIXI.settings
+     * @type {PIXI.PRECISION}
+     * @deprecated since 7.1.0
+     * @see PIXI.Program.defaultFragmentPrecision
+     */
+    PRECISION_FRAGMENT: {
+        get()
+        {
+            return Program.defaultFragmentPrecision;
+        },
+        set(value: PRECISION)
+        {
+            // #if _DEBUG
+            deprecation('7.1.0', 'settings.PRECISION_FRAGMENT is deprecated, use Program.defaultFragmentPrecision');
+            // #endif
+            Program.defaultFragmentPrecision = value;
         },
     },
 });

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -1,9 +1,8 @@
 import { setPrecision,
     getMaxFragmentPrecision } from './utils';
-import { ProgramCache } from '@pixi/utils';
+import { ProgramCache, isMobile } from '@pixi/utils';
 import defaultFragment from './defaultProgram.frag';
 import defaultVertex from './defaultProgram.vert';
-import { settings } from '@pixi/settings';
 import { PRECISION } from '@pixi/constants';
 
 import type { GLProgram } from './GLProgram';
@@ -44,6 +43,25 @@ export interface IProgramExtraData
  */
 export class Program
 {
+    /**
+     * Default specify float precision in vertex shader.
+     * @static
+     * @type {PIXI.PRECISION}
+     * @default PIXI.PRECISION.HIGH
+     */
+    public static defaultVertexPrecision: PRECISION = PRECISION.HIGH;
+
+    /**
+     * Default specify float precision in fragment shader.
+     * iOS is best set at highp due to https://github.com/pixijs/pixijs/issues/3742
+     * @static
+     * @type {PIXI.PRECISION}
+     * @default PIXI.PRECISION.MEDIUM
+     */
+    public static defaultFragmentPrecision: PRECISION = isMobile.apple.device
+        ? PRECISION.HIGH
+        : PRECISION.MEDIUM;
+
     public id: number;
 
     /** Source code for the vertex shader. */
@@ -98,8 +116,16 @@ export class Program
             this.vertexSrc = `#define SHADER_NAME ${name}\n${this.vertexSrc}`;
             this.fragmentSrc = `#define SHADER_NAME ${name}\n${this.fragmentSrc}`;
 
-            this.vertexSrc = setPrecision(this.vertexSrc, settings.PRECISION_VERTEX, PRECISION.HIGH);
-            this.fragmentSrc = setPrecision(this.fragmentSrc, settings.PRECISION_FRAGMENT, getMaxFragmentPrecision());
+            this.vertexSrc = setPrecision(
+                this.vertexSrc,
+                Program.defaultVertexPrecision,
+                PRECISION.HIGH
+            );
+            this.fragmentSrc = setPrecision(
+                this.fragmentSrc,
+                Program.defaultFragmentPrecision,
+                getMaxFragmentPrecision()
+            );
         }
 
         // currently this does not extract structs only default types
@@ -111,7 +137,7 @@ export class Program
 
     /**
      * The default vertex shader source.
-     * @constant
+     * @readonly
      */
     static get defaultVertexSrc(): string
     {
@@ -120,7 +146,7 @@ export class Program
 
     /**
      * The default fragment shader source.
-     * @constant
+     * @readonly
      */
     static get defaultFragmentSrc(): string
     {

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -1,6 +1,4 @@
-import { PRECISION } from '@pixi/constants';
 import { BrowserAdapter } from './adapter';
-import { isMobile } from './utils/isMobile';
 
 import type { ICanvas } from './ICanvas';
 import type { IAdapter } from './adapter';
@@ -29,8 +27,6 @@ interface ISettings
     ADAPTER: IAdapter;
     RESOLUTION: number;
     RENDER_OPTIONS: IRenderOptions;
-    PRECISION_VERTEX: PRECISION;
-    PRECISION_FRAGMENT: PRECISION;
     CREATE_IMAGE_BITMAP: boolean;
     ROUND_PIXELS: boolean;
 }
@@ -108,27 +104,6 @@ export const settings: ISettings & Partial<GlobalMixins.Settings> = {
         legacy: false,
         hello: false,
     },
-
-    /**
-     * Default specify float precision in vertex shader.
-     * @static
-     * @name PRECISION_VERTEX
-     * @memberof PIXI.settings
-     * @type {PIXI.PRECISION}
-     * @default PIXI.PRECISION.HIGH
-     */
-    PRECISION_VERTEX: PRECISION.HIGH,
-
-    /**
-     * Default specify float precision in fragment shader.
-     * iOS is best set at highp due to https://github.com/pixijs/pixijs/issues/3742
-     * @static
-     * @name PRECISION_FRAGMENT
-     * @memberof PIXI.settings
-     * @type {PIXI.PRECISION}
-     * @default PIXI.PRECISION.MEDIUM
-     */
-    PRECISION_FRAGMENT: isMobile.apple.device ? PRECISION.HIGH : PRECISION.MEDIUM,
 
     /**
      * Enables bitmap creation before image load. This feature is experimental.

--- a/packages/settings/test/settings.tests.ts
+++ b/packages/settings/test/settings.tests.ts
@@ -17,14 +17,4 @@ describe('settings', () =>
     {
         expect(settings.RENDER_OPTIONS).toBeObject();
     });
-
-    it('should have PRECISION_VERTEX', () =>
-    {
-        expect(settings.PRECISION_VERTEX).toBeString();
-    });
-
-    it('should have PRECISION_FRAGMENT', () =>
-    {
-        expect(settings.PRECISION_FRAGMENT).toBeString();
-    });
 });


### PR DESCRIPTION
Likely the last PR for now of settings being migrated to classes.

### Deprecate

* Moves `settings.PRECISION_FRAGMENT` to `Program.defaultFragmentPrecision`
* Moves `settings.PRECISION_VERTEX` to `Program.defaultVertexPrecision`

