### PR TITLE
Revert abandoning peerDependencies for internal package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18533,62 +18533,129 @@
     },
     "packages/accessibility": {
       "name": "@pixi/accessibility",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/events": "file:../events"
+      }
     },
     "packages/app": {
       "name": "@pixi/app",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/assets": {
       "name": "@pixi/assets",
       "license": "MIT",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.7"
+      },
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/utils": "file:../utils"
       }
     },
     "packages/basis": {
       "name": "@pixi/basis",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "file:../assets",
+        "@pixi/compressed-textures": "file:../compressed-textures",
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/canvas-display": {
       "name": "@pixi/canvas-display",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/canvas-extract": {
       "name": "@pixi/canvas-extract",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/canvas-graphics": {
       "name": "@pixi/canvas-graphics",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-display": "file:../canvas-display",
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/core": "file:../core",
+        "@pixi/graphics": "file:../graphics"
+      }
     },
     "packages/canvas-mesh": {
       "name": "@pixi/canvas-mesh",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-display": "file:../canvas-display",
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/core": "file:../core",
+        "@pixi/mesh": "file:../mesh",
+        "@pixi/mesh-extras": "file:../mesh-extras"
+      }
     },
     "packages/canvas-particle-container": {
       "name": "@pixi/canvas-particle-container",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/particle-container": "file:../particle-container"
+      }
     },
     "packages/canvas-prepare": {
       "name": "@pixi/canvas-prepare",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/core": "file:../core",
+        "@pixi/prepare": "file:../prepare"
+      }
     },
     "packages/canvas-renderer": {
       "name": "@pixi/canvas-renderer",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/canvas-sprite": {
       "name": "@pixi/canvas-sprite",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-display": "file:../canvas-display",
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/core": "file:../core",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/canvas-sprite-tiling": {
       "name": "@pixi/canvas-sprite-tiling",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-renderer": "file:../canvas-renderer",
+        "@pixi/canvas-sprite": "file:../canvas-sprite",
+        "@pixi/core": "file:../core",
+        "@pixi/sprite-tiling": "file:../sprite-tiling"
+      }
     },
     "packages/canvas-text": {
       "name": "@pixi/canvas-text",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/canvas-sprite": "file:../canvas-sprite",
+        "@pixi/sprite": "file:../sprite",
+        "@pixi/text": "file:../text"
+      }
     },
     "packages/color": {
       "name": "@pixi/color",
@@ -18599,7 +18666,11 @@
     },
     "packages/compressed-textures": {
       "name": "@pixi/compressed-textures",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "file:../assets",
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/constants": {
       "name": "@pixi/constants",
@@ -18626,11 +18697,19 @@
     },
     "packages/display": {
       "name": "@pixi/display",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/events": {
       "name": "@pixi/events",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/utils": "file:../utils"
+      }
     },
     "packages/extensions": {
       "name": "@pixi/extensions",
@@ -18638,39 +18717,69 @@
     },
     "packages/extract": {
       "name": "@pixi/extract",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-alpha": {
       "name": "@pixi/filter-alpha",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-blur": {
       "name": "@pixi/filter-blur",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-color-matrix": {
       "name": "@pixi/filter-color-matrix",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-displacement": {
       "name": "@pixi/filter-displacement",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-fxaa": {
       "name": "@pixi/filter-fxaa",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/filter-noise": {
       "name": "@pixi/filter-noise",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/graphics": {
       "name": "@pixi/graphics",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/graphics-extras": {
       "name": "@pixi/graphics-extras",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/graphics": "file:../graphics"
+      }
     },
     "packages/interaction": {
       "version": "6.5.3",
@@ -18701,31 +18810,59 @@
     },
     "packages/math-extras": {
       "name": "@pixi/math-extras",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/mesh": {
       "name": "@pixi/mesh",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/mesh-extras": {
       "name": "@pixi/mesh-extras",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/mesh": "file:../mesh"
+      }
     },
     "packages/mixin-cache-as-bitmap": {
       "name": "@pixi/mixin-cache-as-bitmap",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/mixin-get-child-by-name": {
       "name": "@pixi/mixin-get-child-by-name",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/mixin-get-global-position": {
       "name": "@pixi/mixin-get-global-position",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/particle-container": {
       "name": "@pixi/particle-container",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/polyfill": {
       "version": "6.5.3",
@@ -18742,7 +18879,13 @@
     },
     "packages/prepare": {
       "name": "@pixi/prepare",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/graphics": "file:../graphics",
+        "@pixi/text": "file:../text"
+      }
     },
     "packages/runner": {
       "name": "@pixi/runner",
@@ -18759,31 +18902,65 @@
     },
     "packages/sprite": {
       "name": "@pixi/sprite",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display"
+      }
     },
     "packages/sprite-animated": {
       "name": "@pixi/sprite-animated",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/sprite-tiling": {
       "name": "@pixi/sprite-tiling",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/spritesheet": {
       "name": "@pixi/spritesheet",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "file:../assets",
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/text": {
       "name": "@pixi/text",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/sprite": "file:../sprite"
+      }
     },
     "packages/text-bitmap": {
       "name": "@pixi/text-bitmap",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/assets": "file:../assets",
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/mesh": "file:../mesh",
+        "@pixi/text": "file:../text"
+      }
     },
     "packages/text-html": {
       "name": "@pixi/text-html",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core",
+        "@pixi/display": "file:../display",
+        "@pixi/sprite": "file:../sprite",
+        "@pixi/text": "file:../text"
+      }
     },
     "packages/ticker": {
       "name": "@pixi/ticker",
@@ -18796,7 +18973,10 @@
     },
     "packages/unsafe-eval": {
       "name": "@pixi/unsafe-eval",
-      "license": "MIT"
+      "license": "MIT",
+      "peerDependencies": {
+        "@pixi/core": "file:../core"
+      }
     },
     "packages/utils": {
       "name": "@pixi/utils",

--- a/packages/accessibility/package.json
+++ b/packages/accessibility/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/events"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/events": "file:../events"
+  }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "@types/css-font-loading-module": "^0.0.7"
   },
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/utils"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/utils": "file:../utils"
+  }
 }

