### PR TITLE
Fix: Prevent NaN in RopeGeometry vertex data

### DIFF
--- a/packages/mesh-extras/src/geometry/RopeGeometry.ts
+++ b/packages/mesh-extras/src/geometry/RopeGeometry.ts
@@ -165,6 +165,7 @@ export class RopeGeometry extends MeshGeometry
 
         const vertices = this.buffers[0].data;
         const total = points.length;
+        const halfWidth = this.textureScale > 0 ? this.textureScale * this._width / 2 : this._width / 2;
 
         for (let i = 0; i < total; i++)
         {
@@ -191,13 +192,20 @@ export class RopeGeometry extends MeshGeometry
             }
 
             const perpLength = Math.sqrt((perpX * perpX) + (perpY * perpY));
-            const num = this.textureScale > 0 ? this.textureScale * this._width / 2 : this._width / 2;
 
-            perpX /= perpLength;
-            perpY /= perpLength;
+            if (perpLength < 1e-6)
+            {
+                perpX = 0;
+                perpY = 0;
+            }
+            else
+            {
+                perpX /= perpLength;
+                perpY /= perpLength;
 
-            perpX *= num;
-            perpY *= num;
+                perpX *= halfWidth;
+                perpY *= halfWidth;
+            }
 
             vertices[index] = point.x + perpX;
             vertices[index + 1] = point.y + perpY;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Prevent dividing by zero in `RopeGeometry#updateVertices`, so that the vertex data won't contain NaN that behave strangely on some devices.

- Before: <https://www.pixiplayground.com/#/edit/lf3-od11oJHrVZsocPxWw>
- After: <https://www.pixiplayground.com/#/edit/jvybc3FllLh2dOOz6mv5K>

Fixes #9179.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
