### PR TITLE
Fix utils dependencies in assets and events

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -1,5 +1,4 @@
-import { extensions, ExtensionType } from '@pixi/core';
-import { deprecation } from '@pixi/utils';
+import { extensions, ExtensionType, utils } from '@pixi/core';
 import { BackgroundLoader } from './BackgroundLoader';
 import { Cache } from './cache/Cache';
 import { Loader } from './loader/Loader';
@@ -850,7 +849,7 @@ export class AssetsClass
     public set preferWorkers(value: boolean)
     {
         // #if _DEBUG
-        deprecation('7.2.0', 'Assets.prefersWorkers is deprecated, '
+        utils.deprecation('7.2.0', 'Assets.prefersWorkers is deprecated, '
             + 'use Assets.setPreferences({ preferWorkers: true }) instead.');
         // #endif
         this.setPreferences({ preferWorkers: value });

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -43,7 +43,6 @@
   },
   "peerDependencies": {
     "@pixi/core": "file:../core",
-    "@pixi/display": "file:../display",
-    "@pixi/utils": "file:../utils"
+    "@pixi/display": "file:../display"
   }
 }

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -1,9 +1,8 @@
+import { utils } from '@pixi/core';
 import { DisplayObject } from '@pixi/display';
-import { deprecation } from '@pixi/utils';
 import { EventSystem } from './EventSystem';
 import { FederatedEvent } from './FederatedEvent';
 
-import type { utils } from '@pixi/core';
 import type { AllFederatedEventMap } from './FederatedEventMap';
 import type { FederatedPointerEvent } from './FederatedPointerEvent';
 import type { FederatedWheelEvent } from './FederatedWheelEvent';
@@ -585,7 +584,7 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
     set interactive(value: boolean)
     {
         // #if _DEBUG
-        deprecation(
+        utils.deprecation(
             '7.2.0',
             // eslint-disable-next-line max-len
             `Setting interactive is deprecated, use eventMode = 'none'/'passive'/'auto'/'static'/'dynamic' instead.`


### PR DESCRIPTION
* Fix `@pixi/utils` shouldn't be included in assets or events. These were likely added recently due to deprecation auto-import.

cc @miltoncandelero 