### PR TITLE
Refactor premultiply utilities to the Color class

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -293,6 +293,55 @@ export class Color
     }
 
     /**
+     * Converts color to a premultiplied alpha format. This action is destructive, and will
+     * override the previous `value` property to be `null`.
+     * @param alpha - The color to multiply by.
+     * @param [applyToRGB=true] - Whether to premultiply RGB channels.
+     * @returns {PIXI.Color} - Itself.
+     */
+    premultiply(alpha: number, applyToRGB = true): this
+    {
+        if (applyToRGB)
+        {
+            this._components[0] *= alpha;
+            this._components[1] *= alpha;
+            this._components[2] *= alpha;
+        }
+        this._components[3] = alpha;
+
+        this.refreshInt();
+        this._value = null;
+
+        return this;
+    }
+
+    /**
+     * Premultiplies alpha with current color.
+     * @param {number} alpha - floating point alpha (0.0-1.0)
+     * @returns {number} tint multiplied by alpha
+     */
+    toPremultiplied(alpha: number): number
+    {
+        if (alpha === 1.0)
+        {
+            return (alpha * 255 << 24) + this._int;
+        }
+        if (alpha === 0.0)
+        {
+            return 0;
+        }
+        let r = ((this._int >> 16) & 0xFF);
+        let g = ((this._int >> 8) & 0xFF);
+        let b = (this._int & 0xFF);
+
+        r = ((r * alpha) + 0.5) | 0;
+        g = ((g * alpha) + 0.5) | 0;
+        b = ((b * alpha) + 0.5) | 0;
+
+        return (alpha * 255 << 24) + (r << 16) + (g << 8) + b;
+    }
+
+    /**
      * Convert to a hexidecimal string.
      * @example
      * import { Color } from 'pixi.js';

--- a/packages/color/test/Color.tests.ts
+++ b/packages/color/test/Color.tests.ts
@@ -230,4 +230,32 @@ describe('Color', () =>
 
         expect(color.value).toBe(0x999999);
     });
+
+    it('should premultiply color correctly', () =>
+    {
+        const color = new Color([0.5, 0.5, 0.5, 1]).premultiply(0.5);
+
+        expect(color.red).toBe(0.25);
+        expect(color.blue).toBe(0.25);
+        expect(color.green).toBe(0.25);
+        expect(color.alpha).toBe(0.5);
+    });
+
+    it('should premultiply alpha only correctly', () =>
+    {
+        const color = new Color([0.5, 0.5, 0.5, 1]).premultiply(0.5, false);
+
+        expect(color.red).toBe(0.5);
+        expect(color.blue).toBe(0.5);
+        expect(color.green).toBe(0.5);
+        expect(color.alpha).toBe(0.5);
+    });
+
+    it('should output premultiplied alpha integer correctly', () =>
+    {
+        const color = new Color([0.5, 0.5, 0.5, 1]);
+
+        expect(color.toPremultiplied(0)).toBe(0);
+        expect(color.toPremultiplied(0.5)).toBe(0x7f404040);
+    });
 });

--- a/packages/core/src/batch/BatchRenderer.ts
+++ b/packages/core/src/batch/BatchRenderer.ts
@@ -1,7 +1,8 @@
+import { Color } from '@pixi/color';
 import { ENV } from '@pixi/constants';
 import { extensions, ExtensionType } from '@pixi/extensions';
 import { settings } from '@pixi/settings';
-import { deprecation, log2, nextPow2, premultiplyBlendMode, premultiplyTint } from '@pixi/utils';
+import { deprecation, log2, nextPow2, premultiplyBlendMode } from '@pixi/utils';
 import { ViewableBuffer } from '../geometry/ViewableBuffer';
 import { checkMaxIfStatementsInShader } from '../shader/utils/checkMaxIfStatementsInShader';
 import { State } from '../state/State';
@@ -776,10 +777,9 @@ export class BatchRenderer extends ObjectRenderer
         const textureId = element._texture.baseTexture._batchLocation;
 
         const alpha = Math.min(element.worldAlpha, 1.0);
-        const argb = (alpha < 1.0
-            && element._texture.baseTexture.alphaMode)
-            ? premultiplyTint(element._tintRGB, alpha)
-            : element._tintRGB + (alpha * 255 << 24);
+        const argb = Color.shared
+            .setValue(element._tintRGB)
+            .toPremultiplied(alpha);
 
         // lets not worry about tint! for now..
         for (let i = 0; i < vertexData.length; i += 2)

--- a/packages/graphics/src/GraphicsGeometry.ts
+++ b/packages/graphics/src/GraphicsGeometry.ts
@@ -6,7 +6,6 @@ import {
     Color,
     DRAW_MODES,
     Point,
-    utils,
     WRAP_MODES
 } from '@pixi/core';
 import { Bounds } from '@pixi/display';
@@ -800,16 +799,19 @@ export class GraphicsGeometry extends BatchGeometry
         size: number,
         offset = 0): void
     {
-        // TODO use the premultiply bits Ivan added
-        const rgb = Color.shared.setValue(color).toLittleEndianNumber();
+        const bgr = Color.shared
+            .setValue(color)
+            .toLittleEndianNumber();
 
-        const rgba = utils.premultiplyTint(rgb, alpha);
+        const result = Color.shared
+            .setValue(bgr)
+            .toPremultiplied(alpha);
 
         colors.length = Math.max(colors.length, offset + size);
 
         for (let i = 0; i < size; i++)
         {
-            colors[offset + i] = rgba;
+            colors[offset + i] = result;
         }
     }
 

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -1,8 +1,8 @@
-import { Color, Matrix, Program, Shader, TextureMatrix, utils } from '@pixi/core';
+import { Color, Matrix, Program, Shader, TextureMatrix } from '@pixi/core';
 import fragment from './shader/mesh.frag';
 import vertex from './shader/mesh.vert';
 
-import type { Texture } from '@pixi/core';
+import type { Texture, utils } from '@pixi/core';
 
 export interface IMeshMaterialOptions
 {
@@ -153,10 +153,12 @@ export class MeshMaterial extends Shader
         {
             this._colorDirty = false;
             const baseTexture = this.texture.baseTexture;
+            const applyToChannels = (baseTexture.alphaMode as unknown as boolean);
 
-            utils.premultiplyTintToRgba(
-                this._tint, this._alpha, this.uniforms.uColor, (baseTexture.alphaMode as unknown as boolean)
-            );
+            Color.shared
+                .setValue(this._tint)
+                .premultiply(this._alpha, applyToChannels)
+                .toArray(this.uniforms.uColor);
         }
         if (this.uvMatrix.update())
         {

--- a/packages/sprite-tiling/src/TilingSpriteRenderer.ts
+++ b/packages/sprite-tiling/src/TilingSpriteRenderer.ts
@@ -1,4 +1,15 @@
-import { extensions, ExtensionType, Matrix, ObjectRenderer, QuadUv, Shader, State, utils, WRAP_MODES } from '@pixi/core';
+import {
+    Color,
+    extensions,
+    ExtensionType,
+    Matrix,
+    ObjectRenderer,
+    QuadUv,
+    Shader,
+    State,
+    utils,
+    WRAP_MODES
+} from '@pixi/core';
 import gl2FragmentSrc from './sprite-tiling.frag';
 import gl2VertexSrc from './sprite-tiling.vert';
 import gl1FragmentSrc from './sprite-tiling-fallback.frag';
@@ -148,8 +159,11 @@ export class TilingSpriteRenderer extends ObjectRenderer
         }
 
         shader.uniforms.uTransform = tempMat.toArray(true);
-        shader.uniforms.uColor = utils.premultiplyTintToRgba(ts.tint, ts.worldAlpha,
-            shader.uniforms.uColor, premultiplied);
+        shader.uniforms.uColor = Color.shared
+            .setValue(ts.tint)
+            .premultiply(ts.worldAlpha, premultiplied)
+            .toArray(shader.uniforms.uColor);
+
         shader.uniforms.translationMatrix = ts.transform.worldTransform.toArray(true);
         shader.uniforms.uSampler = tex;
 

--- a/packages/utils/src/color/premultiply.ts
+++ b/packages/utils/src/color/premultiply.ts
@@ -1,5 +1,6 @@
 import { Color } from '@pixi/color';
 import { BLEND_MODES } from '@pixi/constants';
+import { deprecation } from '../logging/deprecation';
 
 /**
  * Corrects PixiJS blend, takes premultiplied alpha into account
@@ -56,90 +57,69 @@ export function correctBlendMode(blendMode: number, premultiplied: boolean): num
 }
 
 /**
- * combines rgb and alpha to out array
  * @memberof PIXI.utils
  * @function premultiplyRgba
- * @param {Float32Array|number[]} rgb - input rgb
- * @param {number} alpha - alpha param
- * @param {Float32Array} [out] - output
- * @param {boolean} [premultiply=true] - do premultiply it
- * @returns {Float32Array} vec4 rgba
+ * @deprecated since 7.2.0
+ * @see PIXI.Color.premultiply
+ * @param {Float32Array|number[]} rgb -
+ * @param {number} alpha -
+ * @param {Float32Array} [out] -
+ * @param {boolean} [premultiply=true] -
  */
 export function premultiplyRgba(
     rgb: Float32Array | number[],
     alpha: number,
     out?: Float32Array,
-    premultiply?: boolean
+    premultiply = true
 ): Float32Array
 {
-    out = out || new Float32Array(4);
-    if (premultiply || premultiply === undefined)
-    {
-        out[0] = rgb[0] * alpha;
-        out[1] = rgb[1] * alpha;
-        out[2] = rgb[2] * alpha;
-    }
-    else
-    {
-        out[0] = rgb[0];
-        out[1] = rgb[1];
-        out[2] = rgb[2];
-    }
-    out[3] = alpha;
+    // #if _DEBUG
+    deprecation('7.2.0', `utils.premultiplyRgba has moved to Color.premultiply`);
+    // #endif
 
-    return out;
+    return Color.shared
+        .setValue(rgb)
+        .premultiply(alpha, premultiply)
+        .toRgbArray(out ?? new Float32Array(4));
 }
 
 /**
- * premultiplies tint
  * @memberof PIXI.utils
  * @function premultiplyTint
- * @param {number} tint - integer RGB
- * @param {number} alpha - floating point alpha (0.0-1.0)
- * @returns {number} tint multiplied by alpha
+ * @deprecated since 7.2.0
+ * @see PIXI.Color.toPremultiplied
+ * @param {number} tint -
+ * @param {number} alpha -
  */
 export function premultiplyTint(tint: number, alpha: number): number
 {
-    if (alpha === 1.0)
-    {
-        return (alpha * 255 << 24) + tint;
-    }
-    if (alpha === 0.0)
-    {
-        return 0;
-    }
-    let R = ((tint >> 16) & 0xFF);
-    let G = ((tint >> 8) & 0xFF);
-    let B = (tint & 0xFF);
+    // #if _DEBUG
+    deprecation('7.2.0', `utils.premultiplyTint has moved to Color.toPremultiplied`);
+    // #endif
 
-    R = ((R * alpha) + 0.5) | 0;
-    G = ((G * alpha) + 0.5) | 0;
-    B = ((B * alpha) + 0.5) | 0;
-
-    return (alpha * 255 << 24) + (R << 16) + (G << 8) + B;
+    return Color.shared
+        .setValue(tint)
+        .toPremultiplied(alpha);
 }
 
 /**
- * converts integer tint and float alpha to vec4 form, premultiplies by default
  * @memberof PIXI.utils
  * @function premultiplyTintToRgba
- * @param {number} tint - input tint
- * @param {number} alpha - alpha param
- * @param {Float32Array} [out] - output
- * @param {boolean} [premultiply=true] - do premultiply it
- * @returns {Float32Array} vec4 rgba
+ * @deprecated since 7.2.0
+ * @see PIXI.Color.premultiply
+ * @param {number} tint -
+ * @param {number} alpha -
+ * @param {Float32Array} [out] -
+ * @param {boolean} [premultiply=true] -
  */
