### PR TITLE
Chore: Cleanup GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Canvas Dependencies
-      run: sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+      run: sudo apt-get install build-essential libcairo2-dev libgif-dev libjpeg-dev libpango1.0-dev librsvg2-dev xvfb
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
@@ -34,31 +34,25 @@ jobs:
       run: npm ci
 
     - name: Run Unit Tests
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: npm run coverage
+      run: xvfb-run --auto-servernum npm run coverage
       env:
         NODE_ENV: production
 
     - name: Run Unit Tests for @pixi/node
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: npm run coverage:node
+      run: xvfb-run --auto-servernum npm run coverage:node
       env:
         NODE_ENV: production
 
     - name: Extract Branch Name
       id: branch_name
       if: github.event_name == 'push'
-      run: echo ::set-output name=BRANCH_NAME::${GITHUB_REF/refs\/heads\//}
+      run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
     - name: Build for Distribution
       run: npm run dist
 
     - name: Validate Build for Distribution
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: npm run dist-validate
+      run: xvfb-run --auto-servernum npm run dist-validate
 
     # Append assets to releases
     - name: Upload Assets to Release


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Currently there are two deprecation warnings in Github Actions:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, GabrielBB/xvfb-action@v1. For more information see: <https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/>.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>

In this PR:

- For the Node.js 12 warning:
    - `actions/checkout@v2` is upgraded to `actions/checkout@v3`
    - `GabrielBB/xvfb-action@v1` is replaced with native `xvfb-run` command
        - Seems that the maintainer of the action is not active, see GabrielBB/xvfb-action#30
- For the `set-output` warning:
    - `echo ::set-output ...` is replaced with `echo ... >> $GITHUB_OUTPUT`

And all warnings are gone.

Fixes #9090.