### PR TITLE
Deprecate filters namespace

### DIFF
--- a/bundles/pixi.js-node/src/filters.ts
+++ b/bundles/pixi.js-node/src/filters.ts
@@ -1,0 +1,38 @@
+import { utils } from '@pixi/core';
+import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
+import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
+import { DisplacementFilter } from '@pixi/filter-displacement';
+import { FXAAFilter } from '@pixi/filter-fxaa';
+import { NoiseFilter } from '@pixi/filter-noise';
+
+/** @deprecated */
+const filters = {
+    /** @deprecated */
+    BlurFilter,
+    /** @deprecated */
+    BlurFilterPass,
+    /** @deprecated */
+    ColorMatrixFilter,
+    /** @deprecated */
+    DisplacementFilter,
+    /** @deprecated */
+    FXAAFilter,
+    /** @deprecated */
+    NoiseFilter,
+};
+
+for (const i in filters)
+{
+    const key = i as keyof typeof filters;
+
+    Object.defineProperty(filters, key, {
+        get()
+        {
+            utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+
+            return filters[key];
+        },
+    });
+}
+
+export { filters };

--- a/bundles/pixi.js-node/src/filters.ts
+++ b/bundles/pixi.js-node/src/filters.ts
@@ -21,18 +21,18 @@ const filters = {
     NoiseFilter,
 };
 
-for (const i in filters)
+Object.entries(filters).forEach(([key, FilterClass]) =>
 {
-    const key = i as keyof typeof filters;
-
     Object.defineProperty(filters, key, {
         get()
         {
+            // #if _DEBUG
             utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+            // #endif
 
-            return filters[key];
+            return FilterClass;
         },
     });
-}
+});
 
 export { filters };

--- a/bundles/pixi.js-node/src/filters.ts
+++ b/bundles/pixi.js-node/src/filters.ts
@@ -1,4 +1,5 @@
 import { utils } from '@pixi/core';
+import { AlphaFilter } from '@pixi/filter-alpha';
 import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
 import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
 import { DisplacementFilter } from '@pixi/filter-displacement';
