### PR TITLE
Fix: TypeScript 5.0 compatibility

### DIFF
--- a/packages/events/src/FederatedEvent.ts
+++ b/packages/events/src/FederatedEvent.ts
@@ -196,8 +196,8 @@ export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
         this.propagationStopped = true;
     }
 
-    AT_TARGET = 1;
-    BUBBLING_PHASE = 2;
-    CAPTURING_PHASE = 3;
-    NONE = 0;
+    readonly NONE = 0;
+    readonly CAPTURING_PHASE = 1;
+    readonly AT_TARGET = 2;
+    readonly BUBBLING_PHASE = 3;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

[TypeScript 5.0](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) is out now. I tried it out with PixiJS (with `"skipLibCheck": false`) and found several errors:

<details>
<summary><b>package.json</b></summary>

```json
{
    "dependencies": {
        "pixi.js": "^7.2.0"
    },
    "devDependencies": {
        "typescript": "^5.0.2"
    }
}
```
</details>

<details>
<summary><b>tsconfig.json</b></summary>

```json
{
    "compilerOptions": {
        "moduleResolution": "node",
        "target": "esnext",
        "esModuleInterop": true,
        "skipLibCheck": false
    }
}

```
</details>

<details>
<summary><b>index.ts</b></summary>

```ts
import * as PIXI from 'pixi.js';
```
</details>

Run:

```bash
npm i
npx tsc
```

And we got the error message:

```
node_modules/@pixi/events/lib/FederatedEvent.d.ts(123,5): error TS2416: Property 'AT_TARGET' in type 'FederatedEvent<N>' is not assignable to the same property in base type 'UIEvent'.
  Type 'number' is not assignable to type '2'.
node_modules/@pixi/events/lib/FederatedEvent.d.ts(124,5): error TS2416: Property 'BUBBLING_PHASE' in type 'FederatedEvent<N>' is not assignable to the same property in base type 'UIEvent'.
  Type 'number' is not assignable to type '3'.
node_modules/@pixi/events/lib/FederatedEvent.d.ts(125,5): error TS2416: Property 'CAPTURING_PHASE' in type 'FederatedEvent<N>' is not assignable to the same property in base type 'UIEvent'.
  Type 'number' is not assignable to type '1'.
node_modules/@pixi/events/lib/FederatedEvent.d.ts(126,5): error TS2416: Property 'NONE' in type 'FederatedEvent<N>' is not assignable to the same property in base type 'UIEvent'.
  Type 'number' is not assignable to type '0'.
node_modules/@pixi/events/lib/FederatedMouseEvent.d.ts(9,22): error TS2420: Class 'FederatedMouseEvent' incorrectly implements interface 'MouseEvent'.
  Types of property 'NONE' are incompatible.
    Type 'number' is not assignable to type '0'.
node_modules/@pixi/events/lib/FederatedPointerEvent.d.ts(6,22): error TS2420: Class 'FederatedPointerEvent' incorrectly implements interface 'PointerEvent'.
  Types of property 'NONE' are incompatible.
    Type 'number' is not assignable to type '0'.
node_modules/@pixi/events/lib/FederatedWheelEvent.d.ts(6,22): error TS2420: Class 'FederatedWheelEvent' incorrectly implements interface 'WheelEvent'.
  Types of property 'NONE' are incompatible.
    Type 'number' is not assignable to type '0'.
node_modules/@types/css-font-loading-module/index.d.ts(22,9): error TS2717: Subsequent property declarations must have the same type.  Property 'display' must be of type 'FontDisplay', but here has type 'string'.
node_modules/@types/css-font-loading-module/index.d.ts(42,9): error TS2717: Subsequent property declarations must have the same type.  Property 'display' must be of type 'FontDisplay', but here has type 'string'.
```

The `FederatedEvent` related errors are caused by the change of definition of constants in `Event` in **lib.dom.d.ts**:

```diff
- readonly AT_TARGET: number;
- readonly BUBBLING_PHASE: number;
- readonly CAPTURING_PHASE: number;
- readonly NONE: number;
+ readonly NONE: 0;
+ readonly CAPTURING_PHASE: 1;
+ readonly AT_TARGET: 2;
+ readonly BUBBLING_PHASE: 3;
```

I added `readonly` for these constants in `FederatedEvent` and fixed their values to match [`Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event/eventPhase). The diff of `FederatedEvent.d.ts` is shown below:

```diff
- AT_TARGET: number;
- BUBBLING_PHASE: number;
- CAPTURING_PHASE: number;
- NONE: number;
+ readonly NONE: 0;
+ readonly CAPTURING_PHASE: 1;
+ readonly AT_TARGET: 2;
+ readonly BUBBLING_PHASE: 3;
```

This is compatible with both TS 4.x and 5.0.

For the `@types/css-font-loading-module` related errors, we cannot simply bump it since `@types/css-font-loading-module@0.0.8` is not compatible with TS 4.x, so one can suppress it by overriding it in **package.json**:

```json
{
    "overrides": {
        "@types/css-font-loading-module": "^0.0.8"
    }
}
```


#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
