### PR TITLE
Set `GLTexture.samplerType` based on the internal format

### DIFF
--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -41,7 +41,7 @@ export class TextureSystem implements ISystem
     protected CONTEXT_UID: number;
     protected gl: IRenderingContext;
     protected internalFormats: { [type: number]: { [format: number]: number } };
-    protected samplerTypes: { [internalFormats: number]: SAMPLER_TYPES };
+    protected samplerTypes: Record<number, SAMPLER_TYPES>;
     protected webGLVersion: number;
 
     /**

--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -3,6 +3,7 @@ import { extensions, ExtensionType } from '@pixi/extensions';
 import { removeItems } from '@pixi/utils';
 import { BaseTexture } from './BaseTexture';
 import { GLTexture } from './GLTexture';
+import { mapInternalFormatToSamplerType } from './utils/mapInternalFormatToSamplerType';
 import { mapTypeAndFormatToInternalFormat } from './utils/mapTypeAndFormatToInternalFormat';
 
 import type { ExtensionMetadata } from '@pixi/extensions';
@@ -40,6 +41,7 @@ export class TextureSystem implements ISystem
     protected CONTEXT_UID: number;
     protected gl: IRenderingContext;
     protected internalFormats: { [type: number]: { [format: number]: number } };
+    protected samplerTypes: { [internalFormats: number]: SAMPLER_TYPES };
     protected webGLVersion: number;
 
     /**
@@ -90,6 +92,7 @@ export class TextureSystem implements ISystem
         this.webGLVersion = this.renderer.context.webGLVersion;
 
         this.internalFormats = mapTypeAndFormatToInternalFormat(gl);
+        this.samplerTypes = mapInternalFormatToSamplerType(gl);
 
         const maxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
 
@@ -292,6 +295,7 @@ export class TextureSystem implements ISystem
     initTextureType(texture: BaseTexture, glTexture: GLTexture): void
     {
         glTexture.internalFormat = this.internalFormats[texture.type]?.[texture.format] ?? texture.format;
+        glTexture.samplerType = this.samplerTypes[glTexture.internalFormat] ?? SAMPLER_TYPES.FLOAT;
 
         if (this.webGLVersion === 2 && texture.type === TYPES.HALF_FLOAT)
         {

--- a/packages/core/src/textures/utils/mapInternalFormatToSamplerType.ts
+++ b/packages/core/src/textures/utils/mapInternalFormatToSamplerType.ts
@@ -1,0 +1,94 @@
+import { SAMPLER_TYPES } from '@pixi/constants';
+
+/**
+ * Returns a lookup table that maps each internal format to the compatible sampler type.
+ * @memberof PIXI
+ * @function mapInternalFormatToSamplerType
+ * @private
+ * @param {WebGLRenderingContext} gl - The rendering context.
+ * @returns Lookup table.
+ */
+export function mapInternalFormatToSamplerType(gl: WebGLRenderingContextBase):
+{ [internalFormat: number]: SAMPLER_TYPES }
+{
+    let table;
+
+    if ('WebGL2RenderingContext' in globalThis && gl instanceof globalThis.WebGL2RenderingContext)
+    {
+        table = {
+            [gl.RGB]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA]: SAMPLER_TYPES.FLOAT,
+            [gl.ALPHA]: SAMPLER_TYPES.FLOAT,
+            [gl.LUMINANCE]: SAMPLER_TYPES.FLOAT,
+            [gl.LUMINANCE_ALPHA]: SAMPLER_TYPES.FLOAT,
+            [gl.R8]: SAMPLER_TYPES.FLOAT,
+            [gl.R8_SNORM]: SAMPLER_TYPES.FLOAT,
+            [gl.RG8]: SAMPLER_TYPES.FLOAT,
+            [gl.RG8_SNORM]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB8]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB8_SNORM]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB565]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA4]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB5_A1]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA8]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA8_SNORM]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB10_A2]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB10_A2UI]: SAMPLER_TYPES.FLOAT,
+            [gl.SRGB8]: SAMPLER_TYPES.FLOAT,
+            [gl.SRGB8_ALPHA8]: SAMPLER_TYPES.FLOAT,
+            [gl.R16F]: SAMPLER_TYPES.FLOAT,
+            [gl.RG16F]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB16F]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA16F]: SAMPLER_TYPES.FLOAT,
+            [gl.R32F]: SAMPLER_TYPES.FLOAT,
+            [gl.RG32F]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB32F]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA32F]: SAMPLER_TYPES.FLOAT,
+            [gl.R11F_G11F_B10F]: SAMPLER_TYPES.FLOAT,
+            [gl.RGB9_E5]: SAMPLER_TYPES.FLOAT,
+            [gl.R8I]: SAMPLER_TYPES.INT,
+            [gl.R8UI]: SAMPLER_TYPES.UINT,
+            [gl.R16I]: SAMPLER_TYPES.INT,
+            [gl.R16UI]: SAMPLER_TYPES.UINT,
+            [gl.R32I]: SAMPLER_TYPES.INT,
+            [gl.R32UI]: SAMPLER_TYPES.UINT,
+            [gl.RG8I]: SAMPLER_TYPES.INT,
+            [gl.RG8UI]: SAMPLER_TYPES.UINT,
+            [gl.RG16I]: SAMPLER_TYPES.INT,
+            [gl.RG16UI]: SAMPLER_TYPES.UINT,
+            [gl.RG32I]: SAMPLER_TYPES.INT,
+            [gl.RG32UI]: SAMPLER_TYPES.UINT,
+            [gl.RGB8I]: SAMPLER_TYPES.INT,
+            [gl.RGB8UI]: SAMPLER_TYPES.UINT,
+            [gl.RGB16I]: SAMPLER_TYPES.INT,
+            [gl.RGB16UI]: SAMPLER_TYPES.UINT,
+            [gl.RGB32I]: SAMPLER_TYPES.INT,
+            [gl.RGB32UI]: SAMPLER_TYPES.UINT,
+            [gl.RGBA8I]: SAMPLER_TYPES.INT,
+            [gl.RGBA8UI]: SAMPLER_TYPES.UINT,
+            [gl.RGBA16I]: SAMPLER_TYPES.INT,
+            [gl.RGBA16UI]: SAMPLER_TYPES.UINT,
+            [gl.RGBA32I]: SAMPLER_TYPES.INT,
+            [gl.RGBA32UI]: SAMPLER_TYPES.UINT,
+            [gl.DEPTH_COMPONENT16]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH_COMPONENT24]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH_COMPONENT32F]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH_STENCIL]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH24_STENCIL8]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH32F_STENCIL8]: SAMPLER_TYPES.FLOAT,
+        };
+    }
+    else
+    {
+        table = {
+            [gl.RGB]: SAMPLER_TYPES.FLOAT,
+            [gl.RGBA]: SAMPLER_TYPES.FLOAT,
+            [gl.ALPHA]: SAMPLER_TYPES.FLOAT,
+            [gl.LUMINANCE]: SAMPLER_TYPES.FLOAT,
+            [gl.LUMINANCE_ALPHA]: SAMPLER_TYPES.FLOAT,
+            [gl.DEPTH_STENCIL]: SAMPLER_TYPES.FLOAT,
+        };
+    }
+
+    return table;
+}

