### PR TITLE
Chore: Cleanup document for renderer options (for v6.x)

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -22,6 +22,10 @@ export interface IApplicationPlugin
     destroy(): void;
 }
 
+/**
+ * Application options supplied to constructor.
+ * @memberof PIXI
+ */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IApplicationOptions extends IRendererOptionsAuto, GlobalMixins.IApplicationOptions {}
 
@@ -62,39 +66,53 @@ export class Application
     public renderer: Renderer | AbstractRenderer;
 
     /**
-     * @param {object} [options] - The optional renderer parameters.
+     * @param {PIXI.IApplicationOptions} [options] - The optional application and renderer parameters.
+     * @param {boolean} [options.antialias=false] -
+     *  **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+     * @param {boolean} [options.autoDensity=false] -
+     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
      * @param {boolean} [options.autoStart=true] - Automatically starts the rendering after the construction.
-     *     **Note**: Setting this parameter to false does NOT stop the shared ticker even if you set
-     *     options.sharedTicker to true in case that it is already started. Stop it by your own.
-     * @param {number} [options.width=800] - The width of the renderers view.
-     * @param {number} [options.height=600] - The height of the renderers view.
-     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
-     * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1.
-     * @param {boolean} [options.antialias=false] - Sets antialias
-     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation, enable this if you
-     *  need to call toDataUrl on the WebGL context.
-     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution / device pixel ratio of the renderer.
-     * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present, this
-     *   option only is available when using **pixi.js-legacy** or **@pixi/canvas-renderer** modules, otherwise
-     *   it is ignored.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
-     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
-     *  `false` sets backgroundAlpha to 1.
-     * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
-     *   not before the new render pass.
-     * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
-     *  for devices with dual graphics card. **(WebGL only)**.
-     * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.
-     *  If set to false, you cannot register a handler to occur before anything that runs on the shared ticker.
-     *  The system ticker will always run before both the shared ticker and the app ticker.
-     * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
+     *  **Note**: Setting this parameter to false does NOT stop the shared ticker even if you set
+     *  `options.sharedTicker` to `true` in case that it is already started. Stop it by your own.
+     * @param {number} [options.backgroundAlpha=1] -
+     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @param {number} [options.backgroundColor=0x000000] -
+     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+     * @param {boolean} [options.forceCanvas=false] -
+     *  Force using {@link PIXI.CanvasRenderer}, even if WebGL is available. This option only is available when
+     *  using **pixi.js-legacy** or **@pixi/canvas-renderer** packages, otherwise it is ignored.
+     * @param {number} [options.height=600] - The height of the renderer's view.
+     * @param {string} [options.powerPreference] -
+     *  **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
+     *  can be `'default'`, `'high-performance'` or `'low-power'`.
+     *  Setting to `'high-performance'` will prioritize rendering performance over power consumption,
+     *  while setting to `'low-power'` will prioritize power saving over rendering performance.
+     * @param {boolean} [options.premultipliedAlpha=true] -
+     *  **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha.
+     * @param {boolean} [options.preserveDrawingBuffer=false] -
+     *  **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
+     *  its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
      * @param {Window|HTMLElement} [options.resizeTo] - Element to automatically resize stage to.
+     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+     *  The resolution / device pixel ratio of the renderer.
+     * @param {boolean} [options.sharedLoader=false] - `true` to use PIXI.Loader.shared, `false` to create new Loader.
+     * @param {boolean} [options.sharedTicker=false] - `true` to use PIXI.Ticker.shared, `false` to create new ticker.
+     *  If set to `false`, you cannot register a handler to occur before anything that runs on the shared ticker.
+     *  The system ticker will always run before both the shared ticker and the app ticker.
+     * @param {boolean} [options.transparent] -
+     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+     * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
+     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+     *  If you want to set transparency, please use `backgroundAlpha`. \
+     *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+     *  set to `true` and `premultipliedAlpha` will be to `false`.
+     * @param {HTMLCanvasElement} [options.view=null] -
+     *  The canvas to use as the view. If omitted, a new canvas will be created.
+     * @param {number} [options.width=800] - The width of the renderer's view.
      */
     constructor(options?: IApplicationOptions)
     {

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -101,26 +101,28 @@ export class CanvasRenderer extends AbstractRenderer
     _outerBlend = false;
 
     /**
-     * @param options - The optional renderer parameters
-     * @param {number} [options.width=800] - the width of the screen
-     * @param {number} [options.height=600] - the height of the screen
-     * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
-     * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1
-     * @param {boolean} [options.antialias=false] - sets antialias
-     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution / device pixel ratio of the renderer.
-     * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation,
-     *  enable this if you need to call toDataUrl on the webgl context.
-     * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
-     *      not before the new render pass.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
-     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] − **Deprecated**. `true` sets backgroundAlpha to 0,
-     *  `false` sets backgroundAlpha to 1.
+     * @param {PIXI.IRendererOptions} [options] - The optional renderer parameters.
+     * @param {boolean} [options.autoDensity=false] -
+     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
+     * @param {number} [options.backgroundAlpha=1] -
+     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @param {number} [options.backgroundColor=0x000000] -
+     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+     * @param {number} [options.height=600] - The height of the renderer's view.
+     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+     *  The resolution / device pixel ratio of the renderer.
+     * @param {boolean} [options.transparent] -
+     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+     * @param {boolean} [options.useContextAlpha=true] -
+     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+     *  If you want to set transparency, please use `backgroundAlpha`.
+     * @param {HTMLCanvasElement} [options.view=null] -
+     *  The canvas to use as the view. If omitted, a new canvas will be created.
+     * @param {number} [options.width=800] - The width of the renderer's view.
      */
     constructor(options?: IRendererOptions)
     {

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -109,7 +109,6 @@ export class CanvasRenderer extends AbstractRenderer
      * @param {number} [options.backgroundColor=0x000000] -
      *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
      * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
-     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
      * @param {number} [options.height=600] - The height of the renderer's view.
      * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
      *  The resolution / device pixel ratio of the renderer.

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -144,31 +144,17 @@ export abstract class AbstractRenderer extends EventEmitter
     /**
      * @param type - The renderer type.
      * @param {PIXI.IRendererOptions} [options] - The optional renderer parameters.
-     * @param {HTMLCanvasElement} [options.view=null] -
-     *  The canvas to use as the view. If omitted, a new canvas will be created.
-     * @param {number} [options.width=800] - The width of the renderer's view.
-     * @param {number} [options.height=600] - The height of the renderer's view.
-     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
-     *  The resolution / device pixel ratio of the renderer.
-     * @param {boolean} [options.autoDensity=false] -
-     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
-     * @param {number} [options.backgroundColor=0x000000] -
-     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
-     * @param {number} [options.backgroundAlpha=1] -
-     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
-     * @param {boolean} [options.transparent] -
-     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
-     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
-     * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
-     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
-     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
-     *  If you want to set transparency, please use `backgroundAlpha`. \
-     *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
-     *  set to `true` and `premultipliedAlpha` will be to `false`.
-     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
-     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
      * @param {boolean} [options.antialias=false] -
      *  **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+     * @param {boolean} [options.autoDensity=false] -
+     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
+     * @param {number} [options.backgroundAlpha=1] -
+     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @param {number} [options.backgroundColor=0x000000] -
+     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+     * @param {number} [options.height=600] - The height of the renderer's view.
      * @param {string} [options.powerPreference] -
      *  **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
      *  can be `'default'`, `'high-performance'` or `'low-power'`.
@@ -179,6 +165,20 @@ export abstract class AbstractRenderer extends EventEmitter
      * @param {boolean} [options.preserveDrawingBuffer=false] -
      *  **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
      *  its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
+     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+     *  The resolution / device pixel ratio of the renderer.
+     * @param {boolean} [options.transparent] -
+     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+     * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
+     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+     *  If you want to set transparency, please use `backgroundAlpha`. \
+     *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+     *  set to `true` and `premultipliedAlpha` will be to `false`.
+     * @param {HTMLCanvasElement} [options.view=null] -
+     *  The canvas to use as the view. If omitted, a new canvas will be created.
+     * @param {number} [options.width=800] - The width of the renderer's view.
      */
     constructor(type: RENDERER_TYPE = RENDERER_TYPE.UNKNOWN, options?: IRendererOptions)
     {

--- a/packages/core/src/AbstractRenderer.ts
+++ b/packages/core/src/AbstractRenderer.ts
@@ -11,26 +11,87 @@ import type { IRenderableContainer, IRenderableObject } from './IRenderableObjec
 
 const tempMatrix = new Matrix();
 
+/**
+ * Renderer options supplied to constructor.
+ * @memberof PIXI
+ * @see PIXI.settings.RENDER_OPTIONS
+ */
 export interface IRendererOptions extends GlobalMixins.IRendererOptions
 {
-    width?: number;
-    height?: number;
+    /** The canvas to use as the view. If omitted, a new canvas will be created. */
     view?: HTMLCanvasElement;
+    /**
+     * The width of the renderer's view.
+     * @default 800
+     */
+    width?: number;
+    /**
+     * The height of the renderer's view.
+     * @default 600
+     */
+    height?: number;
+    /**
+     * The resolution / device pixel ratio of the renderer.
+     * @default PIXI.settings.RESOLUTION
+     */
+    resolution?: number;
+    /**
+     * Whether the CSS dimensions of the renderer's view should be resized automatically.
+     * @default false
+     */
+    autoDensity?: boolean;
+
+    /**
+     * The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @default 0x000000
+     */
+    backgroundColor?: number;
+    /**
+     * Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @default 1
+     */
+    backgroundAlpha?: number;
+    /**
+     * Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     * canvas needs to be opaque, possibly for performance reasons on some older devices.
+     * If you want to set transparency, please use `backgroundAlpha`.
+     *
+     * **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+     * set to `true` and `premultipliedAlpha` will be to `false`.
+     * @default true
+     */
     useContextAlpha?: boolean | 'notMultiplied';
     /**
      * Use `backgroundAlpha` instead.
-     * @deprecated
+     * @deprecated since 6.0.0
      */
     transparent?: boolean;
-    autoDensity?: boolean;
-    antialias?: boolean;
-    resolution?: number;
-    preserveDrawingBuffer?: boolean;
+    /**
+     * Whether to clear the canvas before new render passes.
+     * @default true
+     */
     clearBeforeRender?: boolean;
-    backgroundColor?: number;
-    backgroundAlpha?: number;
-    powerPreference?: WebGLPowerPreference;
+
+    /** **WebGL Only.** User-provided WebGL rendering context object. */
     context?: IRenderingContext;
+    /**
+     * **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+     * @default false
+     */
+    antialias?: boolean;
+    /**
+     * **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
+     * can be `'default'`, `'high-performance'` or `'low-power'`.
+     * Setting to `'high-performance'` will prioritize rendering performance over power consumption,
+     * while setting to `'low-power'` will prioritize power saving over rendering performance.
+     */
+    powerPreference?: WebGLPowerPreference;
+    /**
+     * **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
+     * its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
+     * @default false
+     */
+    preserveDrawingBuffer?: boolean;
 }
 
 export interface IRendererPlugins
@@ -82,26 +143,42 @@ export abstract class AbstractRenderer extends EventEmitter
 
     /**
      * @param type - The renderer type.
-     * @param [options] - The optional renderer parameters.
-     * @param {number} [options.width=800] - The width of the screen.
-     * @param {number} [options.height=600] - The height of the screen.
-     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
-     * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1.
-     * @param {boolean} [options.antialias=false] - Sets antialias
-     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution / device pixel ratio of the renderer.
-     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,
-     *  enable this if you need to call toDataUrl on the WebGL context.
-     * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
-     *      not before the new render pass.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
-     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
-     * `false` sets backgroundAlpha to 1.
+     * @param {PIXI.IRendererOptions} [options] - The optional renderer parameters.
+     * @param {HTMLCanvasElement} [options.view=null] -
+     *  The canvas to use as the view. If omitted, a new canvas will be created.
+     * @param {number} [options.width=800] - The width of the renderer's view.
+     * @param {number} [options.height=600] - The height of the renderer's view.
+     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+     *  The resolution / device pixel ratio of the renderer.
+     * @param {boolean} [options.autoDensity=false] -
+     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
+     * @param {number} [options.backgroundColor=0x000000] -
+     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @param {number} [options.backgroundAlpha=1] -
+     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @param {boolean} [options.transparent] -
+     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+     * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
+     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+     *  If you want to set transparency, please use `backgroundAlpha`. \
+     *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+     *  set to `true` and `premultipliedAlpha` will be to `false`.
+     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+     * @param {boolean} [options.antialias=false] -
+     *  **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+     * @param {string} [options.powerPreference] -
+     *  **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
+     *  can be `'default'`, `'high-performance'` or `'low-power'`.
+     *  Setting to `'high-performance'` will prioritize rendering performance over power consumption,
+     *  while setting to `'low-power'` will prioritize power saving over rendering performance.
+     * @param {boolean} [options.premultipliedAlpha=true] -
+     *  **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha.
+     * @param {boolean} [options.preserveDrawingBuffer=false] -
+     *  **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
+     *  its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
      */
     constructor(type: RENDERER_TYPE = RENDERER_TYPE.UNKNOWN, options?: IRendererOptions)
     {

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -227,31 +227,42 @@ export class Renderer extends AbstractRenderer
     }
 
     /**
-     * @param [options] - The optional renderer parameters.
-     * @param {number} [options.width=800] - The width of the screen.
-     * @param {number} [options.height=600] - The height of the screen.
-     * @param {HTMLCanvasElement} [options.view] - The canvas to use as a view, optional.
-     * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
-     *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
-     *   canvas needs to be opaque, possibly for performance reasons on some older devices.
-     * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
-     *   resolutions other than 1.
-     * @param {boolean} [options.antialias=false] - Sets antialias. If not available natively then FXAA
-     *  antialiasing is used.
-     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution / device pixel ratio of the renderer.
-     * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear
-     *  the canvas or not before the new render pass. If you wish to set this to false, you *must* set
-     *  preserveDrawingBuffer to `true`.
-     * @param {boolean} [options.preserveDrawingBuffer=false] - Enables drawing buffer preservation,
-     *  enable this if you need to call toDataUrl on the WebGL context.
-     * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
-     *  (shown if not transparent).
-     * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
-     * @param {boolean} [options.transparent] - **Deprecated**. `true` sets backgroundAlpha to 0,
-     *  `false` sets backgroundAlpha to 1.
-     * @param {string} [options.powerPreference] - Parameter passed to WebGL context, set to "high-performance"
-     *  for devices with dual graphics card.
-     * @param {object} [options.context] - If WebGL context already exists, all parameters must be taken from it.
+     * @param {PIXI.IRendererOptions} [options] - The optional renderer parameters.
+     * @param {boolean} [options.antialias=false] -
+     *  **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+     * @param {boolean} [options.autoDensity=false] -
+     *  Whether the CSS dimensions of the renderer's view should be resized automatically.
+     * @param {number} [options.backgroundAlpha=1] -
+     *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+     * @param {number} [options.backgroundColor=0x000000] -
+     *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+     * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+     * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+     * @param {number} [options.height=600] - The height of the renderer's view.
+     * @param {string} [options.powerPreference] -
+     *  **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
+     *  can be `'default'`, `'high-performance'` or `'low-power'`.
+     *  Setting to `'high-performance'` will prioritize rendering performance over power consumption,
+     *  while setting to `'low-power'` will prioritize power saving over rendering performance.
+     * @param {boolean} [options.premultipliedAlpha=true] -
+     *  **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha.
+     * @param {boolean} [options.preserveDrawingBuffer=false] -
+     *  **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
+     *  its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
+     * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+     *  The resolution / device pixel ratio of the renderer.
+     * @param {boolean} [options.transparent] -
+     *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+     *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+     * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
+     *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+     *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+     *  If you want to set transparency, please use `backgroundAlpha`. \
+     *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+     *  set to `true` and `premultipliedAlpha` will be to `false`.
+     * @param {HTMLCanvasElement} [options.view=null] -
+     *  The canvas to use as the view. If omitted, a new canvas will be created.
+     * @param {number} [options.width=800] - The width of the renderer's view.
      */
     constructor(options?: IRendererOptions)
     {

--- a/packages/core/src/autoDetectRenderer.ts
+++ b/packages/core/src/autoDetectRenderer.ts
@@ -1,40 +1,62 @@
 import { Renderer } from './Renderer';
 import type { AbstractRenderer, IRendererOptions } from './AbstractRenderer';
 
+/**
+ * Renderer options supplied to `autoDetectRenderer`.
+ * @memberof PIXI
+ */
 export interface IRendererOptionsAuto extends IRendererOptions
 {
     forceCanvas?: boolean;
 }
+
 /**
  * This helper function will automatically detect which renderer you should be using.
  * WebGL is the preferred renderer as it is a lot faster. If WebGL is not supported by
- * the browser then this function will return a canvas renderer
+ * the browser then this function will return a canvas renderer.
  * @memberof PIXI
  * @function autoDetectRenderer
- * @param {object} [options] - The optional renderer parameters
- * @param {number} [options.width=800] - the width of the renderers view
- * @param {number} [options.height=600] - the height of the renderers view
- * @param {HTMLCanvasElement} [options.view] - the canvas to use as a view, optional
- * @param {boolean} [options.useContextAlpha=true] - Pass-through value for canvas' context `alpha` property.
- *   If you want to set transparency, please use `backgroundAlpha`. This option is for cases where the
- *   canvas needs to be opaque, possibly for performance reasons on some older devices.
- * @param {boolean} [options.autoDensity=false] - Resizes renderer view in CSS pixels to allow for
- *   resolutions other than 1
- * @param {boolean} [options.antialias=false] - sets antialias
- * @param {boolean} [options.preserveDrawingBuffer=false] - enables drawing buffer preservation, enable this if you
- *  need to call toDataUrl on the webgl context
- * @param {number} [options.backgroundColor=0x000000] - The background color of the rendered area
- *  (shown if not transparent).
- * @param {number} [options.backgroundAlpha=1] - Value from 0 (fully transparent) to 1 (fully opaque).
- * @param {boolean} [options.clearBeforeRender=true] - This sets if the renderer will clear the canvas or
- *   not before the new render pass.
- * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution / device pixel ratio of the renderer.
- * @param {boolean} [options.forceCanvas=false] - prevents selection of WebGL renderer, even if such is present, this
- *   option only is available when using **pixi.js-legacy** or **@pixi/canvas-renderer** modules, otherwise
- *   it is ignored.
- * @param {string} [options.powerPreference] - Parameter passed to webgl context, set to "high-performance"
- *  for devices with dual graphics card **webgl only**
- * @returns {PIXI.Renderer|PIXI.CanvasRenderer} Returns WebGL renderer if available, otherwise CanvasRenderer
+ * @param {PIXI.IRendererOptionsAuto} [options] - The optional renderer parameters.
+ * @param {boolean} [options.antialias=false] -
+ *  **WebGL Only.** Whether to enable anti-aliasing. This may affect performance.
+ * @param {boolean} [options.autoDensity=false] -
+ *  Whether the CSS dimensions of the renderer's view should be resized automatically.
+ * @param {number} [options.backgroundAlpha=1] -
+ *  Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
+ * @param {number} [options.backgroundColor=0x000000] -
+ *  The background color used to clear the canvas. It accepts hex numbers (e.g. `0xff0000`).
+ * @param {boolean} [options.clearBeforeRender=true] - Whether to clear the canvas before new render passes.
+ * @param {PIXI.IRenderingContext} [options.context] - **WebGL Only.** User-provided WebGL rendering context object.
+ * @param {boolean} [options.forceCanvas=false] -
+ *  Force using {@link PIXI.CanvasRenderer}, even if WebGL is available. This option only is available when
+ *  using **pixi.js-legacy** or **@pixi/canvas-renderer** packages, otherwise it is ignored.
+ * @param {number} [options.height=600] - The height of the renderer's view.
+ * @param {string} [options.powerPreference] -
+ *  **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
+ *  can be `'default'`, `'high-performance'` or `'low-power'`.
+ *  Setting to `'high-performance'` will prioritize rendering performance over power consumption,
+ *  while setting to `'low-power'` will prioritize power saving over rendering performance.
+ * @param {boolean} [options.premultipliedAlpha=true] -
+ *  **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha.
+ * @param {boolean} [options.preserveDrawingBuffer=false] -
+ *  **WebGL Only.** Whether to enable drawing buffer preservation. If enabled, the drawing buffer will preserve
+ *  its value until cleared or overwritten. Enable this if you need to call `toDataUrl` on the WebGL context.
+ * @param {number} [options.resolution=PIXI.settings.RESOLUTION] -
+ *  The resolution / device pixel ratio of the renderer.
+ * @param {boolean} [options.transparent] -
+ *  **Deprecated since 6.0.0, Use `backgroundAlpha` instead.** \
+ *  `true` sets `backgroundAlpha` to `0`, `false` sets `backgroundAlpha` to `1`.
+ * @param {boolean|'notMultiplied'} [options.useContextAlpha=true] -
+ *  Pass-through value for canvas' context attribute `alpha`. This option is for cases where the
+ *  canvas needs to be opaque, possibly for performance reasons on some older devices.
+ *  If you want to set transparency, please use `backgroundAlpha`. \
+ *  **WebGL Only:** When set to `'notMultiplied'`, the canvas' context attribute `alpha` will be
+ *  set to `true` and `premultipliedAlpha` will be to `false`.
+ * @param {HTMLCanvasElement} [options.view=null] -
+ *  The canvas to use as the view. If omitted, a new canvas will be created.
+ * @param {number} [options.width=800] - The width of the renderer's view.
+ * @returns {PIXI.Renderer|PIXI.CanvasRenderer}
+ *  Returns {@link PIXI.Renderer} if WebGL is available, otherwise {@link PIXI.CanvasRenderer}.
  */
 export function autoDetectRenderer(options?: IRendererOptionsAuto): AbstractRenderer
 {

--- a/packages/settings/src/settings.ts
+++ b/packages/settings/src/settings.ts
@@ -9,16 +9,15 @@ import { maxRecommendedTextures } from './utils/maxRecommendedTextures';
 export interface IRenderOptions
 {
     view: HTMLCanvasElement;
-    antialias: boolean;
+    width: number;
+    height: number;
     autoDensity: boolean;
     backgroundColor: number;
     backgroundAlpha: number;
     useContextAlpha: boolean | 'notMultiplied';
     clearBeforeRender: boolean;
+    antialias: boolean;
     preserveDrawingBuffer: boolean;
-    width: number;
-    height: number;
-    legacy: boolean;
 }
 
 export interface ISettings
@@ -163,30 +162,28 @@ export const settings: ISettings = {
      * @name RENDER_OPTIONS
      * @memberof PIXI.settings
      * @type {object}
-     * @property {HTMLCanvasElement} [view=null] -
-     * @property {boolean} [antialias=false] -
-     * @property {boolean} [autoDensity=false] -
-     * @property {boolean} [useContextAlpha=true]  -
-     * @property {number} [backgroundColor=0x000000] -
-     * @property {number} [backgroundAlpha=1] -
-     * @property {boolean} [clearBeforeRender=true] -
-     * @property {boolean} [preserveDrawingBuffer=false] -
-     * @property {number} [width=800] -
-     * @property {number} [height=600] -
-     * @property {boolean} [legacy=false] -
+     * @property {boolean} [antialias=false] - {@link PIXI.IRendererOptions.antialias}
+     * @property {boolean} [autoDensity=false] - {@link PIXI.IRendererOptions.autoDensity}
+     * @property {number} [backgroundAlpha=1] - {@link PIXI.IRendererOptions.backgroundAlpha}
+     * @property {number} [backgroundColor=0x000000] - {@link PIXI.IRendererOptions.backgroundColor}
+     * @property {boolean} [clearBeforeRender=true] - {@link PIXI.IRendererOptions.clearBeforeRender}
+     * @property {number} [height=600] - {@link PIXI.IRendererOptions.height}
+     * @property {boolean} [preserveDrawingBuffer=false] - {@link PIXI.IRendererOptions.preserveDrawingBuffer}
+     * @property {boolean|'notMultiplied'} [useContextAlpha=true] - {@link PIXI.IRendererOptions.useContextAlpha}
+     * @property {HTMLCanvasElement} [view=null] - {@link PIXI.IRendererOptions.view}
+     * @property {number} [width=800] - {@link PIXI.IRendererOptions.width}
      */
     RENDER_OPTIONS: {
         view: null,
-        antialias: false,
+        width: 800,
+        height: 600,
         autoDensity: false,
         backgroundColor: 0x000000,
         backgroundAlpha: 1,
         useContextAlpha: true,
         clearBeforeRender: true,
+        antialias: false,
         preserveDrawingBuffer: false,
-        width: 800,
-        height: 600,
-        legacy: false,
     },
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Follow up #9120, trying to cleanup `IRendererOptions` related documents for v6.x branch.

Document preview:
- `IRendererOptions` ~Before~ | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.IRendererOptions.html)
- `AbstractRenderer` [Before](https://pixijs.download/v6.5.9/docs/PIXI.AbstractRenderer.html#constructor) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.AbstractRenderer.html#constructor)
- `Renderer` [Before](https://pixijs.download/v6.5.9/docs/PIXI.Renderer.html#constructor) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.Renderer.html#constructor)
- `CanvasRenderer` [Before](https://pixijs.download/v6.5.9/docs/PIXI.CanvasRenderer.html#constructor) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.CanvasRenderer.html#constructor) (- WebGL Only options)
- `autoDetectRenderer` [Before](https://pixijs.download/v6.5.9/docs/PIXI.html#autoDetectRenderer) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.html#autoDetectRenderer) (+ `forceCanvas`)
- `Application` [Before](https://pixijs.download/v6.5.9/docs/PIXI.Application.html#constructor) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.Application.html#constructor) (+ `forceCanvas`, `resizeTo`, `autoStart`, `sharedLoader`, `sharedTicker`)
- `settings.RENDER_OPTIONS` [Before](https://pixijs.download/v6.5.9/docs/PIXI.settings.html#RENDER_OPTIONS) | [After](https://pixijs.download/chore/renderer-options-docs-v6.x/docs/PIXI.settings.html#RENDER_OPTIONS)

Also `settings.RENDER_OPTIONS.legacy` is removed since it is no longer being used.

Fixes #8073. 

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
