### PR TITLE
Provide extensible Asset preferences

### DIFF
--- a/packages/assets/global.d.ts
+++ b/packages/assets/global.d.ts
@@ -1,0 +1,8 @@
+declare namespace GlobalMixins
+{
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface AssetsPreferences
+    {
+
+    }
+}

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -46,6 +46,7 @@
     "@types/css-font-loading-module": "^0.0.7"
   },
   "pixiRequirements": [
-    "@pixi/core"
+    "@pixi/core",
+    "@pixi/utils"
   ]
 }

--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '@pixi/core';
+import { deprecation } from '@pixi/utils';
 import { BackgroundLoader } from './BackgroundLoader';
 import { Cache } from './cache/Cache';
 import { Loader } from './loader/Loader';
@@ -9,10 +10,18 @@ import { isSingleItem } from './utils/isSingleItem';
 
 import type { FormatDetectionParser } from './detections';
 import type { LoadAsset } from './loader';
+import type { LoadTextureConfig } from './loader/parsers';
 import type { ResolveAsset, ResolverBundle, ResolverManifest } from './resolver';
 import type { BundleIdentifierOptions } from './resolver/Resolver';
 
 export type ProgressCallback = (progress: number) => void;
+
+/**
+ * Extensible preferences that can be used, for instance, when configuring loaders.
+ * @since 7.2.0
+ * @memberof PIXI
+ */
+export interface AssetsPreferences extends LoadTextureConfig, GlobalMixins.AssetsPreferences {}
 
 /**
  * Initialization options object for Asset Class.
@@ -46,6 +55,9 @@ export interface AssetInitOptions
 
     /** advanced - override how bundlesIds are generated */
     bundleIdentifier?: BundleIdentifierOptions;
+
+    /** Optional loader preferences */
+    preferences?: Partial<AssetsPreferences>;
 }
 
 /**
@@ -317,6 +329,11 @@ export class AssetsClass
                 resolution,
             },
         });
+
+        if (options.preferences)
+        {
+            this.setPreferences(options.preferences);
+        }
     }
 
     /**
@@ -823,11 +840,8 @@ export class AssetsClass
     }
 
     /**
-     * When set to `true`, loading and decoding images will happen with Worker thread,
-     * if available on the browser. This is much more performant as network requests
-     * and decoding can be expensive on the CPU. However, not all environments support
-     * Workers, in some cases it can be helpful to disable by setting to `false`.
-     * @default true
+     * @deprecated since 7.2.0
+     * @see {@link Assets.setPreferences}
      */
     public get preferWorkers(): boolean
     {
@@ -835,7 +849,32 @@ export class AssetsClass
     }
     public set preferWorkers(value: boolean)
     {
-        loadTextures.config.preferWorkers = value;
+        // #if _DEBUG
+        deprecation('7.2.0', 'Assets.prefersWorkers is deprecated, '
+            + 'use Assets.setPreferences({ preferWorkers: true }) instead.');
+        // #endif
+        this.setPreferences({ preferWorkers: value });
+    }
+
+    /**
+     * General setter for preferences. This is a helper function to set preferences on all parsers.
+     * @param preferences - the preferences to set
+     */
+    public setPreferences(preferences: Partial<AssetsPreferences>): void
+    {
+        // Find matching config keys in loaders with preferences
+        // and set the values
+        this.loader.parsers.forEach((parser) =>
+        {
+            if (!parser.config) return;
+
+            (Object.keys(parser.config) as (keyof AssetsPreferences)[])
+                .filter((key) => key in preferences)
+                .forEach((key) =>
+                {
+                    parser.config[key] = preferences[key];
+                });
+        });
     }
 }
 

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="../global.d.ts" />
 export * from './AssetExtension';
 export * from './Assets';
 export * from './cache';

--- a/packages/assets/src/loader/parsers/LoaderParser.ts
+++ b/packages/assets/src/loader/parsers/LoaderParser.ts
@@ -35,12 +35,13 @@ export enum LoaderParserPriority
  * and some for both!
  * @memberof PIXI
  */
