### PR TITLE
Fix: getCanvasRenderingContext2D in Web Worker

### DIFF
--- a/bundles/pixi.js-webworker/src/adapter.ts
+++ b/bundles/pixi.js-webworker/src/adapter.ts
@@ -11,7 +11,7 @@ export const WebWorkerAdapter = {
      * @param height - height of the canvas
      */
     createCanvas: (width?: number, height?: number) => new OffscreenCanvas(width | 0, height | 0),
-    getCanvasRenderingContext2D: () => CanvasRenderingContext2D,
+    getCanvasRenderingContext2D: () => OffscreenCanvasRenderingContext2D,
     getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => globalThis.location.href,

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -141,12 +141,14 @@ export class TextMetrics
     public static _experimentalLetterSpacingSupported?: boolean;
 
     /**
-     * Checking that we can use modern canvas2D API
-     * https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
-     * Note: This is unstable API, Chrome < 94 use a `textLetterSpacing`, latest use `letterSpacing`
+     * Checking that we can use modern canvas 2D API.
+     *
+     * Note: This is an unstable API, Chrome < 94 use `textLetterSpacing`, later versions use `letterSpacing`.
      * @see PIXI.TextMetrics.experimentalLetterSpacing
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/letterSpacing
+     * @see https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
      */
-    public static get experimentalLetterSpacingSupported()
+    public static get experimentalLetterSpacingSupported(): boolean
     {
         let result = TextMetrics._experimentalLetterSpacingSupported;
 
@@ -166,6 +168,7 @@ export class TextMetrics
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will
      * lead to more accurate letter-spacing results because it does not try to manually draw
      * each character. However, this Chrome API is experimental and may not serve all cases yet.
+     * @see PIXI.TextMetrics.experimentalLetterSpacingSupported
      */
     public static experimentalLetterSpacing = false;
 

--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -138,19 +138,29 @@ export class TextMetrics
         return (s: string) => [...s];
     })();
 
+    public static _experimentalLetterSpacingSupported?: boolean;
+
     /**
      * Checking that we can use modern canvas2D API
      * https://developer.chrome.com/origintrials/#/view_trial/3585991203293757441
      * Note: This is unstable API, Chrome < 94 use a `textLetterSpacing`, latest use `letterSpacing`
      * @see PIXI.TextMetrics.experimentalLetterSpacing
      */
-    public static readonly experimentalLetterSpacingSupported
-        = (() =>
+    public static get experimentalLetterSpacingSupported()
+    {
+        let result = TextMetrics._experimentalLetterSpacingSupported;
+
+        if (result !== undefined)
         {
             const proto = settings.ADAPTER.getCanvasRenderingContext2D().prototype;
 
-            return 'letterSpacing' in proto || 'textLetterSpacing' in proto;
-        })();
+            result
+                = TextMetrics._experimentalLetterSpacingSupported
+                = 'letterSpacing' in proto || 'textLetterSpacing' in proto;
+        }
+
+        return result;
+    }
 
     /**
      * New rendering behavior for letter-spacing which uses Chrome's new native API. This will


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

- `WebWorkerAdapter.getCanvasRenderingContext2D` should return `OffscreenCanvasRenderingContext2D`.
- `TextMetrics.experimentalLetterSpacingSupported` is lazy evaluated, so that it can use the correct `ADAPTER`.

Fixes #8938.

Broken: https://pixijs.io/examples/?v=dev#/offscreen-canvas/web-worker.js
Fixed: https://pixijs.io/examples/?v=fix/8938#/offscreen-canvas/web-worker.js

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