@@ -7,6 +8,8 @@ import { NoiseFilter } from '@pixi/filter-noise';
 
 /** @deprecated */
 const filters = {
+    /** @deprecated */
+    AlphaFilter,
     /** @deprecated */
     BlurFilter,
     /** @deprecated */

--- a/bundles/pixi.js-node/src/index.ts
+++ b/bundles/pixi.js-node/src/index.ts
@@ -1,12 +1,6 @@
 import { ResizePlugin } from '@pixi/app';
 import { loadTextures, loadWebFont } from '@pixi/assets';
 import { extensions, INSTALLED } from '@pixi/core';
-import { AlphaFilter } from '@pixi/filter-alpha';
-import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
-import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
-import { DisplacementFilter } from '@pixi/filter-displacement';
-import { FXAAFilter } from '@pixi/filter-fxaa';
-import { NoiseFilter } from '@pixi/filter-noise';
 import '@pixi/mixin-cache-as-bitmap';
 import '@pixi/mixin-get-child-by-name';
 import '@pixi/mixin-get-global-position';
@@ -23,22 +17,18 @@ extensions.remove(
 INSTALLED.length = 0;
 INSTALLED.push(NodeCanvasResource);
 
-export const filters = {
-    AlphaFilter,
-    BlurFilter,
-    BlurFilterPass,
-    ColorMatrixFilter,
-    DisplacementFilter,
-    FXAAFilter,
-    NoiseFilter,
-};
-
 // Export ES for those importing specifically by name
 export * from '@pixi/app';
 export * from '@pixi/assets';
 export * from '@pixi/core';
 export * from '@pixi/display';
 export * from '@pixi/extract';
+export * from '@pixi/filter-alpha';
+export * from '@pixi/filter-blur';
+export * from '@pixi/filter-color-matrix';
+export * from '@pixi/filter-displacement';
+export * from '@pixi/filter-fxaa';
+export * from '@pixi/filter-noise';
 export * from '@pixi/graphics';
 export * from '@pixi/mesh';
 export * from '@pixi/mesh-extras';

--- a/bundles/pixi.js-node/src/index.ts
+++ b/bundles/pixi.js-node/src/index.ts
@@ -18,6 +18,7 @@ INSTALLED.length = 0;
 INSTALLED.push(NodeCanvasResource);
 
 // Export ES for those importing specifically by name
+export * from './filters';
 export * from '@pixi/app';
 export * from '@pixi/assets';
 export * from '@pixi/core';

--- a/bundles/pixi.js-webworker/src/filters.ts
+++ b/bundles/pixi.js-webworker/src/filters.ts
@@ -1,0 +1,38 @@
+import { utils } from '@pixi/core';
+import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
+import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
+import { DisplacementFilter } from '@pixi/filter-displacement';
+import { FXAAFilter } from '@pixi/filter-fxaa';
+import { NoiseFilter } from '@pixi/filter-noise';
+
+/** @deprecated */
+const filters = {
+    /** @deprecated */
+    BlurFilter,
+    /** @deprecated */
+    BlurFilterPass,
+    /** @deprecated */
+    ColorMatrixFilter,
+    /** @deprecated */
+    DisplacementFilter,
+    /** @deprecated */
+    FXAAFilter,
+    /** @deprecated */
+    NoiseFilter,
+};
+
+for (const i in filters)
+{
+    const key = i as keyof typeof filters;
+
+    Object.defineProperty(filters, key, {
+        get()
+        {
+            utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+
+            return filters[key];
+        },
+    });
+}
+
+export { filters };

--- a/bundles/pixi.js-webworker/src/filters.ts
+++ b/bundles/pixi.js-webworker/src/filters.ts
@@ -21,18 +21,18 @@ const filters = {
     NoiseFilter,
 };
 
-for (const i in filters)
+Object.entries(filters).forEach(([key, FilterClass]) =>
 {
-    const key = i as keyof typeof filters;
-
     Object.defineProperty(filters, key, {
         get()
         {
+            // #if _DEBUG
             utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+            // #endif
 
-            return filters[key];
+            return FilterClass;
         },
     });
-}
+});
 
 export { filters };

--- a/bundles/pixi.js-webworker/src/filters.ts
+++ b/bundles/pixi.js-webworker/src/filters.ts
@@ -1,4 +1,5 @@
 import { utils } from '@pixi/core';
+import { AlphaFilter } from '@pixi/filter-alpha';
 import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
 import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
 import { DisplacementFilter } from '@pixi/filter-displacement';
@@ -7,6 +8,8 @@ import { NoiseFilter } from '@pixi/filter-noise';
 
 /** @deprecated */
 const filters = {
+    /** @deprecated */
+    AlphaFilter,
     /** @deprecated */
     BlurFilter,
     /** @deprecated */

--- a/bundles/pixi.js-webworker/src/index.ts
+++ b/bundles/pixi.js-webworker/src/index.ts
@@ -1,22 +1,6 @@
-import { AlphaFilter } from '@pixi/filter-alpha';
-import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
-import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
-import { DisplacementFilter } from '@pixi/filter-displacement';
-import { FXAAFilter } from '@pixi/filter-fxaa';
-import { NoiseFilter } from '@pixi/filter-noise';
 import '@pixi/mixin-cache-as-bitmap';
 import '@pixi/mixin-get-child-by-name';
 import '@pixi/mixin-get-global-position';
-
-export const filters = {
-    AlphaFilter,
-    BlurFilter,
-    BlurFilterPass,
-    ColorMatrixFilter,
-    DisplacementFilter,
-    FXAAFilter,
-    NoiseFilter,
-};
 
 // Export ES for those importing specifically by name
 export * from '@pixi/app';
@@ -25,6 +9,12 @@ export * from '@pixi/compressed-textures';
 export * from '@pixi/core';
 export * from '@pixi/display';
 export * from '@pixi/extract';
+export * from '@pixi/filter-alpha';
+export * from '@pixi/filter-blur';
+export * from '@pixi/filter-color-matrix';
+export * from '@pixi/filter-displacement';
+export * from '@pixi/filter-fxaa';
+export * from '@pixi/filter-noise';
 export * from '@pixi/graphics';
 export * from '@pixi/mesh';
 export * from '@pixi/mesh-extras';

--- a/bundles/pixi.js-webworker/src/index.ts
+++ b/bundles/pixi.js-webworker/src/index.ts
@@ -3,6 +3,7 @@ import '@pixi/mixin-get-child-by-name';
 import '@pixi/mixin-get-global-position';
 
 // Export ES for those importing specifically by name
+export * from './filters';
 export * from '@pixi/app';
 export * from '@pixi/assets';
 export * from '@pixi/compressed-textures';

--- a/bundles/pixi.js/src/filters.ts
+++ b/bundles/pixi.js/src/filters.ts
@@ -55,18 +55,18 @@ const filters = {
     NoiseFilter,
 };
 
-for (const i in filters)
+Object.entries(filters).forEach(([key, FilterClass]) =>
 {
-    const key = i as keyof typeof filters;
-
     Object.defineProperty(filters, key, {
         get()
         {
+            // #if _DEBUG
             utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+            // #endif
 
-            return filters[key];
+            return FilterClass;
         },
     });
-}
+});
 
 export { filters };

--- a/bundles/pixi.js/src/filters.ts
+++ b/bundles/pixi.js/src/filters.ts
@@ -1,0 +1,72 @@
+import { utils } from '@pixi/core';
+import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
+import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
+import { DisplacementFilter } from '@pixi/filter-displacement';
+import { FXAAFilter } from '@pixi/filter-fxaa';
+import { NoiseFilter } from '@pixi/filter-noise';
+
+/**
+ * Filters namespace has been removed. All filters are now available directly from the root of the package.
+ * @namespace PIXI.filters
+ * @deprecated
+ */
+const filters = {
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.BlurFilter
+     */
+    BlurFilter,
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.BlurFilterPass
+     */
+    BlurFilterPass,
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.ColorMatrixFilter
+     */
+    ColorMatrixFilter,
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.DisplacementFilter
+     */
+    DisplacementFilter,
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.FXAAFilter
+     */
+    FXAAFilter,
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.NoiseFilter
+     */
+    NoiseFilter,
+};
+
+for (const i in filters)
+{
+    const key = i as keyof typeof filters;
+
+    Object.defineProperty(filters, key, {
+        get()
+        {
+            utils.deprecation('7.1.0', `filters.${key} has moved to ${key}`);
+
+            return filters[key];
+        },
+    });
+}
+
+export { filters };

--- a/bundles/pixi.js/src/filters.ts
+++ b/bundles/pixi.js/src/filters.ts
@@ -1,4 +1,5 @@
 import { utils } from '@pixi/core';
+import { AlphaFilter } from '@pixi/filter-alpha';
 import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
 import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
 import { DisplacementFilter } from '@pixi/filter-displacement';
@@ -11,6 +12,13 @@ import { NoiseFilter } from '@pixi/filter-noise';
  * @deprecated
  */
 const filters = {
+    /**
+     * @class
+     * @memberof PIXI.filters
+     * @deprecated since 7.1.0
+     * @see PIXI.AlphaFilter
+     */
+    AlphaFilter,
     /**
      * @class
      * @memberof PIXI.filters

--- a/bundles/pixi.js/src/index.ts
+++ b/bundles/pixi.js/src/index.ts
@@ -1,52 +1,9 @@
-import { AlphaFilter } from '@pixi/filter-alpha';
-import { BlurFilter, BlurFilterPass } from '@pixi/filter-blur';
-import { ColorMatrixFilter } from '@pixi/filter-color-matrix';
-import { DisplacementFilter } from '@pixi/filter-displacement';
-import { FXAAFilter } from '@pixi/filter-fxaa';
-import { NoiseFilter } from '@pixi/filter-noise';
 import '@pixi/mixin-cache-as-bitmap';
 import '@pixi/mixin-get-child-by-name';
 import '@pixi/mixin-get-global-position';
 
-/**
- * This namespace contains WebGL-only display filters that can be applied
- * to DisplayObjects using the {@link PIXI.DisplayObject#filters filters} property.
- *
- * Since PixiJS only had a handful of built-in filters, additional filters
- * can be downloaded {@link https://github.com/pixijs/pixi-filters here} from the
- * PixiJS Filters repository.
- *
- * All filters must extend {@link PIXI.Filter}.
- * @example
- * import { Application, Graphics, filters } from 'pixi.js';
- *
- * // Create a new application
- * const app = new Application();
- *
- * // Draw a green rectangle
- * const rect = new Graphics()
- *     .beginFill(0x00ff00)
- *     .drawRect(40, 40, 200, 200);
- *
- * // Add a blur filter
- * rect.filters = [new filters.BlurFilter()];
- *
- * // Display rectangle
- * app.stage.addChild(rect);
- * document.body.appendChild(app.view);
- * @namespace PIXI.filters
- */
-export const filters = {
-    AlphaFilter,
-    BlurFilter,
-    BlurFilterPass,
-    ColorMatrixFilter,
-    DisplacementFilter,
-    FXAAFilter,
-    NoiseFilter,
-};
-
 // Export ES for those importing specifically by name,
+export * from './filters';
 export * from '@pixi/accessibility';
 export * from '@pixi/app';
 export * from '@pixi/assets';
@@ -55,6 +12,12 @@ export * from '@pixi/core';
 export * from '@pixi/display';
 export * from '@pixi/events';
 export * from '@pixi/extract';
+export * from '@pixi/filter-alpha';
+export * from '@pixi/filter-blur';
+export * from '@pixi/filter-color-matrix';
+export * from '@pixi/filter-displacement';
+export * from '@pixi/filter-fxaa';
+export * from '@pixi/filter-noise';
 export * from '@pixi/graphics';
 export * from '@pixi/mesh';
 export * from '@pixi/mesh-extras';

--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -16,7 +16,7 @@ import type { FilterSystem } from './FilterSystem';
  * render-target.
  *
  * {@link http://pixijs.io/examples/#/filters/blur-filter.js Example} of the
- * {@link PIXI.filters.BlurFilter BlurFilter}.
+ * {@link PIXI.BlurFilter BlurFilter}.
  *
  * ### Usage
  * Filters can be applied to any DisplayObject or Container.
@@ -108,7 +108,7 @@ import type { FilterSystem } from './FilterSystem';
  * const myFilter = new Filter(null, fragment);
  * ```
  *
- * This filter is just one uniform less than {@link PIXI.filters.AlphaFilter AlphaFilter}.
+ * This filter is just one uniform less than {@link PIXI.AlphaFilter AlphaFilter}.
  *
  * **outputFrame**
  *
@@ -156,7 +156,7 @@ import type { FilterSystem } from './FilterSystem';
  * `inputPixel.xy` is the size of framebuffer in real pixels, same as `inputSize.xy * resolution`
  * `inputPixel.zw` is inverted `inputPixel.xy`.
  *
- * It's handy for filters that use neighbour pixels, like {@link PIXI.filters.FXAAFilter FXAAFilter}.
+ * It's handy for filters that use neighbour pixels, like {@link PIXI.FXAAFilter FXAAFilter}.
  *
  * **inputClamp**
  *

--- a/packages/filter-alpha/src/AlphaFilter.ts
+++ b/packages/filter-alpha/src/AlphaFilter.ts
@@ -13,7 +13,7 @@ import fragment from './alpha.frag';
  * 1. Assign a blendMode to this filter, blend all elements inside display object with background.
  *
  * 2. To use clipping in display coordinates, assign a filterArea to the same container that has this filter.
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class AlphaFilter extends Filter
 {

--- a/packages/filter-blur/src/BlurFilter.ts
+++ b/packages/filter-blur/src/BlurFilter.ts
@@ -7,7 +7,7 @@ import type { BLEND_MODES, FilterSystem, RenderTexture } from '@pixi/core';
  * The BlurFilter applies a Gaussian blur to an object.
  *
  * The strength of the blur can be set for the x-axis and y-axis separately.
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class BlurFilter extends Filter
 {

--- a/packages/filter-blur/src/BlurFilterPass.ts
+++ b/packages/filter-blur/src/BlurFilterPass.ts
@@ -6,7 +6,7 @@ import type { FilterSystem, RenderTexture } from '@pixi/core';
 
 /**
  * The BlurFilterPass applies a horizontal or vertical Gaussian blur to an object.
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class BlurFilterPass extends Filter
 {

--- a/packages/filter-color-matrix/src/ColorMatrixFilter.ts
+++ b/packages/filter-color-matrix/src/ColorMatrixFilter.ts
@@ -16,7 +16,7 @@ export type ColorMatrix = utils.ArrayFixed<number, 20>;
  * container.filters = [colorMatrix];
  * colorMatrix.contrast(2);
  * @author Clément Chenebault <clement@goodboydigital.com>
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class ColorMatrixFilter extends Filter
 {

--- a/packages/filter-displacement/src/DisplacementFilter.ts
+++ b/packages/filter-displacement/src/DisplacementFilter.ts
@@ -17,7 +17,7 @@ import type { CLEAR_MODES, FilterSystem, ISpriteMaskTarget, RenderTexture, Textu
  * Instead, it's starting at the output and asking "which pixel from the original goes here".
  * For example, if a displacement map pixel has `red = 1` and the filter scale is `20`,
  * this filter will output the pixel approximately 20 pixels to the right of the original.
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class DisplacementFilter extends Filter
 {

--- a/packages/filter-fxaa/src/FXAAFilter.ts
+++ b/packages/filter-fxaa/src/FXAAFilter.ts
@@ -6,7 +6,7 @@ import vertex from './fxaa.vert';
  * Basic FXAA (Fast Approximate Anti-Aliasing) implementation based on the code on geeks3d.com
  * with the modification that the texture2DLod stuff was removed since it is unsupported by WebGL.
  * @see https://github.com/mitsuhiko/webgl-meincraft
- * @memberof PIXI.filters
+ * @memberof PIXI
  */
 export class FXAAFilter extends Filter
 {

--- a/packages/filter-noise/src/NoiseFilter.ts
+++ b/packages/filter-noise/src/NoiseFilter.ts
@@ -5,7 +5,7 @@ import fragment from './noise.frag';
  * A Noise effect filter.
  *
  * original filter: https://github.com/evanw/glfx.js/blob/master/src/filters/adjust/noise.js
- * @memberof PIXI.filters
+ * @memberof PIXI
  * @author Vico @vicocotea
  */
 export class NoiseFilter extends Filter


### PR DESCRIPTION
An issue came up recently using `importmap` with `pixi-filters` (see https://github.com/pixijs/filters/pull/365) that is fixed by this PR.

We created this synthetic namespace `filters` for adding all the display object filters. We have generally removed all of these namespace from project except for filters. Removing filters seems like a good idea and consistent with recent changes.

### Changed

Deprecate the `filters` namespace export for the bundles:

* `pixi.js`
* `pixi.js-legacy`
* `@pixi/node`
* `@pixi/webworker`

### Links

* [API Documentation](https://pixijs.download/deprecate-filters-namespace/docs/PIXI.filters.html)
* [Example](https://jsfiddle.net/bigtimebuddy/15qbzo6e/)