### PR TITLE
Docs: update documentation

### DIFF
--- a/packages/assets/src/loader/parsers/LoaderParser.ts
+++ b/packages/assets/src/loader/parsers/LoaderParser.ts
@@ -6,6 +6,9 @@ import type { LoadAsset } from '../types';
  * The extension priority for loader parsers.
  * Helpful when managing multiple parsers that share the same extension
  * test. The higher priority parsers will be checked first.
+ * @static
+ * @memberof PIXI
+ * @enum {number}
  */
 export enum LoaderParserPriority
 // eslint-disable-next-line @typescript-eslint/indent

--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -18,6 +18,10 @@ const validFontMIMEs = [
     'font/woff2',
 ];
 
+/**
+ * Loader plugin for handling web fonts
+ * @memberof PIXI
+ */
 export type LoadFontData = {
     family: string;
     display: string;

--- a/packages/basis/src/Basis.ts
+++ b/packages/basis/src/Basis.ts
@@ -126,10 +126,7 @@ export type BasisTextureExtensions = {
 };
 /* eslint-enable camelcase */
 
-/**
- * API provided by basis_universal WebGL library.
- * @ignore
- */
+/** API provided by basis_universal WebGL library. */
 export type BasisBinding = {
     BasisFile: typeof BasisFile,
     initializeBasis(): void

--- a/packages/canvas-renderer/src/CanvasContextSystem.ts
+++ b/packages/canvas-renderer/src/CanvasContextSystem.ts
@@ -9,7 +9,6 @@ const tempMatrix = new Matrix();
 /**
  * Rendering context for all browsers. This includes platform-specific
  * properties that are not included in the spec for CanvasRenderingContext2D
- * @private
  */
 export interface CrossPlatformCanvasRenderingContext2D extends ICanvasRenderingContext2D
 {

--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -66,7 +66,6 @@ export interface CanvasRenderer extends GlobalMixins.CanvasRenderer {}
  * | ------------------------------------ | ----------------------------------------------------------------------------- |
  * | {@link PIXI.CanvasContextSystem}     | This manages the canvas `2d` contexts and their state                         |
  * | {@link PIXI.CanvasMaskSystem}        | This manages masking operations.                                              |
- * | {@link PIXI.CanvasRenderSystem}      | This adds the ability to render a PIXI.DisplayObject                          |
  * | {@link PIXI.CanvasExtract}           | This extracts image data from a PIXI.DisplayObject                            |
  * | {@link PIXI.CanvasPrepare}           | This prepares a PIXI.DisplayObject async for rendering                        |
  *

--- a/packages/compressed-textures/src/const.ts
+++ b/packages/compressed-textures/src/const.ts
@@ -4,77 +4,131 @@
  * @static
  * @name INTERNAL_FORMATS
  * @enum {number}
- * @property {number} [COMPRESSED_RGB_S3TC_DXT1_EXT=0x83F0] -
- * @property {number} [COMPRESSED_RGBA_S3TC_DXT1_EXT=0x83F1] -
- * @property {number} [COMPRESSED_RGBA_S3TC_DXT3_EXT=0x83F2] -
- * @property {number} [COMPRESSED_RGBA_S3TC_DXT5_EXT=0x83F3] -
- * @property {number} [COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT=35917] -
- * @property {number} [COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT=35918] -
- * @property {number} [COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT=35919] -
- * @property {number} [COMPRESSED_SRGB_S3TC_DXT1_EXT=35916] -
- * @property {number} [COMPRESSED_R11_EAC=0x9270] -
- * @property {number} [COMPRESSED_SIGNED_R11_EAC=0x9271] -
- * @property {number} [COMPRESSED_RG11_EAC=0x9272] -
- * @property {number} [COMPRESSED_SIGNED_RG11_EAC=0x9273] -
- * @property {number} [COMPRESSED_RGB8_ETC2=0x9274] -
- * @property {number} [COMPRESSED_RGBA8_ETC2_EAC=0x9278] -
- * @property {number} [COMPRESSED_SRGB8_ETC2=0x9275] -
- * @property {number} [COMPRESSED_SRGB8_ALPHA8_ETC2_EAC=0x9279] -
- * @property {number} [COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2=0x9276] -
- * @property {number} [COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2=0x9277] -
- * @property {number} [COMPRESSED_RGB_PVRTC_4BPPV1_IMG=0x8C00] -
- * @property {number} [COMPRESSED_RGBA_PVRTC_4BPPV1_IMG=0x8C02] -
- * @property {number} [COMPRESSED_RGB_PVRTC_2BPPV1_IMG=0x8C01] -
- * @property {number} [COMPRESSED_RGBA_PVRTC_2BPPV1_IMG=0x8C03] -
- * @property {number} [COMPRESSED_RGB_ETC1_WEBGL=0x8D64] -
- * @property {number} [COMPRESSED_RGB_ATC_WEBGL=0x8C92] -
- * @property {number} [COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL=0x8C92] -
- * @property {number} [COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL=0x87EE] -
- * @property {number} [COMPRESSED_RGBA_ASTC_4x4_KHR=0x93B0] -
  */
 export enum INTERNAL_FORMATS
 // eslint-disable-next-line @typescript-eslint/indent
 {
     // WEBGL_compressed_texture_s3tc
+    /**
+     * @default 0x83F0
+     */
     COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83F0,
+    /**
+     * @default 0x83F1
+     */
     COMPRESSED_RGBA_S3TC_DXT1_EXT = 0x83F1,
+    /**
+     * @default 0x83F2
+     */
     COMPRESSED_RGBA_S3TC_DXT3_EXT = 0x83F2,
+    /**
+     * @default 0x83F3
+     */
     COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83F3,
 
     // WEBGL_compressed_texture_s3tc_srgb
+    /**
+     * @default 35917
+     */
     COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT = 35917,
+    /**
+     * @default 35918
+     */
     COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT = 35918,
+    /**
+     * @default 35919
+     */
     COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT = 35919,
+    /**
+     * @default 35916
+     */
     COMPRESSED_SRGB_S3TC_DXT1_EXT = 35916,
 
     // WEBGL_compressed_texture_etc
+    /**
+     * @default 0x9270
+     */
     COMPRESSED_R11_EAC = 0x9270,
+    /**
+     * @default 0x9271
+     */
     COMPRESSED_SIGNED_R11_EAC = 0x9271,
+    /**
+     * @default 0x9272
+     */
     COMPRESSED_RG11_EAC = 0x9272,
+    /**
+     * @default 0x9273
+     */
     COMPRESSED_SIGNED_RG11_EAC = 0x9273,
+    /**
+     * @default 0x9274
+     */
     COMPRESSED_RGB8_ETC2 = 0x9274,
+    /**
+     * @default 0x9278
+     */
     COMPRESSED_RGBA8_ETC2_EAC = 0x9278,
+    /**
+     * @default 0x9275
+     */
     COMPRESSED_SRGB8_ETC2 = 0x9275,
+    /**
+     * @default 0x9279
+     */
     COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 0x9279,
+    /**
+     * @default 0x9276
+     */
     COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9276,
+    /**
+     * @default 0x9277
+     */
     COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9277,
 
     // WEBGL_compressed_texture_pvrtc
+    /**
+     * @default 0x8C00
+     */
     COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8C00,
+    /**
+     * @default 0x8C02
+     */
     COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8C02,
+    /**
+     * @default 0x8C01
+     */
     COMPRESSED_RGB_PVRTC_2BPPV1_IMG = 0x8C01,
+    /**
+     * @default 0x8C03
+     */
     COMPRESSED_RGBA_PVRTC_2BPPV1_IMG = 0x8C03,
 
     // WEBGL_compressed_texture_etc1
+    /**
+     * @default 0x8D64
+     */
     COMPRESSED_RGB_ETC1_WEBGL = 0x8D64,
 
     // WEBGL_compressed_texture_atc
+    /**
+     * @default 0x8C92
+     */
     COMPRESSED_RGB_ATC_WEBGL = 0x8C92,
+    /**
+     * @default 0x8C92
+     */
     COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL = 0x8C92, // TODO: Probably a bug on the MDN site
+    /**
+     * @default 0x87EE
+     */
     COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL = 0x87EE,
 
     // WEBGL_compressed_texture_astc
     /* eslint-disable-next-line camelcase */
+    /**
+     * @default 0x93B0
+     */
     COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93B0,
 }
 

--- a/packages/compressed-textures/src/resources/BlobResource.ts
+++ b/packages/compressed-textures/src/resources/BlobResource.ts
@@ -25,7 +25,7 @@ export abstract class BlobResource extends BufferResource
      * @param {string} source - the URL of the texture file
      * @param {PIXI.IBlobOptions} options
      * @param {boolean}[options.autoLoad] - whether to fetch the data immediately;
-     *  you can fetch it later via {@link BlobResource#load}
+     *  you can fetch it later via {@link PIXI.BlobResource#load}
      * @param {boolean}[options.width] - the width in pixels.
      * @param {boolean}[options.height] - the height in pixels.
      */

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -2,18 +2,26 @@
  * Different types of environments for WebGL.
  * @static
  * @memberof PIXI
- * @name ENV
  * @enum {number}
- * @property {number} WEBGL_LEGACY - Used for older v1 WebGL devices. PixiJS will aim to ensure compatibility
- *  with older / less advanced devices. If you experience unexplained flickering prefer this environment.
- * @property {number} WEBGL - Version 1 of WebGL
- * @property {number} WEBGL2 - Version 2 of WebGL
  */
 export enum ENV
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Used for older v1 WebGL devices. PixiJS will aim to ensure compatibility
+     * with older / less advanced devices. If you experience unexplained flickering prefer this environment.
+     * @default 0
+     */
     WEBGL_LEGACY,
+    /**
+     * Version 1 of WebGL
+     * @default 1
+     */
     WEBGL,
+    /**
+     * Version 2 of WebGL
+     * @default 2
+     */
     WEBGL2,
 }
 
@@ -21,17 +29,25 @@ export enum ENV
  * Constant to identify the Renderer Type.
  * @static
  * @memberof PIXI
- * @name RENDERER_TYPE
  * @enum {number}
- * @property {number} UNKNOWN - Unknown render type.
- * @property {number} WEBGL - WebGL render type.
- * @property {number} CANVAS - Canvas render type.
  */
 export enum RENDERER_TYPE
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Unknown render type.
+     * @default 0
+     */
     UNKNOWN,
+    /**
+     * WebGL render type.
+     * @default 1
+     */
     WEBGL,
+    /**
+     * Canvas render type.
+     * @default 2
+     */
     CANVAS,
 }
 
@@ -39,17 +55,25 @@ export enum RENDERER_TYPE
  * Bitwise OR of masks that indicate the buffers to be cleared.
  * @static
  * @memberof PIXI
- * @name BUFFER_BITS
  * @enum {number}
- * @property {number} COLOR - Indicates the buffers currently enabled for color writing.
- * @property {number} DEPTH - Indicates the depth buffer.
- * @property {number} STENCIL - Indicates the stencil buffer.
  */
 export enum BUFFER_BITS
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Indicates the buffers currently enabled for color writing.
+     * @default 0x00004000
+     */
     COLOR = 0x00004000,
+    /**
+     * Indicates the depth buffer.
+     * @default 0x00000100
+     */
     DEPTH = 0x00000100,
+    /**
+     * Indicates the stencil buffer.
+     * @default 0x00000400
+     */
     STENCIL = 0x00000400
 }
 
@@ -59,76 +83,192 @@ export enum BUFFER_BITS
  * IMPORTANT - The WebGL renderer only supports the NORMAL, ADD, MULTIPLY and SCREEN blend modes.
  * Anything else will silently act like NORMAL.
  * @memberof PIXI
- * @name BLEND_MODES
  * @enum {number}
- * @property {number} NORMAL -
- * @property {number} ADD -
- * @property {number} MULTIPLY -
- * @property {number} SCREEN -
- * @property {number} OVERLAY -
- * @property {number} DARKEN -
- * @property {number} LIGHTEN -
- * @property {number} COLOR_DODGE -
- * @property {number} COLOR_BURN -
- * @property {number} HARD_LIGHT -
- * @property {number} SOFT_LIGHT -
- * @property {number} DIFFERENCE -
- * @property {number} EXCLUSION -
- * @property {number} HUE -
- * @property {number} SATURATION -
- * @property {number} COLOR -
- * @property {number} LUMINOSITY -
- * @property {number} NORMAL_NPM -
- * @property {number} ADD_NPM -
- * @property {number} SCREEN_NPM -
- * @property {number} NONE -
- * @property {number} SRC_IN -
- * @property {number} SRC_OUT -
- * @property {number} SRC_ATOP -
- * @property {number} DST_OVER -
- * @property {number} DST_IN -
- * @property {number} DST_OUT -
- * @property {number} DST_ATOP -
- * @property {number} SUBTRACT -
- * @property {number} SRC_OVER -
- * @property {number} ERASE -
- * @property {number} XOR -
  */
 export enum BLEND_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * @default 0
+     */
     NORMAL = 0,
+    /**
+     * @default 1
+     */
     ADD = 1,
+    /**
+     * The pixels of the top layer are multiplied with the corresponding pixel of the bottom layer.
+     * A darker picture is the result.
+     * @default 2
+     */
     MULTIPLY = 2,
+    /**
+     * The pixels are inverted, multiplied, and inverted again. A lighter picture is the result (opposite of multiply)
+     * @default 3
+     */
     SCREEN = 3,
+    /**
+     * A combination of multiply and screen. Dark parts on the base layer become darker, and light parts become lighter.
+     *
+     * Canvas Renderer only.
+     * @default 4
+     */
     OVERLAY = 4,
+    /**
+     * Retains the darkest pixels of both layers.
+     *
+     * Canvas Renderer only.
+     * @default 5
+     */
     DARKEN = 5,
+    /**
+     * Retains the lightest pixels of both layers.
+     *
+     * Canvas Renderer only.
+     * @default 6
+     */
     LIGHTEN = 6,
+    /**
+     * Divides the bottom layer by the inverted top layer.
+     *
+     * Canvas Renderer only.
+     * @default 7
+     */
     COLOR_DODGE = 7,
+    /**
+     * Divides the inverted bottom layer by the top layer, and then inverts the result.
+     *
+     * Canvas Renderer only.
+     * @default 8
+     */
     COLOR_BURN = 8,
+    /**
+     * A combination of multiply and screen like overlay, but with top and bottom layer swapped.
+     *
+     * Canvas Renderer only.
+     * @default 9
+     */
     HARD_LIGHT = 9,
+    /**
+     * A softer version of hard-light. Pure black or white does not result in pure black or white.
+     *
+     * Canvas Renderer only.
+     * @default 10
+     */
     SOFT_LIGHT = 10,
+    /**
+     * Subtracts the bottom layer from the top layer or the other way round to always get a positive value.
+     *
+     * Canvas Renderer only.
+     * @default 11
+     */
     DIFFERENCE = 11,
+    /**
+     * Like difference, but with lower contrast.
+     *
+     * Canvas Renderer only.
+     * @default 12
+     */
     EXCLUSION = 12,
+    /**
+     * Preserves the luma and chroma of the bottom layer, while adopting the hue of the top layer.
+     *
+     * Canvas Renderer only.
+     * @default 13
+     */
     HUE = 13,
+    /**
+     * Preserves the luma and hue of the bottom layer, while adopting the chroma of the top layer.
+     *
+     * Canvas Renderer only.
+     * @default 14
+     */
     SATURATION = 14,
+    /**
+     * Preserves the luma of the bottom layer, while adopting the hue and chroma of the top layer.
+     *
+     * Canvas Renderer only.
+     * @default 15
+     */
     COLOR = 15,
+    /**
+     * Preserves the hue and chroma of the bottom layer, while adopting the luma of the top layer.
+     *
+     * Canvas Renderer only.
+     * @default 16
+     */
     LUMINOSITY = 16,
+    /**
+     * @default 17
+     */
     NORMAL_NPM = 17,
+    /**
+     * @default 18
+     */
     ADD_NPM = 18,
+    /**
+     * @default 19
+     */
     SCREEN_NPM = 19,
+    /**
+     * @default 20
+     */
     NONE = 20,
 
+    /**
+     * Draws new shapes on top of the existing canvas content.
+     * @default 0
+     */
     SRC_OVER = 0,
+    /**
+     * The new shape is drawn only where both the new shape and the destination canvas overlap.
+     * Everything else is made transparent.
+     * @default 21
+     */
     SRC_IN = 21,
+    /**
+     * The new shape is drawn where it doesn't overlap the existing canvas content.
+     * @default 22
+     */
     SRC_OUT = 22,
+    /**
+     * The new shape is only drawn where it overlaps the existing canvas content.
+     * @default 23
+     */
     SRC_ATOP = 23,
+    /**
+     * New shapes are drawn behind the existing canvas content.
+     * @default 24
+     */
     DST_OVER = 24,
+    /**
+     * The existing canvas content is kept where both the new shape and existing canvas content overlap.
+     * Everything else is made transparent.
+     * @default 25
+     */
     DST_IN = 25,
+    /**
+     * The existing content is kept where it doesn't overlap the new shape.
+     * @default 26
+     */
     DST_OUT = 26,
+    /**
+     * The existing canvas is only kept where it overlaps the new shape. The new shape is drawn behind the canvas content.
+     * @default 27
+     */
     DST_ATOP = 27,
+    /**
+     * @default 26
+     */
     ERASE = 26,
+    /**
+     * @default 28
+     */
     SUBTRACT = 28,
+    /**
+     * Shapes are made transparent where both overlap and drawn normal everywhere else.
+     * @default 29
+     */
     XOR = 29,
 }
 
@@ -137,25 +277,45 @@ export enum BLEND_MODES
  * under certain situations and renderers.
  * @memberof PIXI
  * @static
- * @name DRAW_MODES
  * @enum {number}
- * @property {number} POINTS -
- * @property {number} LINES -
- * @property {number} LINE_LOOP -
- * @property {number} LINE_STRIP -
- * @property {number} TRIANGLES -
- * @property {number} TRIANGLE_STRIP -
- * @property {number} TRIANGLE_FAN -
  */
 export enum DRAW_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * To draw a series of points.
+     * @default 0
+     */
     POINTS,
+    /**
+     *  To draw a series of unconnected line segments (individual lines).
+     * @default 1
+     */
     LINES,
+    /**
+     *  To draw a series of connected line segments. It also joins the first and last vertices to form a loop.
+     * @default 2
+     */
     LINE_LOOP,
+    /**
+     * To draw a series of connected line segments.
+     * @default 3
+     */
     LINE_STRIP,
+    /**
+     * To draw a series of separate triangles.
+     * @default 4
+     */
     TRIANGLES,
+    /**
+     * To draw a series of connected triangles in strip fashion.
+     * @default 5
+     */
     TRIANGLE_STRIP,
+    /**
+     * To draw a series of connected triangles sharing the first vertex in a fan-like fashion.
+     * @default 6
+     */
     TRIANGLE_FAN,
 }
 
