### PR TITLE
Fix: Wrap non CSS ident-token font names in quotes

### DIFF
--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -34,6 +34,12 @@ export type LoadFontData = {
 };
 
 /**
+ * RegExp for matching CSS <ident-token>. It doesn't consider escape and non-ASCII characters, but enough for us.
+ * @see {@link https://www.w3.org/TR/css-syntax-3/#ident-token-diagram}
+ */
+const CSS_IDENT_TOKEN_REGEX = /^(--|-?[A-Z_])[0-9A-Z_-]*$/i;
+
+/**
  * Return font face name from a file name
  * Ex.: 'fonts/tital-one.woff' turns into 'Titan One'
  * @param url - File url
@@ -47,12 +53,29 @@ export function getFontFamilyName(url: string): string
     const nameWithSpaces = name.replace(/(-|_)/g, ' ');
 
     // Upper case first character of each word
-    const nameTitleCase = nameWithSpaces.toLowerCase()
+    const nameTokens = nameWithSpaces.toLowerCase()
         .split(' ')
-        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-        .join(' ');
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1));
 
-    return nameTitleCase;
+    let valid = nameTokens.length > 0;
+
+    for (const token of nameTokens)
+    {
+        if (!token.match(CSS_IDENT_TOKEN_REGEX))
+        {
+            valid = false;
+            break;
+        }
+    }
+
+    let fontFamilyName = nameTokens.join(' ');
+
+    if (!valid)
+    {
+        fontFamilyName = `"${fontFamilyName.replace(/[\\"]/g, '\\$&')}"`;
+    }
+
+    return fontFamilyName;
 }
 
 /** Web font loader plugin */

--- a/packages/assets/test/loadWebFont.tests.ts
+++ b/packages/assets/test/loadWebFont.tests.ts
@@ -4,16 +4,16 @@ describe('loadWebFont', () =>
 {
     it('should get font family name', () =>
     {
-        expect(getFontFamilyName('AbCdEf')).toBe('Abcdef');
-        expect(getFontFamilyName('ABC def-gHi_JkL')).toBe('Abc Def Ghi Jkl');
-        expect(getFontFamilyName('ABC123')).toBe('Abc123');
+        expect(getFontFamilyName('AbCdEf.ttf')).toBe('Abcdef');
+        expect(getFontFamilyName('ABC def-gHi_JkL.otf')).toBe('Abc Def Ghi Jkl');
+        expect(getFontFamilyName('ABC123.woff')).toBe('Abc123');
     });
 
     it('should escape font family name that is not valid CSS ident-token', () =>
     {
         expect(getFontFamilyName('')).toBe('""');
-        expect(getFontFamilyName('123456')).toBe('"123456"');
-        expect(getFontFamilyName('ABC 123')).toBe('"Abc 123"');
-        expect(getFontFamilyName('2nd-Font')).toBe('"2nd Font"');
+        expect(getFontFamilyName('123456.ttf')).toBe('"123456"');
+        expect(getFontFamilyName('ABC 123.otf')).toBe('"Abc 123"');
+        expect(getFontFamilyName('2nd-Font.woff')).toBe('"2nd Font"');
     });
 });

--- a/packages/assets/test/loadWebFont.tests.ts
+++ b/packages/assets/test/loadWebFont.tests.ts
@@ -1,0 +1,19 @@
+import { getFontFamilyName } from '@pixi/assets';
+
+describe('loadWebFont', () =>
+{
+    it('should get font family name', () =>
+    {
+        expect(getFontFamilyName('AbCdEf')).toBe('Abcdef');
+        expect(getFontFamilyName('ABC def-gHi_JkL')).toBe('Abc Def Ghi Jkl');
+        expect(getFontFamilyName('ABC123')).toBe('Abc123');
+    });
+
+    it('should escape font family name that is not valid CSS ident-token', () =>
+    {
+        expect(getFontFamilyName('')).toBe('""');
+        expect(getFontFamilyName('123456')).toBe('"123456"');
+        expect(getFontFamilyName('ABC 123')).toBe('"Abc 123"');
+        expect(getFontFamilyName('2nd-Font')).toBe('"2nd Font"');
+    });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Wrap font family names in quotes that are not consists of valid [CSS ident-tokens](https://www.w3.org/TR/css-syntax-3/#ident-token-diagram), they will fail to load in Firefox if used directly.

For example, `getFontFamilyName('Press_Start_2P.woff2') === '"Press Start 2p"'`.

Fixes #9286.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
