### PR TITLE
Deprecate interaction for eventMode

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -716,7 +716,7 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
         this.filterArea = null;
         this.hitArea = null;
 
-        this.interactive = false;
+        this.eventMode = 'auto';
         this.interactiveChildren = false;
 
         this.emit('destroyed');

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -32,7 +32,7 @@ declare namespace GlobalMixins
          * The default interaction mode for all display objects.
          * @since 7.2.0
          */
-        defaultInteraction?: import('@pixi/events').Interactive;
+        defaultInteraction?: import('@pixi/events').EventMode;
     }
 
     interface CanvasRenderer

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -32,7 +32,7 @@ declare namespace GlobalMixins
          * The default event mode for all display objects.
          * @since 7.2.0
          */
-        defaultEventMode?: import('@pixi/events').EventMode;
+        eventMode?: import('@pixi/events').EventMode;
     }
 
     interface CanvasRenderer

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -29,10 +29,10 @@ declare namespace GlobalMixins
     interface IRendererOptions
     {
         /**
-         * The default interaction mode for all display objects.
+         * The default event mode for all display objects.
          * @since 7.2.0
          */
-        defaultInteraction?: import('@pixi/events').EventMode;
+        defaultEventMode?: import('@pixi/events').EventMode;
     }
 
     interface CanvasRenderer

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -6,7 +6,7 @@ import { FederatedWheelEvent } from './FederatedWheelEvent';
 
 import type { ExtensionMetadata, IPointData, IRenderer, ISystem } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
-import type { Interactive } from './FederatedEventTarget';
+import type { EventMode } from './FederatedEventTarget';
 import type { FederatedMouseEvent } from './FederatedMouseEvent';
 
 const MOUSE_POINTER_ID = 1;
@@ -27,7 +27,7 @@ export interface EventSystemOptions
      * (included in the **pixi.js** and **pixi.js-legacy** bundle), otherwise it will be ignored.
      * @memberof PIXI.IRendererOptions
      */
-    defaultInteraction?: Interactive;
+    defaultInteraction?: EventMode;
 }
 
 /**
@@ -45,7 +45,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
         ],
     };
 
-    private static _defaultInteraction: boolean | Interactive;
+    private static _defaultInteraction: EventMode;
 
     /**
      * The default interaction mode for all display objects.
@@ -146,8 +146,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
 
         this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
-        // allow for false to keep backwards compatibility
-        EventSystem._defaultInteraction = options.defaultInteraction ?? false;
+        EventSystem._defaultInteraction = options.defaultInteraction ?? 'auto';
     }
 
     /**

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -22,12 +22,12 @@ const TOUCH_TO_POINTER: Record<string, string> = {
 export interface EventSystemOptions
 {
     /**
-     * The default interaction mode for all display objects.
+     * The default event mode mode for all display objects.
      * This option only is available when using **@pixi/events** package
      * (included in the **pixi.js** and **pixi.js-legacy** bundle), otherwise it will be ignored.
      * @memberof PIXI.IRendererOptions
      */
-    defaultInteraction?: EventMode;
+    defaultEventMode?: EventMode;
 }
 
 /**
@@ -45,16 +45,16 @@ export class EventSystem implements ISystem<EventSystemOptions>
         ],
     };
 
-    private static _defaultInteraction: EventMode;
+    private static _defaultEventMode: EventMode;
 
     /**
      * The default interaction mode for all display objects.
      * @readonly
      * @since 7.2.0
      */
-    public static get defaultInteraction()
+    public static get defaultEventMode()
     {
-        return this._defaultInteraction;
+        return this._defaultEventMode;
     }
 
     /**
@@ -146,7 +146,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
 
         this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
-        EventSystem._defaultInteraction = options.defaultInteraction ?? 'auto';
+        EventSystem._defaultEventMode = options.defaultEventMode ?? 'auto';
     }
 
     /**

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -27,7 +27,7 @@ export interface EventSystemOptions
      * (included in the **pixi.js** and **pixi.js-legacy** bundle), otherwise it will be ignored.
      * @memberof PIXI.IRendererOptions
      */
-    defaultEventMode?: EventMode;
+    eventMode?: EventMode;
 }
 
 /**
@@ -49,6 +49,8 @@ export class EventSystem implements ISystem<EventSystemOptions>
 
     /**
      * The default interaction mode for all display objects.
+     * @see PIXI.DisplayObject.eventMode
+     * @type {PIXI.EventMode}
      * @readonly
      * @since 7.2.0
      */
