### PR TITLE
Make MSDF fragment shader "alpha" more like it was "coverage"

### DIFF
--- a/packages/text-bitmap/src/shader/msdf.frag
+++ b/packages/text-bitmap/src/shader/msdf.frag
@@ -28,7 +28,11 @@ void main(void) {
     alpha = 1.0;
   }
 
-  // NPM Textures, NPM outputs
-  gl_FragColor = vec4(uColor.rgb, uColor.a * alpha);
+  // Gamma correction for coverage-like alpha
+  float luma = dot(texColor.rgb, vec3(0.299, 0.587, 0.114));
+  float gamma = mix(1.0, 1.0/2.2, luma);
+  float coverage = pow(uColor.a * alpha, gamma);  
 
+  // NPM Textures, NPM outputs
+  gl_FragColor = vec4(uColor.rgb, coverage);
 }

--- a/packages/text-bitmap/src/shader/msdf.frag
+++ b/packages/text-bitmap/src/shader/msdf.frag
@@ -30,7 +30,7 @@ void main(void) {
 
   // Gamma correction for coverage-like alpha
   float luma = dot(uColor.rgb, vec3(0.299, 0.587, 0.114));
-  float gamma = mix(1.0, 1.0/2.2, luma);
+  float gamma = mix(1.0, 1.0 / 2.2, luma);
   float coverage = pow(uColor.a * alpha, gamma);  
 
   // NPM Textures, NPM outputs

--- a/packages/text-bitmap/src/shader/msdf.frag
+++ b/packages/text-bitmap/src/shader/msdf.frag
@@ -29,7 +29,7 @@ void main(void) {
   }
 
   // Gamma correction for coverage-like alpha
-  float luma = dot(texColor.rgb, vec3(0.299, 0.587, 0.114));
+  float luma = dot(uColor.rgb, vec3(0.299, 0.587, 0.114));
   float gamma = mix(1.0, 1.0/2.2, luma);
   float coverage = pow(uColor.a * alpha, gamma);  
 


### PR DESCRIPTION
## Problem

Hi, i am working on app where i need to draw zoomable node graphs. And in order to make text look good and work fast with big number of nodes, I decided to switch to BitmapText with MSDF Fonts.

After some testing I noticed, that text became less readable compared to PIXI.Text.

I have exactly same problem in one of my previous projects, where I made my own text rendering using MSDF. The problem is in fragment shader that doesn't take in account blending gamma correction. My change make it more valid, not 100% but goodenough from perception point of view.

## Theory

Text rendering, especially on small sizes and low dpi (non-retina) has many pitfals, and one of them - gamma correction. To make text look good and readable, you must use gamma corrected blending. Otherwise, text wouldn't be readable if you change "light-theme" to "dark-theme". Black text on white background always gonna be thicker, than white text on black bg.

Of course, to be correct in 100% cases you need to know, color of text AND background to apply correct gamma correction. But, in 99% of cases when you make GUI's that has good contrast, you could made an asumption that if your text bright, most likely bg will be dark, and wise versa.

More on that problem: 
- [Maxim Shemanarev about Gamma and Text rendering in general](https://agg.sourceforge.net/antigrain.com/research/font_rasterization/index.html#toc0008)
- [About gamma correction in general](https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/)

## Solution
So that you could just take luminance of text (luma of tint color in fram shader), and use it as parameter to lerp between '1' and '1/2.2' gamma. This trick makes alpha more like it was actual coverage of the glyphs. And in most situations you will get same text thickness on black-white and white-black situations.

## Examples
Iv'e made couple examples what will happend if you apply my changes.

```
!!! To get it right, open this examples in 100% scale without resizing on non retina display (96dpi). !!!
Otherwise interpolation will make text blurry.
```

### Synhetic tests: 

PIXI.Text:
![00 - Text](https://user-images.githubusercontent.com/66637406/224505840-a69c213a-92a8-48a9-aa90-d6132e0bc4e4.png)

PIXI.BitmapText with BitmapFont:
![01 - BitmapText](https://user-images.githubusercontent.com/66637406/224505842-1a8658ff-e2e4-42ff-b63f-ced9776742fc.png)

PIXI.BitmapText with MSDF Font (original implementation):
![02 - MSDF Current](https://user-images.githubusercontent.com/66637406/224505844-7d38784c-eac0-4f81-8616-22c049eb56e2.png)

PIXI.BitmapText with MSDF Font (my implementation):
![03 - MSDF Patched](https://user-images.githubusercontent.com/66637406/224507785-975dae9b-8bd8-49fe-bde1-ede1333eaf6f.png)

### Real App: 

PIXI.BitmapText with MSDF Font (original implementation):
![04 - App with MSDF_Current](https://user-images.githubusercontent.com/66637406/224506060-eeba4ed6-c50c-4117-8a5f-f0430a36612b.png)

PIXI.BitmapText with MSDF Font (my implementation):
![05 - App With MSDF_Patched png](https://user-images.githubusercontent.com/66637406/224507568-55da205c-f375-4d5a-8e67-11677fe132fb.png)

PIXI.Text
![06 - App Native Text](https://user-images.githubusercontent.com/66637406/224506063-b44b62da-43de-4e65-af59-c8dfffb1e45c.png)

As you might see, gamma corrected text looks more like `PIXI.Text` which i was used originally.

P.S.
Also there is some problems with layout of MSDF text (all my examples uses same font sizes). Probably, it comes from atlas generator which uses some other metrics, but i didn't dig into that. Not that big problem though, as wrong text thikness...