@@ -165,35 +325,61 @@ export enum DRAW_MODES
  * @static
  * @name FORMATS
  * @enum {number}
- * @property {number} [RGBA=6408] -
- * @property {number} [RGB=6407] -
- * @property {number} [RG=33319] -
- * @property {number} [RED=6403] -
- * @property {number} [RGBA_INTEGER=36249] -
- * @property {number} [RGB_INTEGER=36248] -
- * @property {number} [RG_INTEGER=33320] -
- * @property {number} [RED_INTEGER=36244] -
- * @property {number} [ALPHA=6406] -
- * @property {number} [LUMINANCE=6409] -
- * @property {number} [LUMINANCE_ALPHA=6410] -
- * @property {number} [DEPTH_COMPONENT=6402] -
- * @property {number} [DEPTH_STENCIL=34041] -
  */
 export enum FORMATS
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * @default 6408
+     */
     RGBA = 6408,
+    /**
+     * @default 6407
+     */
     RGB = 6407,
+    /**
+     * @default 33319
+     */
     RG = 33319,
+    /**
+     * @default 6403
+     */
     RED = 6403,
+    /**
+     * @default 36249
+     */
     RGBA_INTEGER = 36249,
+    /**
+     * @default 36248
+     */
     RGB_INTEGER = 36248,
