### PR TITLE
Add `BaseRenderTexture.multisample`

### DIFF
--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -124,6 +124,20 @@ export class BaseRenderTexture extends BaseTexture
     }
 
     /**
+     * Shortcut to `this.framebuffer.multisample`.
+     * @default PIXI.MSAA_QUALITY.NONE
+     */
+    get multisample(): MSAA_QUALITY
+    {
+        return this.framebuffer.multisample;
+    }
+
+    set multisample(value: MSAA_QUALITY)
+    {
+        this.framebuffer.multisample = value;
+    }
+
+    /**
      * Resizes the BaseRenderTexture.
      * @param desiredWidth - The desired width to resize to.
      * @param desiredHeight - The desired height to resize to.

--- a/packages/core/src/renderTexture/BaseRenderTexture.ts
+++ b/packages/core/src/renderTexture/BaseRenderTexture.ts
@@ -45,6 +45,11 @@ export interface BaseRenderTexture extends GlobalMixins.BaseRenderTexture, BaseT
 export class BaseRenderTexture extends BaseTexture
 {
     public _clear: Color;
+
+    /**
+     * The framebuffer of this base texture.
+     * @readonly
+     */
     public framebuffer: Framebuffer;
 
     /** The data structure for the stencil masks. */


### PR DESCRIPTION
##### Description of change

Fixed `BaseRenderTexture.framebuffer` not showing up in the docs too.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
