### PR TITLE
Fix: Remove the check when installing @pixi/unsafe-eval

### DIFF
--- a/packages/unsafe-eval/src/install.ts
+++ b/packages/unsafe-eval/src/install.ts
@@ -1,4 +1,4 @@
-import { ShaderSystem, unsafeEvalSupported, utils } from '@pixi/core';
+import { ShaderSystem, utils } from '@pixi/core';
 import { syncUniforms } from './syncUniforms';
 
 import type { Program, UniformGroup } from '@pixi/core';
@@ -28,8 +28,6 @@ export function install(_core: PIXICore): void
  */
 function selfInstall(): void
 {
-    if (unsafeEvalSupported()) return;
-
     Object.assign(ShaderSystem.prototype,
         {
             systemCheck()


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Remove the `unsafeEvalSupported()` check in `selfInstall()` of @pixi/unsafe-eval, it will cause error when require-trusted-types-for is enabled. We already don't check this before #8805, so it should be ok.

Fixes #9248.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
