### PR TITLE
Prevent `BlobResource.load` from loading the data multiple times

### DIFF
--- a/packages/compressed-textures/src/resources/BlobResource.ts
+++ b/packages/compressed-textures/src/resources/BlobResource.ts
@@ -1,7 +1,5 @@
 import { BufferResource, ViewableBuffer } from '@pixi/core';
 
-import type { Resource } from '@pixi/core';
-
 interface IBlobOptions
 {
     autoLoad?: boolean;
@@ -17,22 +15,28 @@ interface IBlobOptions
  */
 export abstract class BlobResource extends BufferResource
 {
-    protected origin: string;
-    protected buffer: ViewableBuffer;
+    protected origin: string | null;
+    protected buffer: ViewableBuffer | null;
     protected loaded: boolean;
 
     /**
-     * @param {string} source - the URL of the texture file
+     * Promise when loading.
+     * @default null
+     */
+    private _load: Promise<this>;
+
+    /**
+     * @param source - the buffer/URL of the texture file
      * @param {PIXI.IBlobOptions} options
      * @param {boolean}[options.autoLoad] - whether to fetch the data immediately;
      *  you can fetch it later via {@link PIXI.BlobResource#load}
      * @param {boolean}[options.width] - the width in pixels.
      * @param {boolean}[options.height] - the height in pixels.
      */
-    constructor(source: string | Uint8Array | Uint32Array | Float32Array,
+    constructor(source: string | Uint8Array | Uint32Array | Float32Array | null,
         options: IBlobOptions = { width: 1, height: 1, autoLoad: true })
     {
-        let origin: string;
+        let origin: string | null;
         let data: Uint8Array | Uint32Array | Float32Array;
 
         if (typeof source === 'string')
@@ -46,28 +50,32 @@ export abstract class BlobResource extends BufferResource
             data = source;
         }
 
-        super(data, options);
+        super(data ?? new Uint8Array(), options);
 
         /**
          * The URL of the texture file
-         * @member {string}
+         * @type {string|null}
          */
         this.origin = origin;
 
         /**
          * The viewable buffer on the data
-         * @member {ViewableBuffer}
+         * @type {ViewableBuffer|null}
          */
         // HINT: BlobResource allows "null" sources, assuming the child class provides an alternative
         this.buffer = data ? new ViewableBuffer(data) : null;
 
+        this._load = null;
+        this.loaded = false;
+
         // Allow autoLoad = "undefined" still load the resource by default
-        if (this.origin && options.autoLoad !== false)
+        if (this.origin !== null && options.autoLoad !== false)
         {
             this.load();
         }
-        if (data?.length)
+        if (this.origin === null && this.buffer)
         {
+            this._load = Promise.resolve(this);
             this.loaded = true;
             this.onBlobLoaded(this.buffer.rawBinaryData);
         }
@@ -79,19 +87,28 @@ export abstract class BlobResource extends BufferResource
     }
 
     /** Loads the blob */
-    async load(): Promise<Resource>
+    load(): Promise<this>
     {
-        const response = await fetch(this.origin);
-        const blob = await response.blob();
-        const arrayBuffer = await blob.arrayBuffer();
+        if (this._load)
+        {
+            return this._load;
+        }
 
-        this.data = new Uint32Array(arrayBuffer);
-        this.buffer = new ViewableBuffer(arrayBuffer);
-        this.loaded = true;
+        this._load = fetch(this.origin)
+            .then((response) => response.blob())
+            .then((blob) => blob.arrayBuffer())
+            .then((arrayBuffer) =>
+            {
+                this.data = new Uint32Array(arrayBuffer);
+                this.buffer = new ViewableBuffer(arrayBuffer);
+                this.loaded = true;
 
-        this.onBlobLoaded(arrayBuffer);
-        this.update();
+                this.onBlobLoaded(arrayBuffer);
+                this.update();
 
-        return this;
+                return this;
+            });
+
+        return this._load;
     }
 }

--- a/packages/compressed-textures/src/resources/BlobResource.ts
+++ b/packages/compressed-textures/src/resources/BlobResource.ts
@@ -50,7 +50,7 @@ export abstract class BlobResource extends BufferResource
             data = source;
         }
 
