### PR TITLE
Feature/cache warning fix

### DIFF
--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -403,7 +403,7 @@ describe('Assets', () =>
         expect(font).toBeInstanceOf(FontFace);
     });
 
-    it.only('should load not show a cache warning if the same asset is loaded twice', async () =>
+    it('should load not show a cache warning if the same asset is loaded twice', async () =>
     {
         await Assets.init({
             basePath,

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -409,10 +409,10 @@ describe('Assets', () =>
             basePath,
         });
 
-        const spy = jest.spyOn(console, 'warn')
+        const spy = jest.spyOn(console, 'warn');
 
-        const bunnyPromise =  Assets.load('textures/bunny.png');
-        const bunnyPromise2 =  Assets.load('textures/bunny.png');
+        const bunnyPromise = Assets.load('textures/bunny.png');
+        const bunnyPromise2 = Assets.load('textures/bunny.png');
 
         await Promise.all([bunnyPromise, bunnyPromise2]);
 

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -402,4 +402,20 @@ describe('Assets', () =>
 
         expect(font).toBeInstanceOf(FontFace);
     });
+
+    it.only('should load not show a cache warning if the same asset is loaded twice', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const spy = jest.spyOn(console, 'warn')
+
+        const bunnyPromise =  Assets.load('textures/bunny.png');
+        const bunnyPromise2 =  Assets.load('textures/bunny.png');
+
+        await Promise.all([bunnyPromise, bunnyPromise2]);
+
+        expect(spy).not.toHaveBeenCalled();
+    });
 });

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -403,7 +403,7 @@ describe('Assets', () =>
         expect(font).toBeInstanceOf(FontFace);
     });
 
-    it('should load not show a cache warning if the same asset is loaded twice', async () =>
+    it('should not show a cache warning if the same asset is loaded twice', async () =>
     {
         await Assets.init({
             basePath,

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -724,7 +724,8 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
                 baseTexture.textureCacheIds.push(id);
             }
 
-            if (BaseTextureCache[id])
+            // only throw a warning if there is a different base texture mapped to this id.
+            if (BaseTextureCache[id] && BaseTextureCache[id] !== baseTexture)
             {
                 // eslint-disable-next-line no-console
                 console.warn(`BaseTexture added to the cache with an id [${id}] that already had an entry`);

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -522,7 +522,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
             }
 
             // only throw a warning if there is a different texture mapped to this id.
-            if (TextureCache[id]  && TextureCache[id] !== texture)
+            if (TextureCache[id] && TextureCache[id] !== texture)
             {
                 // eslint-disable-next-line no-console
                 console.warn(`Texture added to the cache with an id [${id}] that already had an entry`);

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -521,7 +521,8 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
                 texture.textureCacheIds.push(id);
             }
 
-            if (TextureCache[id])
+            // only throw a warning if there is a different texture mapped to this id.
+            if (TextureCache[id]  && TextureCache[id] !== texture)
             {
                 // eslint-disable-next-line no-console
                 console.warn(`Texture added to the cache with an id [${id}] that already had an entry`);


### PR DESCRIPTION
##### Description of change
The Cache warning now only gets called if a different asset is assigned to the id. No biggie if its the same asset!

fixes #8613

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
