### PR TITLE
Fix: interaction performance

### DIFF
--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -33,6 +33,11 @@ declare namespace GlobalMixins
          * @since 7.2.0
          */
         eventMode?: import('@pixi/events').EventMode;
+        /**
+         * The event features that are enabled by the EventSystem.
+         * @since 7.2.0
+         */
+        eventFeatures?: import('@pixi/events').EventSystemOptions['eventFeatures']
     }
 
     interface CanvasRenderer

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -5,6 +5,7 @@ import { FederatedPointerEvent } from './FederatedPointerEvent';
 import { FederatedWheelEvent } from './FederatedWheelEvent';
 
 import type { DisplayObject } from '@pixi/display';
+import type { EmitterListeners, TrackingData } from './EventBoundaryTypes';
 import type { FederatedEvent } from './FederatedEvent';
 import type {
     Cursor, EventMode, FederatedEventHandler,
@@ -17,55 +18,6 @@ const PROPAGATION_LIMIT = 2048;
 
 const tempHitLocation = new Point();
 const tempLocalMapping = new Point();
-
-/**
- * The tracking data for each pointer held in the state of an {@link PIXI.EventBoundary}.
- *
- * ```ts
- * pressTargetsByButton: {
- *     [id: number]: FederatedEventTarget[];
- * };
- * clicksByButton: {
- *     [id: number]: {
- *         clickCount: number;
- *         target: FederatedEventTarget;
- *         timeStamp: number;
- *     };
- * };
- * overTargets: FederatedEventTarget[];
- * ```
- * @typedef {object} TrackingData
- * @property {Record.<number, PIXI.FederatedEventTarget>} pressTargetsByButton - The pressed display objects'
- *  propagation paths by each button of the pointer.
- * @property {Record.<number, object>} clicksByButton - Holds clicking data for each button of the pointer.
- * @property {PIXI.DisplayObject[]} overTargets - The DisplayObject propagation path over which the pointer is hovering.
- * @memberof PIXI
- */
-type TrackingData = {
-    pressTargetsByButton: {
-        [id: number]: FederatedEventTarget[];
-    };
-    clicksByButton: {
-        [id: number]: {
-            clickCount: number;
-            target: FederatedEventTarget;
-            timeStamp: number;
-        }
-    };
-    overTargets: FederatedEventTarget[];
-};
-
-/**
- * Internal storage of an event listener in EventEmitter.
- * @ignore
- */
-type EmitterListener = { fn(...args: any[]): any, context: any, once: boolean };
-
-/**
- * Internal storage of event listeners in EventEmitter.
- * @ignore
- */
-type EmitterListeners = Record<string, EmitterListener | EmitterListener[]>;
 
 /**
  * Event boundaries are "barriers" where events coming from an upstream scene are modified before downstream propagation.
@@ -154,6 +106,8 @@ export class EventBoundary
      */
     public moveOnAll = false;
 
+    public allowGlobalPointerEvents = true;
+
     /**
      * Maps event types to forwarding handles for them.
      *
@@ -180,6 +134,10 @@ export class EventBoundary
      * @see PIXI.EventBoundary#freeEvent
      */
     protected eventPool: Map<typeof FederatedEvent, FederatedEvent[]> = new Map();
+
+    private _allInteractiveElements: FederatedEventTarget[] = [];
+    private _hitElements: FederatedEventTarget[] = [];
+    private _collectInteractiveElements = false;
 
     /** @param rootTarget - The holder of the event boundary. */
     constructor(rootTarget?: DisplayObject)
@@ -347,40 +305,31 @@ export class EventBoundary
     }
 
     /**
-     * Emits the event {@code e} to all display objects. The event is propagated in the bubbling phase always.
+     * Emits the event {@code e} to all interactive display objects. The event is propagated in the bubbling phase always.
      *
-     * This is used in the `pointermove` legacy mode.
+     * This is used in the `globalpointermove` event.
      * @param e - The emitted event.
      * @param type - The listeners to notify.
-     * @param target
+     * @param targets - The targets to notify.
      */
