### PR TITLE
pointerout fired when interaction started outside of object

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -618,7 +618,7 @@ export class EventBoundary
         const outTarget = this.findMountedTarget(trackingData.overTargets);
 
         // First pointerout/pointerleave
-        if (trackingData.overTargets && outTarget !== e.target)
+        if (trackingData.overTargets?.length > 0 && outTarget !== e.target)
         {
             // pointerout always occurs on the overTarget when the pointer hovers over another element.
             const outType = from.type === 'mousemove' ? 'mouseout' : 'pointerout';


### PR DESCRIPTION
This PR fixes the issue where if you start your interaction outside the bounds of a DisplayObject then release inside of the DisplayObject the `pointerout` event would fire along with the `pointerover` event

Now only the `pointerover` event fires

Fixes #9062 