@@ -146,7 +148,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
 
         this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
-        EventSystem._defaultEventMode = options.defaultEventMode ?? 'auto';
+        EventSystem._defaultEventMode = options.eventMode ?? 'auto';
     }
 
     /**

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -580,7 +580,7 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      */
     get interactive()
     {
-        return this._internalInteractive ?? convertEventModeToInteractiveMode(EventSystem.defaultInteraction);
+        return this._internalInteractive ?? convertEventModeToInteractiveMode(EventSystem.defaultEventMode);
     },
     set interactive(value: boolean)
     {
@@ -623,7 +623,7 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
      */
     get eventMode()
     {
-        return this._internalEventMode ?? EventSystem.defaultInteraction;
+        return this._internalEventMode ?? EventSystem.defaultEventMode;
     },
     set eventMode(value)
     {

--- a/packages/events/test/EventBoundary.tests.ts
+++ b/packages/events/test/EventBoundary.tests.ts
@@ -70,7 +70,7 @@ describe('EventBoundary', () =>
         const container = stage.addChild(new Container());
         const target = container.addChild(new Graphics().beginFill(0).drawRect(0, 0, 100, 100));
 
-        container.interactive = 'none';
+        container.eventMode = 'none';
         target.interactive = true;
 
         expect(boundary.hitTest(50, 50)).toEqual(null);
@@ -83,7 +83,7 @@ describe('EventBoundary', () =>
         const container = stage.addChild(new Container());
         const target = container.addChild(new Graphics().beginFill(0).drawRect(0, 0, 100, 100));
 
-        container.interactive = 'passive';
+        container.eventMode = 'passive';
         container.interactiveChildren = false;
         target.interactive = true;
 
@@ -107,7 +107,7 @@ describe('EventBoundary', () =>
 
         expect(boundary.hitTest(50, 50)).toEqual(target);
 
-        container.interactive = 'passive';
+        container.eventMode = 'passive';
 
         expect(boundary.hitTest(50, 50)).toEqual(target);
     });
@@ -121,9 +121,9 @@ describe('EventBoundary', () =>
         const targetStatic = container.addChild(new Graphics().beginFill(0).drawRect(100, 0, 100, 100));
         const targetDynamic = container.addChild(new Graphics().beginFill(0).drawRect(200, 0, 100, 100));
 
-        targetAuto.interactive = 'auto';
-        targetStatic.interactive = 'static';
-        targetDynamic.interactive = 'dynamic';
+        targetAuto.eventMode = 'auto';
+        targetStatic.eventMode = 'static';
+        targetDynamic.eventMode = 'dynamic';
 
         expect(boundary.hitTest(50, 50)).toEqual(null);
         expect(boundary.hitTest(150, 50)).toEqual(targetStatic);
@@ -146,7 +146,7 @@ describe('EventBoundary', () =>
 
         container.interactive = true;
         target.interactive = true;
-        blocker.interactive = 'none';
+        blocker.eventMode = 'none';
 
         expect(boundary.hitTest(25, 50)).toEqual(target);
         expect(boundary.hitTest(75, 50)).toEqual(target);
@@ -160,7 +160,7 @@ describe('EventBoundary', () =>
         const target = container.addChild(new Graphics().beginFill(0).drawRect(0, 0, 100, 100));
         const blocker = container.addChild(new Graphics().beginFill(0).drawRect(50, 0, 100, 100));
 
-        container.interactive = 'none';
+        container.eventMode = 'none';
         target.interactive = true;
         blocker.interactive = true;
 
@@ -178,15 +178,15 @@ describe('EventBoundary', () =>
         const activeBlocker = container.addChild(new Graphics().beginFill(0).drawRect(75, 0, 25, 100));
         const noneBlocker = container.addChild(new Graphics().beginFill(0).drawRect(25, 0, 50, 100));
 
-        container.interactive = 'passive';
+        container.eventMode = 'passive';
         // this should be hit because it is interactive and parent is passive
         target.interactive = true;
         // this should block the target because it is interactive and parent is passive
         activeBlocker.interactive = true;
         // this should be ignored because it is not interactive and parent is passive
-        autoBlocker.interactive = 'auto';
+        autoBlocker.eventMode = 'auto';
         // this should be ignored because it is using none
-        noneBlocker.interactive = 'none';
+        noneBlocker.eventMode = 'none';
 
         expect(boundary.hitTest(12, 50)).toEqual(target);
         expect(boundary.hitTest(50, 50)).toEqual(target);

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -531,11 +531,11 @@ describe('EventSystem', () =>
         const renderer = new Renderer({
             width: 100,
             height: 100,
-            defaultInteraction: 'dynamic'
+            defaultEventMode: 'dynamic'
         });
 
-        expect(renderer.options.defaultInteraction).toEqual('dynamic');
-        expect(EventSystem.defaultInteraction).toEqual('dynamic');
+        expect(renderer.options.defaultEventMode).toEqual('dynamic');
+        expect(EventSystem.defaultEventMode).toEqual('dynamic');
 
         const graphics = new Graphics();
 
@@ -550,8 +550,8 @@ describe('EventSystem', () =>
             height: 100,
         });
 
-        expect(renderer.options.defaultInteraction).toBeUndefined();
-        expect(EventSystem.defaultInteraction).toEqual('auto');
+        expect(renderer.options.defaultEventMode).toBeUndefined();
+        expect(EventSystem.defaultEventMode).toEqual('auto');
 
         const graphics = new Graphics();
 

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -337,7 +337,7 @@ describe('EventSystem', () =>
         expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
 
-        graphics.interactive = 'none';
+        graphics.eventMode = 'none';
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
@@ -345,7 +345,7 @@ describe('EventSystem', () =>
         expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
 
-        graphics.interactive = 'auto';
+        graphics.eventMode = 'auto';
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
@@ -353,7 +353,7 @@ describe('EventSystem', () =>
         expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
 
-        graphics.interactive = 'passive';
+        graphics.eventMode = 'passive';
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
@@ -361,7 +361,7 @@ describe('EventSystem', () =>
         expect(primaryMoveSpy).toHaveBeenCalledTimes(1);
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(1);
 
-        graphics.interactive = 'dynamic';
+        graphics.eventMode = 'dynamic';
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
@@ -369,7 +369,7 @@ describe('EventSystem', () =>
         expect(primaryMoveSpy).toHaveBeenCalledTimes(2);
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
 
-        graphics.interactive = 'static';
+        graphics.eventMode = 'static';
 
         renderer.events.onPointerMove(
             new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
@@ -539,7 +539,23 @@ describe('EventSystem', () =>
 
         const graphics = new Graphics();
 
-        expect(graphics.interactive).toEqual('dynamic');
-        expect(graphics._internalInteractive).toEqual('dynamic');
+        expect(graphics.interactive).toEqual(true);
+        expect(graphics.eventMode).toEqual('dynamic');
+    });
+
+    it('should use auto for the default interaction when undefined', () =>
+    {
+        const renderer = new Renderer({
+            width: 100,
+            height: 100,
+        });
+
+        expect(renderer.options.defaultInteraction).toBeUndefined();
+        expect(EventSystem.defaultInteraction).toEqual('auto');
+
+        const graphics = new Graphics();
+
+        expect(graphics.interactive).toEqual(false);
+        expect(graphics.eventMode).toEqual('auto');
     });
 });

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -556,10 +556,10 @@ describe('EventSystem', () =>
         const renderer = new Renderer({
             width: 100,
             height: 100,
-            defaultEventMode: 'dynamic'
+            eventMode: 'dynamic'
         });
 
-        expect(renderer.options.defaultEventMode).toEqual('dynamic');
+        expect(renderer.options.eventMode).toEqual('dynamic');
         expect(EventSystem.defaultEventMode).toEqual('dynamic');
 
         const graphics = new Graphics();
@@ -575,7 +575,7 @@ describe('EventSystem', () =>
             height: 100,
         });
 
-        expect(renderer.options.defaultEventMode).toBeUndefined();
+        expect(renderer.options.eventMode).toBeUndefined();
         expect(EventSystem.defaultEventMode).toEqual('auto');
 
         const graphics = new Graphics();


### PR DESCRIPTION
We have now decided to fully deprecate `interactive` and move to using `eventMode` to describe the new interaction types

For backwards compatibility we map `interactive = false` to `eventMode = 'auto` and `interactive = true` to `eventMode = 'static'`

#9167 should be closed in favour of this as i believe i moved everything over from it