### PR TITLE
Bundle @pixi/color correctly

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,24 @@ function prodName(name)
     return name.replace(/\.(m)?js$/, '.min.$1js');
 }
 
+/**
+ * Escapes the `RegExp` special characters.
+ * @param {string} str
+ */
+function escapeRegExp(str)
+{
+    return str.replace(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+}
+
+/**
+ * Convert the name of a package to a `RegExp` that matches the package's export names.
+ * @param {string} packageName
+ */
+function convertPackageNameToRegExp(packageName)
+{
+    return new RegExp(`^${escapeRegExp(packageName)}(/.+)?$`);
+}
+
 async function main()
 {
     const commonPlugins = [
@@ -78,17 +96,18 @@ async function main()
             pluginExports = true,
             bundle,
             bundleModule,
-            dependencies,
-            nodeDependencies,
-            peerDependencies,
-            pixiRequirements,
+            dependencies = {},
+            peerDependencies = {},
+            nodeDependencies = [],
+            pixiRequirements = [],
         } = pkg.config;
 
         // Check for bundle folder
-        const external = Object.keys(dependencies || [])
-            .concat(Object.keys(peerDependencies || []))
-            .concat(nodeDependencies || [])
-            .concat(pixiRequirements || []);
+        const external = Object.keys(dependencies)
+            .concat(Object.keys(peerDependencies))
+            .concat(nodeDependencies)
+            .concat(pixiRequirements)
+            .map(convertPackageNameToRegExp);
         const basePath = path.relative(__dirname, pkg.dir);
         const input = path.join(basePath, 'src/index.ts');
 
@@ -139,8 +158,8 @@ async function main()
             const name = pkg.name.replace(/[^a-z]+/g, '_');
             const file = path.join(basePath, plugin);
             const footer = pluginExports ? `Object.assign(this.PIXI, ${name});` : '';
-            const nsBanner = pluginExports ? `${banner}\nthis.PIXI = this.PIXI || {};`: banner;
-            const globals = external.reduce((obj, name) => ({ ...obj, [name]: 'PIXI' }), {});
+            const nsBanner = pluginExports ? `${banner}\nthis.PIXI = this.PIXI || {};` : banner;
+            const globals = pixiRequirements.reduce((obj, name) => ({ ...obj, [name]: 'PIXI' }), {});
 
             results.push({
                 input,


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Currently there are two problems when bundling `@pixi/color`:

1. Files from `colord/plugins/names` are accidentally bundled into `@pixi/color`, see <https://github.com/pixijs/pixijs/issues/9189#issuecomment-1437309750>.

2. The `Color.mjs.map` file becomes invalid for some reason, causing jsDeliver failed to bundle esm package, see <https://github.com/jsdelivr/jsdelivr/issues/18469#issuecomment-1438494155>:

```json5
{"version":3,"file":null,"sources":[null],"sourcesContent":[null],/* ... */}
```

After fixing the first problems, the source map become normal magically:

```json5
{"version":3,"file":"Color.mjs","sources":["../src/Color.ts"],"sourcesContent":[/* ... */],/* ... */}
```

(Maybe a bug of Rollup?)

This PR fixes these problems. Replace #9191, fixes #9189.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
