### PR TITLE
Add strict null checks to @pixijs/color

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -109,8 +109,10 @@ export class Color
      */
     constructor(value: ColorSource = 0xffffff)
     {
+        this._value = null;
         this._components = new Float32Array(4);
         this._components.fill(1);
+        this._int = 0xffffff;
         this.value = value;
     }
 
@@ -141,6 +143,7 @@ export class Color
     /**
      * Set the value, suitable for chaining
      * @param value
+     * @see PIXI.Color.value
      */
     setValue(value: ColorSource): this
     {
@@ -150,11 +153,20 @@ export class Color
     }
 
     /**
-     * Set the current color source. A return value of `null` means the previous
-     * value was overridden (e.g., `multiply`, `round`).
+     * The current color source.
+     *
+     * When setting:
+     * - Setting to an instance of `Color` will copy its color source and components.
+     * - Otherwise, `Color` will try to normalize the color source and set the components.
+     *   If the color source is invalid, an `Error` will be thrown and the `Color` will left unchanged.
+     *
+     * When getting:
+     * - A return value of `null` means the previous value was overridden  (e.g., {@link PIXI.Color.multiply multiply},
+     *   {@link PIXI.Color.premultiply premultiply} or {@link PIXI.Color.round round}).
+     * - Otherwise, the color source used when setting is returned.
      * @type {PIXI.ColorSource}
      */
-    set value(value: ColorSource)
+    set value(value: ColorSource | null)
     {
         // Support copying from other Color objects
         if (value instanceof Color)
@@ -162,6 +174,10 @@ export class Color
             this._value = value._value;
             this._int = value._int;
             this._components.set(value._components);
+        }
+        else if (value === null)
+        {
+            throw new Error('Cannot set PIXI.Color#value to null');
         }
         else if (this._value !== value)
         {
@@ -215,11 +231,13 @@ export class Color
      * new Color('white').toUint8RgbArray(); // returns [255, 255, 255]
      * @param {number[]|Uint8Array|Uint8ClampedArray} [out] - Output array
      */
-    toUint8RgbArray<T extends (number[] | Uint8Array | Uint8ClampedArray) = number[]>(out?: T): T
+    toUint8RgbArray(): number[];
+    toUint8RgbArray<T extends (number[] | Uint8Array | Uint8ClampedArray)>(out: T): T;
+    toUint8RgbArray<T extends (number[] | Uint8Array | Uint8ClampedArray)>(out?: T): T
     {
         const [r, g, b] = this._components;
 
-        out = out ?? [] as T;
+        out = out ?? [] as unknown as T;
 
         out[0] = Math.round(r * 255);
         out[1] = Math.round(g * 255);
@@ -235,9 +253,11 @@ export class Color
      * new Color('white').toRgbArray(); // returns [1, 1, 1]
      * @param {number[]|Float32Array} [out] - Output array
      */
-    toRgbArray<T extends (number[] | Float32Array) = number[]>(out?: T): T
+    toRgbArray(): number[];
+    toRgbArray<T extends (number[] | Float32Array)>(out: T): T;
+    toRgbArray<T extends (number[] | Float32Array)>(out?: T): T
     {
-        out = out ?? [] as T;
+        out = out ?? [] as unknown as T;
         const [r, g, b] = this._components;
 
         out[0] = r;
@@ -406,9 +426,11 @@ export class Color
      * new Color('white').toArray(); // returns [1, 1, 1, 1]
      * @param {number[]|Float32Array} [out] - Output array
      */
-    toArray<T extends (number[] | Float32Array) = number[]>(out?: T): T
+    toArray(): number[];
+    toArray<T extends (number[] | Float32Array)>(out: T): T;
+    toArray<T extends (number[] | Float32Array)>(out?: T): T
     {
-        out = out ?? [] as T;
+        out = out ?? [] as unknown as T;
         const [r, g, b, a] = this._components;
 
         out[0] = r;
@@ -423,9 +445,9 @@ export class Color
      * Normalize the input value into rgba
      * @param value - Input value
      */
-    private normalize(value: Exclude<ColorSource, Color>): void
+    private normalize(value: Exclude<ColorSource, Color> | null): void
     {
-        let components: number[];
+        let components: number[] | undefined;
 
         if ((Array.isArray(value) || value instanceof Float32Array)
             // Can be rgb or rgba

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -160,8 +160,11 @@ export class Color
      * - Otherwise, `Color` will try to normalize the color source and set the components.
      *   If the color source is invalid, an `Error` will be thrown and the `Color` will left unchanged.
      *
+     * Note: The `null` in the setter's parameter type is added to match the TypeScript rule: return type of getter
+     * must be assignable to its setter's parameter type. Setting `value` to `null` will throw an `Error`.
+     *
      * When getting:
-     * - A return value of `null` means the previous value was overridden  (e.g., {@link PIXI.Color.multiply multiply},
+     * - A return value of `null` means the previous value was overridden (e.g., {@link PIXI.Color.multiply multiply},
      *   {@link PIXI.Color.premultiply premultiply} or {@link PIXI.Color.round round}).
      * - Otherwise, the color source used when setting is returned.
      * @type {PIXI.ColorSource}

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -237,7 +237,7 @@ export class Color
     {
         const [r, g, b] = this._components;
 
-        out = out ?? [] as unknown as T;
+        out = out ?? [] as number[] as T;
 
         out[0] = Math.round(r * 255);
         out[1] = Math.round(g * 255);
@@ -257,7 +257,7 @@ export class Color
     toRgbArray<T extends (number[] | Float32Array)>(out: T): T;
     toRgbArray<T extends (number[] | Float32Array)>(out?: T): T
     {
-        out = out ?? [] as unknown as T;
+        out = out ?? [] as number[] as T;
         const [r, g, b] = this._components;
 
         out[0] = r;
@@ -430,7 +430,7 @@ export class Color
     toArray<T extends (number[] | Float32Array)>(out: T): T;
     toArray<T extends (number[] | Float32Array)>(out?: T): T
     {
-        out = out ?? [] as unknown as T;
+        out = out ?? [] as number[] as T;
         const [r, g, b, a] = this._components;
 
         out[0] = r;

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -445,7 +445,7 @@ export class Color
      * Normalize the input value into rgba
      * @param value - Input value
      */
-    private normalize(value: Exclude<ColorSource, Color> | null): void
+    private normalize(value: Exclude<ColorSource, Color>): void
     {
         let components: number[] | undefined;
 

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -10,7 +10,8 @@
  */
 
 const pathPrefixs = [
-    'packages/utils',
+    'packages/color/',
+    'packages/utils/',
 ];
 const filter = new RegExp(pathPrefixs.length === 0 ? `$^` : `^(${pathPrefixs.join('|')})`);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Ref #8852.

There are two major changes:

1. setter of `value`:

```diff
- set value(value: ColorSource)
+ set value(value: ColorSource | null)
  {
      // ...
  }
```

Or there will be an error:

```
error TS2380: The return type of a 'get' accessor must be assignable to its 'set' accessor type
  Type 'null' is not assignable to type 'ColorSource'.
```

Set `value` to `null` still throw an `Error`. Not sure if this is the best way to handle this.

2. `toUint8RgbArray`, `toRgbArray` and `toArray`:

```diff
- toArray<T extends (number[] | Float32Array) = number[]>(out?: T): T
+ toArray(): number[];
+ toArray<T extends (number[] | Float32Array)>(out: T): T;
+ toArray<T extends (number[] | Float32Array)>(out?: T): T
  {
      // ...
  }
```

This typing improvement prevents usage like `color.toArray<Float32Array>()`.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
