### PR TITLE
`@pixi/node` README.md improvements (Dockerfile example + `vxfb` install)

### DIFF
--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -39,6 +39,17 @@ To build from source you will need to make sure you have the following dependenc
 
 For non-mac users, please refer to the [canvas installation guide](https://www.npmjs.com/package/canvas#compiling) for more information.
 
+### Error unable to auto-detect a suitable renderer
+When running in a headless environment (e.g. server or continuous integration), use `xvfb` as a virtual frame buffer.
+Install with:
+```
+sudo apt-get xvfb
+```
+And then use with node when starting the program:
+```
+xvfb-run node ./src/index.js
+```
+
 ## Basic Usage Example
 
 ```js

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -109,8 +109,9 @@ WORKDIR /usr/src/app
 
 # Add dependencies for gl, canvas and xvfb
 # Important! These dependencies must be installed before running `npm install`
-RUN apt-get update
-RUN apt-get install -y build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev xvfb
+RUN apt-get update \
+    && apt-get install -y build-essential libcairo2-dev libgif-dev libglew-dev libglu1-mesa-dev libjpeg-dev libpango1.0-dev librsvg2-dev libxi-dev pkg-config xvfb \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install app dependencies
 COPY package*.json ./

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -22,7 +22,7 @@ There is no default export. The correct way to import PixiJS is:
 import * as PIXI from "@pixi/node";
 ```
 
-#### Error installing gl package
+### Error installing gl package
 
 In most cases installing `gl` from npm should just work. However, if you run into problems you might need to adjust your system configuration and make sure all your dependencies are up to date
 

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -100,6 +100,9 @@ writeFileSync(output, base64Data, 'base64');
 ```
 
 ## Full environment setup with Docker 🐳
+
+*NOTE: It is recommended to add `node_modules` to your `.dockerignore` file.*
+
 ```Dockerfile
 # Set the base image
 FROM node:16

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -43,7 +43,7 @@ For non-mac users, please refer to the [canvas installation guide](https://www.n
 When running in a headless environment (e.g. server or continuous integration), use `xvfb` as a virtual frame buffer.
 Install with:
 ```
-sudo apt-get xvfb
+sudo apt-get install xvfb
 ```
 And then use with node when starting the program:
 ```

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -121,7 +121,7 @@ COPY . .
 
 # Start the server
 EXPOSE 3000
-CMD [ "xvfb", "node", "./src/index.js" ]
+CMD xvfb-run node ./src/index.js
 ```
 
 ### License

--- a/bundles/pixi.js-node/README.md
+++ b/bundles/pixi.js-node/README.md
@@ -99,6 +99,31 @@ const output = `./test.png`;
 writeFileSync(output, base64Data, 'base64');
 ```
 
+## Full environment setup with Docker 🐳
+```Dockerfile
+# Set the base image
+FROM node:16
+
+# Create and set the working directory
+WORKDIR /usr/src/app
+
+# Add dependencies for gl, canvas and xvfb
+# Important! These dependencies must be installed before running `npm install`
+RUN apt-get update
+RUN apt-get install -y build-essential libxi-dev libglu1-mesa-dev libglew-dev pkg-config libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev xvfb
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Start the server
+EXPOSE 3000
+CMD [ "xvfb", "node", "./src/index.js" ]
+```
+
 ### License
 
 This content is released under the (http://opensource.org/licenses/MIT) MIT License.


### PR DESCRIPTION
The `@pixi/node` package is amazing! However, it is quite tricky to setup; especially when most js programmers are used to running `npm i` and everything just works. I have added a some more information to the README to hopefully aid in getting setup with the package.

##### Description of change
- Fixed inconsistent header sizing in README
- Added section to fix `unable to auto-detect a suitable renderer`
- Added section with example Dockerfile to setup a complete environment for the example 🐳 

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/38284426/210358634-06396717-267c-4b2b-a118-63a4e455621f.png">
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/38284426/210358495-27cfe083-c915-4ce4-b58a-55948eb6059d.png">