### PR TITLE
Chore: Cleanup Text and TextMetrics

### DIFF
--- a/bundles/pixi.js-node/src/adapter/adapter.ts
+++ b/bundles/pixi.js-node/src/adapter/adapter.ts
@@ -1,3 +1,4 @@
+import canvasModule from 'canvas';
 import { fetch, Request, Response } from 'cross-fetch';
 import fs from 'fs';
 import { WebGLRenderingContext } from 'gl';
@@ -15,7 +16,8 @@ export const NodeAdapter = {
      * @param height - height of the canvas
      */
     createCanvas: (width?: number, height?: number) => new NodeCanvasElement(width, height),
-    /** Returns a webgl rendering context using the gl package. */
+    getCanvasRenderingContext2D: () => canvasModule.CanvasRenderingContext2D,
+    /** Returns a WebGL rendering context using the gl package. */
     getWebGLRenderingContext: () => WebGLRenderingContext,
     /** Returns the fake user agent string of `node` */
     getNavigator: () => ({ userAgent: 'node' }),

--- a/bundles/pixi.js-webworker/src/adapter.ts
+++ b/bundles/pixi.js-webworker/src/adapter.ts
@@ -11,6 +11,7 @@ export const WebWorkerAdapter = {
      * @param height - height of the canvas
      */
     createCanvas: (width?: number, height?: number) => new OffscreenCanvas(width | 0, height | 0),
+    getCanvasRenderingContext2D: () => CanvasRenderingContext2D,
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => globalThis.location.href,

--- a/packages/settings/src/ICanvasRenderingContext2D.ts
+++ b/packages/settings/src/ICanvasRenderingContext2D.ts
@@ -28,6 +28,6 @@ export interface ICanvasRenderingContext2D extends
     drawImage(image: CanvasImageSource | ICanvas, sx: number, sy: number, sw: number, sh: number,
         dx: number, dy: number, dw: number, dh: number): void;
 
-    letterSpacing?: number;
-    textLetterSpacing?: number; // For Chrome < 94
+    letterSpacing?: string;
+    textLetterSpacing?: string; // For Chrome < 94
 }

--- a/packages/settings/src/ICanvasRenderingContext2D.ts
+++ b/packages/settings/src/ICanvasRenderingContext2D.ts
@@ -27,4 +27,7 @@ export interface ICanvasRenderingContext2D extends
     drawImage(image: CanvasImageSource | ICanvas, dx: number, dy: number, dw: number, dh: number): void;
     drawImage(image: CanvasImageSource | ICanvas, sx: number, sy: number, sw: number, sh: number,
         dx: number, dy: number, dw: number, dh: number): void;
+
+    letterSpacing?: number;
+    textLetterSpacing?: number; // For Chrome < 94
 }

--- a/packages/settings/src/adapter.ts
+++ b/packages/settings/src/adapter.ts
@@ -1,4 +1,5 @@
 import type { ICanvas } from './ICanvas';
+import type { ICanvasRenderingContext2D } from './ICanvasRenderingContext2D';
 
 /**
  * This interface describes all the DOM dependent calls that Pixi makes throughout its codebase.
@@ -10,7 +11,9 @@ export interface IAdapter
 {
     /** Returns a canvas object that can be used to create a webgl context. */
     createCanvas: (width?: number, height?: number) => ICanvas;
-    /** Returns a webgl rendering context. */
+    /** Returns a 2D rendering context. */
+    getCanvasRenderingContext2D: () => { prototype: ICanvasRenderingContext2D; };
+    /** Returns a WebGL rendering context. */
     getWebGLRenderingContext: () => typeof WebGLRenderingContext;
     /** Returns a partial implementation of the browsers window.navigator */
     getNavigator: () => { userAgent: string };
@@ -37,6 +40,7 @@ export const BrowserAdapter = {
 
         return canvas;
     },
+    getCanvasRenderingContext2D: () => CanvasRenderingContext2D,
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI ?? window.location.href),

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -357,14 +357,14 @@ export class Text extends Sprite
         {
             if (TextMetrics.experimentalLetterSpacing)
             {
-                this.context.letterSpacing = letterSpacing;
-                this.context.textLetterSpacing = letterSpacing;
+                this.context.letterSpacing = `${letterSpacing}px`;
+                this.context.textLetterSpacing = `${letterSpacing}px`;
                 useExperimentalLetterSpacing = true;
             }
             else
             {
-                this.context.letterSpacing = 0;
-                this.context.textLetterSpacing = 0;
+                this.context.letterSpacing = '0px';
+                this.context.textLetterSpacing = '0px';
             }
         }
 

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -10,27 +10,6 @@ import type { IDestroyOptions } from '@pixi/display';
 import type { ICanvas, ICanvasRenderingContext2D } from '@pixi/settings';
 import type { ITextStyle } from './TextStyle';
 
