### PR TITLE
Feat: Add new config options for loadTextures

### DIFF
--- a/packages/assets/src/loader/parsers/textures/loadTextures.ts
+++ b/packages/assets/src/loader/parsers/textures/loadTextures.ts
@@ -45,6 +45,20 @@ export async function loadImageBitmap(url: string): Promise<ImageBitmap>
  * this makes use of imageBitmaps where available.
  * We load the ImageBitmap on a different thread using the WorkerManager
  * We can then use the ImageBitmap as a source for a Pixi Texture
+ *
+ * You can customize the behavior of this loader by setting the `config` property.
+ * ```js
+ * // Set the config
+ * import { loadTextures } from '@pixi/assets';
+ * loadTextures.config = {
+ *    // If true we will use a worker to load the ImageBitmap
+ *    preferWorkers: true,
+ *    // If false we will use new Image() instead of createImageBitmap
+ *    // If false then this will also disable the use of workers as it requires createImageBitmap
+ *    preferCreateImageBitmap: true,
+ *    crossOrigin: 'anonymous',
+ * };
+ * ```
  */
 export const loadTextures = {
     extension: {
@@ -54,6 +68,8 @@ export const loadTextures = {
 
     config: {
         preferWorkers: true,
+        preferCreateImageBitmap: true,
+        crossOrigin: 'anonymous',
     },
 
     test(url: string): boolean
@@ -65,7 +81,7 @@ export const loadTextures = {
     {
         let src: any = null;
 
-        if (globalThis.createImageBitmap)
+        if (globalThis.createImageBitmap && this.config.preferCreateImageBitmap)
         {
             if (this.config.preferWorkers && await WorkerManager.isImageBitmapSupported())
             {
@@ -81,7 +97,7 @@ export const loadTextures = {
             src = await new Promise((resolve) =>
             {
                 src = new Image();
-                src.crossOrigin = 'anonymous';
+                src.crossOrigin = this.config.crossOrigin;
 
                 src.src = url;
                 if (src.complete)


### PR DESCRIPTION
Fixes #9158 

Adds 2 new options for `loadTextures` to allow the user to prefer `createImageBitmap` and set `crossOrigin`