+    /**
+     * @default 33320
+     */
     RG_INTEGER = 33320,
+    /**
+     * @default 36244
+     */
     RED_INTEGER = 36244,
+    /**
+     * @default 6406
+     */
     ALPHA = 6406,
+    /**
+     * @default 6409
+     */
     LUMINANCE = 6409,
+    /**
+     * @default 6410
+     */
     LUMINANCE_ALPHA = 6410,
+    /**
+     * @default 6402
+     */
     DEPTH_COMPONENT = 6402,
+    /**
+     * @default 34041
+     */
     DEPTH_STENCIL = 34041,
 }
 
@@ -201,29 +387,57 @@ export enum FORMATS
  * Various GL target types.
  * @memberof PIXI
  * @static
- * @name TARGETS
  * @enum {number}
- * @property {number} [TEXTURE_2D=3553] -
- * @property {number} [TEXTURE_CUBE_MAP=34067] -
- * @property {number} [TEXTURE_2D_ARRAY=35866] -
- * @property {number} [TEXTURE_CUBE_MAP_POSITIVE_X=34069] -
- * @property {number} [TEXTURE_CUBE_MAP_NEGATIVE_X=34070] -
- * @property {number} [TEXTURE_CUBE_MAP_POSITIVE_Y=34071] -
- * @property {number} [TEXTURE_CUBE_MAP_NEGATIVE_Y=34072] -
- * @property {number} [TEXTURE_CUBE_MAP_POSITIVE_Z=34073] -
- * @property {number} [TEXTURE_CUBE_MAP_NEGATIVE_Z=34074] -
  */
 export enum TARGETS
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * A two-dimensional texture
+     * @default 3553
+     */
     TEXTURE_2D = 3553,
+    /**
+     * A cube-mapped texture. When using a WebGL 2 context, the following values are available additionally:
+     * - gl.TEXTURE_3D: A three-dimensional texture.
+     * - gl.TEXTURE_2D_ARRAY: A two-dimensional array texture.
+     * @default 34067
+     */
     TEXTURE_CUBE_MAP = 34067,
+    /**
+     * A two-dimensional array texture.
+     * @default 35866
+     */
     TEXTURE_2D_ARRAY = 35866,
+    /**
+     * Positive X face for a cube-mapped texture.
+     * @default 34069
+     */
     TEXTURE_CUBE_MAP_POSITIVE_X = 34069,
+    /**
+     * Negative X face for a cube-mapped texture.
+     * @default 34070
+     */
     TEXTURE_CUBE_MAP_NEGATIVE_X = 34070,
+    /**
+     * Positive Y face for a cube-mapped texture.
+     * @default 34071
+     */
     TEXTURE_CUBE_MAP_POSITIVE_Y = 34071,
+    /**
+     * Negative Y face for a cube-mapped texture.
+     * @default 34072
+     */
     TEXTURE_CUBE_MAP_NEGATIVE_Y = 34072,
+    /**
+     * Positive Z face for a cube-mapped texture.
+     * @default 34073
+     */
     TEXTURE_CUBE_MAP_POSITIVE_Z = 34073,
+    /**
+     * Negative Z face for a cube-mapped texture.
+     * @default 34074
+     */
     TEXTURE_CUBE_MAP_NEGATIVE_Z = 34074,
 }
 
@@ -231,43 +445,78 @@ export enum TARGETS
  * Various GL data format types.
  * @memberof PIXI
  * @static
- * @name TYPES
  * @enum {number}
- * @property {number} [UNSIGNED_BYTE=5121] -
- * @property {number} [UNSIGNED_SHORT=5123] -
- * @property {number} [UNSIGNED_SHORT_5_6_5=33635] -
- * @property {number} [UNSIGNED_SHORT_4_4_4_4=32819] -
- * @property {number} [UNSIGNED_SHORT_5_5_5_1=32820] -
- * @property {number} [UNSIGNED_INT=5125] -
- * @property {number} [UNSIGNED_INT_10F_11F_11F_REV=35899] -
- * @property {number} [UNSIGNED_INT_2_10_10_10_REV=33640] -
- * @property {number} [UNSIGNED_INT_24_8=34042] -
- * @property {number} [UNSIGNED_INT_5_9_9_9_REV=35902] -
- * @property {number} [BYTE=5120] -
- * @property {number} [SHORT=5122] -
- * @property {number} [INT=5124] -
- * @property {number} [FLOAT=5126] -
- * @property {number} [FLOAT_32_UNSIGNED_INT_24_8_REV=36269] -
- * @property {number} [HALF_FLOAT=36193] -
  */
 export enum TYPES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * 8 bits per channel for gl.RGBA
+     * @default 5121
+     */
     UNSIGNED_BYTE = 5121,
+    /**
+     * @default 5123
+     */
     UNSIGNED_SHORT = 5123,
+    /**
+     * 5 red bits, 6 green bits, 5 blue bits.
+     * @default 33635
+     */
     UNSIGNED_SHORT_5_6_5 = 33635,
+    /**
+     * 4 red bits, 4 green bits, 4 blue bits, 4 alpha bits.
+     * @default 32819
+     */
     UNSIGNED_SHORT_4_4_4_4 = 32819,
+    /**
+     * 5 red bits, 5 green bits, 5 blue bits, 1 alpha bit.
+     * @default 32820
+     */
     UNSIGNED_SHORT_5_5_5_1 = 32820,
