### PR TITLE
Feature: Implement the possibility to add custom events to DisplayObject

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -1,5 +1,7 @@
 import { autoDetectRenderer, extensions, ExtensionType } from '@pixi/core';
 import { Container } from '@pixi/display';
+import type { DisplayObject } from "@pixi/display";
+import type { utils } from '@pixi/core';
 
 import type { ICanvas, IRenderer, IRendererOptionsAuto, Rectangle } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
@@ -48,7 +50,9 @@ export interface Application extends GlobalMixins.Application {}
  * @class
  * @memberof PIXI
  */
-export class Application<VIEW extends ICanvas = ICanvas>
+export class Application
+    <VIEW extends ICanvas = ICanvas,
+    EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
 {
     /** Collection of installed plugins. */
     static _plugins: IApplicationPlugin[] = [];
@@ -57,7 +61,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      * The root display container that's rendered.
      * @member {PIXI.Container}
      */
-    public stage: Container = new Container();
+    public stage: Container<DisplayObject, EventTypes> = new Container<DisplayObject, EventTypes>();
 
     /**
      * WebGL renderer if available, otherwise CanvasRenderer.

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -16,7 +16,10 @@ function sortChildren(a: DisplayObject, b: DisplayObject): number
     return a.zIndex - b.zIndex;
 }
 
-export interface Container extends GlobalMixins.Container, DisplayObject {}
+export interface Container
+    <T extends DisplayObject = DisplayObject,
+    EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends GlobalMixins.Container, DisplayObject<EventTypes> {}
 
 /**
  * Container is a general-purpose display object that holds children. It also adds built-in support for advanced
@@ -47,7 +50,10 @@ export interface Container extends GlobalMixins.Container, DisplayObject {}
  *     .endFill();
  * @memberof PIXI
  */
-export class Container<T extends DisplayObject = DisplayObject> extends DisplayObject
+export class Container
+    <T extends DisplayObject = DisplayObject,
+    EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends DisplayObject<EventTypes>
 {
     /**
      * Sets the default value for the container property `sortableChildren`.

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -21,8 +21,9 @@ export interface DisplayObjectEvents extends GlobalMixins.DisplayObjectEvents
 }
 
 export interface DisplayObject
-    extends Omit<GlobalMixins.DisplayObject, keyof utils.EventEmitter<DisplayObjectEvents>>,
-    utils.EventEmitter<DisplayObjectEvents> {}
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Omit<GlobalMixins.DisplayObject, keyof utils.EventEmitter<DisplayObjectEvents & EventTypes>>,
+    utils.EventEmitter<DisplayObjectEvents & EventTypes> {}
 
 /**
  * The base class for all objects that are rendered on the screen.
@@ -209,8 +210,12 @@ export interface DisplayObject
  * one is also better in terms of performance.
  * @memberof PIXI
  */
-export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEvents>
+export abstract class DisplayObject
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends utils.EventEmitter<DisplayObjectEvents & EventTypes>
 {
+    eventNames: () => (keyof DisplayObjectEvents)[]
+  
     abstract sortDirty: boolean;
 
     /** The display object container that contains this display object. */

--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -15,7 +15,9 @@ import {
     Texture,
     UniformGroup,
 } from '@pixi/core';
+import type { utils } from "@pixi/core";
 import { Container } from '@pixi/display';
+import type { DisplayObject } from "@pixi/display"
 import { curves, LINE_CAP, LINE_JOIN } from './const';
 import { GraphicsGeometry } from './GraphicsGeometry';
 import { FillStyle } from './styles/FillStyle';
@@ -63,7 +65,9 @@ export interface ILineStyleOptions extends IFillStyleOptions
 // a default shaders map used by graphics..
 const DEFAULT_SHADERS: {[key: string]: Shader} = {};
 
-export interface Graphics extends GlobalMixins.Graphics, Container {}
+export interface Graphics
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends GlobalMixins.Graphics, Container<DisplayObject, EventTypes> {}
 
 /**
  * The Graphics class is primarily used to render primitive shapes such as lines, circles and
@@ -83,7 +87,9 @@ export interface Graphics extends GlobalMixins.Graphics, Container {}
  * properly dereference each GraphicsGeometry and prevent memory leaks.
  * @memberof PIXI
  */
-export class Graphics extends Container
+export class Graphics
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Container<DisplayObject, EventTypes>
 {
     /**
      * Graphics curves resolution settings. If `adaptive` flag is set to `true`,

--- a/packages/particle-container/src/ParticleContainer.ts
+++ b/packages/particle-container/src/ParticleContainer.ts
@@ -1,4 +1,5 @@
 import { BLEND_MODES, Color } from '@pixi/core';
+import type { utils } from '@pixi/core';
 import { Container } from '@pixi/display';
 
 import type { BaseTexture, ColorSource, Renderer } from '@pixi/core';
@@ -40,7 +41,9 @@ export interface IParticleProperties
  * }
  * @memberof PIXI
  */
-export class ParticleContainer extends Container<Sprite>
+export class ParticleContainer
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Container<Sprite, EventTypes>
 {
     /**
      * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL`

--- a/packages/sprite-animated/src/AnimatedSprite.ts
+++ b/packages/sprite-animated/src/AnimatedSprite.ts
@@ -1,5 +1,6 @@
 import { Texture, Ticker, UPDATE_PRIORITY } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
+import type { utils } from '@pixi/core';
 
 import type { IDestroyOptions } from '@pixi/display';
 
@@ -35,7 +36,9 @@ import type { IDestroyOptions } from '@pixi/display';
  * animatedSprite = new AnimatedSprite(sheet.animations['image_sequence']);
  * @memberof PIXI
  */
-export class AnimatedSprite extends Sprite
+export class AnimatedSprite
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Sprite<EventTypes>
 {
     /**
      * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower.

--- a/packages/sprite-tiling/src/TilingSprite.ts
+++ b/packages/sprite-tiling/src/TilingSprite.ts
@@ -1,5 +1,6 @@
 import { Point, Rectangle, Texture, TextureMatrix, Transform } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
+import type { utils } from '@pixi/core';
 
 import type { IBaseTextureOptions, IPoint, IPointData, ISize, ObservablePoint, Renderer, TextureSource } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
@@ -7,13 +8,17 @@ import type { IDestroyOptions } from '@pixi/display';
 const tempPoint = new Point();
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface TilingSprite extends GlobalMixins.TilingSprite {}
+export interface TilingSprite
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends GlobalMixins.TilingSprite {}
 
 /**
  * A tiling sprite is a fast way of rendering a tiling image.
  * @memberof PIXI
  */
-export class TilingSprite extends Sprite
+export class TilingSprite
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Sprite<EventTypes>
 {
     /** Tile transform */
     public tileTransform: Transform;

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -1,5 +1,6 @@
 import { BLEND_MODES, Color, ObservablePoint, Point, Rectangle, settings, Texture, utils } from '@pixi/core';
 import { Bounds, Container } from '@pixi/display';
+import type { DisplayObject } from '@pixi/display';
 
 import type { ColorSource, IBaseTextureOptions, IPointData, Renderer, TextureSource } from '@pixi/core';
 import type { IDestroyOptions } from '@pixi/display';
@@ -9,7 +10,9 @@ const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
 export type SpriteSource = TextureSource | Texture;
 
-export interface Sprite extends GlobalMixins.Sprite, Container {}
+export interface Sprite
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends GlobalMixins.Sprite, Container<DisplayObject, EventTypes> {}
 
 /**
  * The Sprite object is the base for all textured objects that are rendered to the screen
@@ -33,7 +36,9 @@ export interface Sprite extends GlobalMixins.Sprite, Container {}
  * ```
  * @memberof PIXI
  */
-export class Sprite extends Container
+export class Sprite
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Container<DisplayObject, EventTypes>
 {
     /**
      * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL` to reset the blend mode.

--- a/packages/text-bitmap/src/BitmapText.ts
+++ b/packages/text-bitmap/src/BitmapText.ts
@@ -1,5 +1,6 @@
 import { BLEND_MODES, Color, ObservablePoint, Point, Program, settings, Texture, utils } from '@pixi/core';
 import { Container } from '@pixi/display';
+import type { DisplayObject } from '@pixi/display';
 import { Mesh, MeshGeometry, MeshMaterial } from '@pixi/mesh';
 import { BitmapFont } from './BitmapFont';
 import msdfFrag from './shader/msdf.frag';
@@ -67,7 +68,9 @@ const charRenderDataPool: CharRenderData[] = [];
  * });
  * @memberof PIXI
  */
-export class BitmapText extends Container
+export class BitmapText
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Container<DisplayObject, EventTypes>
 {
     public static styleDefaults: Partial<IBitmapTextStyle> = {
         align: 'left',

--- a/packages/text/src/Text.ts
+++ b/packages/text/src/Text.ts
@@ -42,7 +42,9 @@ const defaultDestroyOptions: IDestroyOptions = {
  * });
  * @memberof PIXI
  */
-export class Text extends Sprite
+export class Text
+    <EventTypes extends utils.EventEmitter.ValidEventTypes = unknown>
+    extends Sprite<EventTypes>
 {
     /**
      * Override whether or not the resolution of the text is automatically adjusted to match the resolution of the renderer.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Adds the possibility to add custom events to `DisplayObject`

Closes: #8957 

Cons:
```
Type '(CustomEvents... | keyof DisplayObjectEvents)[]' is not assignable to type '(keyof DisplayObjectEvents)[]'.ts(2345)
```
Unable to get custom events added in `eventNames()` function of `eventemitter3`, it was necessary to add the next line in `DisplayObject` to be able to use in some functions that need the `DisplayObject` parameter as type like for example: `app.renderer.extract.image(displayObject)` to remove the type error.

```typescript
eventNames: () => (keyof DisplayObjectEvents)[]
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
