### PR TITLE
Feature: Expose global pointer event data

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -225,6 +225,16 @@ export class EventSystem implements ISystem<EventSystemOptions>
     }
 
     /**
+     * The global pointer event.
+     * Useful for getting the pointer position without listening to events.
+     * @since 7.2.0
+     */
+    public get pointer(): Readonly<FederatedPointerEvent>
+    {
+        return this.rootPointerEvent;
+    }
+
+    /**
      * Event handler for pointer down events on {@link PIXI.EventSystem#domElement this.domElement}.
      * @param nativeEvent - The native mouse/pointer/touch event.
      */

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -583,4 +583,28 @@ describe('EventSystem', () =>
         expect(graphics.interactive).toEqual(false);
         expect(graphics.eventMode).toEqual('auto');
     });
+
+    it('should provide the correct global pointer event', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+
+        graphics.position.set(35, 35);
+        renderer.render(stage);
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', {
+                clientX: 40,
+                clientY: 40,
+                pointerType: 'mouse',
+            })
+        );
+
+        const e = (renderer.events as EventSystem).pointer;
+
+        expect(e.global.x).toEqual(40);
+        expect(e.global.y).toEqual(40);
+        expect(e.getLocalPosition(graphics).x).toEqual(5);
+        expect(e.getLocalPosition(graphics).y).toEqual(5);
+    });
 });


### PR DESCRIPTION
In pixi v6 there was `interaction.mouse` which allowed you to get the global position of the mouse without listening to an event

This PR exposes this data as `events.pointer`