### PR TITLE
Add strict null checks to packages with no errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:types": "tsc -p tsconfig.types.json && ts-node scripts/fixTypes.ts",
     "postbuild:types": "copyfiles -u 1 \"out/**/*\" . && run-s clean:out",
     "watch": "rollup -cw",
-    "dist": "run-s lint types build build:types docs",
+    "dist": "run-s lint types types:strict build build:types docs",
     "dist-validate": "workspaces-run --only=\"@pixi/node\" -- npm run test:dist",
     "postdist": "copyfiles -f bundles/*/dist/* dist && copyfiles -f packages/*/dist/* dist/packages",
     "prerelease": "run-s clean:build test dist",

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -10,7 +10,60 @@
  */
 
 const pathPrefixs = [
+    'bundles/pixi.js/',
+    'bundles/pixi.js-legacy/',
+    // 'bundles/pixi.js-node/',
+    // 'bundles/pixi.js-webworker/',
+    // 'packages/accessibility/',
+    // 'packages/app/',
+    // 'packages/assets/',
+    // 'packages/basis/',
+    // 'packages/canvas-display/',
+    // 'packages/canvas-extract/',
+    // 'packages/canvas-graphics/',
+    // 'packages/canvas-mesh/',
+    // 'packages/canvas-particle-container/',
+    // 'packages/canvas-prepare/',
+    // 'packages/canvas-renderer/',
+    // 'packages/canvas-sprite/',
+    // 'packages/canvas-sprite-tiling/',
+    'packages/canvas-text/',
     'packages/color/',
+    // 'packages/compressed-textures/',
+    'packages/constants/',
+    // 'packages/core/',
+    // 'packages/display/',
+    // 'packages/events/',
+    // 'packages/extensions/',
+    // 'packages/extract/',
+    'packages/filter-alpha/',
+    // 'packages/filter-blur/',
+    // 'packages/filter-color-matrix/',
+    'packages/filter-displacement/',
+    'packages/filter-fxaa/',
+    'packages/filter-noise/',
+    // 'packages/graphics/',
+    // 'packages/graphics-extras/',
+    // 'packages/math/',
+    // 'packages/math-extras/',
+    // 'packages/mesh/',
+    // 'packages/mesh-extras/',
+    // 'packages/mixin-cache-as-bitmap/',
+    // 'packages/mixin-get-child-by-name/',
+    'packages/mixin-get-global-position/',
+    // 'packages/particle-container/',
+    // 'packages/prepare/',
+    // 'packages/runner/',
+    'packages/settings/',
+    // 'packages/sprite/',
+    // 'packages/sprite-animated/',
+    // 'packages/sprite-tiling/',
+    // 'packages/spritesheet/',
+    // 'packages/text/',
+    // 'packages/text-bitmap/',
+    'packages/text-html/',
+    // 'packages/ticker/',
+    'packages/unsafe-eval/',
     'packages/utils/',
 ];
 const filter = new RegExp(pathPrefixs.length === 0 ? `$^` : `^(${pathPrefixs.join('|')})`);
@@ -48,6 +101,6 @@ stdin.on('end', () =>
     if (matchedErrors.length !== 0)
     {
         console.error(matchedErrors.join('\n'));
-        process.exitCode = 1;
+        // process.exitCode = 1;
     }
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Add packages that already have no error with strict null checks to the filter in `scripts/filterTypeScriptErrors.ts`:

- `bundles/pixi.js/`
- `bundles/pixi.js-legacy/`
- `packages/canvas-text/`
- `packages/constants/`
- `packages/filter-alpha/`
- `packages/filter-displacement/`
- `packages/filter-fxaa/`
- `packages/filter-noise/`
- `packages/mixin-get-global-position/`
- `packages/settings/`
- `packages/text-html/`
- `packages/unsafe-eval/`

Also `types:strict` is added back to `npm run dist` (so we can check it easily on CI), but now it will not break the build when error occurs (`types:strict` will not exit with non-zero code).

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
