### PR TITLE
Fix deprecation docs for global Settings mixins

### DIFF
--- a/packages/canvas-mesh/global.d.ts
+++ b/packages/canvas-mesh/global.d.ts
@@ -24,7 +24,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         MESH_CANVAS_PADDING: number;
     }
 }

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -50,33 +50,33 @@ declare namespace GlobalMixins
 
     interface Settings
     {
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         FILTER_RESOLUTION: number;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         FILTER_MULTISAMPLE: import('@pixi/constants').MSAA_QUALITY;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         SPRITE_MAX_TEXTURES: number;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         SPRITE_BATCH_SIZE: number;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         MIPMAP_TEXTURES: import('@pixi/constants').MIPMAP_MODES;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         ANISOTROPIC_LEVEL: number;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         WRAP_MODE: import('@pixi/constants').WRAP_MODES;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         SCALE_MODE: import('@pixi/constants').SCALE_MODES;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         CAN_UPLOAD_SAME_BUFFER: boolean;
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         PRECISION_VERTEX: import('@pixi/constants').PRECISION,
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         PRECISION_FRAGMENT: import('@pixi/constants').PRECISION,
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         GC_MODE: import('@pixi/constants').GC_MODES,
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         GC_MAX_IDLE: number,
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         GC_MAX_CHECK_COUNT: number,
 
         STRICT_TEXTURE_CACHE: boolean;

--- a/packages/display/global.d.ts
+++ b/packages/display/global.d.ts
@@ -20,7 +20,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         SORTABLE_CHILDREN: boolean;
     }
 }

--- a/packages/display/global.d.ts
+++ b/packages/display/global.d.ts
@@ -20,6 +20,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
+        /** @deprecated */
         SORTABLE_CHILDREN: boolean;
     }
 }

--- a/packages/prepare/global.d.ts
+++ b/packages/prepare/global.d.ts
@@ -7,7 +7,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
-        /** @deprecated */
+        /** @deprecated since 7.1.0 */
         UPLOADS_PER_FRAME: number;
     }
 }

--- a/packages/ticker/global.d.ts
+++ b/packages/ticker/global.d.ts
@@ -15,6 +15,7 @@ declare namespace GlobalMixins
 
     interface Settings
     {
+        /** @deprecated since 7.1.0 */
         TARGET_FPMS: number;
     }
 }


### PR DESCRIPTION
One of the deprecated settings in 7.1.0 wasn't updated in display global.d.ts correctly.