### PR TITLE
Improve typing for `loader.load()` in spritesheetAsset

### DIFF
--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -108,7 +108,7 @@ export const spritesheetAsset = {
             }
 
             const imagePath = basePath + asset.meta.image;
-            const assets = await loader.load([imagePath]) as Record<string, Texture>;
+            const assets = await loader.load<Texture>([imagePath]);
             const texture = assets[imagePath];
             const spritesheet = new Spritesheet(
                 texture.baseTexture,
@@ -142,7 +142,7 @@ export const spritesheetAsset = {
                         continue;
                     }
 
-                    promises.push(loader.load({
+                    promises.push(loader.load<Spritesheet>({
                         src: itemUrl,
                         data: {
                             ignoreMultiPack: true,

--- a/packages/spritesheet/test/spritesheetAsset.tests.ts
+++ b/packages/spritesheet/test/spritesheetAsset.tests.ts
@@ -26,7 +26,7 @@ describe('spritesheetAsset', () =>
 
     it('should load a spritesheet', async () =>
     {
-        const spriteSheet: Spritesheet = await loader.load(`${serverPath}spritesheet.json`);
+        const spriteSheet = await loader.load<Spritesheet>(`${serverPath}spritesheet.json`);
 
         const bunnyTexture = spriteSheet.textures['bunny.png'];
         const senseiTexture = spriteSheet.textures['pic-sensei.jpg'];
@@ -47,14 +47,14 @@ describe('spritesheetAsset', () =>
 
     it('should do nothing if the resource is not JSON', async () =>
     {
-        const spriteSheet = await loader.load(`black.txt`);
+        const spriteSheet = await loader.load<Spritesheet>('black.txt');
 
         expect(spriteSheet).toBeNull();
     });
 
     it('should do nothing if the resource is JSON, but improper format', async () =>
     {
-        const spriteSheet = await loader.load(`${serverPath}test.json`);
+        const spriteSheet = await loader.load<Spritesheet>(`${serverPath}test.json`);
 
         expect(spriteSheet).not.toBeInstanceOf(Spritesheet);
         expect(spriteSheet).toEqual({ testNumber: 23, testString: 'Test String 23' });
@@ -64,7 +64,7 @@ describe('spritesheetAsset', () =>
     {
         Cache['_parsers'].push(spritesheetAsset.cache as CacheParser);
 
-        const spritesheet = await loader.load(`${serverPath}multi-pack-0.json`) as Spritesheet;
+        const spritesheet = await loader.load<Spritesheet>(`${serverPath}multi-pack-0.json`);
 
         Cache.set('multi-pack-0.json', spritesheet);
 
@@ -88,9 +88,9 @@ describe('spritesheetAsset', () =>
         // clear the caches only to avoid cluttering the output
         utils.clearTextureCache();
 
-        const spritesheet = await loader.load(`${serverPath}building1-1.json`) as Spritesheet;
-        const spritesheet2 = await loader.load(`${serverPath}atlas-multipack-wrong-type.json`) as Spritesheet;
-        const spritesheet3 = await loader.load(`${serverPath}atlas-multipack-wrong-array.json`) as Spritesheet;
+        const spritesheet = await loader.load<Spritesheet>(`${serverPath}building1-1.json`);
+        const spritesheet2 = await loader.load<Spritesheet>(`${serverPath}atlas-multipack-wrong-type.json`);
+        const spritesheet3 = await loader.load<Spritesheet>(`${serverPath}atlas-multipack-wrong-array.json`);
 
         expect(spritesheet.linkedSheets.length).toEqual(1);
         expect(spritesheet2.linkedSheets.length).toEqual(0);
@@ -99,7 +99,7 @@ describe('spritesheetAsset', () =>
 
     it('should unload a spritesheet', async () =>
     {
-        const spriteSheet: Spritesheet = await loader.load(`${serverPath}spritesheet.json`);
+        const spriteSheet = await loader.load<Spritesheet>(`${serverPath}spritesheet.json`);
 
         await loader.unload(`${serverPath}spritesheet.json`);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Follow up #8887. I intentionally skipped the `spritesheetAsset` in #8887 to avoid conflict with #8859, but now #8859 is closed, so I'm going to do that in this PR.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
