### PR TITLE
Use the resolution of the renderer for the generated render texture in `Extract._rawPixels`

### DIFF
--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -111,7 +111,9 @@ export class CanvasExtract implements ISystem, IExtract
             }
             else
             {
-                renderTexture = renderer.generateTexture(target);
+                renderTexture = renderer.generateTexture(target, {
+                    resolution: renderer.resolution
+                });
             }
         }
 
@@ -177,7 +179,9 @@ export class CanvasExtract implements ISystem, IExtract
             }
             else
             {
-                renderTexture = renderer.generateTexture(target);
+                renderTexture = renderer.generateTexture(target, {
+                    resolution: renderer.resolution
+                });
             }
         }
 

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -583,6 +583,7 @@ export class FramebufferSystem implements ISystem
             destPixels.left, destPixels.top, destPixels.right, destPixels.bottom,
             gl.COLOR_BUFFER_BIT, sameSize ? gl.NEAREST : gl.LINEAR
         );
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffer.glFramebuffers[this.CONTEXT_UID].framebuffer);
     }
 
     /**

--- a/packages/core/test/FramebufferSystem.tests.ts
+++ b/packages/core/test/FramebufferSystem.tests.ts
@@ -377,4 +377,50 @@ describe('FramebufferSystem', () =>
         expect(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_WIDTH)).toEqual(16);
         expect(gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT)).toEqual(32);
     });
+
+    // eslint-disable-next-line func-names
+    it('should bind blit framebuffer after blit', function ()
+    {
+        renderer.framebuffer['contextChange']();
+
+        if (renderer.context.webGLVersion === 1
+            || renderer.framebuffer['msaaSamples'] === null
+            || renderer.framebuffer['msaaSamples'].every((x) => x <= 1))
+        {
+            return;
+        }
+
+        const { gl, CONTEXT_UID } = renderer;
+
+        const framebuffer = new Framebuffer(4, 4);
+
+        framebuffer.multisample = MSAA_QUALITY.HIGH;
+        framebuffer.addColorTexture(0);
+
+        renderer.framebuffer.bind(framebuffer);
+
+        expect(renderer.framebuffer.current).toBe(framebuffer);
+
+        const fbo = framebuffer.glFramebuffers[CONTEXT_UID];
+
+        expect(gl.checkFramebufferStatus(gl.FRAMEBUFFER)).toBe(gl.FRAMEBUFFER_COMPLETE);
+        expect(gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING)).toBe(fbo.framebuffer);
+        expect(gl.getParameter(gl.READ_FRAMEBUFFER_BINDING)).toBe(fbo.framebuffer);
+        expect(fbo.multisample).toBeGreaterThan(1);
+        expect(fbo.msaaBuffer).not.toBeNull();
+        expect(fbo.blitFramebuffer).toBeNull();
+
+        renderer.framebuffer.blit();
+
+        expect(fbo.blitFramebuffer).not.toBeNull();
+        expect(renderer.framebuffer.current).toBe(fbo.blitFramebuffer);
+
+        const blitFbo = fbo.blitFramebuffer.glFramebuffers[CONTEXT_UID];
+
+        expect(gl.checkFramebufferStatus(gl.FRAMEBUFFER)).toBe(gl.FRAMEBUFFER_COMPLETE);
+        expect(gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING)).toBe(blitFbo.framebuffer);
+        expect(gl.getParameter(gl.READ_FRAMEBUFFER_BINDING)).toBe(blitFbo.framebuffer);
+        expect(blitFbo.multisample).toBe(0);
+        expect(blitFbo.msaaBuffer).toBeNull();
+    });
 });

--- a/packages/core/test/GenerateTextureSystem.tests.ts
+++ b/packages/core/test/GenerateTextureSystem.tests.ts
@@ -1,0 +1,17 @@
+import { Renderer } from '@pixi/core';
+import { Sprite } from '@pixi/sprite';
+
+describe('GenerateTextureSystem', () =>
+{
+    it('should bind render texture', () =>
+    {
+        const renderer = new Renderer();
+        const sprite = new Sprite();
+        const renderTexture = renderer.generateTexture(sprite);
+
+        expect(renderer.renderTexture.current).toBe(renderTexture);
+
+        renderTexture.destroy(true);
+        renderer.destroy();
+    });
+});

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -199,6 +199,13 @@ export class Extract implements ISystem, IExtract
             if (!generated)
             {
                 renderer.renderTexture.bind(renderTexture);
+
+                const fbo = renderTexture.framebuffer.glFramebuffers[renderer.CONTEXT_UID];
+
+                if (fbo.blitFramebuffer)
+                {
+                    renderer.framebuffer.bind(fbo.blitFramebuffer);
+                }
             }
         }
         else

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -184,6 +184,7 @@ export class Extract implements ISystem, IExtract
             else
             {
                 renderTexture = renderer.generateTexture(target, {
+                    resolution: renderer.resolution,
                     multisample: renderer.multisample
                 });
                 generated = true;

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -1,4 +1,4 @@
-import { extensions, ExtensionType, MSAA_QUALITY, Rectangle, RenderTexture, utils } from '@pixi/core';
+import { extensions, ExtensionType, Rectangle, RenderTexture, utils } from '@pixi/core';
 
 import type { ExtensionMetadata, ICanvas, ISystem, Renderer } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
@@ -183,26 +183,9 @@ export class Extract implements ISystem, IExtract
             }
             else
             {
-                const multisample = renderer.context.webGLVersion >= 2 ? renderer.multisample : MSAA_QUALITY.NONE;
-
-                renderTexture = renderer.generateTexture(target, { multisample });
-
-                if (multisample !== MSAA_QUALITY.NONE)
-                {
-                    // Resolve the multisampled texture to a non-multisampled texture
-                    const resolvedTexture = RenderTexture.create({
-                        width: renderTexture.width,
-                        height: renderTexture.height,
-                    });
-
-                    renderer.framebuffer.bind(renderTexture.framebuffer);
-                    renderer.framebuffer.blit(resolvedTexture.framebuffer);
-                    renderer.framebuffer.bind();
-
-                    renderTexture.destroy(true);
-                    renderTexture = resolvedTexture;
-                }
-
+                renderTexture = renderer.generateTexture(target, {
+                    multisample: renderer.multisample
+                });
                 generated = true;
             }
         }
@@ -212,7 +195,11 @@ export class Extract implements ISystem, IExtract
             resolution = renderTexture.baseTexture.resolution;
             frame = frame ?? renderTexture.frame;
             flipY = false;
-            renderer.renderTexture.bind(renderTexture);
+
+            if (!generated)
+            {
+                renderer.renderTexture.bind(renderTexture);
+            }
         }
         else
         {

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -1,4 +1,4 @@
-import { Rectangle, Renderer, RenderTexture, Texture } from '@pixi/core';
+import { MSAA_QUALITY, Rectangle, Renderer, RenderTexture, Texture } from '@pixi/core';
 import { Extract } from '@pixi/extract';
 import { Sprite } from '@pixi/sprite';
 
@@ -72,6 +72,30 @@ describe('Extract', () =>
         expect(await extract.base64(sprite)).toBeString();
         expect(extract.pixels(sprite)).toBeInstanceOf(Uint8Array);
         expect(await extract.image(sprite)).toBeInstanceOf(HTMLImageElement);
+
+        renderer.destroy();
+        sprite.destroy();
+    });
+
+    it('should extract from multisampled render texture', async () =>
+    {
+        const renderer = new Renderer();
+        const extract = renderer.extract;
+        const sprite = new Sprite(Texture.WHITE);
+        const renderTexture = renderer.generateTexture(sprite, {
+            multisample: MSAA_QUALITY.HIGH
+        });
+
+        // unbind renderTexture
+        renderer.renderTexture.bind();
+
+        const pixels = extract.pixels(renderTexture);
+
+        expect(pixels).toBeInstanceOf(Uint8Array);
+        expect(pixels[0]).toBe(255);
+        expect(pixels[1]).toBe(255);
+        expect(pixels[2]).toBe(255);
+        expect(pixels[3]).toBe(255);
 
         renderer.destroy();
         sprite.destroy();


### PR DESCRIPTION
##### Description of change

- After `.blit(blitFramebuffer)` the `blitFramebuffer` is bound and so the `READ_FRAMEBUFFER` binding must be the `blitFramebuffer`. Otherwise we cannot read from it even though it is the bound framebuffer.
- The second render texture isn't necessary: we can read from the blit framebuffer.
- I allowed extraction from multisampled render texture by binding the blit framebuffer. The render texture needs to be blit before the extraction call of course.
- If the multisample of the renderer is used for the generated texture, then so should be the resolution of the renderer. But shouldn't `generateTexture` itself use the the renderer's resolution/multisample automatically then? Doesn't make sense to me if extract does but `generateTexture` doesn't.

Test (antialias and resolution 2):
- Before: https://pixiplayground.com/#/edit/WitDGt6m68RhCOl2sDyXA
- After: https://pixiplayground.com/#/edit/AMaLSAqbFuvCcRbFHFMr3

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
