### PR TITLE
Docs: Cleanup document

### DIFF
--- a/packages/assets/src/cache/CacheParser.ts
+++ b/packages/assets/src/cache/CacheParser.ts
@@ -9,6 +9,7 @@ import type { ExtensionMetadata } from '@pixi/core';
  *
  * Useful if you want to add more than just a raw asset to the cache
  * (for example a spritesheet will want to make all its sub textures easily accessible in the cache)
+ * @memberof PIXI
  */
 export interface CacheParser<T=any>
 {

--- a/packages/assets/src/loader/parsers/LoaderParser.ts
+++ b/packages/assets/src/loader/parsers/LoaderParser.ts
@@ -4,8 +4,9 @@ import type { LoadAsset } from '../types';
 
 /**
  * The extension priority for loader parsers.
- * Helpful when managing multiple parsers that share the same extension
- * test. The higher priority parsers will be checked first.
+ * Helpful when managing multiple parsers that share the same extension test.
+ * The higher priority parsers will be checked first.
+ * @memberof PIXI
  */
 export enum LoaderParserPriority
 // eslint-disable-next-line @typescript-eslint/indent
@@ -31,6 +32,7 @@ export enum LoaderParserPriority
  * some plugins may only be used for parsing,
  * some only for loading
  * and some for both!
+ * @memberof PIXI
  */
 export interface LoaderParser<ASSET = any, META_DATA = any>
 {

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -47,6 +47,7 @@ extend([namesPlugin]);
  *   `{ h: 0, s: 100, v: 100 }`, `{ h: 0, s: 100, v: 100, a: 0.5 }`, etc.
  * - {@link PIXI.Color} objects.
  * @memberof PIXI
+ * @since 7.2.0
  */
 export type ColorSource = string | number | number[] | Float32Array | Uint8Array | Uint8ClampedArray
 | HslColor | HslaColor | HsvColor | HsvaColor | RgbColor | RgbaColor | Color;
@@ -72,6 +73,7 @@ export type ColorSource = string | number | number[] | Float32Array | Uint8Array
  * new Color('hsl(0, 100%, 50%, 50%)').toArray(); // [1, 0, 0, 0.5]
  * new Color({ h: 0, s: 100, v: 100, a: 0.5 }).toArray(); // [1, 0, 0, 0.5]
  * @memberof PIXI
+ * @since 7.2.0
  */
 export class Color
 {

--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -7,9 +7,10 @@ let UID = 0;
 /* eslint-disable max-len */
 
 /**
- * Marks places in PixiJS where you can pass Float32Array, UInt32Array, any typed arrays, and ArrayBuffer
+ * Marks places in PixiJS where you can pass Float32Array, UInt32Array, any typed arrays, and ArrayBuffer.
  *
- * Same as ArrayBuffer in typescript lib, defined here just for documentation
+ * Same as ArrayBuffer in typescript lib, defined here just for documentation.
+ * @memberof PIXI
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface IArrayBuffer extends ArrayBuffer
@@ -20,8 +21,9 @@ export interface IArrayBuffer extends ArrayBuffer
  * PixiJS classes use this type instead of ArrayBuffer and typed arrays
  * to support expressions like `geometry.buffers[0].data[0] = position.x`.
  *
- * Gives access to indexing and `length` field
+ * Gives access to indexing and `length` field.
  * - @popelyshev: If data is actually ArrayBuffer and throws Exception on indexing - its user problem :)
+ * @memberof PIXI
  */
 export interface ITypedArray extends IArrayBuffer
 {

--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -111,6 +111,7 @@ export class BaseRenderTexture extends BaseTexture
     /**
      * Color object when clearning the texture.
      * @readonly
+     * @since 7.2.0
      */
     get clear(): Color
     {

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -16,7 +16,11 @@ const DEFAULT_UVS = new TextureUvs();
 
 export type TextureSource = string | BaseTexture | ImageSource;
 
-/** Stores the width of the non-scalable borders, for example when used with {@link PIXI.NineSlicePlane} texture */
+/**
+ * Stores the width of the non-scalable borders, for example when used with {@link PIXI.NineSlicePlane} texture.
+ * @memberof PIXI
+ * @since 7.2.0
+ */
 export interface ITextureBorders
 {
     /** left border in pixels */
@@ -120,7 +124,8 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
 
     /**
      * Default width of the non-scalable border that is used if 9-slice plane is created with this texture.
-     * (See {@link PIXI.NineSlicePlane})
+     * @since 7.2.0
+     * @see PIXI.NineSlicePlane
      */
     public defaultBorders?: ITextureBorders;
 

--- a/packages/core/src/textures/resources/BufferResource.ts
+++ b/packages/core/src/textures/resources/BufferResource.ts
@@ -5,9 +5,6 @@ import type { ISize } from '@pixi/math';
 import type { Renderer } from '../../Renderer';
 import type { BaseTexture } from '../BaseTexture';
 import type { GLTexture } from '../GLTexture';
-/**
- * @interface SharedArrayBuffer
- */
 
 /**
  * Buffer resource with data of typed array.

--- a/packages/core/src/textures/resources/CanvasResource.ts
+++ b/packages/core/src/textures/resources/CanvasResource.ts
@@ -3,10 +3,6 @@ import { BaseImageResource } from './BaseImageResource';
 import type { ICanvas } from '@pixi/settings';
 
 /**
- * @interface OffscreenCanvas
- */
-
-/**
  * Resource type for HTMLCanvasElement and OffscreenCanvas.
  * @memberof PIXI
  */

--- a/packages/core/src/textures/resources/CubeResource.ts
+++ b/packages/core/src/textures/resources/CubeResource.ts
@@ -8,7 +8,10 @@ import type { BaseTexture } from '../BaseTexture';
 import type { GLTexture } from '../GLTexture';
 import type { Resource } from './Resource';
 
-/** Constructor options for CubeResource */
+/**
+ * Constructor options for CubeResource.
+ * @memberof PIXI
+ */
 export interface ICubeResourceOptions extends ISize
 {
     /** Whether to auto-load resources */

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -28,7 +28,10 @@ declare namespace GlobalMixins
 
     interface IRendererOptions
     {
-        /** The default interaction mode for all display objects. */
+        /**
+         * The default interaction mode for all display objects.
+         * @since 7.2.0
+         */
         defaultInteraction?: import('@pixi/events').Interactive;
     }
 

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -35,7 +35,11 @@ export class EventSystem
 
     private static _defaultInteraction: boolean | Interactive;
 
-    /** The default interaction mode for all display objects. */
+    /**
+     * The default interaction mode for all display objects.
+     * @readonly
+     * @since 7.2.0
+     */
     public static get defaultInteraction()
     {
         return this._defaultInteraction;

--- a/packages/events/src/EventTicker.ts
+++ b/packages/events/src/EventTicker.ts
@@ -2,6 +2,14 @@ import { Ticker, UPDATE_PRIORITY } from '@pixi/core';
 
 import type { EventSystem } from './EventSystem';
 
+/**
+ * This class handles automatic firing of PointerEvents
+ * in the case where the pointer is stationary for too long.
+ * This is to ensure that hit-tests are still run on moving objects.
+ * @memberof PIXI
+ * @since 7.2.0
+ * @see PIXI.EventsTicker
+ */
 class EventsTickerClass
 {
     /** The event system. */
@@ -130,5 +138,8 @@ class EventsTickerClass
  * This class handles automatic firing of PointerEvents
  * in the case where the pointer is stationary for too long.
  * This is to ensure that hit-tests are still run on moving objects.
+ * @memberof PIXI
+ * @type {PIXI.EventsTickerClass}
+ * @since 7.2.0
  */
 export const EventsTicker = new EventsTickerClass();

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -54,7 +54,11 @@ export interface IHitArea
 /** Function type for handlers, e.g., onclick */
 export type FederatedEventHandler<T= FederatedPointerEvent> = (event: T) => void;
 
-/** The type of interaction a DisplayObject can be */
+/**
+ * The type of interaction a DisplayObject can be.
+ * @memberof PIXI
+ * @since 7.2.0
+ */
 export type Interactive = 'none' | 'passive' | 'auto' | 'static' | 'dynamic';
 
 /**
@@ -607,6 +611,7 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      * Determines if the displayObject is interactive or not
      * @returns {boolean} Whether the displayObject is interactive or not
      * @memberof PIXI.DisplayObject#
+     * @since 7.2.0
      * @example
      * import { Sprite } from 'pixi.js';
      * const sprite = new Sprite(texture);

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -25,7 +25,10 @@ import { ArcUtils, BezierUtils, QuadraticUtils } from './utils';
 import type { BatchDrawCall, ColorSource, IPointData, IShape, Renderer } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
 
-/** Batch element computed from Graphics geometry */
+/**
+ * Batch element computed from Graphics geometry.
+ * @memberof PIXI
+ */
 export interface IGraphicsBatchElement
 {
     vertexData: Float32Array;

--- a/packages/graphics/src/const.ts
+++ b/packages/graphics/src/const.ts
@@ -37,7 +37,10 @@ export enum LINE_CAP
     SQUARE = 'square'
 }
 
-/** @deprecated */
+/**
+ * @memberof PIXI
+ * @deprecated
+ */
 export interface IGraphicsCurvesSettings
 {
     adaptive: boolean;

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -2,7 +2,10 @@ import { BaseTexture, Rectangle, Texture, utils } from '@pixi/core';
 
 import type { ImageResource, IPointData, ITextureBorders } from '@pixi/core';
 
-/** Represents the JSON data for a spritesheet atlas. */
+/**
+ * Represents the JSON data for a spritesheet atlas.
+ * @memberof PIXI
+ */
 export interface ISpritesheetFrameData
 {
     frame: {
@@ -25,7 +28,10 @@ export interface ISpritesheetFrameData
     borders?: ITextureBorders;
 }
 
-/** Atlas format. */
+/**
+ * Atlas format.
+ * @memberof PIXI
+ */
 export interface ISpritesheetData
 {
     frames: utils.Dict<ISpritesheetFrameData>;

--- a/packages/text-html/src/HTMLText.ts
+++ b/packages/text-html/src/HTMLText.ts
@@ -25,6 +25,7 @@ import type { ITextStyle } from '@pixi/text';
  * @class
  * @memberof PIXI
  * @extends PIXI.Sprite
+ * @since 7.2.0
  */
 export class HTMLText extends Sprite
 {

--- a/packages/text-html/src/HTMLTextStyle.ts
+++ b/packages/text-html/src/HTMLTextStyle.ts
@@ -9,8 +9,13 @@ import type {
     TextStyleTextBaseline
 } from '@pixi/text';
 
-// HTMLText support more white-space options
-type HTMLTextStyleWhiteSpace = 'normal' | 'pre' | 'pre-line' | 'nowrap' | 'pre-wrap';
+/**
+ * HTMLText support more white-space options.
+ * @memberof PIXI
+ * @since 7.2.0
+ * @see PIXI.IHTMLTextStyle
+ */
+export type HTMLTextStyleWhiteSpace = 'normal' | 'pre' | 'pre-line' | 'nowrap' | 'pre-wrap';
 
 // Subset of ITextStyle
 type ITextStyleIgnore = 'whiteSpace'
@@ -24,23 +29,22 @@ type ITextStyleIgnore = 'whiteSpace'
 
 /**
  * Modifed versions from ITextStyle.
- * @extends ITextStyle
  * @memberof PIXI
+ * @extends PIXI.ITextStyle
+ * @since 7.2.0
  */
-interface IHTMLTextStyle extends Omit<ITextStyle, ITextStyleIgnore>
+export interface IHTMLTextStyle extends Omit<ITextStyle, ITextStyleIgnore>
 {
-    /**
-     * White-space with expanded options
-     * @type {'normal'|'pre'|'pre-line'|'nowrap'|'pre-wrap'}
-     */
+    /** White-space with expanded options. */
     whiteSpace: HTMLTextStyleWhiteSpace;
 }
 
 /**
  * Font information for HTMLText
  * @memberof PIXI
+ * @since 7.2.0
  */
-interface IHTMLFont
+export interface IHTMLFont
 {
     /** User-supplied URL request */
     originalUrl: string;
@@ -63,11 +67,11 @@ interface IHTMLFont
 /**
  * Used internally to restrict text style usage and convert easily to CSS.
  * @class
- * @extends PIXI.TextStyle
  * @memberof PIXI
- * @param {PIXI.ITextStyle|IHTMLTextStyle} [style] - Style to copy.
+ * @param {PIXI.ITextStyle|PIXI.IHTMLTextStyle} [style] - Style to copy.
+ * @since 7.2.0
  */
-class HTMLTextStyle extends TextStyle
+export class HTMLTextStyle extends TextStyle
 {
     /** The collection of installed fonts */
     public static availableFonts: Record<string, IHTMLFont> = {};
@@ -498,6 +502,3 @@ class HTMLTextStyle extends TextStyle
         return super.lineJoin;
     }
 }
-
-export { HTMLTextStyle };
-export type { HTMLTextStyleWhiteSpace, IHTMLTextStyle };


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

I'm also doing some document cleanup recently. In case of conflict with #9161, I put it here.

- Add `@since 7.2.0` for new things in v7.2.0
- Add some missing `@memberof PIXI` (No more `.html` with out `PIXI.` prefix in `dist/docs`!)
- Add `@type {PIXI.EventsTickerClass}` for `EventsTicker` (Webdoc can't determine its type)
- Remove some unused `@interface` (`SharedArrayBuffer`, `OffscreenCanvas`, may come from old code and they are not being used anymore)
- Other minor fixes

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
