### PR TITLE
Support ColorSource with Mesh & BitmapText tint

### DIFF
--- a/packages/canvas-mesh/src/CanvasMeshRenderer.ts
+++ b/packages/canvas-mesh/src/CanvasMeshRenderer.ts
@@ -110,7 +110,7 @@ export class CanvasMeshRenderer
         {
             return;
         }
-        const isTinted = mesh.tint !== 0xFFFFFF;
+        const isTinted = mesh.tintValue !== 0xFFFFFF;
         const base = texture.baseTexture;
         const textureWidth = base.width;
         const textureHeight = base.height;
@@ -127,13 +127,13 @@ export class CanvasMeshRenderer
 
         if (isTinted)
         {
-            if (mesh._cachedTint !== mesh.tint)
+            if (mesh._cachedTint !== mesh.tintValue)
             {
-                mesh._cachedTint = mesh.tint;
+                mesh._cachedTint = mesh.tintValue;
                 mesh._cachedTexture = mesh._cachedTexture || new Texture(base);
                 mesh._tintedCanvas = canvasUtils.getTintedCanvas(
                     { texture: mesh._cachedTexture },
-                    mesh.tint
+                    mesh.tintValue
                 );
             }
         }

--- a/packages/canvas-mesh/src/NineSlicePlane.ts
+++ b/packages/canvas-mesh/src/NineSlicePlane.ts
@@ -38,7 +38,7 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer: Canvas
 {
     const context = renderer.canvasContext.activeContext;
     const transform = this.worldTransform;
-    const isTinted = this.tint !== 0xFFFFFF;
+    const isTinted = this.tintValue !== 0xFFFFFF;
     const texture = this.texture;
 
     if (!texture.valid)
@@ -49,13 +49,13 @@ NineSlicePlane.prototype._renderCanvas = function _renderCanvas(renderer: Canvas
     // Work out tinting
     if (isTinted)
     {
-        if (this._cachedTint !== this.tint)
+        if (this._cachedTint !== this.tintValue)
         {
             // Tint has changed, need to update the tinted texture and use that instead
 
-            this._cachedTint = this.tint;
+            this._cachedTint = this.tintValue;
 
-            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tint);
+            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tintValue);
         }
     }
 

--- a/packages/mesh/src/Mesh.ts
+++ b/packages/mesh/src/Mesh.ts
@@ -2,7 +2,7 @@ import { DRAW_MODES, Point, Polygon, settings, State } from '@pixi/core';
 import { Container } from '@pixi/display';
 import { MeshBatchUvs } from './MeshBatchUvs';
 
-import type { BLEND_MODES, Buffer, Geometry, IPointData, Renderer, Shader, Texture } from '@pixi/core';
+import type { BLEND_MODES, Buffer, ColorSource, Geometry, IPointData, Renderer, Shader, Texture } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
 import type { MeshMaterial } from './MeshMaterial';
 
@@ -232,14 +232,23 @@ export class Mesh<T extends Shader = MeshMaterial> extends Container
      * Null for non-MeshMaterial shaders
      * @default 0xFFFFFF
      */
-    get tint(): number
+    get tint(): ColorSource
     {
         return 'tint' in this.shader ? (this.shader as unknown as MeshMaterial).tint : null;
     }
 
-    set tint(value: number)
+    set tint(value: ColorSource)
     {
         (this.shader as unknown as MeshMaterial).tint = value;
+    }
+
+    /**
+     * The tint color as a RGB integer
+     * @ignore
+     */
+    get tintValue(): number
+    {
+        return (this.shader as unknown as MeshMaterial).tintValue;
     }
 
     /** The texture that the Mesh uses. Null for non-MeshMaterial shaders */

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -7,7 +7,7 @@ import type { ColorSource, Texture, utils } from '@pixi/core';
 export interface IMeshMaterialOptions
 {
     alpha?: number;
-    tint?: number;
+    tint?: ColorSource;
     pluginName?: string;
     program?: Program;
     uniforms?: utils.Dict<unknown>;
@@ -56,7 +56,7 @@ export class MeshMaterial extends Shader
      * @param uSampler - Texture that material uses to render.
      * @param options - Additional options
      * @param {number} [options.alpha=1] - Default alpha.
-     * @param {number} [options.tint=0xFFFFFF] - Default tint.
+     * @param {PIXI.ColorSource} [options.tint=0xFFFFFF] - Default tint.
      * @param {string} [options.pluginName='batch'] - Renderer plugin for batching.
      * @param {PIXI.Program} [options.program=0xFFFFFF] - Custom program.
      * @param {object} [options.uniforms] - Custom uniforms.
@@ -90,7 +90,9 @@ export class MeshMaterial extends Shader
         this.batchable = options.program === undefined;
         this.pluginName = options.pluginName;
 
-        this.tint = options.tint;
+        this._tintColor = new Color(options.tint);
+        this._tintRGB = this._tintColor.toLittleEndianNumber();
+        this._colorDirty = true;
         this.alpha = options.alpha;
     }
 