-    public all(e: FederatedEvent, type?: string, target: FederatedEventTarget = this.rootTarget): void
+    public all(e: FederatedEvent, type?: string | string[], targets = this._allInteractiveElements): void
     {
+        if (targets.length === 0) return;
+
         e.eventPhase = e.BUBBLING_PHASE;
 
-        const children = target.children;
+        const events = Array.isArray(type) ? type : [type];
 
-        const interactionNone = target.eventMode === 'none';
-        const interactionPassive = target.eventMode === 'passive' && !target.interactiveChildren;
-        const interactiveChildren = target.interactiveChildren;
-        const shouldIterateChildren = !interactionNone && interactiveChildren && !interactionPassive;
-
-        if (children && children.length > 0)
+        // loop through all interactive elements and notify them of the event
+        // loop through targets backwards
+        for (let i = targets.length - 1; i >= 0; i--)
         {
-            if (shouldIterateChildren)
+            events.forEach((event) =>
             {
-                for (let i = 0; i < children.length; i++)
-                {
-                    this.all(e, type, children[i]);
-                }
-            }
+                e.currentTarget = targets[i];
+                this.notifyTarget(e, event);
+            });
         }
-
-        e.currentTarget = target;
-
-        if (!target.isInteractive()) return;
-
-        this.notifyTarget(e, type);
     }
 
     /**
@@ -431,11 +380,6 @@ export class EventBoundary
         pruneFn?: (object: DisplayObject, pt: Point) => boolean,
     ): DisplayObject[]
     {
-        if (!currentTarget || !currentTarget.visible)
-        {
-            return null;
-        }
-
         // Attempt to prune this DisplayObject and its subtree as an optimization.
         if (pruneFn(currentTarget, location))
         {
@@ -476,22 +420,38 @@ export class EventBoundary
                     // Only add the current hit-test target to the hit-test chain if the chain
                     // has already started (i.e. the event target has been found) or if the current
                     // target is interactive (i.e. it becomes the event target).
-                    if (nestedHit.length > 0 || currentTarget.isInteractive())
+                    const isInteractive = currentTarget.isInteractive();
+
+                    if (nestedHit.length > 0 || isInteractive)
                     {
+                        if (isInteractive) this._allInteractiveElements.push(currentTarget);
                         nestedHit.push(currentTarget);
                     }
 
-                    return nestedHit;
+                    // store all hit elements
+                    if (this._hitElements.length === 0) this._hitElements = nestedHit;
+                    // only return the hit elements if we are not collecting all interactive elements
+                    if (!this._collectInteractiveElements) return nestedHit;
                 }
             }
         }
 
+        const isInteractiveMode = this._isInteractive(eventMode);
+        const isInteractiveTarget = currentTarget.isInteractive();
+
+        //
+        if (this._collectInteractiveElements)
+        {
+            if (isInteractiveMode && isInteractiveTarget) this._allInteractiveElements.push(currentTarget);
+            if (this._hitElements.length > 0) return null;
+        }
+
         // Finally, hit test this DisplayObject itself.
-        if (this._isInteractive(eventMode) && testFn(currentTarget, location))
+        if (isInteractiveMode && testFn(currentTarget, location))
         {
             // The current hit-test target is the event's target only if it is interactive. Otherwise,
             // the first interactive ancestor will be the event's target.
-            return currentTarget.isInteractive() ? [currentTarget] : [];
+            return isInteractiveTarget ? [currentTarget] : [];
         }
 
         return null;
@@ -512,6 +472,12 @@ export class EventBoundary
      */
     protected hitPruneFn(displayObject: DisplayObject, location: Point): boolean
     {
+        // If displayObject is a mask, invisible, or not renderable then it cannot be hit directly.
+        if (!displayObject || displayObject.isMask || !displayObject.visible || !displayObject.renderable)
+        {
+            return true;
+        }
+
         // If this DisplayObject is none then it cannot be hit by anything.
         if (displayObject.eventMode === 'none')
         {
@@ -529,6 +495,9 @@ export class EventBoundary
         {
             return true;
         }
+
+        // bail out early if we have already found something that hit
+        if (this._hitElements.length > 0) return false;
 
         if (displayObject.hitArea)
         {
@@ -664,7 +633,12 @@ export class EventBoundary
             return;
         }
 
+        this._allInteractiveElements.length = 0;
+        this._hitElements.length = 0;
+        this._collectInteractiveElements = true;
         const e = this.createPointerEvent(from);
+
+        this._collectInteractiveElements = false;
         const isMouse = e.pointerType === 'mouse' || e.pointerType === 'pen';
         const trackingData = this.trackingData(from.pointerId);
         const outTarget = this.findMountedTarget(trackingData.overTargets);
@@ -751,24 +725,33 @@ export class EventBoundary
             this.freeEvent(overEvent);
         }
 
-        const propagationMethod = this.moveOnAll ? 'all' : 'dispatchEvent';
+        const allMethods: string[] = [];
+
+        /* eslint-disable @typescript-eslint/no-unused-expressions */
+        this.moveOnAll ? allMethods.push('pointermove') : this.dispatchEvent(e, 'pointermove');
+        this.allowGlobalPointerEvents && allMethods.push('globalpointermove');
 
         // Then pointermove
-        this[propagationMethod](e, 'pointermove');
-        this.all(e, 'globalpointermove');
-
         if (e.pointerType === 'touch')
         {
-            this[propagationMethod](e, 'touchmove');
-            this.all(e, 'globaltouchmove');
+            this.moveOnAll ? allMethods.splice(1, 0, 'touchmove') : this.dispatchEvent(e, 'touchmove');
+            this.allowGlobalPointerEvents && allMethods.push('globaltouchmove');
         }
 
         if (isMouse)
         {
-            this[propagationMethod](e, 'mousemove');
-            this.all(e, 'globalmousemove');
+            this.moveOnAll ? allMethods.splice(1, 0, 'mousemove') : this.dispatchEvent(e, 'mousemove');
+            this.allowGlobalPointerEvents && allMethods.push('globalmousemove');
             this.cursor = e.target?.cursor;
         }
+
+        if (allMethods.length > 0)
+        {
+            allMethods.forEach((method) => this.all(e, method));
+        }
+        this._allInteractiveElements.length = 0;
+        this._hitElements.length = 0;
+        /* eslint-enable @typescript-eslint/no-unused-expressions */
 
         trackingData.overTargets = e.composedPath();
 
@@ -1125,7 +1108,9 @@ export class EventBoundary
 
         event.nativeEvent = from.nativeEvent;
         event.originalEvent = from;
-        event.target = target ?? this.hitTest(event.global.x, event.global.y) as FederatedEventTarget;
+        event.target = target
+            ?? this.hitTest(event.global.x, event.global.y) as FederatedEventTarget
+            ?? this._hitElements[0];
 
         if (typeof type === 'string')
         {
@@ -1397,564 +1382,3 @@ export class EventBoundary
         }
     }
 }
