### PR TITLE
Update trimCanvas.ts import

### DIFF
--- a/packages/utils/src/media/trimCanvas.ts
+++ b/packages/utils/src/media/trimCanvas.ts
@@ -1,4 +1,4 @@
-import { getCanvasBoundingBox } from '@pixi/utils';
+import { getCanvasBoundingBox } from './getCanvasBoundingBox';
 
 import type { ICanvas } from '@pixi/settings';
 


### PR DESCRIPTION
This should do a relative import. Was producing build errors like this:


```
packages/utils/src/index.ts → packages/utils/lib, packages/utils/lib...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
@pixi/utils (imported by packages/utils/src/media/trimCanvas.ts)
created packages/utils/lib, packages/utils/lib in 51ms
```