### PR TITLE
Fix: IRenderer.generateTexture should return RenderTexture

### DIFF
--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -113,10 +113,9 @@ export interface IRendererRenderOptions
  */
 export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager, GlobalMixins.IRenderer
 {
-
     resize(width: number, height: number): void;
-    render(displayObject: IRenderableObject, options?: IRendererRenderOptions): void
-    generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): void
+    render(displayObject: IRenderableObject, options?: IRendererRenderOptions): void;
+    generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture;
     destroy(removeView?: boolean): void;
     clear(): void;
     reset(): void;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixi.js/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixi.js/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

`IRenderer.generateTexture` should return `RenderTexture` instead of `void`.

Fixes #8947.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