+    /**
+     * @default 5125
+     */
     UNSIGNED_INT = 5125,
+    /**
+     * @default 35899
+     */
     UNSIGNED_INT_10F_11F_11F_REV = 35899,
+    /**
+     * @default 33640
+     */
     UNSIGNED_INT_2_10_10_10_REV = 33640,
+    /**
+     * @default 34042
+     */
     UNSIGNED_INT_24_8 = 34042,
+    /**
+     * @default 35902
+     */
     UNSIGNED_INT_5_9_9_9_REV = 35902,
+    /**
+     * @default 5120
+     */
     BYTE = 5120,
+    /**
+     * @default 5122
+     */
     SHORT = 5122,
+    /**
+     * @default 5124
+     */
     INT = 5124,
+    /**
+     * @default 5126
+     */
     FLOAT = 5126,
+    /**
+     * @default 36269
+     */
     FLOAT_32_UNSIGNED_INT_24_8_REV = 36269,
+    /**
+     * @default 36193
+     */
     HALF_FLOAT = 36193,
 }
 
@@ -276,17 +525,22 @@ export enum TYPES
  * WebGL1 works only with FLOAT.
  * @memberof PIXI
  * @static
- * @name SAMPLER_TYPES
  * @enum {number}
- * @property {number} [FLOAT=0] -
- * @property {number} [INT=1] -
- * @property {number} [UINT=2] -
  */
 export enum SAMPLER_TYPES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * @default 0
+     */
     FLOAT = 0,
+    /**
+     * @default 1
+     */
     INT = 1,
+    /**
+     * @default 2
+     */
     UINT = 2,
 }
 
@@ -297,15 +551,20 @@ export enum SAMPLER_TYPES
  * It can be re-assigned to either LINEAR or NEAREST, depending upon suitability.
  * @memberof PIXI
  * @static
- * @name SCALE_MODES
  * @enum {number}
- * @property {number} LINEAR Smooth scaling
- * @property {number} NEAREST Pixelating scaling
  */
 export enum SCALE_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Pixelating scaling
+     * @default 0
+     */
     NEAREST,
+    /**
+     * Smooth scaling
+     * @default 1
+     */
     LINEAR,
 }
 
@@ -318,19 +577,27 @@ export enum SCALE_MODES
  * only use REPEAT if the texture is po2.
  *
  * This property only affects WebGL.
- * @name WRAP_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} CLAMP - The textures uvs are clamped
- * @property {number} REPEAT - The texture uvs tile and repeat
- * @property {number} MIRRORED_REPEAT - The texture uvs tile and repeat with mirroring
  */
 export enum WRAP_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * The textures uvs are clamped
+     * @default 33071
+     */
     CLAMP = 33071,
+    /**
+     * The texture uvs tile and repeat
+     * @default 10497
+     */
     REPEAT = 10497,
+    /**
+     * The texture uvs tile and repeat with mirroring
+     * @default 33648
+     */
     MIRRORED_REPEAT = 33648,
 }
 
@@ -344,49 +611,82 @@ export enum WRAP_MODES
  * `ON` option will work like `POW2` for WebGL 1.
  *
  * This property only affects WebGL.
- * @name MIPMAP_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} OFF - No mipmaps.
- * @property {number} POW2 - Generate mipmaps if texture dimensions are powers of 2.
- * @property {number} ON - Always generate mipmaps.
- * @property {number} ON_MANUAL - Use mipmaps, but do not auto-generate them;
- *  this is used with a resource that supports buffering each level-of-detail.
  */
 export enum MIPMAP_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * No mipmaps.
+     * @default 0
+     */
     OFF,
+    /**
+     * Generate mipmaps if texture dimensions are powers of 2.
+     * @default 1
+     */
     POW2,
+    /**
+     * Always generate mipmaps.
+     * @default 2
+     */
     ON,
+    /**
+     * Use mipmaps, but do not auto-generate them.
+     * this is used with a resource that supports buffering each level-of-detail.
+     * @default 3
+     */
     ON_MANUAL,
 }
 
 /**
  * How to treat textures with premultiplied alpha
- * @name ALPHA_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} NO_PREMULTIPLIED_ALPHA - Source is not premultiplied, leave it like that.
- *  Option for compressed and data textures that are created from typed arrays.
- * @property {number} PREMULTIPLY_ON_UPLOAD - Source is not premultiplied, premultiply on upload.
- *  Default option, used for all loaded images.
- * @property {number} PREMULTIPLIED_ALPHA - Source is already premultiplied
- *  Example: spine atlases with `_pma` suffix.
- * @property {number} NPM - Alias for NO_PREMULTIPLIED_ALPHA.
- * @property {number} UNPACK - Default option, alias for PREMULTIPLY_ON_UPLOAD.
- * @property {number} PMA - Alias for PREMULTIPLIED_ALPHA.
  */
 export enum ALPHA_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Alias for NO_PREMULTIPLIED_ALPHA.
+     * @type {number}
+     * @default 0
+     */
     NPM = 0,
+    /**
+     * Default option, alias for PREMULTIPLY_ON_UPLOAD.
+     * @type {number}
+     * @default 1
+     */
     UNPACK = 1,
+    /**
+     * Alias for PREMULTIPLIED_ALPHA.
+     * @type {number}
+     * @default 2
+     */
     PMA = 2,
+    /**
+     * Source is not premultiplied, leave it like that.
+     * Option for compressed and data textures that are created from typed arrays.
+     * @type {number}
+     * @default 0
+     */
     NO_PREMULTIPLIED_ALPHA = 0,
+    /**
+     * Source is not premultiplied, premultiply on upload.
+     * Default option, used for all loaded images.
+     * @type {number}
+     * @default 1
+     */
     PREMULTIPLY_ON_UPLOAD = 1,
+    /**
+     * Source is already premultiplied. Example: spine atlases with `_pma` suffix.
+     * @type {number}
+     * @default 2
+     */
     PREMULTIPLIED_ALPHA = 2,
 }
 
@@ -395,25 +695,42 @@ export enum ALPHA_MODES
  *
  * Filter textures need not be cleared if the filter does not use pixel blending. {@link CLEAR_MODES.BLIT} will detect
  * this and skip clearing as an optimization.
- * @name CLEAR_MODES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} BLEND - Do not clear the filter texture. The filter's output will blend on top of the output texture.
- * @property {number} CLEAR - Always clear the filter texture.
- * @property {number} BLIT - Clear only if {@link FilterSystem.forceClear} is set or if the filter uses pixel blending.
- * @property {number} NO - Alias for BLEND, same as `false` in earlier versions
- * @property {number} YES - Alias for CLEAR, same as `true` in earlier versions
- * @property {number} AUTO - Alias for BLIT
  */
 export enum CLEAR_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Alias for BLEND, same as `false` in earlier versions
+     * @default 0
+     */
     NO = 0,
+    /**
+     * Alias for CLEAR, same as `true` in earlier versions
+     * @default 1
+     */
     YES = 1,
+    /**
+     * Alias for BLIT
+     * @default 2
+     */
     AUTO = 2,
+    /**
+     * Do not clear the filter texture. The filter's output will blend on top of the output texture.
+     * @default 0
+     */
     BLEND = 0,
+    /**
+     * Always clear the filter texture.
+     * @default 1
+     */
     CLEAR = 1,
+    /**
+     * Clear only if {@link FilterSystem.forceClear} is set or if the filter uses pixel blending.
+     * @default 2
+     */
     BLIT = 2,
 }
 
@@ -428,58 +745,91 @@ export enum CLEAR_MODES
  *
  * Handy for mobile devices!
  * This property only affects WebGL.
- * @name GC_MODES
  * @enum {number}
  * @static
  * @memberof PIXI
- * @property {number} AUTO - Garbage collection will happen periodically automatically
- * @property {number} MANUAL - Garbage collection will need to be called manually
  */
 export enum GC_MODES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Garbage collection will happen periodically automatically
+     * @default 0
+     */
     AUTO,
+    /**
+     * Garbage collection will need to be called manually
+     * @default 1
+     */
     MANUAL,
 }
 
 /**
  * Constants that specify float precision in shaders.
- * @name PRECISION
  * @memberof PIXI
  * @static
  * @enum {string}
- * @property {string} [LOW='lowp'] -
- * @property {string} [MEDIUM='mediump'] -
- * @property {string} [HIGH='highp'] -
  */
 export enum PRECISION
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * lowp is at least an 9 bit value.
+     * For floating point values they can range from: -2 to +2,
+     * for integer values they are similar to Uint8Array or Int8Array
+     * @default lowp
+     */
     LOW = 'lowp',