--- a/packages/mesh/src/MeshMaterial.ts
+++ b/packages/mesh/src/MeshMaterial.ts
@@ -2,7 +2,7 @@ import { Color, Matrix, Program, Shader, TextureMatrix } from '@pixi/core';
 import fragment from './shader/mesh.frag';
 import vertex from './shader/mesh.vert';
 
-import type { Texture, utils } from '@pixi/core';
+import type { ColorSource, Texture, utils } from '@pixi/core';
 
 export interface IMeshMaterialOptions
 {
@@ -50,7 +50,7 @@ export class MeshMaterial extends Shader
      */
     private _colorDirty: boolean;
     private _alpha: number;
-    private _tint: number;
+    private _tintColor: Color;
 
     /**
      * @param uSampler - Texture that material uses to render.
@@ -133,17 +133,26 @@ export class MeshMaterial extends Shader
      * Multiply tint for the material.
      * @default 0xFFFFFF
      */
-    set tint(value: number)
+    set tint(value: ColorSource)
     {
-        if (value === this._tint) return;
+        if (value === this.tint) return;
 
-        this._tint = value;
-        this._tintRGB = Color.shared.setValue(value).toLittleEndianNumber();
+        this._tintColor.setValue(value);
+        this._tintRGB = this._tintColor.toLittleEndianNumber();
         this._colorDirty = true;
     }
-    get tint(): number
+    get tint(): ColorSource
     {
-        return this._tint;
+        return this._tintColor.value;
+    }
+
+    /**
+     * Get the internal number from tint color
+     * @ignore
+     */
+    get tintValue(): number
+    {
+        return this._tintColor.toNumber();
     }
 
     /** Gets called automatically by the Mesh. Intended to be overridden for custom {@link PIXI.MeshMaterial} objects. */
@@ -156,7 +165,7 @@ export class MeshMaterial extends Shader
             const applyToChannels = (baseTexture.alphaMode as unknown as boolean);
 
             Color.shared
-                .setValue(this._tint)
+                .setValue(this._tintColor)
                 .premultiply(this._alpha, applyToChannels)
                 .toArray(this.uniforms.uColor);
         }

--- a/packages/mesh/test/Mesh.tests.ts
+++ b/packages/mesh/test/Mesh.tests.ts
@@ -66,4 +66,18 @@ describe('Mesh', () =>
         expect(dispose1).toBeCalled();
         expect(dispose2).toBeCalled();
     });
+
+    it('should support color tinting', () =>
+    {
+        const geometry = new MeshGeometry(new Float32Array([0, 0]));
+        const mesh = new Mesh(geometry, new MeshMaterial(Texture.EMPTY));
+
+        mesh.tint = 'red';
+
+        expect(mesh.tint).toBe('red');
+        expect(mesh.tintValue).toBe(0xff0000);
+
+        geometry.dispose();
+        mesh.destroy();
+    });
 });

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -1,4 +1,4 @@
-import { BLEND_MODES, ObservablePoint, Point, Program, settings, Texture, utils } from '@pixi/core';
+import { BLEND_MODES, Color, ObservablePoint, Point, Program, settings, Texture, utils } from '@pixi/core';
 import { Container } from '@pixi/display';
 import { Mesh, MeshGeometry, MeshMaterial } from '@pixi/mesh';
 import { BitmapFont } from './BitmapFont';
@@ -6,7 +6,7 @@ import msdfFrag from './shader/msdf.frag';
 import msdfVert from './shader/msdf.vert';
 import { extractCharCode, splitTextToCharacters } from './utils';
 
