### PR TITLE
fix: cache can-use-blend-mode value

### DIFF
--- a/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
+++ b/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
@@ -2,6 +2,8 @@ import { settings } from '@pixi/core';
 
 import type { ICanvas } from '@pixi/core';
 
+let canUseNewCanvasBlendModesValue = undefined as boolean | undefined;
+
 /**
  * Creates a little colored canvas
  * @ignore
@@ -31,6 +33,11 @@ export function canUseNewCanvasBlendModes(): boolean
         return false;
     }
 
+    if (canUseNewCanvasBlendModesValue !== undefined)
+    {
+        return canUseNewCanvasBlendModesValue;
+    }
+
     const magenta = createColoredCanvas('#ff00ff');
     const yellow = createColoredCanvas('#ffff00');
 
@@ -45,10 +52,15 @@ export function canUseNewCanvasBlendModes(): boolean
 
     if (!imageData)
     {
-        return false;
+        canUseNewCanvasBlendModesValue = false;
+    }
+    else
+    {
+        const data = imageData.data;
+
+        canUseNewCanvasBlendModesValue = (data[0] === 255 && data[1] === 0 && data[2] === 0);
     }
 
-    const data = imageData.data;
 
-    return (data[0] === 255 && data[1] === 0 && data[2] === 0);
+    return canUseNewCanvasBlendModesValue;
 }

--- a/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
+++ b/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
@@ -2,7 +2,7 @@ import { settings } from '@pixi/core';
 
 import type { ICanvas } from '@pixi/core';
 
-let canUseNewCanvasBlendModesValue = undefined as boolean | undefined;
+let canUseNewCanvasBlendModesValue: boolean | undefined;
 
 /**
  * Creates a little colored canvas

--- a/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
+++ b/packages/canvas-renderer/src/utils/canUseNewCanvasBlendModes.ts
@@ -61,6 +61,5 @@ export function canUseNewCanvasBlendModes(): boolean
         canUseNewCanvasBlendModesValue = (data[0] === 255 && data[1] === 0 && data[2] === 0);
     }
 
-
     return canUseNewCanvasBlendModesValue;
 }


### PR DESCRIPTION
##### Description of change
Cache the value of the can-use-blend-mode check. It shows up in my stack traces more than I'd like to, I have many small canvas elements.

![image](https://user-images.githubusercontent.com/1423607/228133339-b61cd5b1-dc97-46e2-8ef8-8c89301fda6a.png)


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