+    /**
+     * mediump is at least a 16 bit value.
+     * For floating point values they can range from: -2^14 to +2^14,
+     * for integer values they are similar to Uint16Array or Int16Array
+     * @default mediump
+     */
     MEDIUM = 'mediump',
+    /**
+     * highp is at least a 32 bit value.
+     * For floating point values they can range from: -2^62 to +2^62,
+     * for integer values they are similar to Uint32Array or Int32Array
+     * @default highp
+     */
     HIGH = 'highp',
 }
 
 /**
  * Constants for mask implementations.
  * We use `type` suffix because it leads to very different behaviours
- * @name MASK_TYPES
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} NONE - Mask is ignored
- * @property {number} SCISSOR - Scissor mask, rectangle on screen, cheap
- * @property {number} STENCIL - Stencil mask, 1-bit, medium, works only if renderer supports stencil
- * @property {number} SPRITE - Mask that uses SpriteMaskFilter, uses temporary RenderTexture
- * @property {number} COLOR - Color mask (RGBA)
  */
 export enum MASK_TYPES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Mask is ignored
+     * @default 0
+     */
     NONE = 0,
+    /**
+     * Scissor mask, rectangle on screen, cheap
+     * @default 1
+     */
     SCISSOR = 1,
+    /**
+     * Stencil mask, 1-bit, medium, works only if renderer supports stencil
+     * @default 2
+     */
     STENCIL = 2,
+    /**
+     * Mask that uses SpriteMaskFilter, uses temporary RenderTexture
+     * @default 3
+     */
     SPRITE = 3,
+    /**
+     * Color mask (RGBA)
+     * @default 4
+     */
     COLOR = 4,
 }
 
@@ -487,59 +837,88 @@ export enum MASK_TYPES
  * Bitwise OR of masks that indicate the color channels that are rendered to.
  * @static
  * @memberof PIXI
- * @name COLOR_MASK_BITS
  * @enum {number}
- * @property {number} RED - Red channel.
- * @property {number} GREEN - Green channel
- * @property {number} BLUE - Blue channel.
- * @property {number} ALPHA - Alpha channel.
  */
 export enum COLOR_MASK_BITS
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Red channel.
+     * @default 0x1
+     */
     RED = 0x1,
+    /**
+     * Green channel
+     * @default 0x2
+     */
     GREEN = 0x2,
+    /**
+     * Blue channel.
+     * @default 0x4
+     */
     BLUE = 0x4,
+    /**
+     * Alpha channel.
+     * @default 0x
+     */
     ALPHA = 0x8
 }
 
 /**
  * Constants for multi-sampling antialiasing.
  * @see PIXI.Framebuffer#multisample
- * @name MSAA_QUALITY
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} NONE - No multisampling for this renderTexture
- * @property {number} LOW - Try 2 samples
- * @property {number} MEDIUM - Try 4 samples
- * @property {number} HIGH - Try 8 samples
  */
 export enum MSAA_QUALITY
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * No multisampling for this renderTexture
+     * @default 0
+     */
     NONE = 0,
+    /**
+     * Try 2 samples
+     * @default 2
+     */
     LOW = 2,
+    /**
+     * Try 4 samples
+     * @default 4
+     */
     MEDIUM = 4,
+    /**
+     * Try 8 samples
+     * @default 8
+     */
     HIGH = 8
 }
 
 /**
  * Constants for various buffer types in Pixi
  * @see PIXI.BUFFER_TYPE
- * @name BUFFER_TYPE
  * @memberof PIXI
  * @static
  * @enum {number}
- * @property {number} ELEMENT_ARRAY_BUFFER - buffer type for using as an index buffer
- * @property {number} ARRAY_BUFFER - buffer type for using attribute data
- * @property {number} UNIFORM_BUFFER - the buffer type is for uniform buffer objects
  */
 export enum BUFFER_TYPE
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * buffer type for using as an index buffer
+     * @default 34963
+     */
     ELEMENT_ARRAY_BUFFER = 34963,
+    /**
+     * buffer type for using attribute data
+     * @default 34962
+     */
     ARRAY_BUFFER = 34962,
-    // NOT YET SUPPORTED
+    /**
+     * the buffer type is for uniform buffer objects
+     * @default 35345
+     */
     UNIFORM_BUFFER = 35345,
 }

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -693,7 +693,7 @@ export enum ALPHA_MODES
 /**
  * Configure whether filter textures are cleared after binding.
  *
- * Filter textures need not be cleared if the filter does not use pixel blending. {@link CLEAR_MODES.BLIT} will detect
+ * Filter textures need not be cleared if the filter does not use pixel blending. {@link PIXI.CLEAR_MODES.BLIT} will detect
  * this and skip clearing as an optimization.
  * @memberof PIXI
  * @static
@@ -728,7 +728,7 @@ export enum CLEAR_MODES
      */
     CLEAR = 1,
     /**
-     * Clear only if {@link FilterSystem.forceClear} is set or if the filter uses pixel blending.
+     * Clear only if {@link PIXI.FilterSystem.forceClear} is set or if the filter uses pixel blending.
      * @default 2
      */
     BLIT = 2,

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -78,8 +78,8 @@ export interface Renderer extends GlobalMixins.Renderer {}
  * | {@link PIXI.ProjectionSystem}        | This manages the `projectionMatrix`, used by shaders to get NDC coordinates.  |
  * | {@link PIXI.RenderTextureSystem}     | This manages render-textures, which are an abstraction over framebuffers.     |
  * | {@link PIXI.MaskSystem}              | This manages masking operations.                                              |
- * | {@link PIXI.ScissorSystem}           | This handles scissor masking, and is used internally by {@link MaskSystem}    |
- * | {@link PIXI.StencilSystem}           | This handles stencil masking, and is used internally by {@link MaskSystem}    |
+ * | {@link PIXI.ScissorSystem}           | This handles scissor masking, and is used internally by {@link PIXI.MaskSystem} |
+ * | {@link PIXI.StencilSystem}           | This handles stencil masking, and is used internally by {@link PIXI.MaskSystem} |
  * | {@link PIXI.FilterSystem}            | This manages the filtering pipeline for post-processing effects.              |
  * | {@link PIXI.BatchSystem}             | This manages object renderers that defer rendering until a flush.             |
  * | {@link PIXI.Prepare}                 | This manages uploading assets to the GPU.                                     |

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -74,7 +74,6 @@ export interface Renderer extends GlobalMixins.Renderer {}
  *
  * | PixiJS High-Level Systems            | Set of specific systems designed to work with PixiJS objects                  |
  * | ------------------------------------ | ----------------------------------------------------------------------------- |
- * | {@link PIXI.RenderSystem}            | This adds the ability to render a PIXI.DisplayObject                          |
  * | {@link PIXI.GenerateTextureSystem}   | This adds the ability to generate textures from any PIXI.DisplayObject        |
  * | {@link PIXI.ProjectionSystem}        | This manages the `projectionMatrix`, used by shaders to get NDC coordinates.  |
  * | {@link PIXI.RenderTextureSystem}     | This manages render-textures, which are an abstraction over framebuffers.     |

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -432,7 +432,7 @@ export class FilterSystem implements ISystem
     /**
      * Draws a filter using the default rendering process.
      *
-     * This should be called only by {@link Filter#apply}.
+     * This should be called only by {@link PIXI.Filter#apply}.
      * @param filter - The filter to draw.
      * @param input - The input render target.
      * @param output - The target to output to.

--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -11,8 +11,7 @@ let UID = 0;
  *
  * Same as ArrayBuffer in typescript lib, defined here just for documentation
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface IArrayBuffer extends ArrayBuffer
+export interface IArrayBuffer extends ArrayBuffer // eslint-disable-line @typescript-eslint/no-empty-interface
 {
 }
 

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -97,7 +97,7 @@ export class Geometry
      * @param {PIXI.Buffer|number[]} buffer - the buffer that holds the data of the attribute . You can also provide an Array and a buffer will be created from it.
      * @param size - the size of the attribute. If you have 2 floats per vertex (eg position x and y) this would be 2
      * @param normalized - should the data be normalized.
-     * @param [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {PIXI.TYPES} to see the ones available
+     * @param [type=PIXI.TYPES.FLOAT] - what type of number is the attribute. Check {@link PIXI.TYPES} to see the ones available
      * @param [stride=0] - How far apart, in bytes, the start of each value is. (used for interleaving data)
      * @param [start=0] - How far into the array to start reading values (used for interleaving data)
      * @param instance - Instancing flag

--- a/packages/core/src/mask/MaskData.ts
+++ b/packages/core/src/mask/MaskData.ts
@@ -42,7 +42,7 @@ export class MaskData
     /** Whether it belongs to MaskSystem pool */
     public pooled: boolean;
 
