### PR TITLE
Fix `TextMetrics.measureFont` breaking if passed a font with size 0

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -783,6 +783,13 @@ export class TextMetrics
 
         baseline = baseline * TextMetrics.BASELINE_MULTIPLIER | 0;
 
+        if (width === 0 || height === 0)
+        {
+            TextMetrics._fonts[font] = properties;
+
+            return properties;
+        }
+
         canvas.width = width;
         canvas.height = height;
 


### PR DESCRIPTION
A text with font size 0 breaks everything at the moment.

Chrome:
```
Uncaught DOMException: Failed to execute 'getImageData' on 'OffscreenCanvasRenderingContext2D': The source width is 0.
```
Firefox:
```
Uncaught DOMException: Index or size is negative or greater than the allowed amount
```

- Before: https://pixiplayground.com/#/edit/cIjE5gOXYJNVBBJXXBaMS
- After: https://pixiplayground.com/#/edit/25iy0k7gKs0e11mp9mbMC