### PR TITLE
Fix building of optional packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "clean:types": "rimraf \"{bundles,packages}/*/lib/**/*.d.ts\"",
     "clean:out": "rimraf out",
     "clean:dist": "rimraf dist/*",
-    "clean:modules": "lerna clean --yes",
     "clean": "run-s clean:*",
     "test:pkg": "ts-node --transpile-only ./test/index.ts",
     "test:pkg:debug": "cross-env DEBUG_MODE=1 ts-node --transpile-only ./test/index.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,7 +80,12 @@ async function main()
         }
     });
 
-    toposort(dependencies).map(name => packagesMap[name]).forEach((pkg) =>
+    // Sort the packages into a flat list, however
+    // this list excludes non-graph packages (graphics-extras, unsafe-eval, etc)
+    const packagesGraph = toposort(dependencies);
+    const packagesExtras = Object.keys(packagesMap).filter(name => !packagesGraph.includes(name));
+
+    [...packagesGraph, ...packagesExtras].map(name => packagesMap[name]).forEach((pkg) =>
     {
         const {
             plugin,


### PR DESCRIPTION
Follow-up to #9125 (remove Lerna)

Closes https://github.com/pixijs/examples/issues/116

**Broken**: https://pixijs.io/examples/#/graphics/simple.js (black screen)
**Fixed**: https://pixijs.io/examples/?v=fix/optional-packages#/graphics/simple.js

### Future Work

- [ ] Linting doesn't consider rollup.config.js
- [ ] Remove `toposort` with `orderByDeps` flag in [workspaces-run](https://github.com/jamiebuilds/workspaces-run/pull/7)