### PR TITLE
Fix `BaseTexture.fromBuffer` creating float texture with the wrong type

### DIFF
--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -707,7 +707,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
         const resource = new BufferResource(buffer, { width, height });
         const type = buffer instanceof Float32Array ? TYPES.FLOAT : TYPES.UNSIGNED_BYTE;
 
-        return new BaseTexture(resource, Object.assign({}, defaultBufferOptions, options || { width, height, type }));
+        return new BaseTexture(resource, Object.assign({}, defaultBufferOptions, { type }, options));
     }
 
     /**

--- a/packages/core/test/BaseTexture.tests.ts
+++ b/packages/core/test/BaseTexture.tests.ts
@@ -1,4 +1,13 @@
-import { BaseTexture, ImageResource, RenderTexture, SVGResource, Texture, VideoResource } from '@pixi/core';
+import {
+    BaseTexture,
+    ImageResource,
+    RenderTexture,
+    SCALE_MODES,
+    SVGResource,
+    Texture,
+    TYPES,
+    VideoResource
+} from '@pixi/core';
 import { settings } from '@pixi/settings';
 import { BaseTextureCache, TextureCache } from '@pixi/utils';
 
@@ -251,5 +260,16 @@ describe('BaseTexture', () =>
         settings.STRICT_TEXTURE_CACHE = true;
         expect(() => BaseTexture.from(id)).toThrowError(`The cacheId "${id}" does not exist in BaseTextureCache.`);
         settings.STRICT_TEXTURE_CACHE = false;
+    });
+
+    it('should create texture from buffer with correct type', () =>
+    {
+        const baseTexture = BaseTexture.fromBuffer(new Float32Array(2 * 3 * 4), 2, 3, {
+            scaleMode: SCALE_MODES.LINEAR
+        });
+
+        expect(baseTexture.type).toBe(TYPES.FLOAT);
+
+        baseTexture.destroy();
     });
 });


### PR DESCRIPTION
##### Description of change

If `options` was given, the detected `type` never made it to the base texture.

`width` and `height` we don't need to add to the options. The `BufferResource` resizes the texture immediately.

If `type` is in the `options`, it replaces the auto detected `type`.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