-    /** Indicator of the type (always true for {@link MaskData} objects) */
+    /** Indicator of the type (always true for {@link PIXI.MaskData} objects) */
     public isMaskData: boolean;// webdoc crashes if the type is true because reasons... (will fix)
 
     /**

--- a/packages/core/src/projection/ProjectionSystem.ts
+++ b/packages/core/src/projection/ProjectionSystem.ts
@@ -97,7 +97,8 @@ export class ProjectionSystem implements ISystem
      * NOTE: It is expected you call `renderer.framebuffer.setViewport(destinationFrame)` after this. This is because
      * the framebuffer viewport converts shader vertex output in normalized device coordinates to window coordinates.
      *
-     * NOTE-2: {@link RenderTextureSystem#bind} updates the projection-matrix when you bind a render-texture. It is expected
+     * NOTE-2: {@link PIXI.RenderTextureSystem#bind} updates the projection-matrix when you bind a render-texture.
+     * It is expected
      * that you dirty the current bindings when calling this manually.
      * @param destinationFrame - The rectangle in the render-target to render the contents into. If rendering to the canvas,
      *  the origin is on the top-left; if rendering to a render-texture, the origin is on the bottom-left.

--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -68,7 +68,7 @@ export class RenderTextureSystem implements ISystem
     /**
      * The destination frame for the render-target's projection mapping.
      *
-     * See {@link PIXI.Projection#destinationFrame} for more details.
+     * See {@link PIXI.ProjectionSystem#destinationFrame} for more details.
      */
     public readonly destinationFrame: Rectangle;
 

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -31,7 +31,7 @@ settings.PREFER_ENV = ENV.WEBGL2;
  * {@link PIXI.BaseTexture.from BaseTexture.from}.
  * Otherwise, these `from` calls throw an exception. Using this property
  * can be useful if you want to enforce preloading all assets with
- * {@link PIXI.Loader Loader}.
+ * {@link PIXI.Assets Loader}.
  * @static
  * @name STRICT_TEXTURE_CACHE
  * @memberof PIXI.settings

--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -132,7 +132,7 @@ export class BaseImageResource extends Resource
         super.update();
     }
 
-    /** Destroy this {@link BaseImageResource} */
+    /** Destroy this {@link PIXI.BaseImageResource} */
     override dispose(): void
     {
         this.source = null;

--- a/packages/core/src/textures/resources/BufferResource.ts
+++ b/packages/core/src/textures/resources/BufferResource.ts
@@ -98,7 +98,7 @@ export class BufferResource extends Resource
     /**
      * Used to auto-detect the type of resource.
      * @param {*} source - The source object
-     * @returns {boolean} `true` if <canvas>
+     * @returns {boolean} `true` if \<canvas\>
      */
     static test(source: unknown): source is Float32Array | Uint8Array | Uint32Array
     {

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -51,7 +51,7 @@ export class ImageResource extends BaseImageResource
     alphaMode: ALPHA_MODES;
 
     /**
-     * The ImageBitmap element created for a {@code HTMLImageElement}.
+     * The ImageBitmap element created for a {@link HTMLImageElement}.
      * @default null
      */
     bitmap: ImageBitmap;

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -18,7 +18,7 @@ export interface IVideoResourceOptionsElement
 }
 
 /**
- * Resource type for {@code HTMLVideoElement}.
+ * Resource type for {@link HTMLVideoElement}.
  * @memberof PIXI
  */
 export class VideoResource extends BaseImageResource

--- a/packages/display/src/Bounds.ts
+++ b/packages/display/src/Bounds.ts
@@ -315,7 +315,7 @@ export class Bounds
     }
 
     /**
-     * Adds other {@link Bounds}.
+     * Adds other {@link PIXI.Bounds}.
      * @param bounds - The Bounds to be added
      */
     addBounds(bounds: Bounds): void

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -48,7 +48,7 @@ export interface DisplayObject
  *
  * ## Transforms
  *
- * The [transform]{@link DisplayObject#transform} of a display object describes the projection from its
+ * The [transform]{@link PIXI.DisplayObject#transform} of a display object describes the projection from its
  * local coordinate space to its parent's local coordinate space. The following properties are derived
  * from the transform:
  *
@@ -162,7 +162,7 @@ export interface DisplayObject
  *
  * ### calculateBounds
  *
- * [Container]{@link Container} already implements `calculateBounds` in a manner that includes children.
+ * [Container]{@link PIXI.Container} already implements `calculateBounds` in a manner that includes children.
  *
  * But for a non-Container display object, the `calculateBounds` method must be overridden in order for `getBounds` and
  * `getLocalBounds` to work. This method must write the bounds into `this._bounds`.

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -346,7 +346,7 @@ export class EventBoundary
     }
 
     /**
-     * Emits the event {@link e} to all display objects. The event is propagated in the bubbling phase always.
+     * Emits the event {@code e} to all display objects. The event is propagated in the bubbling phase always.
      *
      * This is used in the `pointermove` legacy mode.
      * @param e - The emitted event.
@@ -398,7 +398,7 @@ export class EventBoundary
     }
 
     /**
-     * Recursive implementation for {@link EventBoundary.hitTest hitTest}.
+     * Recursive implementation for {@link PIXI.EventBoundary.hitTest hitTest}.
      * @param currentTarget - The DisplayObject that is to be hit tested.
      * @param interactive - Flags whether `currentTarget` or one of its parents are interactive.
      * @param location - The location that is being tested for overlap.
@@ -408,7 +408,7 @@ export class EventBoundary
      *  cannot pass the hit test. It is used as a preliminary optimization to prune entire subtrees
      *  of the scene graph.
      * @returns An array holding the hit testing target and all its ancestors in order. The first element
-     *  is the target itself and the last is {@link EventBoundary.rootTarget rootTarget}. This is the opposite
+     *  is the target itself and the last is {@link PIXI.EventBoundary.rootTarget rootTarget}. This is the opposite
      *  order w.r.t. the propagation path. If no hit testing target is found, null is returned.
      */
     protected hitTestRecursive(
@@ -493,7 +493,7 @@ export class EventBoundary
     /**
      * Checks whether the display object or any of its children cannot pass the hit test at all.
      *
-     * {@link EventBoundary}'s implementation uses the {@link PIXI.DisplayObject.hitArea hitArea}
+     * {@link PIXI.EventBoundary}'s implementation uses the {@link PIXI.DisplayObject.hitArea hitArea}
      * and {@link PIXI.DisplayObject._mask} for pruning.
      * @param displayObject
      * @param location
@@ -988,8 +988,8 @@ export class EventBoundary
      * Maps the upstream `pointerupoutside` event to a downstream `pointerupoutside` event, bubbling from the original
      * `pointerdown` target to `rootTarget`.
      *
-     * (The most specific ancestor of the `pointerdown` event and the `pointerup` event must the {@code EventBoundary}'s
-     * root because the `pointerup` event occurred outside of the boundary.)
+     * (The most specific ancestor of the `pointerdown` event and the `pointerup` event must the
+     * `{@link PIXI.EventBoundary}'s root because the `pointerup` event occurred outside of the boundary.)
      *
      * `touchendoutside`, `mouseupoutside`, and `rightupoutside` events are fired as well for specific pointer
      * types. The tracking data for the specific pointer is cleared of a `pressTarget`.

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -297,7 +297,7 @@ export class EventBoundary
     }
 
     /**
-     * Propagate the passed event from from {@link EventBoundary.rootTarget this.rootTarget} to its
+     * Propagate the passed event from from {@link PIXI.EventBoundary.rootTarget this.rootTarget} to its
      * target {@code e.target}.
      * @param e - The event to propagate.
      * @param type
@@ -1352,7 +1352,7 @@ export class EventBoundary
     }
 
     /**
-     * Similar to {@link EventEmitter.emit}, except it stops if the `propagationImmediatelyStopped` flag
+     * Similar to {@link PIXI.EventEmitter.emit}, except it stops if the `propagationImmediatelyStopped` flag
      * is set on the event.
      * @param e - The event to call each listener with.
      * @param type - The event key.

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -627,7 +627,7 @@ export class EventSystem
     }
 
     /**
-     * Normalizes the {@code nativeEvent} into a federateed {@code FederatedPointerEvent}.
+     * Normalizes the `nativeEvent` into a federateed {@link PIXI.FederatedPointerEvent}.
      * @param event
      * @param nativeEvent
      */

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -85,7 +85,7 @@ export class EventSystem
     /** The resolution used to convert between the DOM client space into world space. */
     public resolution = 1;
 
-    /** The renderer managing this {@link EventSystem}. */
+    /** The renderer managing this {@link PIXI.EventSystem}. */
     public renderer: IRenderer;
 
     private currentCursor: string;
@@ -332,7 +332,7 @@ export class EventSystem
     }
 
     /**
-     * Passive handler for `wheel` events on {@link EventSystem.domElement this.domElement}.
+     * Passive handler for `wheel` events on {@link PIXI.EventSystem.domElement this.domElement}.
      * @param nativeEvent - The native wheel event.
      */
     protected onWheel(nativeEvent: WheelEvent): void

--- a/packages/events/src/EventTicker.ts
+++ b/packages/events/src/EventTicker.ts
@@ -2,6 +2,12 @@ import { Ticker, UPDATE_PRIORITY } from '@pixi/core';
 
 import type { EventSystem } from './EventSystem';
 
+/**
+ * This class handles automatic firing of PointerEvents
+ * in the case where the pointer is stationary for too long.
+ * This is to ensure that hit-tests are still run on moving objects.
+ * @memberof PIXI
+ */
 class EventsTickerClass
 {
     /** The event system. */
@@ -130,5 +136,7 @@ class EventsTickerClass
  * This class handles automatic firing of PointerEvents
  * in the case where the pointer is stationary for too long.
  * This is to ensure that hit-tests are still run on moving objects.
+ * @memberof PIXI
+ * @type {PIXI.EventsTickerClass}
  */
 export const EventsTicker = new EventsTickerClass();

--- a/packages/events/src/FederatedEvent.ts
+++ b/packages/events/src/FederatedEvent.ts
@@ -118,7 +118,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
     }
 
     /**
-     * Fallback for the deprecated {@link PIXI.InteractionEvent.data}.
+     * Fallback for the deprecated @code{PIXI.InteractionEvent.data}.
      * @deprecated since 7.0.0
      */
     get data(): this

--- a/packages/events/src/FederatedEvent.ts
+++ b/packages/events/src/FederatedEvent.ts
@@ -18,7 +18,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
     public cancelBubble = true;
 
     /**
-     * Flags whether this event can be canceled using {@link FederatedEvent.preventDefault}. This is always
+     * Flags whether this event can be canceled using {@link PIXI.FederatedEvent.preventDefault}. This is always
      * false (for now).
      */
     public readonly cancelable = false;
@@ -38,7 +38,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
 
     /**
      * The propagation phase.
-     * @default {@link FederatedEvent.NONE}
+     * @default {@link PIXI.FederatedEvent.NONE}
      */
     public eventPhase = FederatedEvent.prototype.NONE;
 
@@ -75,7 +75,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
     /** The composed path of the event's propagation. The {@code target} is at the end. */
     public path: FederatedEventTarget[];
 
-    /** The {@link EventBoundary} that manages this event. Null for root events. */
+    /** The {@link PIXI.EventBoundary} that manages this event. Null for root events. */
     public readonly manager: EventBoundary;
 
     /** Event-specific detail */
@@ -126,7 +126,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
         return this;
     }
 
