### PR TITLE
Fix: Workaround for transpilation failure with create-react-app

### DIFF
--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -59,18 +59,21 @@ export class ImageBitmapResource extends BaseImageResource
     {
         options = options || {};
 
+        let baseSource;
+        let url;
+
         if (typeof source === 'string')
         {
-            super(ImageBitmapResource.EMPTY);
-
-            this.url = source;
+            baseSource = ImageBitmapResource.EMPTY;
+            url = source;
         }
         else
         {
-            super(source);
-
-            this.url = null;
+            baseSource = source;
+            url = null;
         }
+        super(baseSource);
+        this.url = url;
 
         this.crossOrigin = options.crossOrigin ?? true;
         this.alphaMode = typeof options.alphaMode === 'number' ? options.alphaMode : null;

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -72,6 +72,8 @@ export class ImageBitmapResource extends BaseImageResource
             baseSource = source;
             url = null;
         }
+        // Using super() in if() can cause transpilation problems in some cases, so take it out of if().
+        // See https://github.com/pixijs/pixijs/pull/9093 for details.
         super(baseSource);
         this.url = url;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Users using `create-react-app` + PixiJS are continuously facing problem with transpilation (#8733, #8824 and #9064). Let me explain the details.

In #8698 I added code below in `ImageBitmapResource.constructor`:

<https://github.com/pixijs/pixijs/blob/2f12f4ee46fd17ef5b0ab2eb6bc23f1d03295f76/packages/core/src/textures/resources/ImageBitmapResource.ts#L62-L73>

This looks good, and when releasing it will be transpiled by `esbuild`:

```js
var __super = (...args) => {
  super(...args);
};
if (typeof source === "string") {
  __super(ImageBitmapResource.EMPTY);
  this.url = source;
} else {
  __super(source);
  this.url = null;
}
```

([Source code of related logic in esbuild here.](https://github.com/evanw/esbuild/blob/5fe21253ee75fb4c5ea395a0877b2a5ab51c3575/internal/js_parser/js_parser_lower.go#L3064-L3071))

Until then, everything is fine, but users usually need to do their own transpilation, and here is where it can cause problems. Noticing that `__super = (...args) => { super(...args); }` is an arrow function with railing comma in parameters, and have a `super` call in its body. Unfortunately, due to limitation of transpilation, it is impossible to transpile it without transpiling the whole class (using polyfills like `_createClass` in Babel instead of native ES6 classes).

This situation can happen when using the default setting of `create-react-app`, or `@babel/preset-env` with target `since 2017`. Previously Babel wrongly transpiles this into:

```js
var _supercall = function () {
  return _supercall(...arguments);
};
var __super = function () {
  _supercall(...arguments);
};
if (typeof source === "string") {
  __super(ImageBitmapResource.EMPTY);
  this.url = source;
} else {
  __super(source);
  this.url = null;
}
```

This will lead to infinite recursion. So I opened issue babel/babel#15148 and PR babel/babel#15163 to fix this bug in Babel. Now it will report error when transpiling:

```
SyntaxError: .../ImageBitmapResource.mjs: When using '@babel/plugin-transform-parameters', it's not possible to compile `super()` in an arrow function with default or rest parameters without compiling classes.
Please add '@babel/plugin-transform-classes' to your Babel configuration.
```

Users will get an explicit error instead of a confusing infinite recursion, but it is still quite annoying. So in this PR I just move `super()` out of `if()`, solving this issue.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