-export interface LoaderParser<ASSET = any, META_DATA = any>
+export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<string, any>>
 {
     extension?: ExtensionMetadata;
 
     /** A config to adjust the parser */
-    config?: Record<string, any>
+    config?: CONFIG;
+
     /**
      * each URL to load will be tested here,
      * if the test is passed the assets are loaded using the load function below.

--- a/packages/assets/src/loader/parsers/textures/loadTextures.ts
+++ b/packages/assets/src/loader/parsers/textures/loadTextures.ts
@@ -19,6 +19,34 @@ const validImageMIMEs = [
 ];
 
 /**
+ * Configuration for the `loadTextures` loader plugin.
+ * @memberof PIXI
+ * @see PIXI.loadTextures
+ */
+export interface LoadTextureConfig
+{
+    /**
+     * When set to `true`, loading and decoding images will happen with Worker thread,
+     * if available on the browser. This is much more performant as network requests
+     * and decoding can be expensive on the CPU. However, not all environments support
+     * Workers, in some cases it can be helpful to disable by setting to `false`.
+     * @default true
+     */
+    preferWorkers: boolean;
+    /**
+     * When set to `true`, loading and decoding images will happen with `createImageBitmap`,
+     * otherwise it will use `new Image()`.
+     * @default true
+     */
+    preferCreateImageBitmap: boolean;
+    /**
+     * The crossOrigin value to use for images when `preferCreateImageBitmap` is `false`.
+     * @default 'anonymous'
+     */
+    crossOrigin: HTMLImageElement['crossOrigin'];
+}
+
+/**
  * Returns a promise that resolves an ImageBitmaps.
  * This function is designed to be used by a worker.
  * Part of WorkerManager!
@@ -59,6 +87,7 @@ export async function loadImageBitmap(url: string): Promise<ImageBitmap>
  *    crossOrigin: 'anonymous',
  * };
  * ```
+ * @memberof PIXI
  */
 export const loadTextures = {
     extension: {
@@ -128,6 +157,6 @@ export const loadTextures = {
     {
         texture.destroy(true);
     }
-} as LoaderParser<Texture, IBaseTextureOptions>;
+} as LoaderParser<Texture, IBaseTextureOptions, LoadTextureConfig>;
 
 extensions.add(loadTextures);

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -1,4 +1,4 @@
-import { Assets } from '@pixi/assets';
+import { Assets, loadTextures } from '@pixi/assets';
 import { BaseTexture, Texture } from '@pixi/core';
 import '@pixi/spritesheet';
 
@@ -345,5 +345,18 @@ describe('Assets', () =>
         const bunnyTexture = await Assets.load('bunny');
 
         expect(bunnyTexture.textureCacheIds[0]).toEqual(`${basePath}textures/bunny.png?foo=bar&chicken=nuggets`);
+    });
+
+    it('should support preferences settings', async () =>
+    {
+        await Assets.init({
+            preferences: {
+                preferWorkers: false,
+            }
+        });
+
+        expect(loadTextures.config.preferWorkers).toBe(false);
+        Assets.setPreferences({ preferWorkers: true });
+        expect(loadTextures.config.preferWorkers).toBe(true);
     });
 });


### PR DESCRIPTION
### Added

* Adds `Asset.setPreferences` and `Assets.init` property `preferences` which allow setting Loader configs. 

```ts
await Assets.init({
  preferences: {
    preferWorkers: false,
    preferCreateImageBitmap: false,
    crossOrigin: '',
  }
});
```
Or:
```ts
Assets.setPreferences({
  preferWorkers: false,
  preferCreateImageBitmap: false,
  crossOrigin: '',
});
```
* Adds `AssetPreferences` type, that has a GlobalMixin for extensibility.

### Deprecated

* Deprecates `Asset.preferWorkers` property, use `Assets.setPreferences` instead

### Links

* https://pixijs.download/feature/asset-preferences/docs/index.html