### PR TITLE
Added `transparent` option to 6.x docs

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -84,6 +84,8 @@ export class Application
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
+     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
+     *  `false` sets backgroundAlpha to 1.
      * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
      *   not before the new render pass.
      * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -119,6 +119,8 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
+     * @param {boolean} [options.transparent] − Deprecated. true sets backgroundAlpha to 0,
+     *  false sets backgroundAlpha to 1.
      */
     constructor(options?: IRendererOptions)
     {

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -119,8 +119,8 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] − Deprecated. true sets backgroundAlpha to 0,
-     *  false sets backgroundAlpha to 1.
+     * @param {boolean} [options.transparent] − **Deprecated**. `true` sets backgroundAlpha to 0,
+     *  `false` sets backgroundAlpha to 1.
      */
     constructor(options?: IRendererOptions)
     {

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -100,7 +100,8 @@ export abstract class AbstractRenderer extends EventEmitter
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0, `false` sets backgroundAlpha to 1.
+     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
+     * `false` sets backgroundAlpha to 1.
      */
     constructor(type: RENDERER_TYPE = RENDERER_TYPE.UNKNOWN, options?: IRendererOptions)
     {

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -100,6 +100,7 @@ export abstract class AbstractRenderer extends EventEmitter
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
+     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0, `false` sets backgroundAlpha to 1.
      */
     constructor(type: RENDERER_TYPE = RENDERER_TYPE.UNKNOWN, options?: IRendererOptions)
     {

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -247,6 +247,8 @@ export class Renderer extends AbstractRenderer
      * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
      *  (shown if not transparent).
      * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
+     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
+     *  `false` sets backgroundAlpha to 1.
      * @param {string} [options.powerPreference] - Parameter passed to WebGL context, set to "high-performance"
      *  for devices with dual graphics card.
      * @param {object} [options.context] - If WebGL context already exists, all parameters must be taken from it.


### PR DESCRIPTION
##### Checklist
- [X] I have read the [contributors guide](https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md) and the [code of conduct](https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md)

##### Description of Change
* Closes issue [#8073](https://github.com/pixijs/pixijs/issues/8073)
* Co-authored by @sunveer2001 and @MasonJason23
* Documented the `transparent` option in the AbstractRenderer.ts, Renderer.ts, and Application.ts files. Included explanation of what the transparent option does: it sets the member `backgroundAlpha` to 0 or 1, given a value of false or true, respectively. As the member `transparent` is deprecated, it is not necessary to include these changes beyond the 6.x documentation.