-// The type for Intl.Segmenter is only available since TypeScript 4.7.2, so let's make a polyfill for it.
-interface ISegmentData
-{
-    segment: string;
-}
-interface ISegments
-{
-    [Symbol.iterator](): IterableIterator<ISegmentData>;
-}
-interface ISegmenter
-{
-    segment(input: string): ISegments;
-}
-interface IIntl
-{
-    Segmenter?: {
-        prototype: ISegmenter;
-        new(): ISegmenter;
-    };
-}
-
 const defaultDestroyOptions: IDestroyOptions = {
     texture: true,
     children: false,
@@ -106,29 +85,6 @@ export class Text extends Sprite
      * each character. However, this Chrome API is experimental and may not serve all cases yet.
      */
     public static experimentalLetterSpacing = false;
-
-    /**
-     * A Unicode "character", or "grapheme cluster", can be composed of multiple Unicode code points,
-     * such as letters with diacritical marks (e.g. `'\u0065\u0301'`, letter e with acute)
-     * or emojis with modifiers (e.g. `'\uD83E\uDDD1\u200D\uD83D\uDCBB'`, technologist).
-     * The new `Intl.Segmenter` API in ES2022 can split the string into grapheme clusters correctly. If it is not available,
-     * PixiJS will fallback to use the iterator of String, which can only spilt the string into code points.
-     * If you want to get full functionality in environments that don't support `Intl.Segmenter` (such as Firefox),
-     * you can use other libraries such as [grapheme-splitter]{@link https://www.npmjs.com/package/grapheme-splitter}
-     * or [graphemer]{@link https://www.npmjs.com/package/graphemer} to create a polyfill. Since these libraries can be
-     * relatively large in size to handle various Unicode grapheme clusters properly, PixiJS won't use them directly.
-     */
-    public static graphemeSegmenter: (s: string) => string[] = (() =>
-    {
-        if (typeof (Intl as IIntl)?.Segmenter === 'function')
-        {
-            const segmenter = new (Intl as IIntl).Segmenter();
-
-            return (s: string) => [...segmenter.segment(s)].map((x) => x.segment);
-        }
-
-        return (s: string) => [...s];
-    })();
 
     /** The canvas element that everything is drawn to. */
     public canvas: ICanvas;
@@ -423,7 +379,7 @@ export class Text extends Sprite
 
         let currentPosition = x;
 
-        const stringArray = Text.graphemeSegmenter(text);
+        const stringArray = TextMetrics.graphemeSegmenter(text);
         let previousWidth = this.context.measureText(text).width;
         let currentWidth = 0;
 

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -298,14 +298,14 @@ export class TextMetrics
         {
             if (TextMetrics.experimentalLetterSpacing)
             {
-                context.letterSpacing = letterSpacing;
-                context.textLetterSpacing = letterSpacing;
+                context.letterSpacing = `${letterSpacing}px`;
+                context.textLetterSpacing = `${letterSpacing}px`;
                 useExperimentalLetterSpacing = true;
             }
             else
             {
-                context.letterSpacing = 0;
-                context.textLetterSpacing = 0;
+                context.letterSpacing = '0px';
+                context.textLetterSpacing = '0px';
             }
         }
 

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -49,7 +49,7 @@ interface IFontMetrics
     fontSize: number;
 }
 
-type CharacterWidthCache = { [key: string]: number };
+type CharacterWidthCache = Record<string, number>;
 
 // Default settings used for all getContext calls
 const contextSettings: ICanvasRenderingContext2DSettings = {
@@ -139,7 +139,7 @@ export class TextMetrics
     })();
 
     /** Cache of {@see PIXI.TextMetrics.FontMetrics} objects. */
