### PR TITLE
Add CDN Install section in READMEs for browser builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm install pixi.js
 There is no default export. The correct way to import PixiJS is:
 
 ```js
-import * as PIXI from 'pixi.js'
+import * as PIXI from 'pixi.js';
 ```
 
 #### CDN Install
@@ -71,13 +71,13 @@ import * as PIXI from 'pixi.js'
 Via jsDelivr:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/pixi.js@7.x/dist/browser/pixi.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pixi.js@7.x/dist/pixi.min.js"></script>
 ```
 
 Or via unpkg:
 
 ```html
-<script src="https://unpkg.com/pixi.js@7.x/dist/browser/pixi.min.js"></script>
+<script src="https://unpkg.com/pixi.js@7.x/dist/pixi.min.js"></script>
 ```
 
 ### Demos ###

--- a/bundles/pixi.js-legacy/README.md
+++ b/bundles/pixi.js-legacy/README.md
@@ -28,11 +28,27 @@ PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-i
 ```
 npm install pixi.js-legacy
 ```
+
 There is no default export. The correct way to import PixiJS is:
 
 ```js
-import * as PIXI from 'pixi.js-legacy'
+import * as PIXI from 'pixi.js-legacy';
 ```
+
+#### CDN Install
+
+Via jsDelivr:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/pixi.js-legacy@7.x/dist/pixi-legacy.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<script src="https://unpkg.com/pixi.js-legacy@7.x/dist/pixi-legacy.min.js"></script>
+```
+
 ### Basic Usage Example
 
 ```js

--- a/bundles/pixi.js-webworker/README.md
+++ b/bundles/pixi.js-webworker/README.md
@@ -24,11 +24,27 @@ PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-i
 ```
 npm install @pixi/webworker
 ```
+
 There is no default export. The correct way to import PixiJS is:
 
 ```js
-import * as PIXI from '@pixi/webworker'
+import * as PIXI from '@pixi/webworker';
 ```
+
+#### CDN Install
+
+Via jsDelivr:
+
+```js
+importScripts('https://cdn.jsdelivr.net/npm/pixi.js-webworker@7.x/dist/pixi-webworker.min.js');
+```
+
+Or via unpkg:
+
+```js
+importScripts('https://unpkg.com/pixi.js-webworker@7.x/dist/pixi-webworker.min.js');
+```
+
 ### Basic Usage Example
 
 In `index.js`:

--- a/bundles/pixi.js/README.md
+++ b/bundles/pixi.js/README.md
@@ -24,11 +24,27 @@ PixiJS can be installed with [npm](https://docs.npmjs.com/getting-started/what-i
 ```
 npm install pixi.js
 ```
+
 There is no default export. The correct way to import PixiJS is:
 
 ```js
-import * as PIXI from 'pixi.js'
+import * as PIXI from 'pixi.js';
 ```
+
+#### CDN Install
+
+Via jsDelivr:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/pixi.js@7.x/dist/pixi.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<script src="https://unpkg.com/pixi.js@7.x/dist/pixi.min.js"></script>
+```
+
 ### Basic Usage Example
 
 ```js

--- a/packages/basis/README.md
+++ b/packages/basis/README.md
@@ -13,3 +13,19 @@ npm install @pixi/basis
 ```js
 import '@pixi/basis';
 ```
+
+## CDN Install
+
+Via jsDelivr:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://cdn.jsdelivr.net/npm/@pixi/basis@7.x/dist/basis.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://unpkg.com/@pixi/basis@7.x/dist/basis.min.js"></script>
+```

--- a/packages/graphics-extras/README.md
+++ b/packages/graphics-extras/README.md
@@ -23,3 +23,19 @@ const shapes = new Graphics()
     .beginFill(0xffffff)
     .drawTorus(0, 0, 20, 100);
 ```
+
+## CDN Install
+
+Via jsDelivr:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://cdn.jsdelivr.net/npm/@pixi/graphics-extras@7.x/dist/graphics-extras.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://unpkg.com/@pixi/graphics-extras@7.x/dist/graphics-extras.min.js"></script>
+```

--- a/packages/math-extras/README.md
+++ b/packages/math-extras/README.md
@@ -11,3 +11,19 @@ npm install @pixi/math-extras
 ```js
 import '@pixi/math-extras';
 ```
+
+## CDN Install
+
+Via jsDelivr:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://cdn.jsdelivr.net/npm/@pixi/math-extras@7.x/dist/math-extras.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://unpkg.com/@pixi/math-extras@7.x/dist/math-extras.min.js"></script>
+```

--- a/packages/unsafe-eval/README.md
+++ b/packages/unsafe-eval/README.md
@@ -22,3 +22,18 @@ import '@pixi/unsafe-eval';
 const renderer = new Renderer();
 ```
 
+## CDN Install
+
+Via jsDelivr:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://cdn.jsdelivr.net/npm/@pixi/unsafe-eval@7.x/dist/unsafe-eval.min.js"></script>
+```
+
+Or via unpkg:
+
+```html
+<!-- This script tag should be placed after pixi.min.js -->
+<script src="https://unpkg.com/@pixi/unsafe-eval@7.x/dist/unsafe-eval.min.js"></script>
+```


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Follow up #8827. Users may be confused about how to use browser build version of plugins (#9019), so I add examples for it in package's `README.md`. This will show up on the <https://npmjs.com> pages, and it can be helpful for users.

(The CDN URL in `/README.md` was wrong, caused by the different directory structure between v6 and v7. Now it is fixed.)

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
