### PR TITLE
Fix: crash in unsafe-eval uniformSync and remove unreachable code

### DIFF
--- a/packages/unsafe-eval/test/unsafe-eval.tests.ts
+++ b/packages/unsafe-eval/test/unsafe-eval.tests.ts
@@ -32,7 +32,6 @@ void main() {
     afterAll(() =>
     {
         renderer.destroy();
-        renderer = null;
     });
 
     it('should be able to set float and bool uniforms', () =>

--- a/packages/unsafe-eval/test/unsafe-eval.tests.ts
+++ b/packages/unsafe-eval/test/unsafe-eval.tests.ts
@@ -1,0 +1,50 @@
+import { Renderer, Shader, UniformGroup } from '@pixi/core';
+import '@pixi/unsafe-eval';
+
+describe('unsafe-eval', () =>
+{
+    const vertexSrc = `
+
+uniform bool testBool;
+uniform float testFloat;
+
+void main() {
+    bool t1 = testBool;
+    float t2 = testFloat;
+    if(!t1) t2 = 0.0;
+    gl_Position = vec4(t2, t2, t2, t2);
+}`;
+
+    const fragmentSrc = `
+void main() {
+
+    gl_FragColor = vec4(1., 1., 1., 1.) ;
+
+}`;
+
+    let renderer: Renderer;
+
+    beforeAll(() =>
+    {
+        renderer = new Renderer();
+    });
+
+    afterAll(() =>
+    {
+        renderer.destroy();
+        renderer = null;
+    });
+
+    it('should be able to set float and bool uniforms', () =>
+    {
+        const testBool = true;
+        const testFloat = 1.0;
+        const group1 = UniformGroup.from({ testBool });
+        const uniforms = { testFloat, group: group1 };
+        const shader = Shader.from(vertexSrc, fragmentSrc, uniforms);
+
+        renderer.shader.bind(shader);
+        expect(renderer.shader.getGlProgram().uniformData.testBool.value).toEqual(testBool);
+        expect(renderer.shader.getGlProgram().uniformData.testFloat.value).toEqual(testFloat);
+    });
+});


### PR DESCRIPTION
##### Description of change
Fixes crash with boolean uniforms when using the unsafe-eval package.
Fixes #9303 

Also removed some unreachable code that made it confusing to debug. The GLSL_TO_SINGLE_SETTERS function array had a function for floats that had the same typo as the function for bools, but would never be run since floats are handled further down. The same is the case for several other types, so I see no reason to leave them in.
This file could use some work in general, it should be kept in sync with the mainline shader code in the core package. I see there are some types that have special handling in shader/utils/uniformParsers that are not handled in this one. 

Added a basic test just for floats and bools. The test will crash with an exception as described in #9303 if the fix is not applied and passes otherwise. 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