-        super(data ?? new Uint8Array(), options);
+        super(data, options);
 
         /**
          * The URL of the texture file

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -46,7 +46,7 @@ export class ImageBitmapResource extends BaseImageResource
      * Promise when loading.
      * @default null
      */
-    private _load: Promise<ImageBitmapResource>;
+    private _load: Promise<this>;
 
     /**
      * @param source - ImageBitmap or URL to use
@@ -88,7 +88,7 @@ export class ImageBitmapResource extends BaseImageResource
         }
     }
 
-    load(): Promise<ImageBitmapResource>
+    load(): Promise<this>
     {
         if (this._load)
         {

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -60,10 +60,10 @@ export class ImageResource extends BaseImageResource
      * Promise when loading.
      * @default null
      */
-    private _load: Promise<ImageResource>;
+    private _load: Promise<this>;
 
     /** When process is completed */
-    private _process: Promise<ImageResource>;
+    private _process: Promise<this>;
 
     /**
      * @param source - image source or URL
@@ -121,7 +121,7 @@ export class ImageResource extends BaseImageResource
      * Returns a promise when image will be loaded and processed.
      * @param createBitmap - whether process image into bitmap
      */
-    load(createBitmap?: boolean): Promise<ImageResource>
+    load(createBitmap?: boolean): Promise<this>
     {
         if (this._load)
         {
@@ -185,7 +185,7 @@ export class ImageResource extends BaseImageResource
      * Can be called multiple times, real promise is cached inside.
      * @returns - Cached promise to fill that bitmap
      */
-    process(): Promise<ImageResource>
+    process(): Promise<this>
     {
         const source = this.source as HTMLImageElement;
 

--- a/packages/core/src/textures/resources/Resource.ts
+++ b/packages/core/src/textures/resources/Resource.ts
@@ -144,7 +144,7 @@ export abstract class Resource
      * @protected
      * @returns Handle the validate event
      */
-    load(): Promise<Resource>
+    load(): Promise<this>
     {
         return Promise.resolve(this);
     }

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -36,7 +36,7 @@ export class SVGResource extends BaseImageResource
     private _resolve: () => void;
 
     /** Promise when loading */
-    private _load: Promise<SVGResource>;
+    private _load: Promise<this>;
 
     /** Cross origin value to use */
     private _crossorigin?: boolean | string;
@@ -72,7 +72,7 @@ export class SVGResource extends BaseImageResource
         }
     }
 
-    load(): Promise<SVGResource>
+    load(): Promise<this>
     {
         if (this._load)
         {

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -51,10 +51,10 @@ export class VideoResource extends BaseImageResource
      * Promise when loading.
      * @default null
      */
-    private _load: Promise<VideoResource>;
+    private _load: Promise<this>;
 
     /** Callback when completed with load. */
-    private _resolve: (value?: VideoResource | PromiseLike<VideoResource>) => void;
+    private _resolve: (value?: this | PromiseLike<this>) => void;
 
     /**
      * @param {HTMLVideoElement|object|string|Array<string|object>} source - Video element to use.
@@ -161,7 +161,7 @@ export class VideoResource extends BaseImageResource
      * Start preloading the video resource.
      * @returns {Promise<void>} Handle the validate event
      */
-    load(): Promise<VideoResource>
+    load(): Promise<this>
     {
         if (this._load)
         {


### PR DESCRIPTION
##### Description of change

Another call to `BlobResource.load` shouldn't load the data again.

Changed the return type of all Resource.load implementations to `Promise<this>` to make it consistent.

Added explicit `| null` to the types of some of members/parameters of `BlobResource`

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
