### PR TITLE
Add global move events

### DIFF
--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -2,9 +2,10 @@ declare namespace GlobalMixins
 {
     type FederatedEventEmitterTypes = import('@pixi/events').FederatedEventEmitterTypes;
     type FederatedEventTarget = import('@pixi/events').FederatedEventTarget;
+    type IFederatedDisplayObject = import('@pixi/events').IFederatedDisplayObject;
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface DisplayObject extends FederatedEventTarget
+    interface DisplayObject extends Omit<FederatedEventTarget, keyof IFederatedDisplayObject>, IFederatedDisplayObject
     {
 
     }

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -703,12 +703,18 @@ export class EventBoundary
 
         // Then pointermove
         this[propagationMethod](e, 'pointermove');
+        this.all(e, 'globalpointermove');
 
-        if (e.pointerType === 'touch') this[propagationMethod](e, 'touchmove');
+        if (e.pointerType === 'touch')
+        {
+            this[propagationMethod](e, 'touchmove');
+            this.all(e, 'globaltouchmove');
+        }
 
         if (isMouse)
         {
             this[propagationMethod](e, 'mousemove');
+            this.all(e, 'globalmousemove');
             this.cursor = e.target?.cursor;
         }
 

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -1494,6 +1494,15 @@ export class EventBoundary
  */
 
 /**
+ * Fired when a pointer device (usually a mouse) is moved globally over the scene.
+ * DisplayObject's `interactive` property must be set to `true` to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globalmousemove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
  * Fired when a pointer device (usually a mouse) is moved while over the display object.
  * DisplayObject's `interactive` property must be set to `true` to fire event.
  *
@@ -1670,6 +1679,15 @@ export class EventBoundary
  */
 
 /**
+ * Fired when a pointer device is moved globally over the scene.
+ * DisplayObject's `interactive` property must be set to `true` to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globalpointermove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
  * Fired when a pointer device is moved while over the display object.
  * DisplayObject's `interactive` property must be set to `true` to fire event.
  *
@@ -1837,6 +1855,15 @@ export class EventBoundary
  *
  * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
  * @event PIXI.DisplayObject#touchendoutsidecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is moved globally over the scene.
+ * DisplayObject's `interactive` property must be set to `true` to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globaltouchmove
  * @param {PIXI.FederatedPointerEvent} event - Event
  */
 

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -35,4 +35,8 @@ export type FederatedEventMap = {
 };
 export type FederatedEventEmitterTypes = {
     [K in keyof FederatedEventMap as K | `${K}capture`]: [event: FederatedEventMap[K]];
+} & {
+    'globalpointermove': [event: FederatedPointerEvent];
+    'globaltouchmove': [event: FederatedPointerEvent];
+    'globalmousemove': [event: FederatedPointerEvent];
 };

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -33,10 +33,15 @@ export type FederatedEventMap = {
     touchstart: FederatedPointerEvent;
     wheel: FederatedWheelEvent;
 };
+
+export type GlobalFederatedEventMap = {
+    globalmousemove: FederatedPointerEvent;
+    globalpointermove: FederatedPointerEvent;
+    globaltouchmove: FederatedPointerEvent;
+};
+
 export type FederatedEventEmitterTypes = {
     [K in keyof FederatedEventMap as K | `${K}capture`]: [event: FederatedEventMap[K]];
 } & {
-    'globalpointermove': [event: FederatedPointerEvent];
-    'globaltouchmove': [event: FederatedPointerEvent];
-    'globalmousemove': [event: FederatedPointerEvent];
+    [K in keyof GlobalFederatedEventMap]: [event: GlobalFederatedEventMap[K]];
 };

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -40,6 +40,8 @@ export type GlobalFederatedEventMap = {
     globaltouchmove: FederatedPointerEvent;
 };
 
+export type AllFederatedEventMap = FederatedEventMap & GlobalFederatedEventMap;
+
 export type FederatedEventEmitterTypes = {
     [K in keyof FederatedEventMap as K | `${K}capture`]: [event: FederatedEventMap[K]];
 } & {

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -2,7 +2,7 @@ import { DisplayObject } from '@pixi/display';
 import { FederatedEvent } from './FederatedEvent';
 
 import type { utils } from '@pixi/core';
-import type { FederatedEventMap } from './FederatedEventMap';
+import type { AllFederatedEventMap } from './FederatedEventMap';
 import type { FederatedPointerEvent } from './FederatedPointerEvent';
 import type { FederatedWheelEvent } from './FederatedWheelEvent';
 
@@ -159,9 +159,9 @@ type RemoveListenerOptions = boolean | EventListenerOptions;
 export interface IFederatedDisplayObject
     extends Omit<FederatedEventTarget, 'parent' | 'children' | keyof utils.EventEmitter | 'cursor'>
 {
-    addEventListener<K extends keyof FederatedEventMap>(
+    addEventListener<K extends keyof AllFederatedEventMap>(
         type: K,
-        listener: (e: FederatedEventMap[K]) => any,
+        listener: (e: AllFederatedEventMap[K]) => any,
         options?: AddListenerOptions
     ): void;
     addEventListener(
@@ -169,9 +169,9 @@ export interface IFederatedDisplayObject
         listener: EventListenerOrEventListenerObject,
         options?: AddListenerOptions
     ): void;
-    removeEventListener<K extends keyof FederatedEventMap>(
+    removeEventListener<K extends keyof AllFederatedEventMap>(
         type: K,
-        listener: (e: FederatedEventMap[K]) => any,
+        listener: (e: AllFederatedEventMap[K]) => any,
         options?: RemoveListenerOptions
     ): void;
     removeEventListener(

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -93,8 +93,10 @@ export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
     onmouseenter: FederatedEventHandler | null;
     /** Handler for 'mouseleave' event */
     onmouseleave: FederatedEventHandler | null;
-    /** Handler for 'mouseover' event */
+    /** Handler for 'mousemove' event */
     onmousemove: FederatedEventHandler | null;
+    /** Handler for 'globalmousemove' event */
+    onglobalmousemove: FederatedEventHandler | null;
     /** Handler for 'mouseout' event */
     onmouseout: FederatedEventHandler | null;
     /** Handler for 'mouseover' event */
@@ -113,6 +115,8 @@ export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
     onpointerleave: FederatedEventHandler | null;
     /** Handler for 'pointermove' event */
     onpointermove: FederatedEventHandler | null;
+    /** Handler for 'globalpointermove' event */
+    onglobalpointermove: FederatedEventHandler | null;
     /** Handler for 'pointerout' event */
     onpointerout: FederatedEventHandler | null;
     /** Handler for 'pointerover' event */
@@ -141,6 +145,8 @@ export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
     ontouchendoutside: FederatedEventHandler | null;
     /** Handler for 'touchmove' event */
     ontouchmove: FederatedEventHandler | null;
+    /** Handler for 'globaltouchmove' event */
+    onglobaltouchmove: FederatedEventHandler | null;
     /** Handler for 'touchstart' event */
     ontouchstart: FederatedEventHandler | null;
     /** Handler for 'wheel' event */
@@ -231,6 +237,17 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      * }
      */
     onmousemove: null,
+
+    /**
+     * Property-based event handler for the `globalmousemove` event.
+     * @memberof PIXI.DisplayObject#
+     * @default null
+     * @example
+     * this.onglobalmousemove = (event) => {
+     *  //some function here that happens on globalmousemove
+     * }
+     */
+    onglobalmousemove: null,
 
     /**
      * Property-based event handler for the `mouseout` event.
@@ -330,6 +347,17 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      * }
      */
     onpointermove:  null,
+
+    /**
+     * Property-based event handler for the `globalpointermove` event.
+     * @memberof PIXI.DisplayObject#
+     * @default null
+     * @example
+     * this.onglobalpointermove = (event) => {
+     *  //some function here that happens on globalpointermove
+     * }
+     */
+    onglobalpointermove:  null,
 
     /**
      * Property-based event handler for the `pointerout` event.
@@ -484,6 +512,17 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      * }
      */
     ontouchmove:  null,
+
+    /**
+     * Property-based event handler for the `globaltouchmove` event.
+     * @memberof PIXI.DisplayObject#
+     * @default null
+     * @example
+     * this.onglobaltouchmove = (event) => {
+     *  //some function here that happens on globaltouchmove
+     * }
+     */
+    onglobaltouchmove:  null,
 
     /**
      * Property-based event handler for the `touchstart` event.

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -220,6 +220,7 @@ describe('EventSystem', () =>
         const primaryOverSpy = jest.fn();
         const primaryOutSpy = jest.fn();
         const primaryMoveSpy = jest.fn();
+        const primaryMoveGlobalSpy = jest.fn();
 
         let callCount = 0;
 
@@ -235,9 +236,15 @@ describe('EventSystem', () =>
             primaryMoveSpy();
             ++callCount;
         });
+        graphics.on('globalpointermove', () =>
+        {
+            expect([2, 7]).toContain(callCount);
+            primaryMoveGlobalSpy();
+            ++callCount;
+        });
         graphics.on('pointerout', () =>
         {
-            expect(callCount).toEqual(2);
+            expect(callCount).toEqual(4);
             primaryOutSpy();
             ++callCount;
         });
@@ -245,18 +252,25 @@ describe('EventSystem', () =>
         const secondaryOverSpy = jest.fn();
         const secondaryOutSpy = jest.fn();
         const secondaryMoveSpy = jest.fn();
+        const secondaryMoveGlobalSpy = jest.fn();
 
         second.on('pointerover', () =>
         {
-            expect(callCount).toEqual(3);
+            expect(callCount).toEqual(5);
             secondaryOverSpy();
             ++callCount;
         });
         second.on('pointerout', secondaryOutSpy);
         second.on('pointermove', () =>
         {
-            expect(callCount).toEqual(4);
+            expect(callCount).toEqual(6);
             secondaryMoveSpy();
+            ++callCount;
+        });
+        second.on('globalpointermove', () =>
+        {
+            expect([3, 8]).toContain(callCount);
+            secondaryMoveGlobalSpy();
             ++callCount;
         });
 
@@ -265,6 +279,8 @@ describe('EventSystem', () =>
         );
         expect(primaryOverSpy).toHaveBeenCalledOnce();
         expect(primaryMoveSpy).toHaveBeenCalledOnce();
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+        expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 125, clientY: 25 })
@@ -272,6 +288,8 @@ describe('EventSystem', () =>
         expect(primaryOutSpy).toHaveBeenCalledOnce();
         expect(secondaryOverSpy).toHaveBeenCalledOnce();
         expect(secondaryMoveSpy).toHaveBeenCalledOnce();
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
+        expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
         expect(secondaryOutSpy).not.toBeCalledTimes(1);
     });
 


### PR DESCRIPTION
This PR add 3 new events `globalpointermove`, `globaltouchmove`, and `globalmousemove`

These move events behave like the old interaction system, and is the equivalent of setting `events.rootBoundary.moveOnAll`

This PR also fixes an issue with `displayObject.addEventListener` types not being correctly assigned in the `global.d.ts` file