-
-/**
- * Fired when a mouse button (usually a mouse left-button) is pressed on the display.
- * object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mousedown
- * @param {PIXI.FederatedPointerEvent} event - The mousedown event.
- */
-
-/**
- * Capture phase equivalent of {@code mousedown}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mousedowncapture
- * @param {PIXI.FederatedPointerEvent} event - The capture phase mousedown.
- */
-
-/**
- * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
- * on the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightdown
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code rightdown}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightdowncapture
- * @param {PIXI.FederatedPointerEvent} event - The rightdowncapture event.
- */
-
-/**
- * Fired when a pointer device button (usually a mouse left-button) is released over the display
- * object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseup
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mouseup}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseupcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device secondary button (usually a mouse right-button) is released
- * over the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightup
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code rightup}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightupcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button (usually a mouse left-button) is pressed and released on
- * the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * A {@code click} event fires after the {@code pointerdown} and {@code pointerup} events, in that
- * order. If the mouse is moved over another DisplayObject after the {@code pointerdown} event, the
- * {@code click} event is fired on the most specific common ancestor of the two target DisplayObjects.
- *
- * The {@code detail} property of the event is the number of clicks that occurred within a 200ms
- * window of each other upto the current click. For example, it will be {@code 2} for a double click.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#click
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code click}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#clickcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
- * and released on the display object. DisplayObject's `eventMode`
- * property must be set to `static` or 'dynamic' to fire event.
- *
- * This event follows the semantics of {@code click}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightclick
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code rightclick}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightclickcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button (usually a mouse left-button) is released outside the
- * display object that initially registered a
- * [mousedown]{@link PIXI.DisplayObject#event:mousedown}.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * This event is specific to the Federated Events API. It does not have a capture phase, unlike most of the
- * other events. It only bubbles to the most specific ancestor of the targets of the corresponding {@code pointerdown}
- * and {@code pointerup} events, i.e. the target of the {@code click} event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseupoutside
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mouseupoutside}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseupoutsidecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device secondary button (usually a mouse right-button) is released
- * outside the display object that initially registered a
- * [rightdown]{@link PIXI.DisplayObject#event:rightdown}.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightupoutside
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code rightupoutside}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#rightupoutsidecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device (usually a mouse) is moved globally over the scene.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#globalmousemove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device (usually a mouse) is moved while over the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mousemove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mousemove}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mousemovecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device (usually a mouse) is moved onto the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseover
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mouseover}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseovercapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the mouse pointer is moved over a DisplayObject and its descendant's hit testing boundaries.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseenter
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mouseenter}
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseentercapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device (usually a mouse) is moved off the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * This may be fired on a DisplayObject that was removed from the scene graph immediately after
- * a {@code mouseover} event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseout
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code mouseout}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseoutcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the mouse pointer exits a DisplayObject and its descendants.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseleave
- * @param {PIXI.FederatedPointerEvent} event
- */
-
-/**
- * Capture phase equivalent of {@code mouseleave}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#mouseleavecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button is pressed on the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerdown
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerdown}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerdowncapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button is released over the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerup
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerup}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerupcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the operating system cancels a pointer event.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointercancel
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointercancel}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointercancelcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button is pressed and released on the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointertap
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointertap}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointertapcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device button is released outside the display object that initially
- * registered a [pointerdown]{@link PIXI.DisplayObject#event:pointerdown}.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * This event is specific to the Federated Events API. It does not have a capture phase, unlike most of the
- * other events. It only bubbles to the most specific ancestor of the targets of the corresponding {@code pointerdown}
- * and {@code pointerup} events, i.e. the target of the {@code click} event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerupoutside
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerupoutside}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerupoutsidecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device is moved globally over the scene.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#globalpointermove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device is moved while over the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointermove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointermove}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointermovecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device is moved onto the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerover
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerover}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerovercapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the pointer is moved over a DisplayObject and its descendant's hit testing boundaries.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerenter
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerenter}
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerentercapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a pointer device is moved off the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerout
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code pointerout}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointeroutcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the pointer leaves the hit testing boundaries of a DisplayObject and its descendants.
- *
- * This event notifies only the target and does not bubble.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerleave
- * @param {PIXI.FederatedPointerEvent} event - The `pointerleave` event.
- */
-
-/**
- * Capture phase equivalent of {@code pointerleave}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#pointerleavecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is placed on the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchstart
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code touchstart}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchstartcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is removed from the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchend
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code touchend}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchendcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when the operating system cancels a touch.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchcancel
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code touchcancel}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchcancelcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is placed and removed from the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#tap
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code tap}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#tapcapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is removed outside of the display object that initially
- * registered a [touchstart]{@link PIXI.DisplayObject#event:touchstart}.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchendoutside
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code touchendoutside}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchendoutsidecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is moved globally over the scene.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#globaltouchmove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a touch point is moved along the display object.
- * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchmove
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Capture phase equivalent of {@code touchmove}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#touchmovecapture
- * @param {PIXI.FederatedPointerEvent} event - Event
- */
-
-/**
- * Fired when a the user scrolls with the mouse cursor over a DisplayObject.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#wheel
- * @type {PIXI.FederatedWheelEvent}
- */
-
-/**
- * Capture phase equivalent of {@code wheel}.
- *
- * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
- * @event PIXI.DisplayObject#wheelcapture
- * @type {PIXI.FederatedWheelEvent}
- */

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -106,6 +106,7 @@ export class EventBoundary
      */
     public moveOnAll = false;
 
