### PR TITLE
Deprecate the round and roundColor methods

### DIFF
--- a/packages/canvas-renderer/src/canvasUtils.ts
+++ b/packages/canvas-renderer/src/canvasUtils.ts
@@ -263,7 +263,7 @@ export const canvasUtils = {
     roundColor: (color: number): number =>
     {
         // #if _DEBUG
-        utils.deprecation('7.3.0', 'PIXI.canvasUtils.roundColor is deprecated, use PIXI.Color.round instead');
+        utils.deprecation('7.3.0', 'PIXI.canvasUtils.roundColor is deprecated');
         // #endif
 
         return Color.shared
@@ -275,6 +275,7 @@ export const canvasUtils = {
     /**
      * Number of steps which will be used as a cap when rounding colors.
      * @memberof PIXI.canvasUtils
+     * @deprecated since 7.3.0
      * @type {number}
      */
     cacheStepsPerColorChannel: 8,

--- a/packages/canvas-renderer/src/canvasUtils.ts
+++ b/packages/canvas-renderer/src/canvasUtils.ts
@@ -1,4 +1,4 @@
-import { Color, settings } from '@pixi/core';
+import { Color, settings, utils } from '@pixi/core';
 import { canUseNewCanvasBlendModes } from './utils/canUseNewCanvasBlendModes';
 
 import type { ICanvas, Texture } from '@pixi/core';
@@ -25,10 +25,7 @@ export const canvasUtils = {
     getTintedCanvas: (sprite: { texture: Texture }, color: number): ICanvas | HTMLImageElement =>
     {
         const texture = sprite.texture;
-
-        color = canvasUtils.roundColor(color);
-
-        const stringColor = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
+        const stringColor = Color.shared.setValue(color).toHex();
 
         texture.tintCache = texture.tintCache || {};
 
@@ -81,9 +78,7 @@ export const canvasUtils = {
      */
     getTintedPattern: (texture: Texture, color: number): CanvasPattern =>
     {
-        color = canvasUtils.roundColor(color);
-
-        const stringColor = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
+        const stringColor = Color.shared.setValue(color).toHex();
 
         texture.patternCache = texture.patternCache || {};
 
@@ -127,7 +122,7 @@ export const canvasUtils = {
         canvas.height = Math.ceil(crop.height);
 
         context.save();
-        context.fillStyle = `#${(`00000${(color | 0).toString(16)}`).slice(-6)}`;
+        context.fillStyle = Color.shared.setValue(color).toHex();
 
         context.fillRect(0, 0, crop.width, crop.height);
 
@@ -260,14 +255,22 @@ export const canvasUtils = {
     /**
      * Rounds the specified color according to the canvasUtils.cacheStepsPerColorChannel.
      * @memberof PIXI.canvasUtils
+     * @deprecated since 7.3.0
+     * @see PIXI.Color.round
      * @param {number} color - the color to round, should be a hex color
      * @returns {number} The rounded color.
      */
     roundColor: (color: number): number =>
-        Color.shared
+    {
+        // #if _DEBUG
+        utils.deprecation('7.3.0', 'PIXI.canvasUtils.roundColor is deprecated, use PIXI.Color.round instead');
+        // #endif
+
+        return Color.shared
             .setValue(color)
             .round(canvasUtils.cacheStepsPerColorChannel)
-            .toNumber(),
+            .toNumber();
+    },
 
     /**
      * Number of steps which will be used as a cap when rounding colors.

--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -482,6 +482,7 @@ export class Color
      * Rounds the specified color according to the step. This action is destructive, and will
      * override the previous `value` property to be `null`. The alpha component is not rounded.
      * @param steps - Number of steps which will be used as a cap when rounding colors
+     * @deprecated since 7.3.0
      */
     round(steps: number): this
     {


### PR DESCRIPTION
### Changed

* Deprecates `canvasUtils.roundColor`
* Deprecates `Color.round`

There was an opportunity to simplify the code and remove the rounding (which didn't work anyway prior to #9294). Removes a bunch of redundant inline code for convert an int to hex string.


### Verify

* https://codesandbox.io/s/pixi-js-sandbox-forked-sqlly9