### PR TITLE
Fix passing unclamped values to Color

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -473,7 +473,7 @@ export class Color
      */
     setAlpha(alpha: number): this
     {
-        this._components[3] = this._clamp(alpha, 0, 1);
+        this._components[3] = this._clamp(alpha);
 
         return this;
     }
@@ -547,7 +547,7 @@ export class Color
             && value.length >= 3 && value.length <= 4)
         {
             // make sure all values are 0 - 1
-            value = this._clamp(value, 0, 1);
+            value = this._clamp(value);
 
             const [r, g, b, a = 1.0] = value;
 
@@ -602,7 +602,7 @@ export class Color
     private refreshInt(): void
     {
         // Clamp values to 0 - 1
-        this._clamp(this._components, 0, 1);
+        this._clamp(this._components);
 
         const [r, g, b] = this._components;
 
@@ -615,7 +615,7 @@ export class Color
      * @param min - Minimum value
      * @param max - Maximum value
      */
-    private _clamp<T extends number | number[] | ColorSourceTypedArray>(value: T, min: number, max: number): T
+    private _clamp<T extends number | number[] | ColorSourceTypedArray>(value: T, min = 0, max = 1): T
     {
         if (typeof value === 'number')
         {

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -471,7 +471,7 @@ export class Color
      */
     setAlpha(alpha: number): this
     {
-        this._components[3] = alpha;
+        this._components[3] = Math.min(1, Math.max(0, alpha));
 
         return this;
     }
@@ -542,10 +542,11 @@ export class Color
         }
         else if ((Array.isArray(value) || value instanceof Float32Array)
             // Can be rgb or rgba
-            && value.length >= 3 && value.length <= 4
-            // make sure all values are 0 - 1
-            && value.every((v) => v <= 1 && v >= 0))
+            && value.length >= 3 && value.length <= 4)
         {
+            // make sure all values are 0 - 1
+            value = value.map((v) => Math.min(1, Math.max(0, v)));
+
             const [r, g, b, a = 1.0] = value;
 
             components = [r, g, b, a];
@@ -554,6 +555,8 @@ export class Color
             // Can be rgb or rgba
             && value.length >= 3 && value.length <= 4)
         {
+            // make sure all values are 0 - 255
+            value = value.map((v) => Math.min(255, Math.max(0, v)));
             const [r, g, b, a = 255] = value;
 
             components = [r / 255, g / 255, b / 255, a / 255];

--- a/packages/color/test/Color.tests.ts
+++ b/packages/color/test/Color.tests.ts
@@ -19,14 +19,26 @@ describe('Color', () =>
             'ff',
             [1, 1],
             new Uint8Array([255, 255]),
-            [1, 1, -1, 1],
-            [1, 1, 1.1, 1],
             [1, 1, 1, 1, 0],
         ];
 
         invalidColorValues.forEach((value) =>
         {
             expect(() => new Color(value as any)).toThrow();
+        });
+    });
+
+    it.concurrent('should not throw error for invalid color values', async () =>
+    {
+        const invalidColorValues: any[] = [
+            [1, 1, -1, 1],
+            [1, 1, 1.1, 1],
+            { r: 1, g: 1, b: 1, a: 1.1 },
+        ];
+
+        invalidColorValues.forEach((value) =>
+        {
+            expect(() => new Color(value as any)).not.toThrow();
         });
     });
 

--- a/packages/color/test/Color.tests.ts
+++ b/packages/color/test/Color.tests.ts
@@ -225,6 +225,19 @@ describe('Color', () =>
         expect(color.alpha).toBe(1);
     });
 
+    it('should clamp the color when multiplying', () =>
+    {
+        const worldAlpha = 1.1;
+        const color = new Color().setValue(0xffffff)
+            .multiply([worldAlpha, worldAlpha, worldAlpha])
+            .setAlpha(worldAlpha);
+
+        expect(color.red).toBe(1);
+        expect(color.blue).toBe(1);
+        expect(color.green).toBe(1);
+        expect(color.alpha).toBe(1);
+    });
+
     it('should multiply color correctly', () =>
     {
         const color = new Color([0.5, 0.5, 0.5, 0.5]).multiply([0.5, 0.5, 0.5, 0.5]);


### PR DESCRIPTION
Using a value for `this.alpha` on a Graphics object over 1 would crash the app

A common use case is using a tween to fade the alpha and depending on the ease the number can go above/below 0-1
```
await gsap.to(this, {
    alpha: 1, // alpha to 1
    ease: Back.easeOut.config(1.7),
});
```