### PR TITLE
Fix circular dependencies in build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "types": "tsc --noEmit",
     "types:strict": "npm run types -- --strictNullChecks | ts-node ./scripts/filterTypeScriptErrors.ts",
     "prebuild": "run-s clean:build",
-    "build": "rollup -c",
+    "build": "rollup -c --failAfterWarnings",
     "prebuild:types": "run-s clean:types clean:out",
     "build:types": "tsc -p tsconfig.types.json && ts-node scripts/fixTypes.ts",
     "postbuild:types": "copyfiles -u 1 \"out/**/*\" . && run-s clean:out",

--- a/packages/core/src/batch/BatchTextureArray.ts
+++ b/packages/core/src/batch/BatchTextureArray.ts
@@ -1,4 +1,4 @@
-import type { BaseTexture } from '@pixi/core';
+import type { BaseTexture } from '../textures/BaseTexture';
 
 /**
  * Used by the batcher to build texture batches.

--- a/packages/core/src/mask/MaskData.ts
+++ b/packages/core/src/mask/MaskData.ts
@@ -1,10 +1,10 @@
 import { MASK_TYPES } from '@pixi/constants';
-import { Filter } from '@pixi/core';
+import { Filter } from '../filters/Filter';
 
 import type { COLOR_MASK_BITS, MSAA_QUALITY } from '@pixi/constants';
-import type { ISpriteMaskFilter } from '@pixi/core';
 import type { Matrix, Rectangle } from '@pixi/math';
 import type { IFilterTarget } from '../filters/IFilterTarget';
+import type { ISpriteMaskFilter } from '../filters/spriteMask/SpriteMaskFilter';
 import type { Renderer } from '../Renderer';
 
 export interface IMaskTarget extends IFilterTarget

--- a/packages/core/src/transformFeedback/TransformFeedback.ts
+++ b/packages/core/src/transformFeedback/TransformFeedback.ts
@@ -1,6 +1,6 @@
 import { Runner } from '@pixi/runner';
 
-import type { Buffer } from '@pixi/core';
+import type { Buffer } from '../geometry/Buffer';
 
 /**
  * A TransformFeedback object wrapping GLTransformFeedback object.

--- a/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
+++ b/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
@@ -1,8 +1,11 @@
 import { extensions, ExtensionType } from '@pixi/extensions';
 
 import type { DRAW_MODES } from '@pixi/constants';
-import type { IRenderingContext, ISystem, Renderer, Shader } from '@pixi/core';
 import type { ExtensionMetadata } from '@pixi/extensions';
+import type { IRenderingContext } from '../IRenderer';
+import type { Renderer } from '../Renderer';
+import type { Shader } from '../shader/Shader';
+import type { ISystem } from '../system/ISystem';
 import type { TransformFeedback } from './TransformFeedback';
 
 /**


### PR DESCRIPTION
Core was throwing a bunch of build errors (`Circular dependency` and `Unresolved dependencies`) because things inside of `@pixi/core` were importing from itself. This changes these imports to be relative.

Example Error:

```
packages/core/src/index.ts → packages/core/lib, packages/core/lib...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
@pixi/core (imported by packages/core/src/mask/MaskData.ts)
created packages/core/lib, packages/core/lib in 660ms

bundles/***/src/index.ts → bundles/***/lib, bundles/***/lib...
created bundles/***/lib, bundles/***/lib in 16ms

bundles/***/src/index.ts → bundles/***/dist/***, bundles/***/dist/pixi.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***/dist/***, bundles/***/dist/pixi.mjs in 2.1s

bundles/***/src/index.ts → bundles/***/dist/pixi.min.js, bundles/***/dist/pixi.min.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***/dist/pixi.min.js, bundles/***/dist/pixi.min.mjs in 1.8s

bundles/***-node/src/index.ts → bundles/***-node/lib, bundles/***-node/lib...
created bundles/***-node/lib, bundles/***-node/lib in 52ms

bundles/***-webworker/src/index.ts → bundles/***-webworker/lib, bundles/***-webworker/lib...
created bundles/***-webworker/lib, bundles/***-webworker/lib in 12ms

bundles/***-webworker/src/index.ts → bundles/***-webworker/dist/webworker.js, bundles/***-webworker/dist/webworker.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***-webworker/dist/webworker.js, bundles/***-webworker/dist/webworker.mjs in 1.8s

bundles/***-webworker/src/index.ts → bundles/***-webworker/dist/webworker.min.js, bundles/***-webworker/dist/webworker.min.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***-webworker/dist/webworker.min.js, bundles/***-webworker/dist/webworker.min.mjs in 1.7s

bundles/***-legacy/src/index.ts → bundles/***-legacy/lib, bundles/***-legacy/lib...
created bundles/***-legacy/lib, bundles/***-legacy/lib in 9ms

bundles/***-legacy/src/index.ts → bundles/***-legacy/dist/pixi-legacy.js, bundles/***-legacy/dist/pixi-legacy.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***-legacy/dist/pixi-legacy.js, bundles/***-legacy/dist/pixi-legacy.mjs in 1.8s

bundles/***-legacy/src/index.ts → bundles/***-legacy/dist/pixi-legacy.min.js, bundles/***-legacy/dist/pixi-legacy.min.mjs...
(!) Circular dependency
packages/core/lib/index.mjs -> packages/core/lib/settings.mjs -> packages/core/lib/systems.mjs -> packages/core/lib/mask/MaskSystem.mjs -> packages/core/lib/mask/MaskData.mjs -> packages/core/lib/index.mjs
created bundles/***-legacy/dist/pixi-legacy.min.js, bundles/***-legacy/dist/pixi-legacy.min.mjs in 1.6s
```