### PR TITLE
Fix: TypeScript error with ICanvas

### DIFF
--- a/packages/settings/src/ICanvas.ts
+++ b/packages/settings/src/ICanvas.ts
@@ -112,33 +112,41 @@ export interface ICanvas extends GlobalMixins.ICanvas, Partial<EventTarget>
 
     /**
      * Adds the listener for the specified event.
+     * @method
      * @param {string} type - The type of event to listen for.
      * @param {EventListenerOrEventListenerObject} listener - The callback to invoke when the event is fired.
      * @param {boolean | AddEventListenerOptions} options - The options for adding event listener.
+     * @returns {void}
      */
-    addEventListener?(
-        type: string,
-        listener: EventListenerOrEventListenerObject,
-        options?: boolean | AddEventListenerOptions): void;
-    addEventListener?<K extends keyof WebGLContextEventMap>(
-        type: K,
-        listener: (this: ICanvas, ev: WebGLContextEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions): void;
+    addEventListener?: {
+        (
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | AddEventListenerOptions): void;
+        <K extends keyof WebGLContextEventMap>(
+            type: K,
+            listener: (this: ICanvas, ev: WebGLContextEventMap[K]) => any,
+            options?: boolean | AddEventListenerOptions): void;
+    };
 
     /**
      * Removes the listener for the specified event.
+     * @method
      * @param {string} type - The type of event to listen for.
      * @param {EventListenerOrEventListenerObject} listener - The callback to invoke when the event is fired.
      * @param {boolean | EventListenerOptions} options - The options for removing event listener.
+     * @returns {void}
      */
-    removeEventListener?(
-        type: string,
-        listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions): void;
-    removeEventListener?<K extends keyof WebGLContextEventMap>(
-        type: K,
-        listener: (this: ICanvas, ev: WebGLContextEventMap[K]) => any,
-        options?: boolean | EventListenerOptions): void;
+    removeEventListener?: {
+        (
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | EventListenerOptions): void;
+        <K extends keyof WebGLContextEventMap>(
+            type: K,
+            listener: (this: ICanvas, ev: WebGLContextEventMap[K]) => any,
+            options?: boolean | EventListenerOptions): void;
+    };
 
     /**
      * Dispatches a event.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

I'm encountering errors like this in my project with `"exactOptionalPropertyTypes": true, "skipLibCheck": false`:

```
node_modules/.pnpm/@pixi+settings@7.2.0-beta.4/node_modules/@pixi/settings/lib/ICanvas.d.ts:43:18 - error TS2430: Interface 'ICanvas' incorrectly extends interface 'Partial<EventTarget>'.
  Types of property 'addEventListener' are incompatible.
    Type '{ (type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void; <K extends keyof WebGLContextEventMap>(type: K, listener: (this: ICanvas, ev: WebGLContextEventMap[K]) => any, options?: boolean | ... 1 more ... | undefined): void; } | undefined' is not assignable to type '(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined) => void'.
      Type 'undefined' is not assignable to type '(type: string, callback: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions | undefined) => void'.

43 export interface ICanvas extends GlobalMixins.ICanvas, Partial<EventTarget> {
                    ~~~~~~~
```

I fixed the type of ICanvas and now everything looks fine. Maybe we can consider adding `"exactOptionalPropertyTypes": true` to our tsconfig in the future after we upgrade TypeScript (it is available since TypeScript 4.4).

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
