### PR TITLE
Cache bust banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png?v=1)
 
 [![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/QrnxmQUPGV)
 [![npm version](https://badge.fury.io/js/pixi.js.svg)](https://badge.fury.io/js/pixi.js)

--- a/bundles/pixi.js-legacy/README.md
+++ b/bundles/pixi.js-legacy/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png?v=1)
 
 The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of

--- a/bundles/pixi.js-webworker/README.md
+++ b/bundles/pixi.js-webworker/README.md
@@ -1,7 +1,7 @@
 @pixi/webworker
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png?v=1)
 
 The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of

--- a/bundles/pixi.js/README.md
+++ b/bundles/pixi.js/README.md
@@ -1,7 +1,7 @@
 PixiJS — The HTML5 Creation Engine
 =============
 
-![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png)
+![pixi.js logo](https://pixijs.download/pixijs-banner-no-version.png?v=1)
 
 The aim of this project is to provide a fast lightweight 2D library that works
 across all devices. The PixiJS renderer allows everyone to enjoy the power of


### PR DESCRIPTION
Force cache bust for the banner. GitHub caches this request.

This replaces with our new branding