### PR TITLE
Fix: events firing when they shouldn't

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -359,15 +359,24 @@ export class EventBoundary
 
         const children = target.children;
 
-        if (children)
+        const interactionNone = target._internalInteractive === 'none';
+        const interactionPassive = target._internalInteractive === 'passive' && !target.interactiveChildren;
+        const interactiveChildren = target.interactiveChildren;
+        const shouldIterateChildren = !interactionNone && interactiveChildren && !interactionPassive;
+
+        if (children && children.length > 0)
         {
-            for (let i = 0; i < children.length; i++)
+            if (shouldIterateChildren)
             {
-                this.all(e, type, children[i]);
+                for (let i = 0; i < children.length; i++)
+                {
+                    this.all(e, type, children[i]);
+                }
             }
         }
 
         e.currentTarget = target;
+
         this.notifyTarget(e, type);
     }
 
@@ -1362,6 +1371,7 @@ export class EventBoundary
         const listeners = ((e.currentTarget as any)._events as EmitterListeners)[type];
 
         if (!listeners) return;
+        if (!e.currentTarget.isInteractive()) return;
 
         if ('fn' in listeners)
         {

--- a/packages/events/test/EventBoundary.tests.ts
+++ b/packages/events/test/EventBoundary.tests.ts
@@ -45,7 +45,7 @@ describe('EventBoundary', () =>
         expect(eventSpy).toBeCalledTimes(2);
         expect(captureSpy).toHaveBeenCalledOnce();
         expect(captureSpy).toHaveBeenCalledBefore(eventSpy);
-        expect(stageSpy).toHaveBeenCalledOnce();
+        expect(stageSpy).not.toHaveBeenCalled();
     });
 
     it('should set hit-test target to most specific ancestor if hit object is not interactive', () =>

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -302,6 +302,124 @@ describe('EventSystem', () =>
         expect(secondaryOutSpy).not.toBeCalledTimes(1);
     });
 
+    it('should not dispatch pointer events if not interactive', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+
+        renderer.render(stage);
+
+        const primaryMoveSpy = jest.fn();
+        const primaryMoveGlobalSpy = jest.fn();
+
+        graphics.interactive = false;
+
+        graphics.on('pointermove', () =>
+        {
+            primaryMoveSpy();
+        });
+        graphics.on('globalpointermove', () =>
+        {
+            primaryMoveGlobalSpy();
+        });
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).not.toHaveBeenCalled();
+        expect(primaryMoveGlobalSpy).not.toHaveBeenCalled();
+
+        graphics.interactive = true;
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+
+        graphics.interactive = 'none';
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+
+        graphics.interactive = 'auto';
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+
+        graphics.interactive = 'passive';
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+
+        graphics.interactive = 'dynamic';
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(2);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
+
+        graphics.interactive = 'static';
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(3);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(3);
+
+        // add a second graphics object
+        const second = graphics.addChild(
+            new Graphics()
+                .beginFill(0xFFFFFF)
+                .drawRect(0, 0, 50, 50)
+        );
+
+        // should be called
+        second.interactive = true;
+        // should not be called again
+        graphics.interactive = false;
+
+        const secondaryMoveSpy = jest.fn();
+        const secondaryMoveGlobalSpy = jest.fn();
+
+        second.on('pointermove', () =>
+        {
+            secondaryMoveSpy();
+        });
+        second.on('globalpointermove', () =>
+        {
+            secondaryMoveGlobalSpy();
+        });
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(3);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(3);
+        expect(secondaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+
+        // nothing should be called again
+        graphics.interactiveChildren = false;
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+        expect(primaryMoveSpy).toHaveBeenCalledTimes(3);
+        expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(3);
+        expect(secondaryMoveSpy).toHaveBeenCalledTimes(1);
+        expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should dispatch click events', () =>
     {
         const renderer = createRenderer();


### PR DESCRIPTION
This PR fixes 2 issues

- the global move events fired even if a display object is not interactive
- if you set a child to be interactive, the parent would still receive the events even if it was not interactive
    ```
    const sprites = new PIXI.Container();
    sprites.interactive = false

    // previously this would still fire
    sprites.on('pointermove', ()=>{
        console.log('move')
    })

    app.stage.addChild(sprites);

    const totalSprites = 30;

    for (let i = 0; i < totalSprites; i++) {
        const dude = PIXI.Sprite.from('https://pixijs.io/examples/examples/assets/maggot_tiny.png');
        dude.interactive = true
        sprites.addChild(dude);
    }
    ```

This should also help fix #9156 