### PR TITLE
Set default value for defaultInteraction to auto

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -33,7 +33,7 @@ export class EventSystem
         ],
     };
 
-    private static _defaultInteraction: boolean | Interactive;
+    private static _defaultInteraction: Interactive;
 
     /**
      * The default interaction mode for all display objects.
@@ -135,7 +135,7 @@ export class EventSystem
         this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
         // allow for false to keep backwards compatibility
-        EventSystem._defaultInteraction = options?.defaultInteraction ?? false;
+        EventSystem._defaultInteraction = options?.defaultInteraction ?? 'auto';
     }
 
     /**

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -58,7 +58,8 @@ export interface IHitArea
 export type FederatedEventHandler<T= FederatedPointerEvent> = (event: T) => void;
 
 /**
- * The type of interaction a DisplayObject can be.
+ * The type of interaction a DisplayObject can be. For more information on values and their meaning,
+ * see {@link PIXI.DisplayObject.interactive DisplayObject's interactive property}.
  * @memberof PIXI
  * @since 7.2.0
  */
@@ -603,6 +604,7 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      *     // Handle event
      * });
      * @memberof PIXI.DisplayObject#
+     * @type {PIXI.Interactive|boolean}
      */
     interactive: EventSystem.defaultInteraction,
     /** Internal reference to the normalised interactive value. This should always be used instead of interactive */

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -424,4 +424,20 @@ describe('EventSystem', () =>
         expect(graphics.interactive).toEqual('dynamic');
         expect(graphics._internalInteractive).toEqual('dynamic');
     });
+
+    it('should use auto for the default interaction when undefined', () =>
+    {
+        const renderer = new Renderer({
+            width: 100,
+            height: 100,
+        });
+
+        expect(renderer.options.defaultInteraction).toBeUndefined();
+        expect(EventSystem.defaultInteraction).toEqual('auto');
+
+        const graphics = new Graphics();
+
+        expect(graphics.interactive).toEqual('auto');
+        expect(graphics._internalInteractive).toEqual('auto');
+    });
 });


### PR DESCRIPTION
`defaultInteraction`'s default value was `false` when it should be `auto`, to match documentation.

@Zyie, do you think a `false` value here is really necessary for backward compatibility?