### PR TITLE
Create a `DEPTH_STENCIL` buffer only if depth is enabled

### DIFF
--- a/packages/core/src/framebuffer/GLFramebuffer.ts
+++ b/packages/core/src/framebuffer/GLFramebuffer.ts
@@ -11,7 +11,7 @@ export class GLFramebuffer
     /** The WebGL framebuffer. */
     public framebuffer: WebGLFramebuffer;
 
-    /** Stencil+depth , usually costs 32bits per pixel. */
+    /** The renderbuffer for depth and/or stencil (DEPTH24_STENCIL8, DEPTH_COMPONENT24, or STENCIL_INDEX8) */
     public stencil: WebGLRenderbuffer;
 
     /** Detected AA samples number. */


### PR DESCRIPTION
##### Description of change

I don't have a benchmark, but I assume that should be more efficient.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
