### PR TITLE
Fix missing shiftKey copy from originalEvent

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -1264,6 +1264,7 @@ export class EventBoundary
         to.client.copyFrom(from.client);
         to.ctrlKey = from.ctrlKey;
         to.metaKey = from.metaKey;
+        to.shiftKey = from.shiftKey;
         to.movement.copyFrom(from.movement);
 
         to.screen.copyFrom(from.screen);

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -1250,6 +1250,7 @@ export class EventBoundary
      * + x
      * + y
      * + screen
+     * + shiftKey
      * + global
      * @param from
      * @param to
@@ -1264,10 +1265,9 @@ export class EventBoundary
         to.client.copyFrom(from.client);
         to.ctrlKey = from.ctrlKey;
         to.metaKey = from.metaKey;
-        to.shiftKey = from.shiftKey;
         to.movement.copyFrom(from.movement);
-
         to.screen.copyFrom(from.screen);
+        to.shiftKey = from.shiftKey;
         to.global.copyFrom(from.global);
     }
 


### PR DESCRIPTION
Closes #9241

* Fix missing `shiftKey` in FederatedEvent

Broken: https://pixiplayground.com/#/edit/f8EPRf3qJ9NGiyxMo01og
Fixed: https://jsfiddle.net/bigtimebuddy/9L2oub3q/