--- a/packages/basis/package.json
+++ b/packages/basis/package.json
@@ -45,9 +45,9 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixijs/issues"
   },
-  "pixiRequirements": [
-    "@pixi/assets",
-    "@pixi/compressed-textures",
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/assets": "file:../assets",
+    "@pixi/compressed-textures": "file:../compressed-textures",
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/canvas-display/package.json
+++ b/packages/canvas-display/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-renderer",
-    "@pixi/core",
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/canvas-graphics/package.json
+++ b/packages/canvas-graphics/package.json
@@ -34,10 +34,10 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-display",
-    "@pixi/canvas-renderer",
-    "@pixi/core",
-    "@pixi/graphics"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-display": "file:../canvas-display",
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/core": "file:../core",
+    "@pixi/graphics": "file:../graphics"
+  }
 }

--- a/packages/canvas-mesh/package.json
+++ b/packages/canvas-mesh/package.json
@@ -34,11 +34,11 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-display",
-    "@pixi/canvas-renderer",
-    "@pixi/core",
-    "@pixi/mesh",
-    "@pixi/mesh-extras"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-display": "file:../canvas-display",
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/core": "file:../core",
+    "@pixi/mesh": "file:../mesh",
+    "@pixi/mesh-extras": "file:../mesh-extras"
+  }
 }

--- a/packages/canvas-particle-container/package.json
+++ b/packages/canvas-particle-container/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/particle-container"
-  ]
+  "peerDependencies": {
+    "@pixi/particle-container": "file:../particle-container"
+  }
 }

--- a/packages/canvas-prepare/package.json
+++ b/packages/canvas-prepare/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-renderer",
-    "@pixi/core",
-    "@pixi/prepare"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/core": "file:../core",
+    "@pixi/prepare": "file:../prepare"
+  }
 }

--- a/packages/canvas-renderer/package.json
+++ b/packages/canvas-renderer/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/canvas-sprite-tiling/package.json
+++ b/packages/canvas-sprite-tiling/package.json
@@ -34,10 +34,10 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-renderer",
-    "@pixi/canvas-sprite",
-    "@pixi/core",
-    "@pixi/sprite-tiling"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/canvas-sprite": "file:../canvas-sprite",
+    "@pixi/core": "file:../core",
+    "@pixi/sprite-tiling": "file:../sprite-tiling"
+  }
 }

