### PR TITLE
Flip pixels in `Extract.pixels` if extracted from the renderer

### DIFF
--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -17,6 +17,49 @@ describe('CanvasExtract', () =>
         renderer.destroy();
     });
 
+    it('should extract the same pixels', async () =>
+    {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
+        const expectedPixels = new Uint8ClampedArray([
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            255, 255, 0, 255
+        ]);
+        const renderTexture = renderer.generateTexture(graphics);
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const pixelsRenderer = extract.pixels();
+        const pixelsRenderTexture = extract.pixels(renderTexture);
+        const pixelsGraphics = extract.pixels(graphics);
+
+        expect(pixelsRenderer).toEqual(expectedPixels);
+        expect(pixelsRenderTexture).toEqual(expectedPixels);
+        expect(pixelsGraphics).toEqual(expectedPixels);
+
+        renderTexture.destroy(true);
+        graphics.destroy();
+        renderer.destroy();
+    });
+
     it('should extract pixels from renderer correctly', async () =>
     {
         const renderer = new CanvasRenderer({ width: 2, height: 2 });

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -168,7 +168,12 @@ export class Extract implements ISystem, IExtract
      */
     public pixels(target?: DisplayObject | RenderTexture, frame?: Rectangle): Uint8Array
     {
-        const { pixels } = this._rawPixels(target, frame);
+        const { pixels, width, height, flipY } = this._rawPixels(target, frame);
+
+        if (flipY)
+        {
+            Extract._flipY(pixels, width, height);
+        }
 
         Extract._unpremultiplyAlpha(pixels);
 

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -1,5 +1,6 @@
 import { ALPHA_MODES, FORMATS, MSAA_QUALITY, Rectangle, Renderer, RenderTexture, Texture, TYPES } from '@pixi/core';
 import { Extract } from '@pixi/extract';
+import { Graphics } from '@pixi/graphics';
 import { Sprite } from '@pixi/sprite';
 
 describe('Extract', () =>
@@ -14,7 +15,47 @@ describe('Extract', () =>
         renderer.destroy();
     });
 
-    it('should extract pixels from renderer correctly (without y-flipping)', async () =>
+    it('should extract the same pixels', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const graphics = new Graphics()
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
+        const expectedPixels = new Uint8Array([
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            255, 255, 0, 255
+        ]);
+        const renderTexture = renderer.generateTexture(graphics);
+        const extract = renderer.extract;
+
+        renderer.render(graphics);
+
+        const pixelsRenderer = extract.pixels();
+        const pixelsRenderTexture = extract.pixels(renderTexture);
+        const pixelsGraphics = extract.pixels(graphics);
+
+        expect(pixelsRenderer).toEqual(expectedPixels);
+        expect(pixelsRenderTexture).toEqual(expectedPixels);
+        expect(pixelsGraphics).toEqual(expectedPixels);
+
+        renderTexture.destroy(true);
+        graphics.destroy();
+        renderer.destroy();
+    });
+
+    it('should extract pixels from renderer correctly', async () =>
     {
         const renderer = new Renderer({ width: 2, height: 2 });
         const texturePixels = new Uint8Array([
@@ -36,8 +77,8 @@ describe('Extract', () =>
         const extractedPixels = extract.pixels();
 
         expect(extractedPixels).toEqual(new Uint8Array([
-            0, 0, 102, 255, 51, 51, 0, 255,
-            255, 0, 0, 255, 0, 153, 0, 255
+            255, 0, 0, 255, 0, 153, 0, 255,
+            0, 0, 102, 255, 51, 51, 0, 255
         ]));
 
         texture.destroy(true);
@@ -45,7 +86,7 @@ describe('Extract', () =>
         renderer.destroy();
     });
 
-    it('should extract canvas from renderer correctly (with y-flipping)', async () =>
+    it('should extract canvas from renderer correctly', async () =>
     {
         const renderer = new Renderer({ width: 2, height: 2 });
         const texturePixels = new Uint8Array([


### PR DESCRIPTION
##### Description of change

`Extract.pixels` does not y-flip the pixels currently, which means that the pixels are returned in the wrong orientation if extracted from the renderer. We should always receive the same pixels whether we extract from the display object, extract from a render texture the object was rendered to, or extract from the renderer the object was rendered to. `CanvasExtract.pixels` already passes the included test.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
