### PR TITLE
Add additional payload properties to trigger-website-build workflow

### DIFF
--- a/.github/workflows/trigger-website-build.yml
+++ b/.github/workflows/trigger-website-build.yml
@@ -17,7 +17,4 @@ jobs:
           event-type: update-dev
           repository: pixijs/beta.pixijs.com
           token: ${{ secrets.PAT }}
-          client-payload: '{"sha": "${{ github.event.pull_request.head.sha }}"}'
-
-
-
+          client-payload: '{"ref": "${{ github.ref }}", "pr_sha": "${{ github.sha }}", "sha": "${{ github.event.pull_request.head.sha }}"}'


### PR DESCRIPTION
Adds pr reference and pr merge sha to the repository dispatch payload for informational purposes - it's added to the resulting commit message when a new `pixi-versions.json` file is written during the `update-dev` workflow for `beta.pixijs.com`