### PR TITLE
Fix renderer options not being passed to plugins

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -243,8 +243,8 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
             }
         };
 
-        this.startup.run(startupOptions);
         this.options = options;
+        this.startup.run(startupOptions);
     }
 
     /**

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -405,8 +405,8 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
             },
         };
 
-        this.startup.run(startupOptions);
         this.options = options;
+        this.startup.run(startupOptions);
     }
 
     /**


### PR DESCRIPTION
In #9010 renderer options were added, however the reference to the options was set after the plugins/systems got initialised, so they could not be used