### PR TITLE
Missing view option to CanvasRenderer

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -234,6 +234,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
                 width: options.width,
                 autoDensity: options.autoDensity,
                 resolution: options.resolution,
+                view: options.view,
             }
         };
 


### PR DESCRIPTION
Closes #8924

If the `view` option was set for CanvasRenderer, it was not getting passed to the ViewSystem.

**Broken**: https://jsfiddle.net/bigtimebuddy/trj3g907/ (v7.0.4)
**Fixed**: https://jsfiddle.net/bigtimebuddy/t1u9678x/ (this PR)