### PR TITLE
Chore: Remove some duplicate definitions

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -38,9 +38,6 @@ const { deprecation } = utils;
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CanvasRenderer extends GlobalMixins.CanvasRenderer {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface CanvasRenderer extends GlobalMixins.CanvasRenderer {}
-
 /**
  * The CanvasRenderer draws the scene and all its content onto a 2d canvas.
  *

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -38,9 +38,6 @@ import type { ViewSystem } from './view/ViewSystem';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Renderer extends GlobalMixins.Renderer {}
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Renderer extends GlobalMixins.Renderer {}
-
 /**
  * The Renderer draws the scene and all its content onto a WebGL enabled canvas.
  *


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

There are some duplicate definitions in `Renderer` and `CanvasRenderer`:

https://github.com/pixijs/pixijs/blob/bd4b997e510a7528e89c5868b71c558987ead15c/packages/core/src/Renderer.ts#L38-L42

https://github.com/pixijs/pixijs/blob/bd4b997e510a7528e89c5868b71c558987ead15c/packages/canvas-renderer/src/CanvasRenderer.ts#L38-L42

It seems that they were accidentally introduced when merging #8425 and #8427, and should be removed.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