-    private static _fonts: { [font: string]: IFontMetrics } = {};
+    private static _fonts: Record<string, IFontMetrics> = {};
 
     /** Cache of new line chars. */
     private static _newlines: number[] = [

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -3,6 +3,45 @@ import { settings } from '@pixi/core';
 import type { ICanvas, ICanvasRenderingContext2D, ICanvasRenderingContext2DSettings } from '@pixi/settings';
 import type { TextStyle, TextStyleWhiteSpace } from './TextStyle';
 
+// The type for Intl.Segmenter is only available since TypeScript 4.7.2, so let's make a polyfill for it.
+interface ISegmentData
+{
+    segment: string;
+}
+interface ISegments
+{
+    [Symbol.iterator](): IterableIterator<ISegmentData>;
+}
+interface ISegmenter
+{
+    segment(input: string): ISegments;
+}
+interface IIntl
+{
+    Segmenter?: {
+        prototype: ISegmenter;
+        new(): ISegmenter;
+    };
+}
+
+/**
+ * Internal return object for {@link PIXI.TextMetrics.measureFont `TextMetrics.measureFont`}.
+ * @typedef {object} FontMetrics
+ * @property {number} ascent - The ascent distance
+ * @property {number} descent - The descent distance
+ * @property {number} fontSize - Font size from ascent to descent
+ * @memberof PIXI.TextMetrics
+ * @private
+ */
+
+/**
+ * A number, or a string containing a number.
+ * @memberof PIXI
+ * @typedef {object} IFontMetrics
+ * @property {number} ascent - Font ascent
+ * @property {number} descent - Font descent
+ * @property {number} fontSize - Font size
+ */
 interface IFontMetrics
 {
     ascent: number;
@@ -58,24 +97,76 @@ export class TextMetrics
     /** The maximum line width for all measured lines. */
     public maxLineWidth: number;
 
-    /**
-     * The font properties object from TextMetrics.measureFont.
-     * @type {PIXI.IFontMetrics}
-     */
+    /** The font properties object from TextMetrics.measureFont. */
     public fontProperties: IFontMetrics;
 
-    public static METRICS_STRING: string;
-    public static BASELINE_SYMBOL: string;
-    public static BASELINE_MULTIPLIER: number;
-    public static HEIGHT_MULTIPLIER: number;
+    /**
+     * String used for calculate font metrics.
+     * These characters are all tall to help calculate the height required for text.
+     */
+    public static METRICS_STRING = '|ÉqÅ';
+
+    /** Baseline symbol for calculate font metrics. */
+    public static BASELINE_SYMBOL = 'M';
+
+    /** Baseline multiplier for calculate font metrics. */
+    public static BASELINE_MULTIPLIER = 1.4;
+
+    /** Height multiplier for setting height of canvas to calculate font metrics. */
+    public static HEIGHT_MULTIPLIER = 2.0;
+
+    /**
+     * A Unicode "character", or "grapheme cluster", can be composed of multiple Unicode code points,
+     * such as letters with diacritical marks (e.g. `'\u0065\u0301'`, letter e with acute)
+     * or emojis with modifiers (e.g. `'\uD83E\uDDD1\u200D\uD83D\uDCBB'`, technologist).
+     * The new `Intl.Segmenter` API in ES2022 can split the string into grapheme clusters correctly. If it is not available,
+     * PixiJS will fallback to use the iterator of String, which can only spilt the string into code points.
+     * If you want to get full functionality in environments that don't support `Intl.Segmenter` (such as Firefox),
+     * you can use other libraries such as [grapheme-splitter]{@link https://www.npmjs.com/package/grapheme-splitter}
+     * or [graphemer]{@link https://www.npmjs.com/package/graphemer} to create a polyfill. Since these libraries can be
+     * relatively large in size to handle various Unicode grapheme clusters properly, PixiJS won't use them directly.
+     */
+    public static graphemeSegmenter: (s: string) => string[] = (() =>
+    {
+        if (typeof (Intl as IIntl)?.Segmenter === 'function')
+        {
+            const segmenter = new (Intl as IIntl).Segmenter();
+
+            return (s: string) => [...segmenter.segment(s)].map((x) => x.segment);
+        }
+
+        return (s: string) => [...s];
+    })();
+
+    /** Cache of {@see PIXI.TextMetrics.FontMetrics} objects. */
+    private static _fonts: { [font: string]: IFontMetrics } = {};
+
+    /** Cache of new line chars. */
+    private static _newlines: number[] = [
+        0x000A, // line feed
+        0x000D, // carriage return
+    ];
+
+    /** Cache of breaking spaces. */
+    private static _breakingSpaces: number[] = [
+        0x0009, // character tabulation
+        0x0020, // space
+        0x2000, // en quad
+        0x2001, // em quad
+        0x2002, // en space
+        0x2003, // em space
+        0x2004, // three-per-em space
+        0x2005, // four-per-em space
+        0x2006, // six-per-em space
+        0x2008, // punctuation space
+        0x2009, // thin space
+        0x200A, // hair space
+        0x205F, // medium mathematical space
+        0x3000, // ideographic space
+    ];
 
     private static __canvas: ICanvas;
     private static __context: ICanvasRenderingContext2D;
-
-    // TODO: These should be protected but they're initialized outside of the class.
-    public static _fonts: { [font: string]: IFontMetrics };
-    public static _newlines: number[];
-    public static _breakingSpaces: number[];
 
     /**
      * @param text - the text that was measured
@@ -276,14 +367,14 @@ export class TextMetrics
                     for (let j = 0; j < characters.length; j++)
                     {
                         let char = characters[j];
+                        let lastChar = char;
 
                         let k = 1;
-                        // we are not at the end of the token
 
+                        // we are not at the end of the token
                         while (characters[j + k])
                         {
                             const nextChar = characters[j + k];
-                            const lastChar = char[char.length - 1];
 
                             // should not split chars
                             if (!TextMetrics.canBreakChars(lastChar, nextChar, token, j, style.breakWords))
@@ -296,10 +387,11 @@ export class TextMetrics
                                 break;
                             }
 
+                            lastChar = nextChar;
                             k++;
                         }
 
-                        j += char.length - 1;
+                        j += k - 1;
 
                         const characterWidth = TextMetrics.getFromCache(char, letterSpacing, cache, context);
 
@@ -425,7 +517,7 @@ export class TextMetrics
     /**
      * Determines whether we should collapse newLine chars.
      * @param whiteSpace - The white space
-     * @returns  should collapse
+     * @returns should collapse
      */
     private static collapseNewlines(whiteSpace: TextStyleWhiteSpace): boolean
     {
@@ -434,7 +526,7 @@ export class TextMetrics
 
     /**
      * Trims breaking whitespaces from string.
-     * @param  text - The text
+     * @param text - The text
      * @returns Trimmed string
      */
     private static trimRight(text: string): string
@@ -461,7 +553,7 @@ export class TextMetrics
 
     /**
      * Determines if char is a newline.
-     * @param  char - The character
+     * @param char - The character
      * @returns True if newline, False otherwise.
      */
     private static isNewline(char: string): boolean
@@ -496,8 +588,8 @@ export class TextMetrics
 
     /**
      * Splits a string into words, breaking-spaces and newLine characters
-     * @param  text - The text
-     * @returns  A tokenized array
+     * @param text - The text
+     * @returns A tokenized array
      */
     private static tokenize(text: string): string[]
     {
@@ -545,7 +637,7 @@ export class TextMetrics
      * Examples are if the token is CJK or numbers.
      * It must return a boolean.
      * @param _token - The token
-     * @param  breakWords - The style attr break words
+     * @param breakWords - The style attr break words
      * @returns Whether to break word or not
      */
     static canBreakWords(_token: string, breakWords: boolean): boolean
@@ -579,15 +671,13 @@ export class TextMetrics
      * It is called when a token (usually a word) has to be split into separate pieces
      * in order to determine the point to break a word.
      * It must return an array of characters.
-     * @example
-     * // Correctly splits emojis, eg "🤪🤪" will result in two element array, each with one emoji.
-     * TextMetrics.wordWrapSplit = (token) => [...token];
-     * @param  token - The token to split
+     * @param token - The token to split
      * @returns The characters of the token
+     * @see TextMetrics.graphemeSegmenter
      */
     static wordWrapSplit(token: string): string[]
     {
-        return token.split('');
+        return TextMetrics.graphemeSegmenter(token);
     }
 
     /**
@@ -764,105 +854,3 @@ export class TextMetrics
         return TextMetrics.__context;
     }
 }
-
-/**
- * Internal return object for {@link PIXI.TextMetrics.measureFont `TextMetrics.measureFont`}.
- * @typedef {object} FontMetrics
- * @property {number} ascent - The ascent distance
- * @property {number} descent - The descent distance
- * @property {number} fontSize - Font size from ascent to descent
- * @memberof PIXI.TextMetrics
- * @private
- */
-
-/**
- * Cache of {@see PIXI.TextMetrics.FontMetrics} objects.
- * @memberof PIXI.TextMetrics
- * @type {object}
- * @private
- */
-TextMetrics._fonts = {};
-
-/**
- * String used for calculate font metrics.
- * These characters are all tall to help calculate the height required for text.
- * @static
- * @memberof PIXI.TextMetrics
- * @name METRICS_STRING
- * @type {string}
- * @default |ÉqÅ
- */
-TextMetrics.METRICS_STRING = '|ÉqÅ';
-
-/**
- * Baseline symbol for calculate font metrics.
- * @static
- * @memberof PIXI.TextMetrics
- * @name BASELINE_SYMBOL
- * @type {string}
- * @default M
- */
-TextMetrics.BASELINE_SYMBOL = 'M';
-
-/**
- * Baseline multiplier for calculate font metrics.
- * @static
- * @memberof PIXI.TextMetrics
- * @name BASELINE_MULTIPLIER
- * @type {number}
- * @default 1.4
- */
-TextMetrics.BASELINE_MULTIPLIER = 1.4;
-
-/**
- * Height multiplier for setting height of canvas to calculate font metrics.
- * @static
- * @memberof PIXI.TextMetrics
- * @name HEIGHT_MULTIPLIER
- * @type {number}
- * @default 2.00
- */
-TextMetrics.HEIGHT_MULTIPLIER = 2.0;
-
-/**
- * Cache of new line chars.
- * @memberof PIXI.TextMetrics
- * @type {number[]}
- * @private
- */
-TextMetrics._newlines = [
-    0x000A, // line feed
-    0x000D, // carriage return
-];
-
-/**
- * Cache of breaking spaces.
- * @memberof PIXI.TextMetrics
- * @type {number[]}
- * @private
- */
-TextMetrics._breakingSpaces = [
-    0x0009, // character tabulation
-    0x0020, // space
-    0x2000, // en quad
-    0x2001, // em quad
-    0x2002, // en space
-    0x2003, // em space
-    0x2004, // three-per-em space
-    0x2005, // four-per-em space
-    0x2006, // six-per-em space
-    0x2008, // punctuation space
-    0x2009, // thin space
-    0x200A, // hair space
-    0x205F, // medium mathematical space
-    0x3000, // ideographic space
-];
-
-/**
- * A number, or a string containing a number.
- * @memberof PIXI
- * @typedef {object} IFontMetrics
- * @property {number} ascent - Font ascent
- * @property {number} descent - Font descent
- * @property {number} fontSize - Font size
- */

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -311,9 +311,16 @@ export class TextMetrics
 
         let width = context.measureText(text).width;
 
-        if (!useExperimentalLetterSpacing)
+        if (width > 0)
         {
-            width += (TextMetrics.graphemeSegmenter(text).length - 1) * letterSpacing;
+            if (useExperimentalLetterSpacing)
+            {
+                width -= letterSpacing;
+            }
+            else
+            {
+                width += (TextMetrics.graphemeSegmenter(text).length - 1) * letterSpacing;
+            }
         }
 
         return width;

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -145,7 +145,12 @@ export class TextMetrics
      * @see PIXI.TextMetrics.experimentalLetterSpacing
      */
     public static readonly experimentalLetterSpacingSupported
-        = 'letterSpacing' in CanvasRenderingContext2D.prototype || 'textLetterSpacing' in CanvasRenderingContext2D.prototype;
+        = (() =>
+        {
+            const proto = settings.ADAPTER.getCanvasRenderingContext2D().prototype;
+
+            return 'letterSpacing' in proto || 'textLetterSpacing' in proto;
+        })();
 
     /**
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

- `Text.graphemeSegmenter` is moved to `TextMetrics.graphemeSegmenter`, so that we can use it in `TextMetrics.wordWrapSplit`
    - Fortunately there is no new release since #8893, so no breaking change :)
- `Text.experimentalLetterSpacing` is moved to `TextMetrics.experimentalLetterSpacing`
- Add `IAdapter.getCanvasRenderingContext2D`
- Fix `TextMetrics.wordWrap`, now it support characters with multiple code points
    - Before: https://pixiplayground.com/#/edit/xFjAqYprZeC30XfEqbK_5
    - After: https://pixiplayground.com/#/edit/MPDAY7vYU-o3zgYn_FOf2
    - After (with `TextMetrics.experimentalLetterSpacing = true`): https://pixiplayground.com/#/edit/THqQ6nbHZmXDyqSnZBoEk
    - See also https://github.com/pixijs/pixijs/issues/5571#issuecomment-1328875757
- Move static initialization that is outside of `TextMetrics` into its class body
- Some small fixes in comment

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
