### PR TITLE
Fix: Extract should use multisample

### DIFF
--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -1,4 +1,4 @@
-import { extensions, ExtensionType, Rectangle, RenderTexture, utils } from '@pixi/core';
+import { extensions, ExtensionType, MSAA_QUALITY, Rectangle, RenderTexture, utils } from '@pixi/core';
 
 import type { ExtensionMetadata, ICanvas, ISystem, Renderer } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
@@ -103,7 +103,57 @@ export class Extract implements ISystem
      * @param frame - The frame the extraction is restricted to.
      * @returns - A Canvas element with the texture rendered on.
      */
-    public canvas(target: DisplayObject | RenderTexture, frame?: Rectangle): ICanvas
+    public canvas(target?: DisplayObject | RenderTexture, frame?: Rectangle): ICanvas
+    {
+        const { pixels, width, height, flipY } = this._rawPixels(target, frame);
+
+        let canvasBuffer = new utils.CanvasRenderTarget(width, height, 1);
+
+        // Add the pixels to the canvas
+        const canvasData = canvasBuffer.context.getImageData(0, 0, width, height);
+
+        Extract.arrayPostDivide(pixels, canvasData.data);
+
+        canvasBuffer.context.putImageData(canvasData, 0, 0);
+
+        // Flipping pixels
+        if (flipY)
+        {
+            const target = new utils.CanvasRenderTarget(canvasBuffer.width, canvasBuffer.height, 1);
+
+            target.context.scale(1, -1);
+
+            // We can't render to itself because we should be empty before render.
+            target.context.drawImage(canvasBuffer.canvas, 0, -height);
+
+            canvasBuffer.destroy();
+            canvasBuffer = target;
+        }
+
+        // Send the canvas back
+        return canvasBuffer.canvas;
+    }
+
+    /**
+     * Will return a one-dimensional array containing the pixel data of the entire texture in RGBA
+     * order, with integer values between 0 and 255 (included).
+     * @param target - A displayObject or renderTexture
+     *  to convert. If left empty will use the main renderer
+     * @param frame - The frame the extraction is restricted to.
+     * @returns - One-dimensional array containing the pixel data of the entire texture
+     */
+    public pixels(target?: DisplayObject | RenderTexture, frame?: Rectangle): Uint8Array
+    {
+        const { pixels } = this._rawPixels(target, frame);
+
+        Extract.arrayPostDivide(pixels, pixels);
+
+        return pixels;
+    }
+
+    private _rawPixels(target?: DisplayObject | RenderTexture, frame?: Rectangle): {
+        pixels: Uint8Array, width: number, height: number, flipY: boolean,
+    }
     {
         const renderer = this.renderer;
         let resolution;
@@ -119,7 +169,26 @@ export class Extract implements ISystem
             }
             else
             {
-                renderTexture = this.renderer.generateTexture(target);
+                const multisample = renderer.context.webGLVersion >= 2 ? renderer.multisample : MSAA_QUALITY.NONE;
+
+                renderTexture = this.renderer.generateTexture(target, { multisample });
+
+                if (multisample !== MSAA_QUALITY.NONE)
+                {
+                    // Resolve the multisampled texture to a non-multisampled texture
+                    const resolvedTexture = RenderTexture.create({
+                        width: renderTexture.width,
+                        height: renderTexture.height,
+                    });
+
+                    renderer.framebuffer.bind(renderTexture.framebuffer);
+                    renderer.framebuffer.blit(resolvedTexture.framebuffer);
+                    renderer.framebuffer.bind(null);
+
+                    renderTexture.destroy(true);
+                    renderTexture = resolvedTexture;
+                }
+
                 generated = true;
             }
         }
@@ -149,11 +218,9 @@ export class Extract implements ISystem
         const width = Math.round(frame.width * resolution);
         const height = Math.round(frame.height * resolution);
 
-        let canvasBuffer = new utils.CanvasRenderTarget(width, height, 1);
+        const pixels = new Uint8Array(BYTES_PER_PIXEL * width * height);
 