--- a/packages/canvas-sprite/package.json
+++ b/packages/canvas-sprite/package.json
@@ -34,10 +34,10 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-display",
-    "@pixi/canvas-renderer",
-    "@pixi/core",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-display": "file:../canvas-display",
+    "@pixi/canvas-renderer": "file:../canvas-renderer",
+    "@pixi/core": "file:../core",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/canvas-text/package.json
+++ b/packages/canvas-text/package.json
@@ -31,9 +31,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/canvas-sprite",
-    "@pixi/sprite",
-    "@pixi/text"
-  ]
+  "peerDependencies": {
+    "@pixi/canvas-sprite": "file:../canvas-sprite",
+    "@pixi/sprite": "file:../sprite",
+    "@pixi/text": "file:../text"
+  }
 }

--- a/packages/compressed-textures/package.json
+++ b/packages/compressed-textures/package.json
@@ -45,8 +45,8 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixijs/issues"
   },
-  "pixiRequirements": [
-    "@pixi/assets",
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/assets": "file:../assets",
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/display/package.json
+++ b/packages/display/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -41,9 +41,9 @@
   "bugs": {
     "url": "https://github.com/pixijs/pixijs/issues"
   },
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/utils"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/utils": "file:../utils"
+  }
 }

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-alpha/package.json
+++ b/packages/filter-alpha/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-blur/package.json
+++ b/packages/filter-blur/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-color-matrix/package.json
+++ b/packages/filter-color-matrix/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-displacement/package.json
+++ b/packages/filter-displacement/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-fxaa/package.json
+++ b/packages/filter-fxaa/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/filter-noise/package.json
+++ b/packages/filter-noise/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/graphics-extras/package.json
+++ b/packages/graphics-extras/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/graphics"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/graphics": "file:../graphics"
+  }
 }

--- a/packages/graphics/package.json
+++ b/packages/graphics/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/math-extras/package.json
+++ b/packages/math-extras/package.json
@@ -37,7 +37,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/mesh-extras/package.json
+++ b/packages/mesh-extras/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/mesh"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/mesh": "file:../mesh"
+  }
 }

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/mixin-cache-as-bitmap/package.json
+++ b/packages/mixin-cache-as-bitmap/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/mixin-get-child-by-name/package.json
+++ b/packages/mixin-get-child-by-name/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/mixin-get-global-position/package.json
+++ b/packages/mixin-get-global-position/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/particle-container/package.json
+++ b/packages/particle-container/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/prepare/package.json
+++ b/packages/prepare/package.json
@@ -34,10 +34,10 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/graphics",
-    "@pixi/text"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/graphics": "file:../graphics",
+    "@pixi/text": "file:../text"
+  }
 }

--- a/packages/sprite-animated/package.json
+++ b/packages/sprite-animated/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/sprite-tiling/package.json
+++ b/packages/sprite-tiling/package.json
@@ -34,9 +34,9 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/sprite/package.json
+++ b/packages/sprite/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/display"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display"
+  }
 }

--- a/packages/spritesheet/package.json
+++ b/packages/spritesheet/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/assets",
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/assets": "file:../assets",
+    "@pixi/core": "file:../core"
+  }
 }

--- a/packages/text-bitmap/package.json
+++ b/packages/text-bitmap/package.json
@@ -34,11 +34,11 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/assets",
-    "@pixi/core",
-    "@pixi/display",
-    "@pixi/mesh",
-    "@pixi/text"
-  ]
+  "peerDependencies": {
+    "@pixi/assets": "file:../assets",
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/mesh": "file:../mesh",
+    "@pixi/text": "file:../text"
+  }
 }

