### PR TITLE
Fix tint cache clearing code for Mesh on canvas

### DIFF
--- a/packages/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -115,6 +115,16 @@ export class CanvasMeshRenderer
         const textureWidth = base.width;
         const textureHeight = base.height;
 
+        // Invalidate texture if base texture was updated
+        // either because mesh.texture or mesh.shader.texture was changed
+        if (mesh._cachedTexture && mesh._cachedTexture.baseTexture !== base)
+        {
+            mesh._cachedTint = 0xffffff;
+            mesh._cachedTexture?.destroy();
+            mesh._cachedTexture = null;
+            mesh._tintedCanvas = null;
+        }
+
         if (isTinted)
         {
             if (mesh._cachedTint !== mesh.tint)


### PR DESCRIPTION
Closes #8929 

Cached tint texture/canvas was not getting cleared when the texture changed.

**Broken**: https://jsfiddle.net/pegta1Lr/
**FIxed**: https://jsfiddle.net/bigtimebuddy/p2cmyw9h/