### PR TITLE
Fix: Ensure Color internal integer is refreshed when multiplying

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -338,6 +338,7 @@ export class Color
             Math.min(255, (g / step) * step),
             Math.min(255, (b / step) * step),
         ]);
+        this.refreshInt();
 
         return this;
     }

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -282,6 +282,8 @@ export class Color
         this._components[2] *= b;
         this._components[3] *= a;
 
+        this.refreshInt();
+
         return this;
     }
 
@@ -421,14 +423,20 @@ export class Color
         // Cache normalized values for rgba and hex integer
         if (components)
         {
-            const [r, g, b] = components;
-
             this._components.set(components);
-            this._int = (((r * 255) << 16) + ((g * 255) << 8) + (b * 255 | 0));
+            this.refreshInt();
         }
         else
         {
             throw new Error(`Unable to convert color ${value}`);
         }
+    }
+
+    /** Refresh the internal color rgb number */
+    private refreshInt(): void
+    {
+        const [r, g, b] = this._components;
+
+        this._int = (((r * 255) << 16) + ((g * 255) << 8) + (b * 255 | 0));
     }
 }

--- a/packages/color/test/Color.tests.ts
+++ b/packages/color/test/Color.tests.ts
@@ -204,4 +204,15 @@ describe('Color', () =>
             expect(color.toUint8RgbArray()).toEqual(expected.uint8RgbArray);
         });
     });
+
+    it('should multiply color correctly', () =>
+    {
+        const color = new Color([0.5, 0.5, 0.5, 0.5]).multiply([0.5, 0.5, 0.5, 0.5]);
+
+        expect(color.red).toBe(0.25);
+        expect(color.blue).toBe(0.25);
+        expect(color.green).toBe(0.25);
+        expect(color.alpha).toBe(0.25);
+        expect(color.toNumber()).toBe(0x3f3f3f);
+    });
 });


### PR DESCRIPTION
Closes #9144 

Validation: 
https://jsfiddle.net/bigtimebuddy/84ug5tsh/
