### PR TITLE
Extract performance improvements

### DIFF
--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -65,7 +65,7 @@ export class CanvasExtract implements ISystem, IExtract
 
         if (canvas.toBlob !== undefined)
         {
-            return await new Promise<string>((resolve, reject) =>
+            return new Promise<string>((resolve, reject) =>
             {
                 canvas.toBlob((blob) =>
                 {
@@ -85,7 +85,7 @@ export class CanvasExtract implements ISystem, IExtract
         {
             const blob = await canvas.convertToBlob({ type: format, quality });
 
-            return await new Promise<string>((resolve, reject) =>
+            return new Promise<string>((resolve, reject) =>
             {
                 const reader = new FileReader();
 

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -63,6 +63,20 @@ export class CanvasExtract implements ISystem, IExtract
     {
         const canvas = this.canvas(target);
 
+        if (canvas.toBlob !== undefined)
+        {
+            return await new Promise<string>((resolve, reject) =>
+            {
+                canvas.toBlob((blob) =>
+                {
+                    const reader = new FileReader();
+
+                    reader.onload = () => resolve(reader.result as string);
+                    reader.onerror = reject;
+                    reader.readAsDataURL(blob);
+                }, format, quality);
+            });
+        }
         if (canvas.toDataURL !== undefined)
         {
             return canvas.toDataURL(format, quality);
@@ -71,16 +85,18 @@ export class CanvasExtract implements ISystem, IExtract
         {
             const blob = await canvas.convertToBlob({ type: format, quality });
 
-            return await new Promise<string>((resolve) =>
+            return await new Promise<string>((resolve, reject) =>
             {
                 const reader = new FileReader();
 
                 reader.onload = () => resolve(reader.result as string);
+                reader.onerror = reject;
                 reader.readAsDataURL(blob);
             });
         }
 
-        throw new Error('CanvasExtract.base64() requires ICanvas.toDataURL or ICanvas.convertToBlob to be implemented');
+        throw new Error('CanvasExtract.base64() requires ICanvas.toDataURL, ICanvas.toBlob, '
+            + 'or ICanvas.convertToBlob to be implemented');
     }
 
     /**

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -67,8 +67,16 @@ export class CanvasExtract implements ISystem, IExtract
         {
             return new Promise<string>((resolve, reject) =>
             {
-                canvas.toBlob((blob) =>
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                canvas.toBlob!((blob) =>
                 {
+                    if (!blob)
+                    {
+                        reject(new Error('ICanvas.toBlob failed!'));
+
+                        return;
+                    }
+
                     const reader = new FileReader();
 
                     reader.onload = () => resolve(reader.result as string);

--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -6,8 +6,10 @@ import { Graphics } from '@pixi/graphics';
 import { Sprite } from '@pixi/sprite';
 import '@pixi/canvas-display';
 
-describe('CanvasExtract', () => {
-    it('should access extract on renderer', () => {
+describe('CanvasExtract', () =>
+{
+    it('should access extract on renderer', () =>
+    {
         const renderer = new CanvasRenderer();
 
         expect(renderer.extract).toBeInstanceOf(CanvasExtract);
@@ -15,16 +17,25 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract pixels from renderer correctly', async () => {
+    it('should extract pixels from renderer correctly', async () =>
+    {
         const renderer = new CanvasRenderer({ width: 2, height: 2 });
 
         renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
 
         const graphics = new Graphics()
-            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
-            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
-            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
-            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
         const extract = renderer.extract;
 
         renderer.render(graphics);
@@ -40,16 +51,25 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract canvas from renderer correctly', async () => {
+    it('should extract canvas from renderer correctly', async () =>
+    {
         const renderer = new CanvasRenderer({ width: 2, height: 2 });
 
         renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
 
         const graphics = new Graphics()
-            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
-            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
-            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
-            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
         const extract = renderer.extract;
 
         renderer.render(graphics);
@@ -67,16 +87,25 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract pixels from render texture correctly', async () => {
+    it('should extract pixels from render texture correctly', async () =>
+    {
         const renderer = new CanvasRenderer({ width: 2, height: 2 });
 
         renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
 
         const graphics = new Graphics()
-            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
-            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
-            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
-            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
         const extract = renderer.extract;
 
         renderer.render(graphics);
@@ -92,16 +121,25 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract canvas from render texture correctly', async () => {
+    it('should extract canvas from render texture correctly', async () =>
+    {
         const renderer = new CanvasRenderer({ width: 2, height: 2 });
 
         renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
 
         const graphics = new Graphics()
-            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
-            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
-            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
-            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
         const extract = renderer.extract;
 
         renderer.render(graphics);
@@ -119,7 +157,8 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract an sprite', async () => {
+    it('should extract an sprite', async () =>
+    {
         const renderer = new CanvasRenderer();
         const sprite = new Sprite(Texture.WHITE);
         const extract = renderer.extract as CanvasExtract;
@@ -133,7 +172,8 @@ describe('CanvasExtract', () => {
         sprite.destroy();
     });
 
-    it('should extract with no arguments', async () => {
+    it('should extract with no arguments', async () =>
+    {
         const renderer = new CanvasRenderer();
         const extract = renderer.extract as CanvasExtract;
 
@@ -145,7 +185,8 @@ describe('CanvasExtract', () => {
         renderer.destroy();
     });
 
-    it('should extract a render texture', async () => {
+    it('should extract a render texture', async () =>
+    {
         const renderer = new CanvasRenderer();
         const extract = renderer.extract as CanvasExtract;
         const renderTexture = RenderTexture.create({ width: 10, height: 10 });

--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -76,9 +76,9 @@ describe('CanvasExtract', () =>
 
         const canvas = extract.canvas();
         const context = canvas.getContext('2d');
-        const imageData = context.getImageData(0, 0, 2, 2);
+        const imageData = context?.getImageData(0, 0, 2, 2);
 
-        expect(imageData.data).toEqual(new Uint8ClampedArray([
+        expect(imageData?.data).toEqual(new Uint8ClampedArray([
             255, 0, 0, 255, 0, 255, 0, 255,
             0, 0, 255, 255, 255, 255, 0, 255
         ]));
@@ -146,9 +146,9 @@ describe('CanvasExtract', () =>
 
         const canvas = extract.canvas(graphics);
         const context = canvas.getContext('2d');
-        const imageData = context.getImageData(0, 0, 2, 2);
+        const imageData = context?.getImageData(0, 0, 2, 2);
 
-        expect(imageData.data).toEqual(new Uint8ClampedArray([
+        expect(imageData?.data).toEqual(new Uint8ClampedArray([
             255, 0, 0, 255, 0, 255, 0, 255,
             0, 0, 255, 255, 255, 255, 0, 255
         ]));

--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -1,13 +1,13 @@
 import { CanvasExtract } from '@pixi/canvas-extract';
+import { CanvasGraphicsRenderer } from '@pixi/canvas-graphics';
 import { CanvasRenderer } from '@pixi/canvas-renderer';
 import { RenderTexture, Texture } from '@pixi/core';
+import { Graphics } from '@pixi/graphics';
 import { Sprite } from '@pixi/sprite';
 import '@pixi/canvas-display';
 
-describe('CanvasExtract', () =>
-{
-    it('should access extract on renderer', () =>
-    {
+describe('CanvasExtract', () => {
+    it('should access extract on renderer', () => {
         const renderer = new CanvasRenderer();
 
         expect(renderer.extract).toBeInstanceOf(CanvasExtract);
@@ -15,8 +15,111 @@ describe('CanvasExtract', () =>
         renderer.destroy();
     });
 
-    it('should extract an sprite', async () =>
-    {
+    it('should extract pixels from renderer correctly', async () => {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
+            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
+            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
+            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const extractedPixels = extract.pixels();
+
+        expect(extractedPixels).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+
+        graphics.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract canvas from renderer correctly', async () => {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
+            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
+            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
+            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const canvas = extract.canvas();
+        const context = canvas.getContext('2d');
+        const imageData = context.getImageData(0, 0, 2, 2);
+
+        expect(imageData.data).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+
+        graphics.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract pixels from render texture correctly', async () => {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
+            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
+            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
+            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const extractedPixels = extract.pixels(graphics);
+
+        expect(extractedPixels).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+
+        graphics.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract canvas from render texture correctly', async () => {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000).drawRect(0, 0, 1, 1).endFill()
+            .beginFill(0x00FF00).drawRect(1, 0, 1, 1).endFill()
+            .beginFill(0x0000FF).drawRect(0, 1, 1, 1).endFill()
+            .beginFill(0xFFFF00).drawRect(1, 1, 1, 1).endFill();
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const canvas = extract.canvas(graphics);
+        const context = canvas.getContext('2d');
+        const imageData = context.getImageData(0, 0, 2, 2);
+
+        expect(imageData.data).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+
+        graphics.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract an sprite', async () => {
         const renderer = new CanvasRenderer();
         const sprite = new Sprite(Texture.WHITE);
         const extract = renderer.extract as CanvasExtract;
@@ -30,8 +133,7 @@ describe('CanvasExtract', () =>
         sprite.destroy();
     });
 
-    it('should extract with no arguments', async () =>
-    {
+    it('should extract with no arguments', async () => {
         const renderer = new CanvasRenderer();
         const extract = renderer.extract as CanvasExtract;
 
@@ -43,8 +145,7 @@ describe('CanvasExtract', () =>
         renderer.destroy();
     });
 
-    it('should extract a render texture', async () =>
-    {
+    it('should extract a render texture', async () => {
         const renderer = new CanvasRenderer();
         const extract = renderer.extract as CanvasExtract;
         const renderTexture = RenderTexture.create({ width: 10, height: 10 });

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -131,14 +131,14 @@ export class Extract implements ISystem, IExtract
     {
         const { pixels, width, height, flipY } = this._rawPixels(target, frame);
 
+        Extract.arrayPostDivide(pixels, pixels);
+
         let canvasBuffer = new utils.CanvasRenderTarget(width, height, 1);
 
         // Add the pixels to the canvas
-        const canvasData = canvasBuffer.context.getImageData(0, 0, width, height);
+        const imageData = new ImageData(new Uint8ClampedArray(pixels.buffer), width, height);
 
-        Extract.arrayPostDivide(pixels, canvasData.data);
-
-        canvasBuffer.context.putImageData(canvasData, 0, 0);
+        canvasBuffer.context.putImageData(imageData, 0, 0);
 
         // Flipping pixels
         if (flipY)

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -84,6 +84,20 @@ export class Extract implements ISystem, IExtract
     {
         const canvas = this.canvas(target);
 
+        if (canvas.toBlob !== undefined)
+        {
+            return await new Promise<string>((resolve, reject) =>
+            {
+                canvas.toBlob((blob) =>
+                {
+                    const reader = new FileReader();
+
+                    reader.onload = () => resolve(reader.result as string);
+                    reader.onerror = reject;
+                    reader.readAsDataURL(blob);
+                }, format, quality);
+            });
+        }
         if (canvas.toDataURL !== undefined)
         {
             return canvas.toDataURL(format, quality);
@@ -92,16 +106,18 @@ export class Extract implements ISystem, IExtract
         {
             const blob = await canvas.convertToBlob({ type: format, quality });
 
-            return await new Promise<string>((resolve) =>
+            return await new Promise<string>((resolve, reject) =>
             {
                 const reader = new FileReader();
 
                 reader.onload = () => resolve(reader.result as string);
+                reader.onerror = reject;
                 reader.readAsDataURL(blob);
             });
         }
 
-        throw new Error('Extract.base64() requires ICanvas.toDataURL or ICanvas.convertToBlob to be implemented');
+        throw new Error('Extract.base64() requires ICanvas.toDataURL, ICanvas.toBlob, '
+            + 'or ICanvas.convertToBlob to be implemented');
     }
 
     /**

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -88,8 +88,16 @@ export class Extract implements ISystem, IExtract
         {
             return new Promise<string>((resolve, reject) =>
             {
-                canvas.toBlob((blob) =>
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                canvas.toBlob!((blob) =>
                 {
+                    if (!blob)
+                    {
+                        reject(new Error('ICanvas.toBlob failed!'));
+
+                        return;
+                    }
+
                     const reader = new FileReader();
 
                     reader.onload = () => resolve(reader.result as string);

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -134,17 +134,7 @@ export class Extract implements ISystem, IExtract
         // Flipping pixels
         if (flipY)
         {
-            const temp = new Uint8Array(width);
-
-            for (let y = 0, h = height >> 1; y < h; y++)
-            {
-                const t = y * width;
-                const b = (height - y - 1) * width;
-
-                temp.set(pixels.subarray(t, t + width));
-                pixels.copyWithin(t, b, b + width);
-                pixels.set(temp, b);
-            }
+            Extract._flipY(pixels, width, height);
         }
 
         Extract.arrayPostDivide(pixels, pixels);
@@ -277,6 +267,23 @@ export class Extract implements ISystem, IExtract
     public destroy(): void
     {
         this.renderer = null;
+    }
+
+    private static _flipY(pixels: Uint8Array | Uint8ClampedArray, width: number, height: number): void
+    {
+        const w = width << 2;
+        const h = height >> 1;
+        const temp = new Uint8Array(w);
+
+        for (let y = 0; y < h; y++)
+        {
+            const t = y * w;
+            const b = (height - y - 1) * w;
+
+            temp.set(pixels.subarray(t, t + w));
+            pixels.copyWithin(t, b, b + w);
+            pixels.set(temp, b);
+        }
     }
 
     /**

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -86,7 +86,7 @@ export class Extract implements ISystem, IExtract
 
         if (canvas.toBlob !== undefined)
         {
-            return await new Promise<string>((resolve, reject) =>
+            return new Promise<string>((resolve, reject) =>
             {
                 canvas.toBlob((blob) =>
                 {
@@ -106,7 +106,7 @@ export class Extract implements ISystem, IExtract
         {
             const blob = await canvas.convertToBlob({ type: format, quality });
 
-            return await new Promise<string>((resolve, reject) =>
+            return new Promise<string>((resolve, reject) =>
             {
                 const reader = new FileReader();
 

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -1,4 +1,4 @@
-import { Rectangle, Renderer, RenderTexture, Texture } from '@pixi/core';
+import { ALPHA_MODES, FORMATS, Rectangle, Renderer, RenderTexture, Texture, TYPES } from '@pixi/core';
 import { Extract } from '@pixi/extract';
 import { Sprite } from '@pixi/sprite';
 
@@ -11,6 +11,124 @@ describe('Extract', () =>
         expect(renderer.plugins.extract).toBeInstanceOf(Extract);
         expect(renderer.extract).toBeInstanceOf(Extract);
 
+        renderer.destroy();
+    });
+
+    it('should extract pixels from renderer correctly (without y-flipping)', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+        const texture = Texture.fromBuffer(texturePixels, 2, 2, {
+            width: 2,
+            height: 2,
+            format: FORMATS.RGBA,
+            type: TYPES.UNSIGNED_BYTE,
+            alphaMode: ALPHA_MODES.UNPACK
+        });
+        const sprite = new Sprite(texture);
+        const extract = renderer.extract;
+
+        renderer.render(sprite);
+
+        const extractedPixels = extract.pixels();
+
+        expect(extractedPixels).toEqual(new Uint8Array([
+            0, 0, 102, 255, 51, 51, 0, 255,
+            255, 0, 0, 255, 0, 153, 0, 255
+        ]));
+
+        texture.destroy(true);
+        sprite.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract canvas from renderer correctly (with y-flipping)', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+        const texture = Texture.fromBuffer(texturePixels, 2, 2, {
+            width: 2,
+            height: 2,
+            format: FORMATS.RGBA,
+            type: TYPES.UNSIGNED_BYTE,
+            alphaMode: ALPHA_MODES.UNPACK
+        });
+        const sprite = new Sprite(texture);
+        const extract = renderer.extract;
+
+        renderer.render(sprite);
+
+        const canvas = extract.canvas();
+        const context = canvas.getContext('2d');
+        const imageData = context.getImageData(0, 0, 2, 2);
+
+        expect(imageData.data).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 153, 0, 255,
+            0, 0, 102, 255, 51, 51, 0, 255
+        ]));
+
+        texture.destroy(true);
+        sprite.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract pixels from render texture correctly', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+        const texture = Texture.fromBuffer(texturePixels, 2, 2, {
+            width: 2,
+            height: 2,
+            format: FORMATS.RGBA,
+            type: TYPES.UNSIGNED_BYTE,
+            alphaMode: ALPHA_MODES.UNPACK
+        });
+        const sprite = new Sprite(texture);
+        const extract = renderer.extract;
+
+        const extractedPixels = extract.pixels(sprite);
+
+        expect(extractedPixels).toEqual(texturePixels);
+
+        texture.destroy(true);
+        sprite.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract canvas from render texture correctly', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+        const texture = Texture.fromBuffer(texturePixels, 2, 2, {
+            width: 2,
+            height: 2,
+            format: FORMATS.RGBA,
+            type: TYPES.UNSIGNED_BYTE,
+            alphaMode: ALPHA_MODES.UNPACK
+        });
+        const sprite = new Sprite(texture);
+        const extract = renderer.extract;
+
+        const canvas = extract.canvas(sprite);
+        const context = canvas.getContext('2d');
+        const imageData = context.getImageData(0, 0, 2, 2);
+
+        expect(imageData.data).toEqual(new Uint8ClampedArray(texturePixels.buffer));
+
+        texture.destroy(true);
+        sprite.destroy();
         renderer.destroy();
     });
 

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -66,9 +66,9 @@ describe('Extract', () =>
 
         const canvas = extract.canvas();
         const context = canvas.getContext('2d');
-        const imageData = context.getImageData(0, 0, 2, 2);
+        const imageData = context?.getImageData(0, 0, 2, 2);
 
-        expect(imageData.data).toEqual(new Uint8ClampedArray([
+        expect(imageData?.data).toEqual(new Uint8ClampedArray([
             255, 0, 0, 255, 0, 153, 0, 255,
             0, 0, 102, 255, 51, 51, 0, 255
         ]));
@@ -123,9 +123,9 @@ describe('Extract', () =>
 
         const canvas = extract.canvas(sprite);
         const context = canvas.getContext('2d');
-        const imageData = context.getImageData(0, 0, 2, 2);
+        const imageData = context?.getImageData(0, 0, 2, 2);
 
-        expect(imageData.data).toEqual(new Uint8ClampedArray(texturePixels.buffer));
+        expect(imageData?.data).toEqual(new Uint8ClampedArray(texturePixels.buffer));
 
         texture.destroy(true);
         sprite.destroy();

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -194,4 +194,51 @@ describe('Extract', () =>
         renderer.destroy();
         sprite.destroy();
     });
+
+    it('should unpremultiply alpha correctly', () =>
+    {
+        const pixels1 = new Uint8Array(4);
+        const pixels2 = new Uint8ClampedArray(4);
+
+        Extract['_unpremultiplyAlpha'](pixels1);
+        Extract['_unpremultiplyAlpha'](pixels2);
+
+        expect(pixels1[0]).toBe(0);
+        expect(pixels1[1]).toBe(0);
+        expect(pixels1[2]).toBe(0);
+        expect(pixels1[3]).toBe(0);
+        expect(pixels2[0]).toBe(0);
+        expect(pixels2[1]).toBe(0);
+        expect(pixels2[2]).toBe(0);
+        expect(pixels2[3]).toBe(0);
+
+        for (let alpha = 1; alpha < 256; alpha++)
+        {
+            for (let x = 0; x <= alpha; x++)
+            {
+                pixels1[0] = x;
+                pixels1[1] = 0;
+                pixels1[2] = 0;
+                pixels1[3] = alpha;
+                pixels2[0] = x;
+                pixels2[1] = 0;
+                pixels2[2] = 0;
+                pixels2[3] = alpha;
+
+                Extract['_unpremultiplyAlpha'](pixels1);
+                Extract['_unpremultiplyAlpha'](pixels2);
+
+                const y = Math.min(Math.max(Math.round((x * 255) / alpha), 0), 255);
+
+                expect(pixels1[0]).toBe(y);
+                expect(pixels1[1]).toBe(0);
+                expect(pixels1[2]).toBe(0);
+                expect(pixels1[3]).toBe(alpha);
+                expect(pixels2[0]).toBe(y);
+                expect(pixels2[1]).toBe(0);
+                expect(pixels2[2]).toBe(0);
+                expect(pixels2[3]).toBe(alpha);
+            }
+        }
+    });
 });

--- a/packages/settings/src/ICanvas.ts
+++ b/packages/settings/src/ICanvas.ts
@@ -93,20 +93,40 @@ export interface ICanvas extends GlobalMixins.ICanvas, Partial<EventTarget>
 
     /**
      * Get the content of the canvas as data URL.
-     * @param {string} type - The MIME type for the image format to return. If not specify, the default value is image/png.
-     * @param {any} options - The options for creating data URL.
-     * @returns {string} The content of the canvas as data URL.
+     * @param {string} [type] - A string indicating the image format. The default type is `image/png`;
+     *      that type is also used if the given type isn't supported.
+     * @param {string} [quality] - A number between 0 and 1 indicating the image quality to be used when
+     *      creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+     *      A user agent will use its default quality value if this option is not specified, or if the number
+     *      is outside the allowed range.
+     * @returns {string} A string containing the requested data URL.
      */
-    toDataURL?(type?: string, options?: any): string;
+    toDataURL?(type?: string, quality?: number): string;
+
+    /**
+     * Creates a Blob from the content of the canvas.
+     * @param {(blob: Blob | null) => void} callback - A callback function with the resulting `Blob` object
+     *      as a single argument. `null` may be passed if the image cannot be created for any reason.
+     * @param {string} [type] - A string indicating the image format. The default type is `image/png`;
+     *      that type is also used if the given type isn't supported.
+     * @param {string} [quality] - A number between 0 and 1 indicating the image quality to be used when
+     *      creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+     *      A user agent will use its default quality value if this option is not specified, or if the number
+     *      is outside the allowed range.
+     * @returns {void}
+     */
+    toBlob?(callback: (blob: Blob | null) => void, type?: string, quality?: number): void;
 
     /**
      * Get the content of the canvas as Blob.
-     * @param {object} options - The options for creating Blob.
-     * @param {string} options.type
-     *     - The MIME type for the image format to return. If not specify, the default value is image/png.
-     * @param {string} options.quality
-     *     - The image quality to be used when creating images using file formats that support lossy compression.
-     * @returns {Promise<Blob>} The content of the canvas as Blob.
+     * @param {object} [options] - The options for creating Blob.
+     * @param {string} [options.type] - A string indicating the image format. The default type is `image/png`;
+     *      that type is also used if the given type isn't supported.
+     * @param {string} [options.quality] - A number between 0 and 1 indicating the image quality to be used when
+     *      creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
+     *      A user agent will use its default quality value if this option is not specified, or if the number
+     *      is outside the allowed range.
+     * @returns {Promise<Blob>} A `Promise` returning a Blob object representing the image contained in the canvas.
      */
     convertToBlob?(options?: { type?: string, quality?: number }): Promise<Blob>;
 


### PR DESCRIPTION
##### Description of change

- 3d2d89c9d6ad1a6fe6bfb78fec5a2a4dc10d9d8f: `canvas.toBlob` instead of `toDataURL` blocks the main thread for a shorter duration.
- 4a2ff59114c9f015b9c96f7f1c04fd4e53c331c2: Improves performance (~50ms => ~42ms in my test). The `getImageData` is unnessecary.
- 4b2ce461ddd34465d27a138ed245c7eaf9d876ca: Improves performance even more (~42ms => ~34ms in my test).

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
