### PR TITLE
Add public `Framebuffer.depth` and `Framebuffer.stencil` properties

### DIFF
--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -14,10 +14,16 @@ import type { GLFramebuffer } from './GLFramebuffer';
  */
 export class Framebuffer
 {
-    /** Width of framebuffer in pixels. */
+    /**
+     * Width of the framebuffer in pixels.
+     * @readonly
+     */
     public width: number;
 
-    /** Height of framebuffer in pixels. */
+    /**
+     * Height of the framebuffer in pixels.
+     * @readonly
+     */
     public height: number;
 
     /**

--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -37,8 +37,8 @@ export class Framebuffer
      */
     public multisample: MSAA_QUALITY;
 
-    stencil: boolean;
-    depth: boolean;
+    _stencil: boolean;
+    _depth: boolean;
     dirtyId: number;
     dirtyFormat: number;
     dirtySize: number;
@@ -56,8 +56,8 @@ export class Framebuffer
         this.width = Math.round(width || 100);
         this.height = Math.round(height || 100);
 
-        this.stencil = false;
-        this.depth = false;
+        this._stencil = false;
+        this._depth = false;
 
         this.dirtyId = 0;
         this.dirtyFormat = 0;
@@ -126,24 +126,54 @@ export class Framebuffer
         return this;
     }
 
+    /** Does this framebuffer need/have a depth buffer? */
+    get depth(): boolean
+    {
+        return this._depth;
+    }
+
+    set depth(value: boolean)
+    {
+        if (this._depth === value)
+        {
+            return;
+        }
+
+        this._depth = value;
+        this.dirtyId++;
+        this.dirtyFormat++;
+    }
+
     /** Enable depth on the frame buffer. */
     enableDepth(): this
     {
         this.depth = true;
 
+        return this;
+    }
+
+    /** Does this framebuffer need/have a depth buffer? */
+    get stencil(): boolean
+    {
+        return this._stencil;
+    }
+
+    set stencil(value: boolean)
+    {
+        if (this._stencil === value)
+        {
+            return;
+        }
+
+        this._stencil = value;
         this.dirtyId++;
         this.dirtyFormat++;
-
-        return this;
     }
 
     /** Enable stencil on the frame buffer. */
     enableStencil(): this
     {
         this.stencil = true;
-
-        this.dirtyId++;
-        this.dirtyFormat++;
 
         return this;
     }

--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -158,7 +158,7 @@ export class Framebuffer
         return this;
     }
 
-    /** Does this framebuffer need/have a depth buffer? */
+    /** Does this framebuffer need/have a stencil buffer? */
     get stencil(): boolean
     {
         return this._stencil;

--- a/packages/core/src/framebuffer/FramebufferSystem.ts
+++ b/packages/core/src/framebuffer/FramebufferSystem.ts
@@ -671,7 +671,7 @@ export class FramebufferSystem implements ISystem
             return;
         }
 
-        framebuffer.stencil = true;
+        framebuffer._stencil = true;
 
         const w = framebuffer.width;
         const h = framebuffer.height;


### PR DESCRIPTION
##### Description of change

I thought it might be useful if these properties are publicly accessible and can be changed with the framebuffer automatically updating.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
