### PR TITLE
Fix: WheelEvent.deltaMode consistency

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -592,10 +592,17 @@ export class EventSystem
 
         this.transferMouseData(event, nativeEvent);
 
-        event.deltaMode = nativeEvent.deltaMode;
+        // When WheelEvent is triggered by scrolling with mouse wheel, reading WheelEvent.deltaMode
+        // before deltaX/deltaY/deltaZ will result in deltaMode === WheelEvent.DOM_DELTA_LINE (1)
+        // on Firefox, while reading deltaMode after deltaX/deltaY/deltaZ or reading in any order
+        // on other browsers will result in deltaMode === WheelEvent.DOM_DELTA_PIXEL (0).
+        // Therefore, we need to read deltaMode after deltaX/deltaY/deltaZ in order to make its
+        // behavior more consistent across browsers.
+        // @see https://github.com/pixijs/pixijs/issues/8970
         event.deltaX = nativeEvent.deltaX;
         event.deltaY = nativeEvent.deltaY;
         event.deltaZ = nativeEvent.deltaZ;
+        event.deltaMode = nativeEvent.deltaMode;
 
         this.mapPositionToPoint(event.screen, nativeEvent.clientX, nativeEvent.clientY);
         event.global.copyFrom(event.screen);

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -593,11 +593,11 @@ export class EventSystem
         this.transferMouseData(event, nativeEvent);
 
         // When WheelEvent is triggered by scrolling with mouse wheel, reading WheelEvent.deltaMode
-        // before deltaX/deltaY/deltaZ will result in deltaMode === WheelEvent.DOM_DELTA_LINE (1)
-        // on Firefox, while reading deltaMode after deltaX/deltaY/deltaZ or reading in any order
-        // on other browsers will result in deltaMode === WheelEvent.DOM_DELTA_PIXEL (0).
-        // Therefore, we need to read deltaMode after deltaX/deltaY/deltaZ in order to make its
-        // behavior more consistent across browsers.
+        // before deltaX/deltaY/deltaZ on Firefox will result in WheelEvent.DOM_DELTA_LINE (1),
+        // while reading WheelEvent.deltaMode after deltaX/deltaY/deltaZ on Firefox or reading
+        // in any order on other browsers will result in WheelEvent.DOM_DELTA_PIXEL (0).
+        // Therefore, we need to read WheelEvent.deltaMode after deltaX/deltaY/deltaZ in order to
+        // make its behavior more consistent across browsers.
         // @see https://github.com/pixijs/pixijs/issues/8970
         event.deltaX = nativeEvent.deltaX;
         event.deltaY = nativeEvent.deltaY;


### PR DESCRIPTION
#### Description of change

When `WheelEvent` is triggered by scrolling with mouse wheel, reading `WheelEvent.deltaMode` before `deltaX`/`deltaY`/`deltaZ` on Firefox will result in `WheelEvent.DOM_DELTA_LINE (1)`, while reading `WheelEvent.deltaMode` after `deltaX`/`deltaY`/`deltaZ` on Firefox or reading in any order on other browsers will result in `WheelEvent.DOM_DELTA_PIXEL (0)`.
Therefore, we need to read `WheelEvent.deltaMode` after `deltaX`/`deltaY`/`deltaZ` in order to make its behavior more consistent across browsers.

Fixes #8970.

Example (Use Firefox, scroll the mouse wheel on the right and see result in console):
- **Before**: <https://www.pixiplayground.com/#/edit/-0JdGEPsmMGlNkGUYw0ed>
- **After**: <https://www.pixiplayground.com/#/edit/03E9XWNqQPJMSXzoIfdbb>

#### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
