### PR TITLE
Support ColorSource with Graphics tint

### DIFF
--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -1095,4 +1095,16 @@ describe('Graphics', () =>
             expect(geometry.batches[1].size).toEqual(30);
         });
     });
+
+    describe('tint', () =>
+    {
+        it('should allow for other color sources', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics.tint = 'red';
+            expect(graphics.tint).toEqual('red');
+            graphics.destroy();
+        });
+    });
 });


### PR DESCRIPTION
### Added

* Adds support for ColorSource to `tint` in Graphics

```ts
const graphics = new Graphics();
graphics.tint = 'red';
```
https://jsfiddle.net/bigtimebuddy/4kdbg3n9/
