### PR TITLE
Fix events not firing when mouse does not move

### DIFF
--- a/packages/ticker/src/const.ts
+++ b/packages/ticker/src/const.ts
@@ -14,6 +14,7 @@
 export enum UPDATE_PRIORITY
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    INTERACTION = 50,
     HIGH = 25,
     NORMAL = 0,
     LOW = -25,


### PR DESCRIPTION
With the new events system events did not fire when the mouse does not move

This PR implements these change by firing a `pointermove` event if the user hasn't moved there mouse.

Most of this logical was directly taken from the old interaction system

todo:

- [ ] fix issue where touch events behave differently to both v6 old interaction & new v7 events 