### PR TITLE
Premultiply clear color if render target has premultiplied alpha

### DIFF
--- a/packages/core/test/RenderTexture.tests.ts
+++ b/packages/core/test/RenderTexture.tests.ts
@@ -55,7 +55,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -90,7 +90,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -130,7 +130,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 2, height: 2 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -179,7 +179,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -221,7 +221,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 2, height: 2 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -275,7 +275,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -309,7 +309,7 @@ describe('RenderTexture', () =>
 
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
-        renderTexture.baseTexture.clearColor = [0.2, 0.2, 0.2, 0.2];
+        renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.2];
 
         const framebuffer = renderTexture.framebuffer;
 
@@ -353,7 +353,7 @@ describe('RenderTexture', () =>
 
             const renderTexture = RenderTexture.create({ width: 2, height: 2, format: FORMATS.RED, type: TYPES.FLOAT });
 
-            renderTexture.baseTexture.clearColor = [0.5, 0.5, 0.5, 0.5];
+            renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.5];
 
             const framebuffer = renderTexture.framebuffer;
 
@@ -401,7 +401,7 @@ describe('RenderTexture', () =>
 
             const renderTexture = RenderTexture.create({ width: 1, height: 1, format: FORMATS.RED, type: TYPES.FLOAT });
 
-            renderTexture.baseTexture.clearColor = [0.5, 0.5, 0.5, 0.5];
+            renderTexture.baseTexture.clearColor = [1.0, 1.0, 1.0, 0.5];
 
             const framebuffer = renderTexture.framebuffer;
 

--- a/packages/core/test/RenderTextureSystem.tests.ts
+++ b/packages/core/test/RenderTextureSystem.tests.ts
@@ -1,4 +1,4 @@
-import { Renderer } from '@pixi/core';
+import { ALPHA_MODES, Renderer, RenderTexture } from '@pixi/core';
 import { Rectangle } from '@pixi/math';
 
 describe('RenderTextureSystem', () =>
@@ -52,5 +52,133 @@ describe('RenderTextureSystem', () =>
         expect(sourceFrame.y).toEqual(renderTextureSystem.sourceFrame.y);
         expect(sourceFrame.width).toEqual(renderTextureSystem.sourceFrame.width);
         expect(sourceFrame.height).toEqual(renderTextureSystem.sourceFrame.height);
+    });
+
+    it('should clear renderer (alpha=false) correctly', () =>
+    {
+        const renderer = new Renderer({
+            width: 1,
+            height: 1,
+            backgroundColor: 0xFF0000
+        });
+
+        renderer.renderTexture.bind();
+        renderer.renderTexture.clear();
+
+        const gl = renderer.gl;
+        const pixel = new Uint8Array(4);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+        expect(pixel[0]).toBe(255);
+        expect(pixel[1]).toBe(0);
+        expect(pixel[2]).toBe(0);
+        expect(pixel[3]).toBe(255);
+
+        renderer.destroy();
+    });
+
+    it('should clear renderer (alpha=true, premultipliedAlpha=false) correctly', () =>
+    {
+        const renderer = new Renderer({
+            width: 1,
+            height: 1,
+            backgroundColor: 0xFF0000,
+            backgroundAlpha: 0.4,
+            premultipliedAlpha: false
+        });
+
+        renderer.renderTexture.bind();
+        renderer.renderTexture.clear();
+
+        const gl = renderer.gl;
+        const pixel = new Uint8Array(4);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+        expect(pixel[0]).toBe(255);
+        expect(pixel[1]).toBe(0);
+        expect(pixel[2]).toBe(0);
+        expect(pixel[3]).toBe(102);
+
+        renderer.destroy();
+    });
+
+    it('should clear renderer (alpha=true, premultipliedAlpha=true) correctly', () =>
+    {
+        const renderer = new Renderer({
+            width: 1,
+            height: 1,
+            backgroundColor: 0xFF0000,
+            backgroundAlpha: 0.4,
+            premultipliedAlpha: true
+        });
+
+        renderer.renderTexture.bind();
+        renderer.renderTexture.clear();
+
+        const gl = renderer.gl;
+        const pixel = new Uint8Array(4);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+        expect(pixel[0]).toBe(102);
+        expect(pixel[1]).toBe(0);
+        expect(pixel[2]).toBe(0);
+        expect(pixel[3]).toBe(102);
+
+        renderer.destroy();
+    });
+
+    it('should clear render texture (NPM) correctly', () =>
+    {
+        const renderer = new Renderer();
+        const renderTexture = RenderTexture.create({
+            width: 1,
+            height: 1,
+            alphaMode: ALPHA_MODES.NPM
+        });
+
+        renderTexture.baseTexture.clearColor = 'rgba(255, 0, 0, 0.4)';
+        renderer.renderTexture.bind(renderTexture);
+        renderer.renderTexture.clear();
+
+        const gl = renderer.gl;
+        const pixel = new Uint8Array(4);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+        expect(pixel[0]).toBe(255);
+        expect(pixel[1]).toBe(0);
+        expect(pixel[2]).toBe(0);
+        expect(pixel[3]).toBe(102);
+
+        renderer.destroy();
+    });
+
+    it('should clear render texture (PMA/UNPACK) correctly', () =>
+    {
+        const renderer = new Renderer();
+        const renderTexture = RenderTexture.create({
+            width: 1,
+            height: 1,
+            alphaMode: ALPHA_MODES.PMA
+        });
+
+        renderTexture.baseTexture.clearColor = 'rgba(255, 0, 0, 0.4)';
+        renderer.renderTexture.bind(renderTexture);
+        renderer.renderTexture.clear();
+
+        const gl = renderer.gl;
+        const pixel = new Uint8Array(4);
+
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+
+        expect(pixel[0]).toBe(102);
+        expect(pixel[1]).toBe(0);
+        expect(pixel[2]).toBe(0);
+        expect(pixel[3]).toBe(102);
+
+        renderer.destroy();
     });
 });


### PR DESCRIPTION
##### Description of change

Fixed: Clear color is not premultiplied if `premultipliedAlpha`/`PMA`.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
