### PR TITLE
Fix: Extract should use multisample (for v6.x)

### DIFF
--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -38,6 +38,7 @@
     "*.d.ts"
   ],
   "peerDependencies": {
+    "@pixi/constants": "6.5.8",
     "@pixi/core": "6.5.8",
     "@pixi/math": "6.5.8",
     "@pixi/utils": "6.5.8"

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -68,4 +68,19 @@ describe('Extract', () =>
         renderTexture.destroy();
         sprite.destroy();
     });
+
+    it('should extract with multisample', async () =>
+    {
+        const renderer = new Renderer({ antialias: true });
+        const extract = renderer.extract;
+        const sprite = new Sprite(Texture.WHITE);
+
+        expect(extract.canvas(sprite)).toBeInstanceOf(HTMLCanvasElement);
+        expect(await extract.base64(sprite)).toBeString();
+        expect(extract.pixels(sprite)).toBeInstanceOf(Uint8Array);
+        expect(await extract.image(sprite)).toBeInstanceOf(HTMLImageElement);
+
+        renderer.destroy();
+        sprite.destroy();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Follow up #9102.

Example (Left: Direct rendering; Right: Extracted image):

- Before: <https://pixiplayground.com/#/edit/KV6JEp2oLzZoEC5ZYUbBU>
- After: <https://pixiplayground.com/#/edit/G5ZiCEToxK4nFSAB-T5fz>

Fixes #8757.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