+    /** Enables or disables global pointer events `globalpointermove`, `globalmousemove`. `globaltouchmove`. */
     public allowGlobalPointerEvents = true;
 
     /**
@@ -135,8 +136,11 @@ export class EventBoundary
      */
     protected eventPool: Map<typeof FederatedEvent, FederatedEvent[]> = new Map();
 
+    /** Every interactive element gathered from the scene. Only used in `pointermove` */
     private _allInteractiveElements: FederatedEventTarget[] = [];
+    /** Every element that passed the hit test. Only used in `pointermove` */
     private _hitElements: FederatedEventTarget[] = [];
+    /** Whether or not to collect all the interactive elements from the scene. Enabled in `pointermove` */
     private _collectInteractiveElements = false;
 
     /** @param rootTarget - The holder of the event boundary. */

--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -6,7 +6,6 @@ import { FederatedWheelEvent } from './FederatedWheelEvent';
 
 import type { DisplayObject } from '@pixi/display';
 import type { EmitterListeners, TrackingData } from './EventBoundaryTypes';
-import type { EventSystem } from './EventSystem';
 import type { FederatedEvent } from './FederatedEvent';
 import type {
     Cursor, EventMode, FederatedEventHandler,
@@ -107,6 +106,9 @@ export class EventBoundary
      */
     public moveOnAll = false;
 
+    /** Enables the global move events. `globalpointermove`, `globaltouchmove`, and `globalmousemove` */
+    public enableGlobalMoveEvents = true;
+
     /**
      * Maps event types to forwarding handles for them.
      *
@@ -134,8 +136,6 @@ export class EventBoundary
      */
     protected eventPool: Map<typeof FederatedEvent, FederatedEvent[]> = new Map();
 
-    private _eventSystem: EventSystem;
-
     /** Every interactive element gathered from the scene. Only used in `pointermove` */
     private _allInteractiveElements: FederatedEventTarget[] = [];
     /** Every element that passed the hit test. Only used in `pointermove` */
@@ -145,12 +145,10 @@ export class EventBoundary
 
     /**
      * @param rootTarget - The holder of the event boundary.
-     * @param eventSystem - The event system that manages this boundary.
      */
-    constructor(rootTarget?: DisplayObject, eventSystem?: EventSystem)
+    constructor(rootTarget?: DisplayObject)
     {
         this.rootTarget = rootTarget;
-        this._eventSystem = eventSystem;
 
         this.hitPruneFn = this.hitPruneFn.bind(this);
         this.hitTestFn = this.hitTestFn.bind(this);
@@ -734,7 +732,7 @@ export class EventBoundary
         }
 
         const allMethods: string[] = [];
-        const allowGlobalPointerEvents = this._eventSystem?.features.globalMove ?? true;
+        const allowGlobalPointerEvents = this.enableGlobalMoveEvents ?? true;
 
         /* eslint-disable @typescript-eslint/no-unused-expressions */
         this.moveOnAll ? allMethods.push('pointermove') : this.dispatchEvent(e, 'pointermove');
@@ -756,7 +754,7 @@ export class EventBoundary
 
         if (allMethods.length > 0)
         {
-            allMethods.forEach((method) => this.all(e, method));
+            this.all(e, allMethods);
         }
         this._allInteractiveElements.length = 0;
         this._hitElements.length = 0;

--- a/packages/events/src/EventBoundaryTypes.ts
+++ b/packages/events/src/EventBoundaryTypes.ts
@@ -1,0 +1,611 @@
+import type { FederatedEventTarget } from './FederatedEventTarget';
+
+/**
+ * The tracking data for each pointer held in the state of an {@link PIXI.EventBoundary}.
+ *
+ * ```ts
+ * pressTargetsByButton: {
+ *     [id: number]: FederatedEventTarget[];
+ * };
+ * clicksByButton: {
+ *     [id: number]: {
+ *         clickCount: number;
+ *         target: FederatedEventTarget;
+ *         timeStamp: number;
+ *     };
+ * };
+ * overTargets: FederatedEventTarget[];
+ * ```
+ * @typedef {object} TrackingData
+ * @property {Record.<number, PIXI.FederatedEventTarget>} pressTargetsByButton - The pressed display objects'
+ *  propagation paths by each button of the pointer.
+ * @property {Record.<number, object>} clicksByButton - Holds clicking data for each button of the pointer.
+ * @property {PIXI.DisplayObject[]} overTargets - The DisplayObject propagation path over which the pointer is hovering.
+ * @memberof PIXI
+ */
+export type TrackingData = {
+    pressTargetsByButton: {
+        [id: number]: FederatedEventTarget[];
+    };
+    clicksByButton: {
+        [id: number]: {
+            clickCount: number;
+            target: FederatedEventTarget;
+            timeStamp: number;
+        }
+    };
+    overTargets: FederatedEventTarget[];
+};
+
+/**
+ * Internal storage of an event listener in EventEmitter.
+ * @ignore
+ */
+type EmitterListener = { fn(...args: any[]): any, context: any, once: boolean };
+
+/**
+ * Internal storage of event listeners in EventEmitter.
+ * @ignore
+ */
+export type EmitterListeners = Record<string, EmitterListener | EmitterListener[]>;
+
+/**
+ * Fired when a mouse button (usually a mouse left-button) is pressed on the display.
+ * object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mousedown
+ * @param {PIXI.FederatedPointerEvent} event - The mousedown event.
+ */
+
+/**
+ * Capture phase equivalent of {@code mousedown}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mousedowncapture
+ * @param {PIXI.FederatedPointerEvent} event - The capture phase mousedown.
+ */
+
+/**
+ * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+ * on the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightdown
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code rightdown}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightdowncapture
+ * @param {PIXI.FederatedPointerEvent} event - The rightdowncapture event.
+ */
+
+/**
+ * Fired when a pointer device button (usually a mouse left-button) is released over the display
+ * object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseup
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseup}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseupcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device secondary button (usually a mouse right-button) is released
+ * over the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightup
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code rightup}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightupcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button (usually a mouse left-button) is pressed and released on
+ * the display object. DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * A {@code click} event fires after the {@code pointerdown} and {@code pointerup} events, in that
+ * order. If the mouse is moved over another DisplayObject after the {@code pointerdown} event, the
+ * {@code click} event is fired on the most specific common ancestor of the two target DisplayObjects.
+ *
+ * The {@code detail} property of the event is the number of clicks that occurred within a 200ms
+ * window of each other upto the current click. For example, it will be {@code 2} for a double click.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#click
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code click}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#clickcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+ * and released on the display object. DisplayObject's `eventMode`
+ * property must be set to `static` or 'dynamic' to fire event.
+ *
+ * This event follows the semantics of {@code click}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightclick
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code rightclick}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightclickcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button (usually a mouse left-button) is released outside the
+ * display object that initially registered a
+ * [mousedown]{@link PIXI.DisplayObject#event:mousedown}.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * This event is specific to the Federated Events API. It does not have a capture phase, unlike most of the
+ * other events. It only bubbles to the most specific ancestor of the targets of the corresponding {@code pointerdown}
+ * and {@code pointerup} events, i.e. the target of the {@code click} event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseupoutside
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseupoutside}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseupoutsidecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device secondary button (usually a mouse right-button) is released
+ * outside the display object that initially registered a
+ * [rightdown]{@link PIXI.DisplayObject#event:rightdown}.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightupoutside
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code rightupoutside}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#rightupoutsidecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device (usually a mouse) is moved globally over the scene.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globalmousemove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device (usually a mouse) is moved while over the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mousemove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mousemove}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mousemovecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device (usually a mouse) is moved onto the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseover
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseover}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseovercapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the mouse pointer is moved over a DisplayObject and its descendant's hit testing boundaries.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseenter
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseenter}
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseentercapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device (usually a mouse) is moved off the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * This may be fired on a DisplayObject that was removed from the scene graph immediately after
+ * a {@code mouseover} event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseout
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseout}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseoutcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the mouse pointer exits a DisplayObject and its descendants.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseleave
+ * @param {PIXI.FederatedPointerEvent} event
+ */
+
+/**
+ * Capture phase equivalent of {@code mouseleave}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#mouseleavecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button is pressed on the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerdown
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerdown}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerdowncapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button is released over the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerup
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerup}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerupcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the operating system cancels a pointer event.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointercancel
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointercancel}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointercancelcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button is pressed and released on the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointertap
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointertap}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointertapcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device button is released outside the display object that initially
+ * registered a [pointerdown]{@link PIXI.DisplayObject#event:pointerdown}.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * This event is specific to the Federated Events API. It does not have a capture phase, unlike most of the
+ * other events. It only bubbles to the most specific ancestor of the targets of the corresponding {@code pointerdown}
+ * and {@code pointerup} events, i.e. the target of the {@code click} event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerupoutside
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerupoutside}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerupoutsidecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device is moved globally over the scene.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globalpointermove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device is moved while over the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointermove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointermove}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointermovecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device is moved onto the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerover
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerover}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerovercapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the pointer is moved over a DisplayObject and its descendant's hit testing boundaries.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerenter
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerenter}
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerentercapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a pointer device is moved off the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerout
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerout}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointeroutcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the pointer leaves the hit testing boundaries of a DisplayObject and its descendants.
+ *
+ * This event notifies only the target and does not bubble.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerleave
+ * @param {PIXI.FederatedPointerEvent} event - The `pointerleave` event.
+ */
+
+/**
+ * Capture phase equivalent of {@code pointerleave}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#pointerleavecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is placed on the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchstart
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code touchstart}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchstartcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is removed from the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchend
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code touchend}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchendcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when the operating system cancels a touch.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchcancel
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code touchcancel}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchcancelcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is placed and removed from the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#tap
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code tap}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#tapcapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is removed outside of the display object that initially
+ * registered a [touchstart]{@link PIXI.DisplayObject#event:touchstart}.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchendoutside
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code touchendoutside}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchendoutsidecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is moved globally over the scene.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#globaltouchmove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a touch point is moved along the display object.
+ * DisplayObject's `eventMode` property must be set to `static` or 'dynamic' to fire event.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchmove
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Capture phase equivalent of {@code touchmove}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#touchmovecapture
+ * @param {PIXI.FederatedPointerEvent} event - Event
+ */
+
+/**
+ * Fired when a the user scrolls with the mouse cursor over a DisplayObject.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#wheel
+ * @type {PIXI.FederatedWheelEvent}
+ */
+
+/**
+ * Capture phase equivalent of {@code wheel}.
+ *
+ * These events are propagating from the {@link PIXI.EventSystem EventSystem} in @pixi/events.
+ * @event PIXI.DisplayObject#wheelcapture
+ * @type {PIXI.FederatedWheelEvent}
+ */

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -30,7 +30,7 @@ export interface EventSystemOptions
     eventMode?: EventMode;
 
     /**
-     * The event types that are enabled by the EventSystem
+     * The event features that are enabled by the EventSystem
      * This option only is available when using **@pixi/events** package
      * (included in the **pixi.js** and **pixi.js-legacy** bundle), otherwise it will be ignored.
      * @memberof PIXI.IRendererOptions
@@ -59,7 +59,7 @@ export interface EventSystemOptions
      *   },
      * });
      */
-    events?: Partial<Record<'move' | 'globalMove' | 'click' | 'wheel', boolean>>
+    eventFeatures?: Partial<Record<'move' | 'globalMove' | 'click' | 'wheel', boolean>>
 }
 
 /**
@@ -76,38 +76,6 @@ export class EventSystem implements ISystem<EventSystemOptions>
             ExtensionType.CanvasRendererSystem
         ],
     };
-
-    private static _defaultEvents: Record<'move' | 'globalMove' | 'click' | 'wheel', boolean> = {
-        move: true,
-        globalMove: true,
-        click: true,
-        wheel: true,
-    };
-
-    /**
-     * The event types that are enabled by the EventSystem
-     * @type {object}
-     * @readonly
-     * @since 7.2.0
-     * @property {boolean} move - Enables pointer events associated with pointer movement:
-     * - `pointermove` / `mousemove` / `touchmove`
-     * - `pointerout` / `mouseout`
-     * - `pointerover` / `mouseover`
-     * @property {boolean} globalMove - Enables global pointer move events:
-     * - `globalpointermove`
-     * - `globalmousemove`
-     * - `globaltouchemove`
-     * @property {boolean} click - Enables pointer events associated with clicking:
-     * - `pointerup` / `mouseup` / `touchend` / 'rightup'
-     * - `pointerupoutside` / `mouseupoutside` / `touchendoutside` / 'rightupoutside'
-     * - `pointerdown` / 'mousedown' / `touchstart` / 'rightdown'
-     * - `click` / `tap`
-     * @property {boolean} wheel - Enables wheel events.
-     */
-    public static get defaultEvents()
-    {
-        return this._defaultEvents;
-    }
 
     private static _defaultEventMode: EventMode;
 
