### PR TITLE
Fix global move event with custom hit areas and masks

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -504,8 +504,9 @@ export class EventBoundary
             return true;
         }
 
-        // bail out early if we have already found something that hit
-        if (this._collectInteractiveElements && this._hitElements.length > 0) return false;
+        // with pointermove we can't test for hitArea or mask, so we need to return false
+        // otherwise DisplayObjects will be skipped
+        if (this._collectInteractiveElements) return false;
 
         if (displayObject.hitArea)
         {

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -1,4 +1,4 @@
-import { Renderer } from '@pixi/core';
+import { Rectangle, Renderer } from '@pixi/core';
 import { Container } from '@pixi/display';
 import { EventSystem } from '@pixi/events';
 import { Graphics } from '@pixi/graphics';
@@ -669,5 +669,53 @@ describe('EventSystem', () =>
         );
 
         expect(eventSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should dispatch global pointer move event with custom hitArea', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        graphics.hitArea = new Rectangle(0, 0, 100, 100);
+
+        graphics.addEventListener('globalpointermove', () =>
+        {
+            eventSpy();
+        });
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 250, clientY: 250 })
+        );
+
+        expect(eventSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dispatch global pointer move event with mask', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        const mask = new Graphics().beginFill(0xffffff).drawRect(0, 0, 10, 10);
+
+        stage.addChild(mask);
+
+        graphics.mask = mask;
+
+        graphics.addEventListener('globalpointermove', () =>
+        {
+            eventSpy();
+        });
+
+        renderer.events.onPointerMove(
+            new PointerEvent('pointermove', { clientX: 250, clientY: 250 })
+        );
+
+        expect(eventSpy).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Fixes #9271 

There was a slight oversight where I accidently pruned DisplayObjects with masks and hit areas but we can't prune these on pointermove