--- a/packages/core/src/textures/utils/mapInternalFormatToSamplerType.ts
+++ b/packages/core/src/textures/utils/mapInternalFormatToSamplerType.ts
@@ -9,7 +9,7 @@ import { SAMPLER_TYPES } from '@pixi/constants';
  * @returns Lookup table.
  */
 export function mapInternalFormatToSamplerType(gl: WebGLRenderingContextBase):
-{ [internalFormat: number]: SAMPLER_TYPES }
+Record<number, SAMPLER_TYPES>
 {
     let table;
 

--- a/packages/core/test/TextureSystem.tests.ts
+++ b/packages/core/test/TextureSystem.tests.ts
@@ -1,4 +1,4 @@
-import { FORMATS, SAMPLER_TYPES, TYPES, WRAP_MODES } from '@pixi/constants';
+import { FORMATS, TYPES, WRAP_MODES } from '@pixi/constants';
 import { BaseTexture, Renderer, Texture } from '@pixi/core';
 
 describe('TextureSystem', () =>
@@ -93,26 +93,19 @@ describe('TextureSystem', () =>
 
     function createIntegerTexture()
     {
-        // @ts-expect-error ---
-        const baseTexture = BaseTexture.fromBuffer(new Uint32Array([0, 0, 0, 0]), 1, 1);
-        const oldUpload = baseTexture.resource.upload.bind(baseTexture);
-
-        baseTexture.resource.upload = (renderer, baseTexture, glTexture) =>
-        {
-            glTexture.samplerType = SAMPLER_TYPES.INT;
-            if (renderer.context.webGLVersion === 2)
-            {
-                glTexture.internalFormat = renderer.context['gl'].RGBA32I;
-            }
-
-            return oldUpload(renderer, baseTexture, glTexture);
-        };
-
-        return baseTexture;
+        return BaseTexture.fromBuffer(new Uint8Array([0]), 1, 1, {
+            format: FORMATS.RED_INTEGER,
+            type: TYPES.UNSIGNED_BYTE
+        });
     }
 
     it('should unbind textures with non-float samplerType for batching', () =>
     {
+        if (renderer.context.webGLVersion === 1)
+        {
+            return;
+        }
+
         const textureSystem = renderer.texture;
         const { boundTextures } = textureSystem;
         const sampleTex = createIntegerTexture();


### PR DESCRIPTION
##### Description of change

The `samplerType` shouldn't be `FLOAT` for integer textures.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
