### PR TITLE
Support loading SVG / JSON / TXT assets from data URLs

### DIFF
--- a/packages/assets/src/loader/parsers/loadJson.ts
+++ b/packages/assets/src/loader/parsers/loadJson.ts
@@ -1,7 +1,12 @@
-import { extensions, ExtensionType, settings, utils } from '@pixi/core';
+import { extensions, ExtensionType, settings } from '@pixi/core';
+import { checkDataUrl } from '../../utils/checkDataUrl';
+import { checkExtension } from '../../utils/checkExtension';
 import { LoaderParserPriority } from './LoaderParser';
 
 import type { LoaderParser } from './LoaderParser';
+
+const validJSONExtension = '.json';
+const validJSONMIME = 'application/json';
 
 /** simple loader plugin for loading json data */
 export const loadJson = {
@@ -14,7 +19,7 @@ export const loadJson = {
 
     test(url: string): boolean
     {
-        return (utils.path.extname(url).toLowerCase() === '.json');
+        return checkDataUrl(url, validJSONMIME) || checkExtension(url, validJSONExtension);
     },
 
     async load<T>(url: string): Promise<T>

--- a/packages/assets/src/loader/parsers/loadTxt.ts
+++ b/packages/assets/src/loader/parsers/loadTxt.ts
@@ -1,7 +1,12 @@
-import { extensions, ExtensionType, settings, utils } from '@pixi/core';
+import { extensions, ExtensionType, settings } from '@pixi/core';
+import { checkDataUrl } from '../../utils/checkDataUrl';
+import { checkExtension } from '../../utils/checkExtension';
 import { LoaderParserPriority } from './LoaderParser';
 
 import type { LoaderParser } from './LoaderParser';
+
+const validTXTExtension = '.txt';
+const validTXTMIME = 'text/plain';
 
 /** Simple loader plugin for loading text data */
 export const loadTxt = {
@@ -15,7 +20,7 @@ export const loadTxt = {
 
     test(url: string): boolean
     {
-        return (utils.path.extname(url).toLowerCase() === '.txt');
+        return checkDataUrl(url, validTXTMIME) || checkExtension(url, validTXTExtension);
     },
 
     async load(url: string): Promise<string>

--- a/packages/assets/src/loader/parsers/textures/loadSVG.ts
+++ b/packages/assets/src/loader/parsers/textures/loadSVG.ts
@@ -1,4 +1,6 @@
 import { BaseTexture, extensions, ExtensionType, settings, SVGResource, utils } from '@pixi/core';
+import { checkDataUrl } from '../../../utils/checkDataUrl';
+import { checkExtension } from '../../../utils/checkExtension';
 import { LoaderParserPriority } from '../LoaderParser';
 import { loadTextures } from './loadTextures';
 import { createTexture } from './utils/createTexture';
@@ -7,6 +9,9 @@ import type { IBaseTextureOptions, Texture } from '@pixi/core';
 import type { Loader } from '../../Loader';
 import type { LoadAsset } from '../../types';
 import type { LoaderParser } from '../LoaderParser';
+
+const validSVGExtension = '.svg';
+const validSVGMIME = 'image/svg+xml';
 
 /** Loads SVG's into Textures */
 export const loadSVG = {
@@ -19,7 +24,7 @@ export const loadSVG = {
 
     test(url: string): boolean
     {
-        return (utils.path.extname(url).toLowerCase() === '.svg');
+        return checkDataUrl(url, validSVGMIME) || checkExtension(url, validSVGExtension);
     },
 
     async testParse(data: string): Promise<boolean>

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -247,20 +247,26 @@ describe('Assets', () =>
 
     it('should load TXT assets from data URL', async () =>
     {
-        let txtDataURL = `
+        let txtDataURL1 = `
         data:text/plain,Hello, world!
         `;
 
-        txtDataURL = encodeURI(txtDataURL.trim());
+        txtDataURL1 = encodeURI(txtDataURL1.trim());
 
-        const txt = await Assets.load(txtDataURL);
+        const txt1 = await Assets.load(txtDataURL1);
 
-        expect(txt).toBe('Hello, world!');
+        expect(txt1).toBe('Hello, world!');
+
+        const txtDataURL2 = 'data:text/plain;base64,SGVsbG8sIHdvcmxkIQ==';
+
+        const txt2 = await Assets.load(txtDataURL2);
+
+        expect(txt2).toBe('Hello, world!');
     });
 
     it('should load JSON assets from data URL', async () =>
     {
-        let jsonDataURL = `
+        let jsonDataURL1 = `
         data:application/json,
         {
             "text": "Hello, world!",
@@ -268,11 +274,17 @@ describe('Assets', () =>
         }
         `;
 
-        jsonDataURL = encodeURI(jsonDataURL.trim());
+        jsonDataURL1 = encodeURI(jsonDataURL1.trim());
 
-        const json = await Assets.load(jsonDataURL);
+        const json1 = await Assets.load(jsonDataURL1);
 
-        expect(json).toStrictEqual({ text: 'Hello, world!', value: 123 });
+        expect(json1).toStrictEqual({ text: 'Hello, world!', value: 123 });
+
+        const jsonDataURL2 = 'data:application/json;base64,eyJ0ZXh0IjoiSGVsbG8sIHdvcmxkISIsInZhbHVlIjogMTIzfQ==';
+
+        const json2 = await Assets.load(jsonDataURL2);
+
+        expect(json2).toStrictEqual({ text: 'Hello, world!', value: 123 });
     });
 
     it('should load PNG assets from data URL', async () =>
@@ -304,18 +316,30 @@ describe('Assets', () =>
 
     it('should load SVG assets from data URL', async () =>
     {
-        let svgDataURL = `
+        let svgDataURL1 = `
         data:image/svg+xml,
         <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
             <circle cx="50" cy="50" r="25" fill="red"/>
         </svg>
         `;
 
-        svgDataURL = encodeURI(svgDataURL.trim());
+        svgDataURL1 = encodeURI(svgDataURL1.trim());
 
-        const svg = await Assets.load(svgDataURL);
+        const svg1 = await Assets.load(svgDataURL1);
 
-        expect(svg).toBeInstanceOf(Texture);
+        expect(svg1).toBeInstanceOf(Texture);
+
+        let svgDataURL2 = `
+        data:image/svg+xml;base64,
+        PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMDAiIGhlaWdodD0iMTAwIiB2aWV3Qm94PSIw
+        IDAgMTAwIDEwMCI+PGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgcj0iMjUiIGZpbGw9InJlZCIvPjwvc3ZnPg==
+        `;
+
+        svgDataURL2 = svgDataURL2.replace(/\s/g, '');
+
+        const svg2 = await Assets.load(svgDataURL2);
+
+        expect(svg2).toBeInstanceOf(Texture);
     });
 
     it('should load TTF assets from data URL', async () =>

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -245,6 +245,36 @@ describe('Assets', () =>
         expect(bunny.baseTexture).toBe(null);
     });
 
+    it('should load TXT assets from data URL', async () =>
+    {
+        let txtDataURL = `
+        data:text/plain,Hello, world!
+        `;
+
+        txtDataURL = encodeURI(txtDataURL.trim());
+
+        const txt = await Assets.load(txtDataURL);
+
+        expect(txt).toBe('Hello, world!');
+    });
+
+    it('should load JSON assets from data URL', async () =>
+    {
+        let jsonDataURL = `
+        data:application/json,
+        {
+            "text": "Hello, world!",
+            "value": 123
+        }
+        `;
+
+        jsonDataURL = encodeURI(jsonDataURL.trim());
+
+        const json = await Assets.load(jsonDataURL);
+
+        expect(json).toStrictEqual({ text: 'Hello, world!', value: 123 });
+    });
+
     it('should load PNG assets from data URL', async () =>
     {
         // Other formats (JPEG, WEBP, AVIF) can be added similarly.
@@ -270,6 +300,22 @@ describe('Assets', () =>
         const bunny = await Assets.load(bunnyDataURL);
 
         expect(bunny).toBeInstanceOf(Texture);
+    });
+
+    it('should load SVG assets from data URL', async () =>
+    {
+        let svgDataURL = `
+        data:image/svg+xml,
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="25" fill="red"/>
+        </svg>
+        `;
+
+        svgDataURL = encodeURI(svgDataURL.trim());
+
+        const svg = await Assets.load(svgDataURL);
+
+        expect(svg).toBeInstanceOf(Texture);
     });
 
     it('should load TTF assets from data URL', async () =>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Support loading SVG / JSON / TXT assets from data URLs.

- TXT: `text/plain`
- JSON: `application/json`
- SVG: `image/svg+xml`

Closes #9256.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
