### PR TITLE
Fix: Add background and autoDensity types to IRenderer

### DIFF
--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -5,7 +5,13 @@ import type { IRendererPlugins } from './plugin/PluginSystem';
 import type { IGenerateTextureOptions } from './renderTexture/GenerateTextureSystem';
 import type { RenderTexture } from './renderTexture/RenderTexture';
 import type { SystemManager } from './system/SystemManager';
-import type { BackgroundSystemOptions, ContextSystemOptions, StartupSystemOptions, ViewSystemOptions } from './systems';
+import type {
+    BackgroundSystem,
+    BackgroundSystemOptions,
+    ContextSystemOptions,
+    StartupSystemOptions,
+    ViewSystemOptions,
+} from './systems';
 import type { ImageSource } from './textures/BaseTexture';
 
 /**
@@ -152,4 +158,6 @@ export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager
     readonly lastObjectRendered: IRenderableObject
     /** Collection of plugins */
     readonly plugins: IRendererPlugins
+    /** Background color, alpha and clear behavior */
+    readonly background: BackgroundSystem
 }

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -149,6 +149,8 @@ export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager
     readonly width: number
     /** the height of the screen */
     readonly height: number
+    /** Whether CSS dimensions of canvas view should be resized to screen dimensions automatically. */
+    readonly autoDensity: boolean
     /**
      * Measurements of the screen. (0, 0, screenWidth, screenHeight).
      * Its safe to use as filterArea or hitArea for the whole stage.


### PR DESCRIPTION
Closes #9308

* Adds `background` property to IRenderer
* Adds `autoDensity` property to IRenderer

<img width="730" alt="Screen Shot 2023-03-28 at 8 44 52 AM" src="https://user-images.githubusercontent.com/864393/228240518-32e35c53-afa8-4142-b0d7-60b56d617e48.png">