-import type { Rectangle, Renderer } from '@pixi/core';
+import type { ColorSource, Rectangle, Renderer } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
 import type { TextStyleAlign } from '@pixi/text';
 import type { IBitmapTextStyle } from './BitmapTextStyle';
@@ -166,7 +166,7 @@ export class BitmapText extends Container
      * Private tracker for the current tint.
      * @private
      */
-    protected _tint = 0xFFFFFF;
+    protected _tintColor: Color;
 
     /**
      * If true PixiJS will Math.floor() x/y values when rendering.
@@ -185,7 +185,7 @@ export class BitmapText extends Container
      *.     this will default to the BitmapFont size.
      * @param {string} [style.align='left'] - Alignment for multiline text ('left', 'center', 'right' or 'justify'),
      *      does not affect single line text.
-     * @param {number} [style.tint=0xFFFFFF] - The tint color.
+     * @param {PIXI.ColorSource} [style.tint=0xFFFFFF] - The tint color.
      * @param {number} [style.letterSpacing=0] - The amount of spacing between letters.
      * @param {number} [style.maxWidth=0] - The max width of the text before line wrapping.
      */
@@ -206,7 +206,7 @@ export class BitmapText extends Container
         this._textWidth = 0;
         this._textHeight = 0;
         this._align = align;
-        this._tint = tint;
+        this._tintColor = new Color(tint);
         this._font = undefined;
         this._fontName = fontName;
         this._fontSize = fontSize;
@@ -432,7 +432,7 @@ export class BitmapText extends Container
                 _textureCache[baseTextureUid] = _textureCache[baseTextureUid] || new Texture(texture.baseTexture);
                 pageMeshData.mesh.texture = _textureCache[baseTextureUid];
 
-                pageMeshData.mesh.tint = this._tint;
+                pageMeshData.mesh.tint = this._tintColor.value;
 
                 newPagesMeshData.push(pageMeshData);
 
@@ -680,16 +680,16 @@ export class BitmapText extends Container
      * The tint of the BitmapText object.
      * @default 0xffffff
      */
-    public get tint(): number
+    public get tint(): ColorSource
     {
-        return this._tint;
+        return this._tintColor.value;
     }
 
-    public set tint(value: number)
+    public set tint(value: ColorSource)
     {
-        if (this._tint === value) return;
+        if (this.tint === value) return;
 
-        this._tint = value;
+        this._tintColor.setValue(value);
 
         for (let i = 0; i < this._activePagesMeshData.length; i++)
         {
@@ -942,6 +942,7 @@ export class BitmapText extends Container
         }
 
         this._font = null;
+        this._tintColor = null;
         this._textureCache = null;
 
         super.destroy(options);

--- a/packages/text-bitmap/src/BitmapTextStyle.ts
+++ b/packages/text-bitmap/src/BitmapTextStyle.ts
@@ -1,10 +1,11 @@
+import type { ColorSource } from '@pixi/core';
 import type { TextStyleAlign } from '@pixi/text';
 
 export interface IBitmapTextStyle
 {
     fontName: string;
     fontSize: number;
-    tint: number;
+    tint: ColorSource;
     align: TextStyleAlign;
     letterSpacing: number;
     maxWidth: number;

--- a/packages/text-bitmap/test/BitmapText.tests.ts
+++ b/packages/text-bitmap/test/BitmapText.tests.ts
@@ -321,4 +321,21 @@ describe('BitmapText', () =>
 
         expect(text.dirty).toBeFalse();
     });
+
+    it('should support tinting', () =>
+    {
+        const text = new BitmapText('123ABCabc', {
+            fontName: font.font,
+        });
+
+        text.tint = 'red';
+
+        expect(text.tint).toEqual('red');
+
+        text.updateText();
+
+        text['_activePagesMeshData'].every((mesh) => mesh.mesh.tintValue === 0xff0000);
+
+        text.destroy(true);
+    });
 });


### PR DESCRIPTION
Support ColorSource for Mesh & BitmapText `tint`

```ts
const mesh = new Mesh();
mesh.tint = 'red';
```

Example:
https://jsfiddle.net/bigtimebuddy/4L6yebdx/