### PR TITLE
Add generic type variable for ParticleContainer

### DIFF
--- a/packages/particle-container/src/ParticleContainer.ts
+++ b/packages/particle-container/src/ParticleContainer.ts
@@ -40,7 +40,7 @@ export interface IParticleProperties
  * }
  * @memberof PIXI
  */
-export class ParticleContainer extends Container<Sprite>
+export class ParticleContainer<T extends Sprite = Sprite> extends Container<T>
 {
     /**
      * The blend mode to be applied to the sprite. Apply a value of `PIXI.BLEND_MODES.NORMAL`


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Replace `class ParticleContainer extends Container<Sprite>` with `class ParticleContainer<T extends Sprite = Sprite> extends Container<T>`, so that users can specify the type of `ParticleContainer`'s children.

Closes #9348.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