@@ -174,6 +142,12 @@ export class EventSystem implements ISystem<EventSystemOptions>
     private rootPointerEvent: FederatedPointerEvent;
     private rootWheelEvent: FederatedWheelEvent;
     private eventsAdded: boolean;
+    private _features: Record<'move' | 'globalMove' | 'click' | 'wheel', boolean> = {
+        move: true,
+        globalMove: true,
+        click: true,
+        wheel: true,
+    };
 
     /**
      * @param {PIXI.Renderer} renderer
@@ -213,8 +187,8 @@ export class EventSystem implements ISystem<EventSystemOptions>
         this.setTargetElement(view as HTMLCanvasElement);
         this.resolution = resolution;
         EventSystem._defaultEventMode = options.eventMode ?? 'auto';
-        EventSystem._defaultEvents = { ...EventSystem._defaultEvents, ...options.events };
-        this.rootBoundary.allowGlobalPointerEvents = EventSystem._defaultEvents.globalMove;
+        this._features = { ...this._features, ...options.eventFeatures };
+        this.rootBoundary.allowGlobalPointerEvents = this._features.globalMove;
     }
 
     /**
@@ -471,10 +445,10 @@ export class EventSystem implements ISystem<EventSystemOptions>
          */
         if (this.supportsPointerEvents)
         {
-            if (EventSystem.defaultEvents.move)
+            if (this._features.move)
             { globalThis.document.addEventListener('pointermove', this.onPointerMove, true); }
 
-            if (EventSystem.defaultEvents.click)
+            if (this._features.click)
             {
                 this.domElement.addEventListener('pointerdown', this.onPointerDown, true);
 
@@ -490,10 +464,10 @@ export class EventSystem implements ISystem<EventSystemOptions>
         }
         else
         {
-            if (EventSystem.defaultEvents.move)
+            if (this._features.move)
             { globalThis.document.addEventListener('mousemove', this.onPointerMove, true); }
 
-            if (EventSystem.defaultEvents.click)
+            if (this._features.click)
             {
                 this.domElement.addEventListener('mousedown', this.onPointerDown, true);
                 this.domElement.addEventListener('mouseout', this.onPointerOverOut, true);
@@ -507,10 +481,10 @@ export class EventSystem implements ISystem<EventSystemOptions>
         // PointerEvents whenever available
         if (this.supportsTouchEvents)
         {
-            if (EventSystem.defaultEvents.move)
+            if (this._features.move)
             { this.domElement.addEventListener('touchmove', this.onPointerMove, true); }
 
-            if (EventSystem.defaultEvents.click)
+            if (this._features.click)
             {
                 this.domElement.addEventListener('touchstart', this.onPointerDown, true);
                 // this.domElement.addEventListener('touchcancel', this.onPointerCancel, true);

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -190,7 +190,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
      *  wheel: false,
      * })
      */
-    public features: EventSystemFeatures;
+    public readonly features: EventSystemFeatures;
 
     private currentCursor: string;
     private rootPointerEvent: FederatedPointerEvent;

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -583,4 +583,67 @@ describe('EventSystem', () =>
         expect(graphics.interactive).toEqual(false);
         expect(graphics.eventMode).toEqual('auto');
     });
+
+    it('should not dispatch events if the feature is turned off', () =>
+    {
+        const renderer = createRenderer(undefined, undefined, {
+            eventFeatures: {
+                click: false,
+                move: false,
+                wheel: false,
+                globalMove: false,
+            }
+        });
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        graphics.addEventListener('pointertap', () =>
+        {
+            eventSpy();
+        });
+        graphics.addEventListener('pointerup', () =>
+        {
+            eventSpy();
+        });
+        graphics.addEventListener('pointerupoutside', () =>
+        {
+            eventSpy();
+        });
+        graphics.addEventListener('pointerdown', () =>
+        {
+            eventSpy();
+        });
+        graphics.addEventListener('pointermove', () =>
+        {
+            eventSpy();
+        });
+        graphics.addEventListener('globalpointermove', () =>
+        {
+            eventSpy();
+        });
+
+        renderer.events.onPointerDown(
+            new PointerEvent('pointerdown', { clientX: 25, clientY: 25 })
+        );
+
+        expect(eventSpy).not.toHaveBeenCalled();
+
+        (renderer.events as EventSystem).features.move = true;
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+
+        expect(eventSpy).toHaveBeenCalledTimes(1);
+
+        (renderer.events as EventSystem).features.globalMove = true;
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 25, clientY: 25 })
+        );
+
+        expect(eventSpy).toHaveBeenCalledTimes(3);
+    });
 });


