### PR TITLE
Always await loading of resource in loadSVG

### DIFF
--- a/packages/assets/src/loader/parsers/textures/loadSVG.ts
+++ b/packages/assets/src/loader/parsers/textures/loadSVG.ts
@@ -36,6 +36,8 @@ export const loadSVG = {
     {
         const src = new SVGResource(asset, data?.data?.resourceOptions);
 
+        await src.load();
+
         const base = new BaseTexture(src, {
             resolution: utils.getResolutionOfUrl(asset),
             ...data?.data,
@@ -44,11 +46,6 @@ export const loadSVG = {
         base.resource.src = asset;
 
         const texture = createTexture(base, loader, asset);
-
-        if (!data?.data?.resourceOptions?.autoLoad)
-        {
-            await src.load();
-        }
 
         return texture;
     },

--- a/packages/assets/test/loader.tests.ts
+++ b/packages/assets/test/loader.tests.ts
@@ -41,6 +41,38 @@ describe('Loader', () =>
         expect(texture.height).toBe(512);
     });
 
+    it('should load svg if autoLoad is true', async () =>
+    {
+        const loader = new Loader();
+
+        loader['_parsers'].push(loadSVG);
+
+        const texture = await loader.load<Texture>({
+            src: `${serverPath}svg/logo.svg`,
+            data: { resourceOptions: { autoLoad: true } }
+        });
+
+        expect(texture.baseTexture.valid).toBe(true);
+        expect(texture.width).toBe(512);
+        expect(texture.height).toBe(512);
+    });
+
+    it('should load svg if autoLoad is false', async () =>
+    {
+        const loader = new Loader();
+
+        loader['_parsers'].push(loadSVG);
+
+        const texture = await loader.load<Texture>({
+            src: `${serverPath}svg/logo.svg`,
+            data: { resourceOptions: { autoLoad: false } }
+        });
+
+        expect(texture.baseTexture.valid).toBe(true);
+        expect(texture.width).toBe(512);
+        expect(texture.height).toBe(512);
+    });
+
     it('should allow setting SVG width/height through metadata', async () =>
     {
         const loader = new Loader();


### PR DESCRIPTION
##### Description of change

Before this change the test `"should load svg if autoLoad is true"` failed.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
