### PR TITLE
Remove navigator.onLine check

### DIFF
--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -65,12 +65,6 @@ export const loadWebFont = {
 
     async load(url: string, options?: LoadAsset<LoadFontData>): Promise<FontFace | FontFace[]>
     {
-        // Prevent loading font if navigator is not online
-        if (!globalThis.navigator.onLine)
-        {
-            throw new Error('[loadWebFont] Cannot load font - navigator is offline');
-        }
-
         const fonts = settings.ADAPTER.getFontFaceSet();
 
         if (fonts)


### PR DESCRIPTION
Fixes #8990 

I believe the `onLine` check was a legacy hack from the Goodboy days of the loader to fix an ie11 issue
We don't need this check in pixi