### PR TITLE
Fix: Renderer#type not available

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -1,9 +1,10 @@
 import {
     extensions,
     ExtensionType,
+    RENDERER_TYPE,
     settings,
     SystemManager,
-    utils,
+    utils
 } from '@pixi/core';
 
 import type {
@@ -23,10 +24,9 @@ import type {
     Matrix,
     PluginSystem,
     Rectangle,
-    RENDERER_TYPE,
     RenderTexture,
     StartupSystem,
-    ViewSystem
+    ViewSystem,
 } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
 import type { CanvasContextSystem, SmoothingEnabledProperties } from './CanvasContextSystem';
@@ -109,7 +109,7 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
      * @member {number}
      * @see PIXI.RENDERER_TYPE
      */
-    public readonly type: RENDERER_TYPE.CANVAS;
+    public readonly type = RENDERER_TYPE.CANVAS;
 
     /** When logging Pixi to the console, this is the name we will show */
     public readonly rendererLogId = 'Canvas';

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -1,3 +1,4 @@
+import { RENDERER_TYPE } from '@pixi/constants';
 import { extensions, ExtensionType } from '@pixi/extensions';
 import { Matrix } from '@pixi/math';
 import { settings } from '@pixi/settings';
@@ -6,7 +7,7 @@ import { UniformGroup } from './shader/UniformGroup';
 import { SystemManager } from './system/SystemManager';
 
 import type { ColorSource } from '@pixi/color';
-import type { MSAA_QUALITY, RENDERER_TYPE } from '@pixi/constants';
+import type { MSAA_QUALITY } from '@pixi/constants';
 import type { ExtensionMetadata } from '@pixi/extensions';
 import type { Rectangle } from '@pixi/math';
 import type { ICanvas } from '@pixi/settings';
@@ -101,7 +102,7 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      * @member {number}
      * @see PIXI.RENDERER_TYPE
      */
-    public readonly type: RENDERER_TYPE.WEBGL;
+    public readonly type = RENDERER_TYPE.WEBGL;
 
     /**
      * Options passed to the constructor.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

I suddenly realized that `app.renderer.type` is always `undefined`. This PR fixes this issue.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
