### PR TITLE
Chore: Remove constant tag from documentation

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -446,7 +446,6 @@ export enum GC_MODES
  * Constants that specify float precision in shaders.
  * @name PRECISION
  * @memberof PIXI
- * @constant
  * @static
  * @enum {string}
  * @property {string} [LOW='lowp'] -

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -302,7 +302,7 @@ export class Filter extends Shader
 
     /**
      * The default vertex shader source
-     * @constant
+     * @readonly
      */
     static get defaultVertexSrc(): string
     {
@@ -311,7 +311,7 @@ export class Filter extends Shader
 
     /**
      * The default fragment shader source
-     * @constant
+     * @readonly
      */
     static get defaultFragmentSrc(): string
     {

--- a/packages/core/src/renderTexture/RenderTexturePool.ts
+++ b/packages/core/src/renderTexture/RenderTexturePool.ts
@@ -220,7 +220,7 @@ export class RenderTexturePool
 
     /**
      * Key that is used to store fullscreen renderTextures in a pool
-     * @constant
+     * @readonly
      */
     static SCREEN_KEY = -1;
 }

--- a/packages/core/src/shader/Program.ts
+++ b/packages/core/src/shader/Program.ts
@@ -111,7 +111,7 @@ export class Program
 
     /**
      * The default vertex shader source.
-     * @constant
+     * @readonly
      */
     static get defaultVertexSrc(): string
     {
@@ -120,7 +120,7 @@ export class Program
 
     /**
      * The default fragment shader source.
-     * @constant
+     * @readonly
      */
     static get defaultFragmentSrc(): string
     {

--- a/packages/display/src/settings.ts
+++ b/packages/display/src/settings.ts
@@ -5,7 +5,6 @@ Object.defineProperties(settings, {
     /**
      * Sets the default value for the container property 'sortableChildren'.
      * @static
-     * @constant
      * @name SORTABLE_CHILDREN
      * @memberof PIXI.settings
      * @deprecated since 7.1.0

--- a/packages/graphics/src/const.ts
+++ b/packages/graphics/src/const.ts
@@ -85,7 +85,7 @@ export const curves = {
 
 /**
  * @static
- * @constant
+ * @readonly
  * @memberof PIXI
  * @name GRAPHICS_CURVES
  * @type {object}

--- a/packages/math/src/groupD8.ts
+++ b/packages/math/src/groupD8.ts
@@ -116,8 +116,7 @@ export const groupD8 = {
      * | Rotation | Direction |
      * |----------|-----------|
      * | 0°       | East      |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     E: 0,
 
@@ -125,8 +124,7 @@ export const groupD8 = {
      * | Rotation | Direction |
      * |----------|-----------|
      * | 45°↻     | Southeast |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     SE: 1,
 
@@ -134,8 +132,7 @@ export const groupD8 = {
      * | Rotation | Direction |
      * |----------|-----------|
      * | 90°↻     | South     |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     S: 2,
 
@@ -143,8 +140,7 @@ export const groupD8 = {
      * | Rotation | Direction |
      * |----------|-----------|
      * | 135°↻    | Southwest |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     SW: 3,
 
@@ -152,8 +148,7 @@ export const groupD8 = {
      * | Rotation | Direction |
      * |----------|-----------|
      * | 180°     | West      |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     W: 4,
 
@@ -161,8 +156,7 @@ export const groupD8 = {
      * | Rotation    | Direction    |
      * |-------------|--------------|
      * | -135°/225°↻ | Northwest    |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     NW: 5,
 
@@ -170,8 +164,7 @@ export const groupD8 = {
      * | Rotation    | Direction    |
      * |-------------|--------------|
      * | -90°/270°↻  | North        |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     N: 6,
 
@@ -179,41 +172,35 @@ export const groupD8 = {
      * | Rotation    | Direction    |
      * |-------------|--------------|
      * | -45°/315°↻  | Northeast    |
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     NE: 7,
 
     /**
      * Reflection about Y-axis.
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     MIRROR_VERTICAL: 8,
 
     /**
      * Reflection about the main diagonal.
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     MAIN_DIAGONAL: 10,
 
     /**
      * Reflection about X-axis.
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     MIRROR_HORIZONTAL: 12,
 
     /**
      * Reflection about reverse diagonal.
-     * @memberof PIXI.groupD8
-     * @constant {PIXI.GD8Symmetry}
+     * @readonly
      */
     REVERSE_DIAGONAL: 14,
 
     /**
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
      * @returns {PIXI.GD8Symmetry} The X-component of the U-axis
      *    after rotating the axes.
@@ -221,7 +208,6 @@ export const groupD8 = {
     uX: (ind: GD8Symmetry): GD8Symmetry => ux[ind],
 
     /**
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
      * @returns {PIXI.GD8Symmetry} The Y-component of the U-axis
      *    after rotating the axes.
@@ -229,7 +215,6 @@ export const groupD8 = {
     uY: (ind: GD8Symmetry): GD8Symmetry => uy[ind],
 
     /**
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
      * @returns {PIXI.GD8Symmetry} The X-component of the V-axis
      *    after rotating the axes.
@@ -237,7 +222,6 @@ export const groupD8 = {
     vX: (ind: GD8Symmetry): GD8Symmetry => vx[ind],
 
     /**
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} ind - sprite rotation angle.
      * @returns {PIXI.GD8Symmetry} The Y-component of the V-axis
      *    after rotating the axes.
@@ -245,7 +229,6 @@ export const groupD8 = {
     vY: (ind: GD8Symmetry): GD8Symmetry => vy[ind],
 
     /**
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} rotation - symmetry whose opposite
      *   is needed. Only rotations have opposite symmetries while
      *   reflections don't.
@@ -278,7 +261,6 @@ export const groupD8 = {
      * | N^=14 | N^  | W^  | S^  | E^  | N    | W     | S     | E     |
      *
      * [This is a Cayley table]{@link https://en.wikipedia.org/wiki/Cayley_table}
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} rotationSecond - Second operation, which
      *   is the row in the above cayley table.
      * @param {PIXI.GD8Symmetry} rotationFirst - First operation, which
@@ -291,7 +273,6 @@ export const groupD8 = {
 
     /**
      * Reverse of `add`.
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} rotationSecond - Second operation
      * @param {PIXI.GD8Symmetry} rotationFirst - First operation
      * @returns {PIXI.GD8Symmetry} Result
@@ -303,7 +284,6 @@ export const groupD8 = {
     /**
      * Adds 180 degrees to rotation, which is a commutative
      * operation.
-     * @memberof PIXI.groupD8
      * @param {number} rotation - The number to rotate.
      * @returns {number} Rotated number
      */
@@ -312,7 +292,6 @@ export const groupD8 = {
     /**
      * Checks if the rotation angle is vertical, i.e. south
      * or north. It doesn't work for reflections.
-     * @memberof PIXI.groupD8
      * @param {PIXI.GD8Symmetry} rotation - The number to check.
      * @returns {boolean} Whether or not the direction is vertical
      */
@@ -321,7 +300,6 @@ export const groupD8 = {
     /**
      * Approximates the vector `V(dx,dy)` into one of the
      * eight directions provided by `groupD8`.
-     * @memberof PIXI.groupD8
      * @param {number} dx - X-component of the vector
      * @param {number} dy - Y-component of the vector
      * @returns {PIXI.GD8Symmetry} Approximation of the vector into
@@ -366,7 +344,6 @@ export const groupD8 = {
 
     /**
      * Helps sprite to compensate texture packer rotation.
-     * @memberof PIXI.groupD8
      * @param {PIXI.Matrix} matrix - sprite world matrix
      * @param {PIXI.GD8Symmetry} rotation - The rotation factor to use.
      * @param {number} tx - sprite anchoring

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -145,7 +145,6 @@ export const settings: ISettings & Partial<GlobalMixins.Settings> = {
      * Advantages can include sharper image quality (like text) and faster rendering on canvas.
      * The main disadvantage is movement of objects may appear less smooth.
      * @static
-     * @constant
      * @memberof PIXI.settings
      * @type {boolean}
      * @default false

--- a/packages/text/src/const.ts
+++ b/packages/text/src/const.ts
@@ -1,7 +1,6 @@
 /**
  * Constants that define the type of gradient on text.
  * @static
- * @constant
  * @name TEXT_GRADIENT
  * @memberof PIXI
  * @type {object}

--- a/packages/ticker/src/const.ts
+++ b/packages/ticker/src/const.ts
@@ -3,7 +3,6 @@
  * the {@link PIXI.Ticker} object. Higher priority items are updated first and lower
  * priority items, such as render, should go later.
  * @static
- * @constant
  * @name UPDATE_PRIORITY
  * @memberof PIXI
  * @enum {number}

--- a/packages/utils/src/color/premultiply.ts
+++ b/packages/utils/src/color/premultiply.ts
@@ -37,7 +37,6 @@ function mapPremultipliedBlendModes(): number[][]
 /**
  * maps premultiply flag and blendMode to adjusted blendMode
  * @memberof PIXI.utils
- * @constant premultiplyBlendMode
  * @type {Array<number[]>}
  */
 export const premultiplyBlendMode = mapPremultipliedBlendModes();

--- a/packages/utils/src/const.ts
+++ b/packages/utils/src/const.ts
@@ -2,8 +2,11 @@
  * Regexp for data URI.
  * Based on: {@link https://github.com/ragingwind/data-uri-regex}
  * @static
- * @constant {RegExp|string} DATA_URI
+ * @type {RegExp}
  * @memberof PIXI
- * @example data:image/png;base64
+ * @example
+ * import { DATA_URI } from 'pixi.js';
+ *
+ * DATA_URI.test('data:image/png;base64,foobar'); // => true
  */
 export const DATA_URI = /^\s*data:(?:([\w-]+)\/([\w+.-]+))?(?:;charset=([\w-]+))?(?:;(base64))?,(.*)/i;


### PR DESCRIPTION
Documentation cleanup to remove `@constant` which is not a thing in webdoc.
Clarified in some places with `@readonly`.