### PR TITLE
Fix: @pixi/node: loadNoadTexture tried to load data-urls

### DIFF
--- a/bundles/pixi.js-node/src/adapter/loadNodeTexture.ts
+++ b/bundles/pixi.js-node/src/adapter/loadNodeTexture.ts
@@ -6,18 +6,6 @@ import type { LoadAsset, LoaderParser } from '@pixi/assets';
 
 const { loadImage } = canvasModule;
 const validImages = ['.jpg', '.png', '.jpeg', '.svg'];
-const validMimes = ['image/png', 'image/jpg', 'image/jpeg', 'image/svg'];
-
-function isSupportedDataURL(url: string): boolean
-{
-    const match = url.match(/^data:([^;]+);base64,/);
-
-    if (!match) return false;
-
-    const mimeType = match[1];
-
-    return validMimes.includes(mimeType);
-}
 
 /** loads our textures into a node canvas */
 export const loadNodeTexture = {
@@ -25,7 +13,7 @@ export const loadNodeTexture = {
 
     test(url: string): boolean
     {
-        return validImages.includes(utils.path.extname(url).toLowerCase()) || isSupportedDataURL(url);
+        return validImages.includes(utils.path.extname(url).toLowerCase());
     },
 
     async load(url: string, asset: LoadAsset): Promise<Texture>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
`@pixi/node` is unable to load base64 encoded data urls because the wrong handler will try to fetch the file.

`loadNodeBase64.ts` handles loading base64 data URLs already. `loadNodeTexture.ts` must not attempt this because it will try to use `readFileSync` the data url which will cause a rejection.

This PR removes the invalid code.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
