### PR TITLE
Resolution isn't readonly in current renderer implementation

### DIFF
--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -138,7 +138,7 @@ export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager
     /** Flag if we are rendering to the screen vs renderTexture */
     readonly renderingToScreen: boolean
     /** The resolution / device pixel ratio of the renderer. */
-    readonly resolution: number
+    resolution: number
     /** the width of the screen */
     readonly width: number
     /** the height of the screen */


### PR DESCRIPTION
`Irenderer` currently lists `resolution` as `readonly` but the `Renderer` implementation has a setter for `resolution`: https://github.com/pixijs/pixijs/blob/dev/packages/core/src/Renderer.ts#L459