-    /** The propagation path for this event. Alias for {@link EventBoundary.propagationPath}. */
+    /** The propagation path for this event. Alias for {@link PIXI.EventBoundary.propagationPath}. */
     composedPath(): FederatedEventTarget[]
     {
         // Find the propagation path if it isn't cached or if the target has changed since since
@@ -179,7 +179,7 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
 
     /**
      * Stop this event from propagating to any addition listeners, including on the
-     * {@link FederatedEventTarget.currentTarget currentTarget} and also the following
+     * {@link PIXI.FederatedEventTarget.currentTarget currentTarget} and also the following
      * event targets on the propagation path.
      */
     stopImmediatePropagation(): void
@@ -188,8 +188,8 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
     }
 
     /**
-     * Stop this event from propagating to the next {@link FederatedEventTarget}. The rest of the listeners
-     * on the {@link FederatedEventTarget.currentTarget currentTarget} will still be notified.
+     * Stop this event from propagating to the next {@link PIXI.FederatedEventTarget}. The rest of the listeners
+     * on the {@link PIXI.FederatedEventTarget.currentTarget currentTarget} will still be notified.
      */
     stopPropagation(): void
     {

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -64,7 +64,7 @@ export type FederatedEventHandler<T= FederatedPointerEvent> = (event: T) => void
 export type Interactive = 'none' | 'passive' | 'auto' | 'static' | 'dynamic';
 
 /**
- * Describes the shape for a {@link FederatedEvent}'s' `eventTarget`.
+ * Describes the shape for a {@link PIXI.FederatedEvent}'s' `eventTarget`.
  * @memberof PIXI
  */
 export interface FederatedEventTarget extends utils.EventEmitter, EventTarget

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -51,10 +51,16 @@ export interface IHitArea
     contains(x: number, y: number): boolean;
 }
 
-/** Function type for handlers, e.g., onclick */
+/**
+ * Function type for handlers, e.g., onclick
+ * @memberof PIXI
+ */
 export type FederatedEventHandler<T= FederatedPointerEvent> = (event: T) => void;
 
-/** The type of interaction a DisplayObject can be */
+/**
+ * The type of interaction a DisplayObject can be
+ * @memberof PIXI
+ */
 export type Interactive = 'none' | 'passive' | 'auto' | 'static' | 'dynamic';
 
 /**

--- a/packages/events/src/FederatedMouseEvent.ts
+++ b/packages/events/src/FederatedMouseEvent.ts
@@ -40,13 +40,13 @@ MouseEvent | PointerEvent | TouchEvent
     public get clientY(): number { return this.client.y; }
 
     /**
-     * Alias for {@link FederatedMouseEvent.clientX this.clientX}.
+     * Alias for {@link PIXI.FederatedMouseEvent.clientX this.clientX}.
      * @readonly
      */
     get x(): number { return this.clientX; }
 
     /**
-     * Alias for {@link FederatedMouseEvent.clientY this.clientY}.
+     * Alias for {@link PIXI.FederatedMouseEvent.clientY this.clientY}.
      * @readonly
      */
     get y(): number { return this.clientY; }

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -7,28 +7,20 @@ import {
     DRAW_MODES,
     Point,
     utils,
-    WRAP_MODES,
+    WRAP_MODES
 } from '@pixi/core';
 import { Bounds } from '@pixi/display';
 import { GraphicsData } from './GraphicsData';
 import {
-    BATCH_POOL,
-    BatchPart,
-    buildLine,
+    BATCH_POOL, BatchPart, buildLine,
     buildPoly,
     DRAW_CALL_POOL,
-    FILL_COMMANDS,
+    FILL_COMMANDS
 } from './utils';
 
-import type { Circle, Ellipse, IPointData, Matrix, Polygon, Rectangle, RoundedRectangle, Texture } from '@pixi/core';
+import type { IPointData, IShape, Matrix, Texture } from '@pixi/core';
 import type { FillStyle } from './styles/FillStyle';
 import type { LineStyle } from './styles/LineStyle';
-
-/*
- * Complex shape type
- * @todo Move to Math shapes
- */
-type IShape = Circle | Ellipse | Polygon | Rectangle | RoundedRectangle;
 
 const tmpPoint = new Point();
 

--- a/packages/graphics/src/const.ts
+++ b/packages/graphics/src/const.ts
@@ -2,38 +2,54 @@
  * Supported line joints in `PIXI.LineStyle` for graphics.
  * @see PIXI.Graphics#lineStyle
  * @see https://graphicdesign.stackexchange.com/questions/59018/what-is-a-bevel-join-of-two-lines-exactly-illustrator
- * @name LINE_JOIN
  * @memberof PIXI
  * @static
  * @enum {string}
- * @property {string} MITER - 'miter': make a sharp corner where outer part of lines meet
- * @property {string} BEVEL - 'bevel': add a square butt at each end of line segment and fill the triangle at turn
- * @property {string} ROUND - 'round': add an arc at the joint
  */
 export enum LINE_JOIN
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * 'miter': make a sharp corner where outer part of lines meet
+     * @default miter
+     */
     MITER = 'miter',
+    /**
+     * 'bevel': add a square butt at each end of line segment and fill the triangle at turn
+     * @default bevel
+     */
     BEVEL = 'bevel',
+    /**
+     * 'round': add an arc at the joint
+     * @default round
+     */
     ROUND = 'round'
 }
 
 /**
  * Support line caps in `PIXI.LineStyle` for graphics.
  * @see PIXI.Graphics#lineStyle
- * @name LINE_CAP
  * @memberof PIXI
  * @static
  * @enum {string}
- * @property {string} BUTT - 'butt': don't add any cap at line ends (leaves orthogonal edges)
- * @property {string} ROUND - 'round': add semicircle at ends
- * @property {string} SQUARE - 'square': add square at end (like `BUTT` except more length at end)
  */
 export enum LINE_CAP
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * 'butt': don't add any cap at line ends (leaves orthogonal edges)
+     * @default butt
+     */
     BUTT = 'butt',
