### PR TITLE
Colors are incorrect order for framebuffer clear

### DIFF
--- a/packages/core/src/renderTexture/RenderTextureSystem.ts
+++ b/packages/core/src/renderTexture/RenderTextureSystem.ts
@@ -219,7 +219,7 @@ export class RenderTextureSystem implements ISystem
             this.renderer.gl.scissor(x, y, width, height);
         }
 
-        this.renderer.framebuffer.clear(color.red, color.blue, color.green, color.alpha, mask);
+        this.renderer.framebuffer.clear(color.red, color.green, color.blue, color.alpha, mask);
 
         if (clearMask)
         {


### PR DESCRIPTION
Closes #9164 

Framebuffer clear color components are ordered incorrectly.

https://pixijs.io/examples/?v=fix/clear-color#/demos-basic/container.js