-        const webglPixels = new Uint8Array(BYTES_PER_PIXEL * width * height);
-
-        // read pixels to the array
+        // Read pixels to the array
         const gl = renderer.gl;
 
         gl.readPixels(
@@ -163,103 +230,7 @@ export class Extract implements ISystem
             height,
             gl.RGBA,
             gl.UNSIGNED_BYTE,
-            webglPixels
-        );
-
-        // add the pixels to the canvas
-        const canvasData = canvasBuffer.context.getImageData(0, 0, width, height);
-
-        Extract.arrayPostDivide(webglPixels, canvasData.data);
-
-        canvasBuffer.context.putImageData(canvasData, 0, 0);
-
-        // pulling pixels
-        if (flipY)
-        {
-            const target = new utils.CanvasRenderTarget(canvasBuffer.width, canvasBuffer.height, 1);
-
-            target.context.scale(1, -1);
-
-            // we can't render to itself because we should be empty before render.
-            target.context.drawImage(canvasBuffer.canvas, 0, -height);
-
-            canvasBuffer.destroy();
-            canvasBuffer = target;
-        }
-
-        if (generated)
-        {
-            renderTexture.destroy(true);
-        }
-
-        // send the canvas back..
-        return canvasBuffer.canvas;
-    }
-
-    /**
-     * Will return a one-dimensional array containing the pixel data of the entire texture in RGBA
-     * order, with integer values between 0 and 255 (included).
-     * @param target - A displayObject or renderTexture
-     *  to convert. If left empty will use the main renderer
-     * @param frame - The frame the extraction is restricted to.
-     * @returns - One-dimensional array containing the pixel data of the entire texture
-     */
-    public pixels(target?: DisplayObject | RenderTexture, frame?: Rectangle): Uint8Array
-    {
-        const renderer = this.renderer;
-        let resolution;
-        let renderTexture;
-        let generated = false;
-
-        if (target)
-        {
-            if (target instanceof RenderTexture)
-            {
-                renderTexture = target;
-            }
-            else
-            {
-                renderTexture = this.renderer.generateTexture(target);
-                generated = true;
-            }
-        }
-
-        if (renderTexture)
-        {
-            resolution = renderTexture.baseTexture.resolution;
-            frame = frame ?? renderTexture.frame;
-            renderer.renderTexture.bind(renderTexture);
-        }
-        else
-        {
-            resolution = renderer.resolution;
-
-            if (!frame)
-            {
-                frame = TEMP_RECT;
-                frame.width = renderer.width;
-                frame.height = renderer.height;
-            }
-
-            renderer.renderTexture.bind(null);
-        }
-
-        const width = Math.round(frame.width * resolution);
-        const height = Math.round(frame.height * resolution);
-
-        const webglPixels = new Uint8Array(BYTES_PER_PIXEL * width * height);
-
-        // read pixels to the array
-        const gl = renderer.gl;
-
-        gl.readPixels(
-            Math.round(frame.x * resolution),
-            Math.round(frame.y * resolution),
-            width,
-            height,
-            gl.RGBA,
-            gl.UNSIGNED_BYTE,
-            webglPixels
+            pixels
         );
 
         if (generated)
@@ -267,9 +238,7 @@ export class Extract implements ISystem
             renderTexture.destroy(true);
         }
 
-        Extract.arrayPostDivide(webglPixels, webglPixels);
-
-        return webglPixels;
+        return { pixels, width, height, flipY };
     }
 
     /** Destroys the extract. */

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -61,4 +61,19 @@ describe('Extract', () =>
         renderTexture.destroy();
         sprite.destroy();
     });
+
+    it('should extract with multisample', async () =>
+    {
+        const renderer = new Renderer({ antialias: true });
+        const extract = renderer.extract;
+        const sprite = new Sprite(Texture.WHITE);
+
+        expect(extract.canvas(sprite)).toBeInstanceOf(HTMLCanvasElement);
+        expect(await extract.base64(sprite)).toBeString();
+        expect(extract.pixels(sprite)).toBeInstanceOf(Uint8Array);
+        expect(await extract.image(sprite)).toBeInstanceOf(HTMLImageElement);
+
+        renderer.destroy();
+        sprite.destroy();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Currently the `Extract#canvas` and `Extract#pixels` doesn't consider the `renderer.multisample`, and this results in the extracted image being rendered without anti-aliasing (#8757), so I add support for multisample in Extract. Also the common part of `Extract#canvas` and `Extract#pixels` ate moved to a separate function `Extract#_rawPixels`.

Example (Left: Direct rendering; Right: Extracted image):

- Before: <https://pixiplayground.com/#/edit/dvxrRjI2Kb7SIIz1vNGcA>
- After: <https://pixiplayground.com/#/edit/jhGoI3tGmcRxrQ_hzCdi->

Fix for v6.x is in #9103.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
