### PR TITLE
Add defaultSearchParams option to Assets

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -24,7 +24,7 @@ export interface AssetInitOptions
     basePath?: string;
 
     /** a default URL parameter string to append to all assets loaded */
-    defaultUrlParameters?: string | Record<string, any>;
+    defaultSearchParams?: string | Record<string, any>;
 
     /**
      * a manifest to tell the asset loader upfront what all your assets are
@@ -256,9 +256,9 @@ export class AssetsClass
 
         this._initialized = true;
 
-        if (options.defaultUrlParameters)
+        if (options.defaultSearchParams)
         {
-            this.resolver.setUrlParameters(options.defaultUrlParameters);
+            this.resolver.setDefaultSearchParams(options.defaultSearchParams);
         }
 
         if (options.basePath)

--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -224,8 +224,6 @@ export class AssetsClass
 
     private _initialized = false;
 
-    private _defaultQueryString: string;
-
     constructor()
     {
         this.resolver = new Resolver();

--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -22,6 +22,10 @@ export interface AssetInitOptions
     // basic...
     /** a base path for any assets loaded */
     basePath?: string;
+
+    /** a default URL parameter string to append to all assets loaded */
+    defaultUrlParameters?: string | Record<string, any>;
+
     /**
      * a manifest to tell the asset loader upfront what all your assets are
      * this can be the manifest object itself, or a URL to the manifest.
@@ -220,6 +224,8 @@ export class AssetsClass
 
     private _initialized = false;
 
+    private _defaultQueryString: string;
+
     constructor()
     {
         this.resolver = new Resolver();
@@ -251,6 +257,11 @@ export class AssetsClass
         }
 
         this._initialized = true;
+
+        if (options.defaultUrlParameters)
+        {
+            this.resolver.setUrlParameters(options.defaultUrlParameters);
+        }
 
         if (options.basePath)
         {

--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -50,7 +50,7 @@ export class Resolver
     private _basePath: string;
     private _manifest: ResolverManifest;
     private _bundles: Record<string, string[]> = {};
-    private _defaultUrlParameters: string;
+    private _defaultSearchParams: string;
 
     /**
      * Let the resolver know which assets you prefer to use when resolving assets.
@@ -178,20 +178,20 @@ export class Resolver
     }
 
     /**
-     * Sets the default URL parameters for the URL resolver. The urls can be specified as a string or an object.
-     * @param urlParameters - the default url parameters to append when resolving urls
+     * Sets the default URL search parameters for the URL resolver. The urls can be specified as a string or an object.
+     * @param searchParams - the default url parameters to append when resolving urls
      */
