### PR TITLE
Expose options for Renderers

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -85,6 +85,12 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
     };
 
     /**
+     * Options passed to the constructor.
+     * @member {PIXI.IRendererOptions}
+     */
+    public readonly options: IRendererOptions;
+
+    /**
      * Used with autoDetectRenderer, this is always supported for any environment, so return true.
      * @ignore
      */
@@ -241,6 +247,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
         };
 
         this.startup.run(startupOptions);
+        this.options = options;
     }
 
     /**

--- a/packages/canvas-renderer/test/CanvasRenderer.tests.ts
+++ b/packages/canvas-renderer/test/CanvasRenderer.tests.ts
@@ -55,4 +55,17 @@ describe('CanvasRenderer', () =>
         expect(cont.worldTransform.tx).toEqual(0);
         expect(cont.worldTransform.ty).toEqual(0);
     });
+
+    it('should expose constructor options', () =>
+    {
+        const options = { width: 1, height: 2, antialias: true, resolution: 2 };
+        const renderer = new CanvasRenderer(options);
+
+        expect(renderer.options.width).toBe(1);
+        expect(renderer.options.height).toBe(2);
+        expect(renderer.options.antialias).toBe(true);
+        expect(renderer.options.resolution).toBe(2);
+
+        renderer.destroy();
+    });
 });

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -74,27 +74,46 @@ export interface IRenderingContext extends WebGL2RenderingContext
         srcData: ArrayBufferView | null, srcOffset?: GLuint): void;
 }
 
+/**
+ * Renderer options supplied to constructor.
+ * @memberof PIXI
+ */
 export interface IRendererOptions extends GlobalMixins.IRendererOptions
 {
+    /** Width of the view */
     width?: number;
+    /** Height of the view */
     height?: number;
+    /** Canvas or OffscreenCanvas to use, will be created if omitted */
     view?: ICanvas;
     /**
      * Use premultipliedAlpha and backgroundAlpha instead
      * @deprecated since 7.0.0
      */
     useContextAlpha?: boolean | 'notMultiplied';
+    /** Consider the resolution when resizing the view */
     autoDensity?: boolean;
+    /** Antialias turn on for WebGL, impacts performance */
     antialias?: boolean;
+    /** Base resolution for the Renderer */
     resolution?: number;
+    /** Preserve the drawing buffer */
     preserveDrawingBuffer?: boolean;
+    /** Clear the draw before render */
     clearBeforeRender?: boolean;
+    /** The background color, can be number (`0xff0000`) or string (`#f00`) */
     backgroundColor?: number | string;
+    /** Alias for `backgroundColor` */
     background?: number | string;
+    /** Background color alpha */
     backgroundAlpha?: number;
+    /** Premultiply alpha */
     premultipliedAlpha?: boolean;
+    /** Power preference, for multiple GPUs */
     powerPreference?: WebGLPowerPreference;
+    /** User-proviced rendering context object */
     context?: IRenderingContext;
+    /** Console log the version and type of Renderer */
     hello?: boolean;
 }
 
@@ -125,6 +144,12 @@ export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager
      * @see PIXI.RENDERER_TYPE
      */
     readonly type: RENDERER_TYPE
+
+    /**
+     * The options passed in to create a new instance of the renderer.
+     * @type {PIXI.IRendererOptions}
+     */
+    readonly options: IRendererOptions
 
     /** When logging Pixi to the console, this is the name we will show */
     readonly rendererLogId: string

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -107,6 +107,12 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
     public readonly type: RENDERER_TYPE.WEBGL;
 
     /**
+     * Options passed to the constructor.
+     * @type {PIXI.IRendererOptions}
+     */
+    public readonly options: IRendererOptions;
+
+    /**
      * WebGL context, set by {@link PIXI.ContextSystem this.context}.
      * @readonly
      * @member {WebGLRenderingContext}
@@ -403,6 +409,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
         };
 
         this.startup.run(startupOptions);
+        this.options = options;
     }
 
     /**

--- a/packages/core/test/Renderer.tests.ts
+++ b/packages/core/test/Renderer.tests.ts
@@ -146,4 +146,17 @@ describe('Renderer', () =>
 
         renderer.destroy();
     });
+
+    it('should expose constructor options', () =>
+    {
+        const options = { width: 1, height: 2, antialias: true, resolution: 2 };
+        const renderer = new Renderer(options);
+
+        expect(renderer.options.width).toBe(1);
+        expect(renderer.options.height).toBe(2);
+        expect(renderer.options.antialias).toBe(true);
+        expect(renderer.options.resolution).toBe(2);
+
+        renderer.destroy();
+    });
 });


### PR DESCRIPTION
While working on https://github.com/pixijs/graphics-smooth I noticed that the Renderer use to save a reference to the constructor options in v6. I have re-added this. It's helpful for debugging to conditional rendering based on options.