### PR TITLE
Add `defaultAutoResolution` to Filter

### DIFF
--- a/packages/core/src/filters/Filter.ts
+++ b/packages/core/src/filters/Filter.ts
@@ -213,7 +213,7 @@ export class Filter extends Shader
      * // filter has a resolution of 2
      * const filter = new GlowFilter();
      */
-    public static defaultResolution = 1;
+    public static defaultResolution: number;
 
     /**
      * Default filter samples for any filter.

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -153,17 +153,29 @@ export class FilterSystem implements ISystem
         const state = this.statePool.pop() || new FilterState();
         const renderTextureSystem = this.renderer.renderTexture;
 
-        let resolution = filters[0].resolution;
-        let multisample = filters[0].multisample;
-        let padding = filters[0].padding;
-        let autoFit = filters[0].autoFit;
+        const firstFilter = filters[0];
+
+        if (firstFilter._autoResolution && firstFilter._resolution !== renderer.resolution)
+        {
+            firstFilter._resolution = renderer.resolution;
+        }
+
+        let resolution = firstFilter.resolution;
+        let multisample = firstFilter.multisample;
+        let padding = firstFilter.padding;
+        let autoFit = firstFilter.autoFit;
         // We don't know whether it's a legacy filter until it was bound for the first time,
         // therefore we have to assume that it is if legacy is undefined.
-        let legacy = filters[0].legacy ?? true;
+        let legacy = firstFilter.legacy ?? true;
 
         for (let i = 1; i < filters.length; i++)
         {
             const filter = filters[i];
+
+            if (filter._autoResolution && filter._resolution !== renderer.resolution)
+            {
+                filter._resolution = renderer.resolution;
+            }
 
             // let's use the lowest resolution
             resolution = Math.min(resolution, filter.resolution);
@@ -441,11 +453,6 @@ export class FilterSystem implements ISystem
     applyFilter(filter: Filter, input: RenderTexture, output: RenderTexture, clearMode?: CLEAR_MODES): void
     {
         const renderer = this.renderer;
-
-        if (filter._autoResolution && filter._resolution !== renderer.resolution)
-        {
-            filter._resolution = renderer.resolution;
-        }
 
         // Set state before binding, so bindAndClear gets the blend mode.
         renderer.state.set(filter.state);

--- a/packages/core/src/filters/FilterSystem.ts
+++ b/packages/core/src/filters/FilterSystem.ts
@@ -442,6 +442,11 @@ export class FilterSystem implements ISystem
     {
         const renderer = this.renderer;
 
+        if (filter._autoResolution && filter._resolution !== renderer.resolution)
+        {
+            filter._resolution = renderer.resolution;
+        }
+
         // Set state before binding, so bindAndClear gets the blend mode.
         renderer.state.set(filter.state);
         this.bindAndClear(output, clearMode);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
When I was developing my application, I noticed that the filters have a resolution of 1 by default, I think it would be more convenient if the resolution by default was equal to the `renderer` resolution like in `Text`.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
