### PR TITLE
Fix: TilingSprite#tileScale inconsistency between WebGL and Canvas

### DIFF
--- a/packages/canvas-sprite-tiling/src/TilingSprite.ts
+++ b/packages/canvas-sprite-tiling/src/TilingSprite.ts
@@ -125,7 +125,7 @@ TilingSprite.prototype._renderCanvas = function _renderCanvas(renderer: CanvasRe
         patternMatrix.translate(-this.anchor.x * W, -this.anchor.y * H);
     }
 
-    patternMatrix.scale(this.tileScale.x / baseTextureResolution, this.tileScale.y / baseTextureResolution);
+    patternMatrix.scale(1 / baseTextureResolution, 1 / baseTextureResolution);
     worldMatrix.prepend(patternMatrix);
     worldMatrix.prepend(transform);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

https://github.com/pixijs/pixijs/blob/699b515bed7a0c4ea2429f46e94def5286704e90/packages/canvas-sprite-tiling/src/TilingSprite.ts#L120-L128

`lt` (`tileTransform.localTransform`) already contains `tileScale` (which is actually `tileTransform.scale`), so there is no need to multiply it again. (It is introduced in #8059.)

- Before: <https://jsfiddle.net/bigtimebuddy/n3g78rdm/>
- After: <https://jsfiddle.net/SuperSodaSea/w6bosd8v/>

Fixes #9205.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
