### PR TITLE
Chore: Fix prerelease tag

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -100,4 +100,4 @@ jobs:
     # Publish to NPM with prerelease dist-tag
     - name: Publish Latest Prerelease
       if: github.event_name == 'release' && github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
-      run: npm run publish-ci -- --dist-tag prerelease
+      run: npm run publish-ci -- --tag prerelease


### PR DESCRIPTION
In our previous prereleases, tags weren't getting updated correctly. For instance, here's 7.2.0-beta.2
https://github.com/pixijs/pixijs/actions/runs/4244955704/jobs/7379807833#step:18:19

Publish command was:
```
npm publish --dist-tag prerelease
```
Should be:
```
npm publish --tag prerelease
```