### PR TITLE
Support ColorSource with Sprite tint

### DIFF
--- a/packages/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas-sprite-tiling/src/TilingSprite.ts
@@ -31,7 +31,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
     const baseTextureResolution = baseTexture.resolution;
 
     // create a nice shiny pattern!
-    if (this._textureID !== this._texture._updateID || this._cachedTint !== this.tint)
+    if (this._textureID !== this._texture._updateID || this._cachedTint !== this.tintValue)
     {
         this._textureID = this._texture._updateID;
         // cut an object from a spritesheet..
@@ -40,9 +40,9 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
             baseTextureResolution);
 
         // Tint the tiling sprite
-        if (this.tint !== 0xFFFFFF)
+        if (this.tintValue !== 0xFFFFFF)
         {
-            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tint);
+            this._tintedCanvas = canvasUtils.getTintedCanvas(this, this.tintValue);
             tempCanvas.context.drawImage(this._tintedCanvas, 0, 0);
         }
         else
@@ -50,7 +50,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
             tempCanvas.context.drawImage(source,
                 -texture._frame.x * baseTextureResolution, -texture._frame.y * baseTextureResolution);
         }
-        this._cachedTint = this.tint;
+        this._cachedTint = this.tintValue;
         this._canvasPattern = tempCanvas.context.createPattern(tempCanvas.canvas, 'repeat');
     }
 

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -152,12 +152,12 @@ export class CanvasSpriteRenderer
 
         if (sprite.tint !== 0xFFFFFF)
         {
-            if (sprite._cachedTint !== sprite.tint || sprite._tintedCanvas.tintId !== sprite._texture._updateID)
+            if (sprite._cachedTint !== sprite.tintValue || sprite._tintedCanvas.tintId !== sprite._texture._updateID)
             {
-                sprite._cachedTint = sprite.tint;
+                sprite._cachedTint = sprite.tintValue;
 
                 // TODO clean up caching - how to clean up the caches?
-                sprite._tintedCanvas = canvasUtils.getTintedCanvas(sprite, sprite.tint);
+                sprite._tintedCanvas = canvasUtils.getTintedCanvas(sprite, sprite.tintValue);
             }
 
             context.drawImage(

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -1,7 +1,7 @@
 import { BLEND_MODES, Color, ObservablePoint, Point, Rectangle, settings, Texture, utils } from '@pixi/core';
 import { Bounds, Container } from '@pixi/display';
 
-import type { IBaseTextureOptions, IPointData, Renderer, TextureSource } from '@pixi/core';
+import type { ColorSource, IBaseTextureOptions, IPointData, Renderer, TextureSource } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
 
 const tempPoint = new Point();
@@ -125,7 +125,7 @@ export class Sprite extends Container
      * The tint applied to the sprite. This is a hex value. A value of 0xFFFFFF will remove any tint effect.
      * @default 0xFFFFFF
      */
-    private _tint: number;
+    private _tintColor: Color;
 
     // Internal-only properties
     /**
@@ -151,7 +151,7 @@ export class Sprite extends Container
 
         this._width = 0;
         this._height = 0;
-        this._tint = null;
+        this._tintColor = new Color(0xFFFFFF);
         this._tintRGB = null;
 
         this.tint = 0xFFFFFF;
@@ -580,15 +580,24 @@ export class Sprite extends Container
      * A value of 0xFFFFFF will remove any tint effect.
      * @default 0xFFFFFF
      */
-    get tint(): number
+    get tint(): ColorSource
     {
-        return this._tint;
+        return this._tintColor.value;
     }
 
-    set tint(value: number)
+    set tint(value: ColorSource)
     {
-        this._tint = value;
-        this._tintRGB = Color.shared.setValue(value).toLittleEndianNumber();
+        this._tintColor.setValue(value);
+        this._tintRGB = this._tintColor.toLittleEndianNumber();
+    }
+
+    /**
+     * Get the tint as a RGB integer.
+     * @ignore
+     */
+    get tintValue(): number
+    {
+        return this._tintColor.toNumber();
     }
 
     /** The texture that the sprite is using. */

--- a/packages/sprite/test/Sprite.tests.ts
+++ b/packages/sprite/test/Sprite.tests.ts
@@ -219,4 +219,19 @@ describe('Sprite', () =>
             texture.destroy(true);
         });
     });
+
+    describe('tint', () =>
+    {
+        it('should support ColorSource inputs', () =>
+        {
+            const sprite = new Sprite(Texture.WHITE);
+
+            sprite.tint = 'red';
+
+            expect(sprite.tint).toEqual('red');
+            expect(sprite.tintValue).toEqual(0xff0000);
+
+            sprite.destroy();
+        });
+    });
 });


### PR DESCRIPTION
Support ColorSource for Sprite `tint`
```ts
const sprite = new Sprite();
sprite.tint = 'red';
```
Example:
https://jsfiddle.net/bigtimebuddy/beroq52x/