### PR TITLE
Fix: Ensure prepare and extract systems are available from IRenderer

### DIFF
--- a/packages/canvas-extract/package.json
+++ b/packages/canvas-extract/package.json
@@ -37,6 +37,7 @@
   "peerDependencies": {
     "@pixi/canvas-renderer": "file:../canvas-renderer",
     "@pixi/core": "file:../core",
-    "@pixi/display": "file:../display"
+    "@pixi/display": "file:../display",
+    "@pixi/extract": "file:../extract"
   }
 }

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -3,6 +3,7 @@ import { extensions, ExtensionType, Rectangle, RenderTexture, utils } from '@pix
 import type { CanvasRenderer } from '@pixi/canvas-renderer';
 import type { BaseRenderTexture, ExtensionMetadata, ICanvas, ISystem } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
+import type { IExtract } from '@pixi/extract';
 
 const TEMP_RECT = new Rectangle();
 
@@ -13,7 +14,7 @@ const TEMP_RECT = new Rectangle();
  * @class
  * @memberof PIXI
  */
-export class CanvasExtract implements ISystem
+export class CanvasExtract implements ISystem, IExtract
 {
     /** @ignore */
     static extension: ExtensionMetadata = {

--- a/packages/extract/global.d.ts
+++ b/packages/extract/global.d.ts
@@ -4,4 +4,9 @@ declare namespace GlobalMixins
     {
         readonly extract: import('@pixi/extract').Extract;
     }
+
+    interface IRenderer
+    {
+        readonly extract: import('@pixi/extract').IExtract;
+    }
 }

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -6,6 +6,14 @@ import type { DisplayObject } from '@pixi/display';
 const TEMP_RECT = new Rectangle();
 const BYTES_PER_PIXEL = 4;
 
+export interface IExtract
+{
+    image(target: DisplayObject | RenderTexture, format?: string, quality?: number): Promise<HTMLImageElement>;
+    base64(target: DisplayObject | RenderTexture, format?: string, quality?: number): Promise<string>;
+    canvas(target?: DisplayObject | RenderTexture, frame?: Rectangle): ICanvas;
+    pixels(target: DisplayObject | RenderTexture, frame?: Rectangle): Uint8Array | Uint8ClampedArray;
+}
+
 /**
  * This class provides renderer-specific plugins for exporting content from a renderer.
  * For instance, these plugins can be used for saving an Image, Canvas element or for exporting the raw image data (pixels).
@@ -28,7 +36,7 @@ const BYTES_PER_PIXEL = 4;
  * @memberof PIXI
  */
 
-export class Extract implements ISystem
+export class Extract implements ISystem, IExtract
 {
     /** @ignore */
     static extension: ExtensionMetadata = {

--- a/packages/prepare/global.d.ts
+++ b/packages/prepare/global.d.ts
@@ -10,4 +10,9 @@ declare namespace GlobalMixins
         /** @deprecated since 7.1.0 */
         UPLOADS_PER_FRAME: number;
     }
+
+    interface IRenderer
+    {
+        readonly prepare: import('@pixi/prepare').BasePrepare;
+    }
 }


### PR DESCRIPTION
Closes #9207

### Fixed

* Fix: Ensure `prepare` and `extract` extensions are available from `IRenderer`

### Before
```ts
import { Application, Renderer } from 'pixi.js';

const app = new Application();
(app.renderer as Renderer).extract.base64(); // throws type error without cast
```

### After
```ts
import { Application } from 'pixi.js';

const app = new Application();
app.renderer.extract.base64();
```