### PR TITLE
Fix xadvance calculating when rendering BitmapText

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -507,9 +507,9 @@ export class BitmapFont
                 height,
                 xoffset: 0,
                 yoffset: 0,
-                xadvance: Math.ceil(width
+                xadvance: width
                         - (style.dropShadow ? style.dropShadowDistance : 0)
-                        - (style.stroke ? style.strokeThickness : 0)),
+                        - (style.stroke ? style.strokeThickness : 0),
             });
 
             positionX += (textureGlyphWidth + (2 * padding)) * resolution;

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -298,8 +298,8 @@ export class BitmapText extends Container
             charRenderData.texture = charData.texture;
             charRenderData.line = line;
             charRenderData.charCode = charCode;
-            charRenderData.position.x = pos.x + charData.xOffset + (this._letterSpacing / 2);
-            charRenderData.position.y = pos.y + charData.yOffset;
+            charRenderData.position.x = Math.round(pos.x + charData.xOffset + (this._letterSpacing / 2));
+            charRenderData.position.y = Math.round(pos.y + charData.yOffset);
             charRenderData.prevSpaces = spaceCount;
 
             chars.push(charRenderData);


### PR DESCRIPTION
Closes #9082 

v7.1.0:
https://jsfiddle.net/bigtimebuddy/xot0qn1c/
![Screen Shot 2023-01-20 at 10 12 21 AM](https://user-images.githubusercontent.com/864393/213732641-739eafc7-0cdb-40d7-a290-0b7eb59c6c84.png)


This PR:
https://jsfiddle.net/bigtimebuddy/jekt7vyn/
![Screen Shot 2023-01-20 at 10 12 48 AM](https://user-images.githubusercontent.com/864393/213732723-ef682feb-fa36-42b7-bc0c-64f3b6c48c51.png)

_Top: HTML, Middle: PIXI.Text, Bottom: PIXI.BitmapText w/ BitmapFont_