### PR TITLE
Clarify the onProgress design limitations in docs

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -498,9 +498,10 @@ export class AssetsClass
      * // Load another bundle...
      * gameScreenAssets = await Assets.loadBundle('game-screen');
      * @param bundleIds - the bundle id or ids to load
-     * @param onProgress - optional function that is called when progress on asset loading is made.
+     * @param onProgress - Optional function that is called when progress on asset loading is made.
      * The function is passed a single parameter, `progress`, which represents the percentage (0.0 - 1.0)
-     * of the assets loaded.
+     * of the assets loaded. Do not use this function to detect when assets are complete and available,
+     * instead use the Promise returned by this function.
      * @returns all the bundles assets or a hash of assets for each bundle specified
      */
     public async loadBundle(bundleIds: string | string[], onProgress?: ProgressCallback): Promise<any>

--- a/packages/assets/src/loader/Loader.ts
+++ b/packages/assets/src/loader/Loader.ts
@@ -101,7 +101,10 @@ export class Loader
      * const assets = await Loader.load(['cool.png', 'cooler.png']);
      * console.log(assets);
      * @param assetsToLoadIn - urls that you want to load, or a single one!
-     * @param onProgress - a function that gets called when the progress changes
+     * @param onProgress - For multiple asset loading only, an optional function that is called
+     * when progress on asset loading is made. The function is passed a single parameter, `progress`,
+     * which represents the percentage (0.0 - 1.0) of the assets loaded. Do not use this function
+     * to detect when assets are complete and available, instead use the Promise returned by this function.
      */
     public async load<T = any>(
         assetsToLoadIn: string | LoadAsset,


### PR DESCRIPTION
Closes #8819

Make it explicit not to fetch assets in the onProgress callback.