-export function premultiplyTintToRgba(tint: number, alpha: number, out?: Float32Array, premultiply?: boolean): Float32Array
+export function premultiplyTintToRgba(tint: number, alpha: number, out?: Float32Array, premultiply = true): Float32Array
 {
-    out = Color.shared.setValue(tint).toRgbArray(out ?? new Float32Array(4));
+    // #if _DEBUG
+    deprecation('7.2.0', `utils.premultiplyTintToRgba has moved to Color.premultiply`);
+    // #endif
 
-    if (premultiply || premultiply === undefined)
-    {
-        out[0] *= alpha;
-        out[1] *= alpha;
-        out[2] *= alpha;
-    }
-    out[3] = alpha;
-
-    return out;
+    return Color.shared
+        .setValue(tint)
+        .premultiply(alpha, premultiply)
+        .toRgbArray(out ?? new Float32Array(4));
 }

--- a/packages/utils/src/color/premultiply.ts
+++ b/packages/utils/src/color/premultiply.ts
@@ -80,7 +80,7 @@ export function premultiplyRgba(
     return Color.shared
         .setValue(rgb)
         .premultiply(alpha, premultiply)
-        .toRgbArray(out ?? new Float32Array(4));
+        .toArray(out ?? new Float32Array(4));
 }
 
 /**
@@ -121,5 +121,5 @@ export function premultiplyTintToRgba(tint: number, alpha: number, out?: Float32
     return Color.shared
         .setValue(tint)
         .premultiply(alpha, premultiply)
-        .toRgbArray(out ?? new Float32Array(4));
+        .toArray(out ?? new Float32Array(4));
 }

--- a/packages/utils/test/utils.tests.ts
+++ b/packages/utils/test/utils.tests.ts
@@ -184,4 +184,94 @@ describe('utils', () =>
             expect(utils.earcut).toBeInstanceOf(Function);
         });
     });
+
+    describe('premultiplyTintToRgba', () =>
+    {
+        it('should successfully premultiply alpha float', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyTintToRgba(0xffffff, 0.5);
+
+            expect(a).toBe(0.5);
+            expect(r).toBe(0.5);
+            expect(g).toBe(0.5);
+            expect(b).toBe(0.5);
+        });
+
+        it('should successfully premultiply alpha 0', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyTintToRgba(0xffffff, 0);
+
+            expect(a).toBe(0);
+            expect(r).toBe(0);
+            expect(g).toBe(0);
+            expect(b).toBe(0);
+        });
+
+        it('should successfully premultiply alpha 1', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyTintToRgba(0xffffff, 1);
+
+            expect(a).toBe(1);
+            expect(r).toBe(1);
+            expect(g).toBe(1);
+            expect(b).toBe(1);
+        });
+    });
+
+    describe('premultiplyTint', () =>
+    {
+        it('should successfully premultiply alpha float', () =>
+        {
+            const tint = utils.premultiplyTint(0xffffff, 0.5);
+
+            expect(tint).toBe(0x7f808080);
+        });
+
+        it('should successfully premultiply alpha 0', () =>
+        {
+            const tint = utils.premultiplyTint(0xffffff, 0);
+
+            expect(tint).toBe(0);
+        });
+
+        it('should successfully premultiply alpha 1', () =>
+        {
+            const tint = utils.premultiplyTint(0xffffff, 1);
+
+            expect(tint).toBe(-1);
+        });
+    });
+
+    describe('premultiplyRgba', () =>
+    {
+        it('should successfully premultiply alpha float', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyRgba([0.5, 0.5, 0.5, 1], 0.5);
+
+            expect(r).toBe(0.25);
+            expect(g).toBe(0.25);
+            expect(b).toBe(0.25);
+            expect(a).toBe(0.5);
+        });
+
+        it('should successfully premultiply alpha 0', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyRgba([0.5, 0.5, 0.5, 1], 0);
+
+            expect(r).toBe(0);
+            expect(g).toBe(0);
+            expect(b).toBe(0);
+            expect(a).toBe(0);
+        });
+
+        it('should successfully premultiply alpha 1', () =>
+        {
+            const [r, g, b, a] = utils.premultiplyRgba([0.5, 0.5, 0.5, 1], 1);
+
+            expect(r).toBe(0.5);
+            expect(g).toBe(0.5);
+            expect(b).toBe(0.5);
+            expect(a).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
### Deprecated

* `utils.premultiplyRgba`
* `utils.premultiplyTint`
* `premultiplyTintToRgba`

### Added

* `Color.premultiply` (applies a premultiply alpha transform to color)
* `Color.toPremultiplied` (get the current color as an integer with alpha)