-    public setUrlParameters(urlParameters: string | Record<string, unknown>): void
+    public setDefaultSearchParams(searchParams: string | Record<string, unknown>): void
     {
-        if (typeof urlParameters === 'string')
+        if (typeof searchParams === 'string')
         {
-            this._defaultUrlParameters = urlParameters;
+            this._defaultSearchParams = searchParams;
         }
         else
         {
-            const queryValues = urlParameters as Record<string, any>;
+            const queryValues = searchParams as Record<string, any>;
 
-            this._defaultUrlParameters = Object.keys(queryValues)
+            this._defaultSearchParams = Object.keys(queryValues)
                 .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(queryValues[key])}`)
                 .join('&');
         }
@@ -366,7 +366,7 @@ export class Resolver
                 formattedAsset.src = utils.path.toAbsolute(formattedAsset.src, this._basePath, this._rootPath);
             }
 
-            formattedAsset.src = this._appendDefaultUrlParameters(formattedAsset.src);
+            formattedAsset.src = this._appendDefaultSearchParams(formattedAsset.src);
 
             formattedAsset.data = formattedAsset.data ?? data;
 
@@ -534,7 +534,7 @@ export class Resolver
                     }
 
                     // make sure to append any default parameters
-                    src = this._appendDefaultUrlParameters(src);
+                    src = this._appendDefaultSearchParams(src);
 
                     // if the resolver fails we just pass back the key assuming its a url
                     this._resolverHash[key] = {
@@ -576,12 +576,12 @@ export class Resolver
      * @param url - The url to append the default parameters to
      * @returns - The url with the default parameters appended
      */
-    private _appendDefaultUrlParameters(url: string): string
+    private _appendDefaultSearchParams(url: string): string
     {
-        if (!this._defaultUrlParameters) return url;
+        if (!this._defaultSearchParams) return url;
 
         const paramConnector = (/\?/).test(url) ? '&' : '?';
 
-        return `${url}${paramConnector}${this._defaultUrlParameters}`;
+        return `${url}${paramConnector}${this._defaultSearchParams}`;
     }
 }

--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -50,6 +50,7 @@ export class Resolver
     private _basePath: string;
     private _manifest: ResolverManifest;
     private _bundles: Record<string, string[]> = {};
+    private _defaultUrlParameters: string;
 
     /**
      * Let the resolver know which assets you prefer to use when resolving assets.
@@ -174,6 +175,26 @@ export class Resolver
         this._rootPath = null;
         this._basePath = null;
         this._manifest = null;
+    }
+
+    /**
+     * Sets the default URL parameters for the URL resolver. The urls can be specified as a string or an object.
+     * @param urlParameters - the default url parameters to append when resolving urls
+     */
+    public setUrlParameters(urlParameters: string | Record<string, unknown>): void
+    {
+        if (typeof urlParameters === 'string')
+        {
+            this._defaultUrlParameters = urlParameters;
+        }
+        else
+        {
+            const queryValues = urlParameters as Record<string, any>;
+
+            this._defaultUrlParameters = Object.keys(queryValues)
+                .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(queryValues[key])}`)
+                .join('&');
+        }
     }
 
     /**
@@ -345,6 +366,8 @@ export class Resolver
                 formattedAsset.src = utils.path.toAbsolute(formattedAsset.src, this._basePath, this._rootPath);
             }
 
+            formattedAsset.src = this._appendDefaultUrlParameters(formattedAsset.src);
+
             formattedAsset.data = formattedAsset.data ?? data;
 
             return formattedAsset;
@@ -510,6 +533,9 @@ export class Resolver
                         src = utils.path.toAbsolute(src, this._basePath, this._rootPath);
                     }
 
+                    // make sure to append any default parameters
+                    src = this._appendDefaultUrlParameters(src);
+
                     // if the resolver fails we just pass back the key assuming its a url
                     this._resolverHash[key] = {
                         src,
@@ -543,5 +569,19 @@ export class Resolver
         }
 
         return this._preferredOrder[0];
+    }
+
+    /**
+     * Appends the default url parameters to the url
+     * @param url - The url to append the default parameters to
+     * @returns - The url with the default parameters appended
+     */
+    private _appendDefaultUrlParameters(url: string): string
+    {
+        if (!this._defaultUrlParameters) return url;
+
+        const paramConnector = (/\?/).test(url) ? '&' : '?';
+
+        return `${url}${paramConnector}${this._defaultUrlParameters}`;
     }
 }

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -423,7 +423,7 @@ describe('Assets', () =>
     {
         await Assets.init({
             basePath,
-            defaultUrlParameters: {
+            defaultSearchParams: {
                 foo: 'bar',
                 chicken: 'nuggets',
             },

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -418,4 +418,20 @@ describe('Assets', () =>
 
         expect(spy).not.toHaveBeenCalled();
     });
+
+    it.only('should append default url params when specified in the constructor', async () =>
+    {
+        await Assets.init({
+            basePath,
+            defaultUrlParameters: {
+                foo: 'bar',
+                chicken: 'nuggets',
+            },
+        });
+
+        Assets.add('bunny', 'textures/bunny.png');
+        const bunnyTexture = await Assets.load('bunny');
+
+        expect(bunnyTexture.textureCacheIds[0]).toEqual(`${basePath}textures/bunny.png?foo=bar&chicken=nuggets`);
+    });
 });

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -419,7 +419,7 @@ describe('Assets', () =>
         expect(spy).not.toHaveBeenCalled();
     });
 
-    it.only('should append default url params when specified in the constructor', async () =>
+    it('should append default url params when specified in the constructor', async () =>
     {
         await Assets.init({
             basePath,

--- a/packages/assets/test/resolver.tests.ts
+++ b/packages/assets/test/resolver.tests.ts
@@ -446,7 +446,7 @@ describe('Resolver', () =>
     {
         const resolver = new Resolver();
 
-        resolver.setUrlParameters({
+        resolver.setDefaultSearchParams({
             hello: 'world',
             lucky: 23,
         });
@@ -460,7 +460,7 @@ describe('Resolver', () =>
     {
         const resolver = new Resolver();
 
-        resolver.setUrlParameters('hello=world&lucky=23');
+        resolver.setDefaultSearchParams('hello=world&lucky=23');
 
         resolver.add('test', 'my-image.png');
 
@@ -471,7 +471,7 @@ describe('Resolver', () =>
     {
         const resolver = new Resolver();
 
-        resolver.setUrlParameters('hello=world&lucky=23');
+        resolver.setDefaultSearchParams('hello=world&lucky=23');
 
         resolver.add('test', 'my-image.png?chicken=egg');
 
@@ -482,7 +482,7 @@ describe('Resolver', () =>
     {
         const resolver = new Resolver();
 
-        resolver.setUrlParameters('hello=world&lucky=23');
+        resolver.setDefaultSearchParams('hello=world&lucky=23');
 
         expect(resolver.resolveUrl('my-image.png')).toBe('my-image.png?hello=world&lucky=23');
     });

--- a/packages/assets/test/resolver.tests.ts
+++ b/packages/assets/test/resolver.tests.ts
@@ -441,4 +441,49 @@ describe('Resolver', () =>
 
         expect(resolver.resolveUrl('test')).toBe('my-image.webp');
     });
+
+    it('should be able to append a default url params object correctly', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver.setUrlParameters({
+            hello: 'world',
+            lucky: 23,
+        });
+
+        resolver.add('test', 'my-image.png');
+
+        expect(resolver.resolveUrl('test')).toBe('my-image.png?hello=world&lucky=23');
+    });
+
+    it('should be able to append a default url params string correctly', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver.setUrlParameters('hello=world&lucky=23');
+
+        resolver.add('test', 'my-image.png');
+
+        expect(resolver.resolveUrl('test')).toBe('my-image.png?hello=world&lucky=23');
+    });
+
+    it('should be able to append default url params correctly even if the url already has some', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver.setUrlParameters('hello=world&lucky=23');
+
+        resolver.add('test', 'my-image.png?chicken=egg');
+
+        expect(resolver.resolveUrl('test')).toBe('my-image.png?chicken=egg&hello=world&lucky=23');
+    });
+
+    it('should be able to append default url params correctly even if the url has no key', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver.setUrlParameters('hello=world&lucky=23');
+
+        expect(resolver.resolveUrl('my-image.png')).toBe('my-image.png?hello=world&lucky=23');
+    });
 });


### PR DESCRIPTION
##### Description of change
Adds support for default url params via the init function.

```
await Assets.init({
            defaultSearchParams: {
                foo: 'bar',
                chicken: 'nuggets',
            },
        });

const bunnyTexture = await Assets.load('bunny.png'); // url = bunny.png?foo=bar&chicken=nuggets
```


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
