### PR TITLE
Chore: Remove all dependencies from module bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10817,7 +10817,6 @@
     },
     "node_modules/ismobilejs": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isobject": {
@@ -19901,9 +19900,7 @@
       "license": "MIT",
       "dependencies": {
         "@pixi/constants": "file:../constants",
-        "@types/css-font-loading-module": "^0.0.7"
-      },
-      "devDependencies": {
+        "@types/css-font-loading-module": "^0.0.7",
         "ismobilejs": "^1.1.0"
       }
     },
@@ -27566,8 +27563,7 @@
       "version": "2.0.0"
     },
     "ismobilejs": {
-      "version": "1.1.1",
-      "dev": true
+      "version": "1.1.1"
     },
     "isobject": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "rollup": "^2.78.0",
         "rollup-plugin-esbuild": "^4.9.1",
         "rollup-plugin-jscc": "^2.0.0",
-        "rollup-plugin-rename-node-modules": "^1.3.1",
         "rollup-plugin-sourcemaps": "^0.4.2",
         "rollup-plugin-string": "^3.0.0",
         "semver": "^7.3.8",
@@ -17210,25 +17209,6 @@
         "estree-walker": "^0.6.1"
       }
     },
-    "node_modules/rollup-plugin-rename-node-modules": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
-      "integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^2.28.2"
-      }
-    },
-    "node_modules/rollup-plugin-rename-node-modules/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
     "node_modules/rollup-plugin-sourcemaps": {
       "version": "0.4.2",
       "dev": true,
@@ -32316,24 +32296,6 @@
           "requires": {
             "estree-walker": "^0.6.1"
           }
-        }
-      }
-    },
-    "rollup-plugin-rename-node-modules": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz",
-      "integrity": "sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^2.0.1",
-        "magic-string": "^0.25.7"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "rollup": "^2.78.0",
     "rollup-plugin-esbuild": "^4.9.1",
     "rollup-plugin-jscc": "^2.0.0",
-    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-string": "^3.0.0",
     "semver": "^7.3.8",

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -36,9 +36,7 @@
   ],
   "dependencies": {
     "@pixi/constants": "file:../constants",
-    "@types/css-font-loading-module": "^0.0.7"
-  },
-  "devDependencies": {
+    "@types/css-font-loading-module": "^0.0.7",
     "ismobilejs": "^1.1.0"
   }
 }

--- a/packages/settings/src/utils/isMobile.ts
+++ b/packages/settings/src/utils/isMobile.ts
@@ -2,8 +2,7 @@ import isMobileJs from 'ismobilejs';
 
 // ismobilejs have different import behavior for CJS and ESM, so here is the hack
 type isMobileJsType = typeof isMobileJs & { default?: typeof isMobileJs };
-const isMobileJsModule = isMobileJs as isMobileJsType;
-const isMobileCall = isMobileJsModule.default ?? isMobileJsModule;
+const isMobileCall = (isMobileJs as isMobileJsType).default ?? isMobileJs;
 
 export type isMobileResult = {
     apple: {

--- a/packages/settings/src/utils/isMobile.ts
+++ b/packages/settings/src/utils/isMobile.ts
@@ -1,4 +1,9 @@
-import isMobileCall from 'ismobilejs';
+import isMobileJs from 'ismobilejs';
+
+// ismobilejs have different import behavior for CJS and ESM, so here is the hack
+type isMobileJsType = typeof isMobileJs & { default?: typeof isMobileJs };
+const isMobileJsModule = isMobileJs as isMobileJsType;
+const isMobileCall = isMobileJsModule.default ?? isMobileJsModule;
 
 export type isMobileResult = {
     apple: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import resolve from '@rollup/plugin-node-resolve';
-import rename from 'rollup-plugin-rename-node-modules';
 import { string } from 'rollup-plugin-string';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import esbuild from 'rollup-plugin-esbuild';
@@ -59,7 +58,6 @@ async function main()
     ];
 
     const plugins = [
-        rename(),
         jscc({ values: { _VERSION: repo.version, _DEBUG: true } }),
         esbuild({ target: moduleTarget }),
         ...commonPlugins


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Move `ismobilejs` from `devDependencies` to `dependencies`, so that it will not be bundled into `@pixi/settings` and generating invalid source maps (see <https://unpkg.com/browse/@pixi/settings@7.2.0-beta.2/lib/external/ismobilejs/esm/>).

Also remove `rollup-plugin-rename-node-modules`, since there is no bundled dependency now.

Fixes #9189.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