+    /**
+     * 'round': add semicircle at ends
+     * @default round
+     */
     ROUND = 'round',
+    /**
+     * 'square': add square at end (like `BUTT` except more length at end)
+     * @default square
+     */
     SQUARE = 'square'
 }
 

--- a/packages/math/src/Transform.ts
+++ b/packages/math/src/Transform.ts
@@ -10,7 +10,11 @@ export interface Transform extends GlobalMixins.Transform {}
  */
 export class Transform
 {
-    /** A default (identity) transform. */
+    /**
+     * A default (identity) transform.
+     * @static
+     * @type {PIXI.Transform}
+     */
     public static readonly IDENTITY = new Transform();
 
     /** The world transformation matrix. */

--- a/packages/math/src/const.ts
+++ b/packages/math/src/const.ts
@@ -27,18 +27,33 @@ export const DEG_TO_RAD = Math.PI / 180;
  * @static
  * @memberof PIXI
  * @enum {number}
- * @property {number} POLY Polygon
- * @property {number} RECT Rectangle
- * @property {number} CIRC Circle
- * @property {number} ELIP Ellipse
- * @property {number} RREC Rounded Rectangle
  */
 export enum SHAPES
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * @property {number} RECT Rectangle
+     * @default 0
+     */
     POLY = 0,
+    /**
+     * @property {number} POLY Polygon
+     * @default 1
+     */
     RECT = 1,
+    /**
+     * @property {number} CIRC Circle
+     * @default 2
+     */
     CIRC = 2,
+    /**
+     * @property {number} ELIP Ellipse
+     * @default 3
+     */
     ELIP = 3,
+    /**
+     * @property {number} RREC Rounded Rectangle
+     * @default 4
+     */
     RREC = 4,
 }

--- a/packages/math/src/groupD8.ts
+++ b/packages/math/src/groupD8.ts
@@ -97,7 +97,7 @@ type GD8Symmetry = number;
  * of an angle of `a: GD8Constant` are the vectors `(uX(a), uY(a))`
  * and `(vX(a), vY(a))`. These aren't necessarily unit vectors.
  *
- * **Origin:**<br>
+ * **Origin:**
  *  This is the small part of gameofbombs.com portal system. It works.
  * @see PIXI.groupD8.E
  * @see PIXI.groupD8.SE

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -25,11 +25,15 @@ export { RoundedRectangle };
 
 export * from './const';
 
-/*
- * @description Complex shape type
+/**
+ * Complex shape type
+ * @memberof PIXI
  */
 export type IShape = Circle | Ellipse | Polygon | Rectangle | RoundedRectangle;
 
+/**
+ * @memberof PIXI
+ */
 export interface ISize
 {
     width: number;

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -146,7 +146,7 @@ export class MeshMaterial extends Shader
         return this._tint;
     }
 
-    /** Gets called automatically by the Mesh. Intended to be overridden for custom {@link MeshMaterial} objects. */
+    /** Gets called automatically by the Mesh. Intended to be overridden for custom {@link PIXI.MeshMaterial} objects. */
     public update(): void
     {
         if (this._colorDirty)

--- a/packages/settings/src/utils/isMobile.ts
+++ b/packages/settings/src/utils/isMobile.ts
@@ -1,6 +1,6 @@
 import isMobileCall from 'ismobilejs';
 
-type isMobileResult = {
+export type isMobileResult = {
     apple: {
         phone: boolean;
         ipod: boolean;

--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -6,7 +6,7 @@ import type { AssetExtension, LoadAsset, Loader, ResolveAsset } from '@pixi/asse
 import type { Texture } from '@pixi/core';
 import type { ISpritesheetData } from './Spritesheet';
 
-interface SpriteSheetJson extends ISpritesheetData
+export interface SpriteSheetJson extends ISpritesheetData
 {
     meta: {
         image: string;
@@ -50,6 +50,7 @@ function getCacheableAssets(keys: string[], asset: Spritesheet, ignoreMultiPack:
 /**
  * Asset extension for loading spritesheets.
  * @memberof PIXI
+ * @type {PIXI.AssetExtension}
  */
 export const spritesheetAsset = {
     extension: ExtensionType.Asset,

--- a/packages/text/src/const.ts
+++ b/packages/text/src/const.ts
@@ -1,15 +1,20 @@
 /**
  * Constants that define the type of gradient on text.
  * @static
- * @name TEXT_GRADIENT
  * @memberof PIXI
  * @type {object}
- * @property {number} LINEAR_VERTICAL Vertical gradient
- * @property {number} LINEAR_HORIZONTAL Linear gradient
  */
 export enum TEXT_GRADIENT
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Vertical gradient
+     * @default 0
+     */
     LINEAR_VERTICAL = 0,
+    /**
+     * Linear gradient
+     * @default 1
+     */
     LINEAR_HORIZONTAL = 1
 }

--- a/packages/ticker/src/const.ts
+++ b/packages/ticker/src/const.ts
@@ -3,20 +3,35 @@
  * the {@link PIXI.Ticker} object. Higher priority items are updated first and lower
  * priority items, such as render, should go later.
  * @static
- * @name UPDATE_PRIORITY
  * @memberof PIXI
  * @enum {number}
- * @property {number} [HIGH=25] High priority updating, {@link PIXI.VideoBaseTexture} and {@link PIXI.AnimatedSprite}
- * @property {number} [NORMAL=0] Default priority for ticker events, see {@link PIXI.Ticker#add}.
- * @property {number} [LOW=-25] Low priority used for {@link PIXI.Application} rendering.
- * @property {number} [UTILITY=-50] Lowest priority used for {@link PIXI.BasePrepare} utility.
  */
 export enum UPDATE_PRIORITY
 // eslint-disable-next-line @typescript-eslint/indent
 {
+    /**
+     * Highest priority used for interaction events in {@link PIXI.EventSystem}
+     * @default 50
+     */
     INTERACTION = 50,
+    /**
+     * High priority updating, used by {@link PIXI.AnimatedSprite}
+     * @default 25
+     */
     HIGH = 25,
+    /**
+     * Default priority for ticker events, see {@link PIXI.Ticker#add}.
+     * @default 0
+     */
     NORMAL = 0,
+    /**
+     * Low priority used for {@link PIXI.Application} rendering.
+     * @default -25
+     */
     LOW = -25,
+    /**
+     * Lowest priority used for {@link PIXI.BasePrepare} utility.
+     * @default -50
+     */
     UTILITY = -50,
 }

--- a/packages/utils/src/media/BoundingBox.ts
+++ b/packages/utils/src/media/BoundingBox.ts
@@ -39,6 +39,9 @@ export class BoundingBox
         return this.left === this.right || this.top === this.bottom;
     }
 
-    /** An empty BoundingBox. */
+    /**
+     * An empty BoundingBox.
+     * @type {PIXI.utils.BoundingBox}
+     */
     public static readonly EMPTY = new BoundingBox(0, 0, 0, 0);
 }

--- a/packages/utils/src/media/caches.ts
+++ b/packages/utils/src/media/caches.ts
@@ -5,7 +5,7 @@ import type { BaseTexture, Program, Texture } from '@pixi/core';
  * @static
  * @name ProgramCache
  * @memberof PIXI.utils
- * @type {object}
+ * @type {Record<string, Program>}
  */
 export const ProgramCache: {[key: string]: Program} = {};
 
@@ -14,7 +14,7 @@ export const ProgramCache: {[key: string]: Program} = {};
  * @static
  * @name TextureCache
  * @memberof PIXI.utils
- * @type {object}
+ * @type {Record<string, Texture>}
  */
 export const TextureCache: {[key: string]: Texture} = Object.create(null);
 
@@ -23,7 +23,7 @@ export const TextureCache: {[key: string]: Texture} = Object.create(null);
  * @static
  * @name BaseTextureCache
  * @memberof PIXI.utils
- * @type {object}
+ * @type {Record<string, BaseTexture>}
  */
 export const BaseTextureCache: {[key: string]: BaseTexture} = Object.create(null);
 


### PR DESCRIPTION
As i have been going through writing a markdown parser for webdoc I noticed a few issues with the docs

The main change here is that the docs for eums are now inlined. This means things like vscode can now get the descriptions when you hover over them

Also i fixed a whole bunch of `@link` that did not resolve because they were missing the `PIXI` namespace