--- a/packages/text-html/package.json
+++ b/packages/text-html/package.json
@@ -1,51 +1,50 @@
 {
-    "name": "@pixi/text-html",
-    "main": "lib/index.js",
-    "module": "lib/index.mjs",
-    "types": "lib/index.d.ts",
-    "exports": {
-      ".": {
-        "import": {
-          "types": "./lib/index.d.ts",
-          "default": "./lib/index.mjs"
-        },
-        "require": {
-          "types": "./lib/index.d.ts",
-          "default": "./lib/index.js"
-        }
+  "name": "@pixi/text-html",
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
       }
-    },
-    "description": "Multi-Style Text Rendering Plugin for PixiJS",
-    "author": "Matt Karl <matt@mattkarl.com>",
-    "homepage": "http://pixijs.com/",
-    "bugs": "https://github.com/pixijs/pixijs/issues",
-    "license": "MIT",
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/pixijs/pixijs.git"
-    },
-    "publishConfig": {
-      "access": "public"
-    },
-    "files": [
-      "dist",
-      "lib",
-      "*.d.ts"
-    ],
-    "keywords": [
-        "pixijs",
-        "html",
-        "text",
-        "rendering",
-        "layout",
-        "rtl",
-        "emoji"
-      ],
-    "pixiRequirements": [
-      "@pixi/core",
-      "@pixi/display",
-      "@pixi/sprite",
-      "@pixi/text"
-    ]
+    }
+  },
+  "description": "Multi-Style Text Rendering Plugin for PixiJS",
+  "author": "Matt Karl <matt@mattkarl.com>",
+  "homepage": "http://pixijs.com/",
+  "bugs": "https://github.com/pixijs/pixijs/issues",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pixijs/pixijs.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "lib",
+    "*.d.ts"
+  ],
+  "keywords": [
+    "pixijs",
+    "html",
+    "text",
+    "rendering",
+    "layout",
+    "rtl",
+    "emoji"
+  ],
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/display": "file:../display",
+    "@pixi/sprite": "file:../sprite",
+    "@pixi/text": "file:../text"
   }
-  
+}

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -34,8 +34,8 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core",
-    "@pixi/sprite"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core",
+    "@pixi/sprite": "file:../sprite"
+  }
 }

--- a/packages/unsafe-eval/package.json
+++ b/packages/unsafe-eval/package.json
@@ -34,7 +34,7 @@
     "lib",
     "*.d.ts"
   ],
-  "pixiRequirements": [
-    "@pixi/core"
-  ]
+  "peerDependencies": {
+    "@pixi/core": "file:../core"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -96,15 +96,11 @@ async function main()
             bundleModule,
             dependencies = {},
             peerDependencies = {},
-            nodeDependencies = [],
-            pixiRequirements = [],
         } = pkg.config;
 
         // Check for bundle folder
         const external = Object.keys(dependencies)
             .concat(Object.keys(peerDependencies))
-            .concat(nodeDependencies)
-            .concat(pixiRequirements)
             .map(convertPackageNameToRegExp);
         const basePath = path.relative(__dirname, pkg.dir);
         const input = path.join(basePath, 'src/index.ts');
@@ -157,7 +153,7 @@ async function main()
             const file = path.join(basePath, plugin);
             const footer = pluginExports ? `Object.assign(this.PIXI, ${name});` : '';
             const nsBanner = pluginExports ? `${banner}\nthis.PIXI = this.PIXI || {};` : banner;
-            const globals = pixiRequirements.reduce((obj, name) => ({ ...obj, [name]: 'PIXI' }), {});
+            const globals = Object.keys(peerDependencies).reduce((obj, name) => ({ ...obj, [name]: 'PIXI' }), {});
 
             results.push({
                 input,

--- a/scripts/prepublish.ts
+++ b/scripts/prepublish.ts
@@ -24,6 +24,7 @@ async function main()
 
         bumpDependencies(workspace.config.dependencies, version);
         bumpDependencies(workspace.config.devDependencies, version);
+        bumpDependencies(workspace.config.peerDependencies, version);
 
         await writeJSON(path.join(workspace.dir, 'package.json'), workspace.config);
     });


### PR DESCRIPTION
Closes #9189
Closes #8798

This reverts #8630 and restores the use of `peerDependencies` to define the relationships between packages.

We know that this is going to have some negative consequences that we saw in v6, but not defining these dependencies is creating more issues with skypack, jsdelivr and other tools which rely on explicitly declaring relationships.

In v8, we'll be moving toward shipping a single package which will address this as a breaking change.