### PR TITLE
Add SVG Assets parser to list of parsers

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -85,7 +85,7 @@ export interface AssetInitOptions
  * Here both promises will be the same. Once resolved... Forever resolved! It makes for really easy resource management!
  *
  * Out of the box it supports the following files:
- * - textures (avif, webp, png, jpg, gif)
+ * - textures (avif, webp, png, jpg, gif, svg)
  * - sprite sheets (json)
  * - bitmap fonts (xml, fnt, txt)
  * - web fonts (ttf, woff, woff2)

--- a/packages/assets/src/loader/parsers/textures/loadSVG.ts
+++ b/packages/assets/src/loader/parsers/textures/loadSVG.ts
@@ -1,4 +1,4 @@
-import { BaseTexture, ExtensionType, settings, SVGResource, utils } from '@pixi/core';
+import { BaseTexture, extensions, ExtensionType, settings, SVGResource, utils } from '@pixi/core';
 import { LoaderParserPriority } from '../LoaderParser';
 import { loadTextures } from './loadTextures';
 import { createTexture } from './utils/createTexture';
@@ -56,3 +56,5 @@ export const loadSVG = {
     unload: loadTextures.unload,
 
 } as LoaderParser<Texture | string, IBaseTextureOptions>;
+
+extensions.add(loadSVG);


### PR DESCRIPTION
##### Description of change

Based off this issue https://github.com/pixijs/pixijs/issues/8592, I noticed that SVG support for the Assets loader was supposed to be implemented in 6.5.2. It _was_ implemented here https://github.com/pixijs/pixijs/pull/8574, but I think I noticed an issue that it's not actually available for use because it's not added to the list of parsers.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

I'm struggling to npm install and run these commands myself.