### PR DESCRIPTION
Changes:

- We can now turn on/off different interactions through renderer settings
I've conceptualised these as `move`, `globalMove`, `click`, and `wheel`
```ts
/**
 * The event types that are enabled by the EventSystem
 * @type {object}
 * @readonly
 * @since 7.2.0
 * @property {boolean} move - Enables pointer events associated with pointer movement:
 * - `pointermove` / `mousemove` / `touchmove`
 * - `pointerout` / `mouseout`
 * - `pointerover` / `mouseover`
 * @property {boolean} globalMove - Enables global pointer move events:
 * - `globalpointermove`
 * - `globalmousemove`
 * - `globaltouchemove`
 * @property {boolean} click - Enables pointer events associated with clicking:
 * - `pointerup` / `mouseup` / `touchend` / 'rightup'
 * - `pointerupoutside` / `mouseupoutside` / `touchendoutside` / 'rightupoutside'
 * - `pointerdown` / 'mousedown' / `touchstart` / 'rightdown'
 * - `click` / `tap`
 * @property {boolean} wheel - Enables wheel events.
 */
public static get defaultEvents()
{
    return this._defaultEvents;
}
```
These should reduce the number of hit tests that are done if you do not care about certain events.

- Previously we were looping through the entire scene 3 times per move event. Now we only loop through the scene once.. This does mean that the global pointer events now happen after mouse or touch events
  - before `pointermove`, `globalpointermove`, `mousemove`, `globalmousemove`, `touchmove`, `globaltouchmove`
  - after `pointermove`, `mousemove`, `touchmove`, `globalpointermove`, `globalmousemove`, `globaltouchmove`