### PR TITLE
Fix: Typos in deprecation messages

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -57,7 +57,7 @@ Object.defineProperties(settings, {
         set(value: WRAP_MODES)
         {
             // #if _DEBUG
-            deprecation('7.1.0', 'settings.WRAP_MODE is deprecated, use BaseTeture.defaultOptions.wrapMode');
+            deprecation('7.1.0', 'settings.WRAP_MODE is deprecated, use BaseTexture.defaultOptions.wrapMode');
             // #endif
             BaseTexture.defaultOptions.wrapMode = value;
         },
@@ -79,7 +79,7 @@ Object.defineProperties(settings, {
         set(value: SCALE_MODES)
         {
             // #if _DEBUG
-            deprecation('7.1.0', 'settings.SCALE_MODE is deprecated, use BaseTeture.defaultOptions.scaleMode');
+            deprecation('7.1.0', 'settings.SCALE_MODE is deprecated, use BaseTexture.defaultOptions.scaleMode');
             // #endif
             BaseTexture.defaultOptions.scaleMode = value;
         },
@@ -102,7 +102,7 @@ Object.defineProperties(settings, {
         set(value: MIPMAP_MODES)
         {
             // #if _DEBUG
-            deprecation('7.1.0', 'settings.MIPMAP_TEXTURES is deprecated, use BaseTeture.defaultOptions.mipmap');
+            deprecation('7.1.0', 'settings.MIPMAP_TEXTURES is deprecated, use BaseTexture.defaultOptions.mipmap');
             // #endif
             BaseTexture.defaultOptions.mipmap = value;
         },
@@ -126,8 +126,8 @@ Object.defineProperties(settings, {
         set(value: number)
         {
             // #if _DEBUG
-            // eslint-disable-next-line max-len
-            deprecation('7.1.0', 'settings.ANISOTROPIC_LEVEL is deprecated, use BaseTeture.defaultOptions.anisotropicLevel');
+            deprecation(
+                '7.1.0', 'settings.ANISOTROPIC_LEVEL is deprecated, use BaseTexture.defaultOptions.anisotropicLevel');
             // #endif
             BaseTexture.defaultOptions.anisotropicLevel = value;
         },


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Fix some typos in deprecation messages added in 7.1.0: `BaseTeture` -> `BaseTexture`

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
