### PR TITLE
Default to the renderer's resolution/multisample in `generateTexture`

### DIFF
--- a/packages/canvas-renderer/src/CanvasRenderer.ts
+++ b/packages/canvas-renderer/src/CanvasRenderer.ts
@@ -218,12 +218,11 @@ export class CanvasRenderer extends SystemManager<CanvasRenderer> implements IRe
      * Useful function that returns a texture of the display object that can then be used to create sprites
      * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
      * @param displayObject - The displayObject the object will be generated from.
-     * @param {object} options - Generate texture options.
-     * @param {PIXI.SCALE_MODES} options.scaleMode - The scale mode of the texture.
-     * @param {number} options.resolution - The resolution / device pixel ratio of the texture being generated.
+     * @param {IGenerateTextureOptions} options - Generate texture options.
      * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
      *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @param {PIXI.MSAA_QUALITY} options.multisample - The number of samples of the frame buffer.
+     * @param {number} [options.resolution] - If not given, the renderer's resolution is used.
+     * @param {PIXI.MSAA_QUALITY} [options.multisample] - If not given, the renderer's multisample is used.
      * @returns A texture of the graphics object.
      */
     generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture

--- a/packages/core/src/IRenderer.ts
+++ b/packages/core/src/IRenderer.ts
@@ -1,4 +1,4 @@
-import type { RENDERER_TYPE } from '@pixi/constants';
+import type { MSAA_QUALITY, RENDERER_TYPE } from '@pixi/constants';
 import type { Matrix, Rectangle, Transform } from '@pixi/math';
 import type { ICanvas } from '@pixi/settings';
 import type { IRendererPlugins } from './plugin/PluginSystem';
@@ -145,6 +145,8 @@ export interface IRenderer<VIEW extends ICanvas = ICanvas> extends SystemManager
     readonly renderingToScreen: boolean
     /** The resolution / device pixel ratio of the renderer. */
     resolution: number
+    /** The number of MSAA samples of the renderer. */
+    multisample?: MSAA_QUALITY
     /** the width of the screen */
     readonly width: number
     /** the height of the screen */

--- a/packages/core/src/Renderer.ts
+++ b/packages/core/src/Renderer.ts
@@ -618,12 +618,11 @@ export class Renderer extends SystemManager<Renderer> implements IRenderer
      * Useful function that returns a texture of the display object that can then be used to create sprites
      * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
      * @param displayObject - The displayObject the object will be generated from.
-     * @param {object} options - Generate texture options.
-     * @param {PIXI.SCALE_MODES} options.scaleMode - The scale mode of the texture.
-     * @param {number} options.resolution - The resolution / device pixel ratio of the texture being generated.
+     * @param {IGenerateTextureOptions} options - Generate texture options.
      * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
      *        if no region is specified, defaults to the local bounds of the displayObject.
-     * @param {PIXI.MSAA_QUALITY} options.multisample - The number of samples of the frame buffer.
+     * @param {number} [options.resolution] - If not given, the renderer's resolution is used.
+     * @param {PIXI.MSAA_QUALITY} [options.multisample] - If not given, the renderer's multisample is used.
      * @returns A texture of the graphics object.
      */
     generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture

--- a/packages/core/src/renderTexture/GenerateTextureSystem.ts
+++ b/packages/core/src/renderTexture/GenerateTextureSystem.ts
@@ -73,6 +73,8 @@ export class GenerateTextureSystem implements ISystem
             {
                 width: region.width,
                 height: region.height,
+                resolution: this.renderer.resolution,
+                multisample: this.renderer.multisample,
                 ...textureOptions,
             });
 

--- a/packages/core/src/renderTexture/GenerateTextureSystem.ts
+++ b/packages/core/src/renderTexture/GenerateTextureSystem.ts
@@ -57,6 +57,10 @@ export class GenerateTextureSystem implements ISystem
      * This can be quite useful if your displayObject is complicated and needs to be reused multiple times.
      * @param displayObject - The displayObject the object will be generated from.
      * @param {IGenerateTextureOptions} options - Generate texture options.
+     * @param {PIXI.Rectangle} options.region - The region of the displayObject, that shall be rendered,
+     *        if no region is specified, defaults to the local bounds of the displayObject.
+     * @param {number} [options.resolution] - If not given, the renderer's resolution is used.
+     * @param {PIXI.MSAA_QUALITY} [options.multisample] - If not given, the renderer's multisample is used.
      * @returns a shiny new texture of the display object passed in
      */
     generateTexture(displayObject: IRenderableObject, options?: IGenerateTextureOptions): RenderTexture

--- a/packages/core/src/renderTexture/GenerateTextureSystem.ts
+++ b/packages/core/src/renderTexture/GenerateTextureSystem.ts
@@ -2,27 +2,26 @@ import { extensions, ExtensionType } from '@pixi/extensions';
 import { Matrix, Transform } from '@pixi/math';
 import { RenderTexture } from './RenderTexture';
 
-import type { MSAA_QUALITY, SCALE_MODES } from '@pixi/constants';
+import type { MSAA_QUALITY } from '@pixi/constants';
 import type { ExtensionMetadata } from '@pixi/extensions';
 import type { Rectangle } from '@pixi/math';
 import type { IRenderableContainer, IRenderableObject, IRenderer } from '../IRenderer';
 import type { ISystem } from '../system/ISystem';
+import type { IBaseTextureOptions } from '../textures/BaseTexture';
 
 const tempTransform = new Transform();
 
 // TODO could this just be part of extract?
-export interface IGenerateTextureOptions
+export interface IGenerateTextureOptions extends IBaseTextureOptions
 {
-    /** The scale mode of the texture. Optional, defaults to `PIXI.BaseTexture.defaultOptions.scaleMode`. */
-    scaleMode?: SCALE_MODES;
-    /** The resolution / device pixel ratio of the texture being generated. Optional defaults to Renderer resolution. */
-    resolution?: number;
     /**
      * The region of the displayObject, that shall be rendered,
      * if no region is specified, defaults to the local bounds of the displayObject.
      */
     region?: Rectangle;
-    /** The number of samples of the frame buffer. */
+    /** The resolution / device pixel ratio of the texture being generated. The default is the renderer's resolution. */
+    resolution?: number;
+    /** The number of samples of the frame buffer. The default is the renderer's multisample. */
     multisample?: MSAA_QUALITY;
 }
 


### PR DESCRIPTION
##### Description of change

`Extract` uses the renderer's resolution and multisample. I think `extract.pixels(generateTexture(object))` and `extract.pixels(object)` should give the same result.

`IGenerateTextureOptions.resolution` already made the claim that it defaults to the renderer's resolution, but that wasn't the case (`PIXI.settings.RESOLUTION` was the default):
>   The resolution / device pixel ratio of the texture being generated. Optional defaults to Renderer resolution.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
