### PR TITLE
Chore: Bump required Node.js to 18+

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install Canvas Dependencies
-      run: sudo apt-get install build-essential libcairo2-dev libgif-dev libjpeg-dev libpango1.0-dev librsvg2-dev xvfb
+      run: sudo apt-get -o Acquire::Retries=3 install build-essential libcairo2-dev libgif-dev libjpeg-dev libpango1.0-dev librsvg2-dev xvfb
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm
       run: npm install -g npm@8

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,8 @@
         "yargs-parser": "^21.0.1"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=7",
+        "node": ">=18",
+        "npm": ">=8",
         "yarn": "please-use-npm"
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "lintfix"
   ],
   "engines": {
-    "node": ">=14",
+    "node": ">=18",
     "yarn": "please-use-npm",
-    "npm": ">=7"
+    "npm": ">=8"
   },
   "devDependencies": {
     "@pixi/eslint-config": "^4.0.1",


### PR DESCRIPTION
@vikpe pointed this out

![Screen Shot 2023-02-06 at 11 17 01 AM](https://user-images.githubusercontent.com/864393/217026519-6688242f-0a0e-4fcc-b943-5291b6de1292.png)

Would probably be good to get on 18 LTS version for the project.