### PR TITLE
Avoid object creation in `Color.normalize`

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -590,10 +590,10 @@ export class Color
         // Cache normalized values for rgba and hex integer
         if (r !== undefined)
         {
-            this._components[0] = r;
-            this._components[1] = g;
-            this._components[2] = b;
-            this._components[3] = a;
+            this._components[0] = r as number;
+            this._components[1] = g as number;
+            this._components[2] = b as number;
+            this._components[3] = a as number;
             this.refreshInt();
         }
         else

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -526,10 +526,10 @@ export class Color
      */
     private normalize(value: Exclude<ColorSource, Color>): void
     {
-        let r: number;
-        let g: number;
-        let b: number;
-        let a: number;
+        let r: number | undefined;
+        let g: number | undefined;
+        let b: number | undefined;
+        let a: number | undefined;
 
         // Number is a primative so typeof works fine, but in the case
         // that someone creates a class that extends Number, we also

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -526,7 +526,10 @@ export class Color
      */
     private normalize(value: Exclude<ColorSource, Color>): void
     {
-        let components: number[] | undefined;
+        let r: number;
+        let g: number;
+        let b: number;
+        let a: number;
 
         // Number is a primative so typeof works fine, but in the case
         // that someone creates a class that extends Number, we also
@@ -535,12 +538,10 @@ export class Color
         {
             const int = value as number; // cast required because instanceof Number is ambiguous for TS
 
-            components = [
-                ((int >> 16) & 0xFF) / 255,
-                ((int >> 8) & 0xFF) / 255,
-                (int & 0xFF) / 255,
-                1.0
-            ];
+            r = ((int >> 16) & 0xFF) / 255;
+            g = ((int >> 8) & 0xFF) / 255;
+            b = (int & 0xFF) / 255;
+            a = 1.0;
         }
         else if ((Array.isArray(value) || value instanceof Float32Array)
             // Can be rgb or rgba
@@ -548,10 +549,7 @@ export class Color
         {
             // make sure all values are 0 - 1
             value = this._clamp(value);
-
-            const [r, g, b, a = 1.0] = value;
-
-            components = [r, g, b, a];
+            [r, g, b, a = 1.0] = value;
         }
         else if ((value instanceof Uint8Array || value instanceof Uint8ClampedArray)
             // Can be rgb or rgba
@@ -559,9 +557,11 @@ export class Color
         {
             // make sure all values are 0 - 255
             value = this._clamp(value, 0, 255);
-            const [r, g, b, a = 255] = value;
-
-            components = [r / 255, g / 255, b / 255, a / 255];
+            [r, g, b, a = 255] = value;
+            r /= 255;
+            g /= 255;
+            b /= 255;
+            a /= 255;
         }
         else if (typeof value === 'string' || typeof value === 'object')
         {
@@ -580,16 +580,20 @@ export class Color
 
             if (color.isValid())
             {
-                const { r, g, b, a } = color.rgba;
-
-                components = [r / 255, g / 255, b / 255, a];
+                ({ r, g, b, a } = color.rgba);
+                r /= 255;
+                g /= 255;
+                b /= 255;
             }
         }
 
         // Cache normalized values for rgba and hex integer
-        if (components)
+        if (r !== undefined)
         {
-            this._components.set(components);
+            this._components[0] = r;
+            this._components[1] = g;
+            this._components[2] = b;
+            this._components[3] = a;
             this.refreshInt();
         }
         else


### PR DESCRIPTION
`Color.shared.setValue(...)` shouldn't produce any garbage if possible as it might be called every frame multiple times.