### PR TITLE
Fix: Listeners registered with EventEmitter#once should only trigger once

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -56,13 +56,16 @@ type TrackingData = {
 };
 
 /**
+ * Internal storage of an event listener in EventEmitter.
+ * @ignore
+ */
+type EmitterListener = { fn(...args: any[]): any, context: any, once: boolean };
+
+/**
  * Internal storage of event listeners in EventEmitter.
  * @ignore
  */
-type EmitterListeners = Record<string,
-| Array<{ fn(...args: any[]): any, context: any }>
-| { fn(...args: any[]): any, context: any }
->;
+type EmitterListeners = Record<string, EmitterListener | EmitterListener[]>;
 
 /**
  * Event boundaries are "barriers" where events coming from an upstream scene are modified before downstream propagation.
@@ -1373,6 +1376,7 @@ export class EventBoundary
 
         if ('fn' in listeners)
         {
+            if (listeners.once) e.currentTarget.removeListener(type, listeners.fn, undefined, true);
             listeners.fn.call(listeners.context, e);
         }
         else
@@ -1382,6 +1386,7 @@ export class EventBoundary
                 i < j && !e.propagationImmediatelyStopped;
                 i++)
             {
+                if (listeners[i].once) e.currentTarget.removeListener(type, listeners[i].fn, undefined, true);
                 listeners[i].fn.call(listeners[i].context, e);
             }
         }

--- a/packages/events/test/EventBoundary.tests.ts
+++ b/packages/events/test/EventBoundary.tests.ts
@@ -302,4 +302,58 @@ describe('EventBoundary', () =>
         expect(containerOutSpy).toHaveBeenCalledOnce();
         expect(toOverSpy).toHaveBeenCalledOnce();
     });
+
+    it('should only call listener once when using .once() to register listener', () =>
+    {
+        const stage = new Container();
+        const boundary = new EventBoundary(stage);
+        const container = stage.addChild(new Container());
+        const target1 = container.addChild(
+            new Graphics().drawRect(0, 0, 100, 100)
+        );
+        const target2 = container.addChild(
+            new Graphics().drawRect(100, 0, 100, 100)
+        );
+
+        target1.interactive = true;
+        target2.interactive = true;
+
+        // With a single listener
+        const eventSpy1 = jest.fn();
+
+        target1.once('click', eventSpy1);
+
+        const event1 = new FederatedPointerEvent(boundary);
+
+        event1.target = target1;
+        event1.global.set(50, 50);
+        event1.type = 'click';
+
+        boundary.dispatchEvent(event1);
+        boundary.dispatchEvent(event1);
+
+        expect(eventSpy1).toHaveBeenCalledOnce();
+
+        // With multiple listeners
+        const eventSpy2 = jest.fn();
+        const eventSpy3 = jest.fn();
+        const eventSpy4 = jest.fn();
+
+        target2.once('click', eventSpy2);
+        target2.on('click', eventSpy3);
+        target2.addEventListener('click', eventSpy4);
+
+        const event2 = new FederatedPointerEvent(boundary);
+
+        event2.target = target2;
+        event2.global.set(150, 50);
+        event2.type = 'click';
+
+        boundary.dispatchEvent(event2);
+        boundary.dispatchEvent(event2);
+
+        expect(eventSpy2).toHaveBeenCalledOnce();
+        expect(eventSpy3).toHaveBeenCalledTimes(2);
+        expect(eventSpy4).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Call `removeListener` on listeners registered with `once` in `EventBoundary#notifyListeners`, so that it can match the behavior of `EventEmitter#emit` (<https://github.com/primus/eventemitter3/blob/b99e3efb9d62392c7c7275d2f98d3d9dbc9b368f/index.js#L159-L216>).

Fixes #9195.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
