### PR TITLE
Generate frame-sized render texture for extraction

### DIFF
--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -140,8 +140,10 @@ export class CanvasExtract implements ISystem, IExtract
             else
             {
                 renderTexture = renderer.generateTexture(target, {
+                    region: frame,
                     resolution: renderer.resolution
                 });
+                frame = undefined;
             }
         }
 
@@ -208,8 +210,10 @@ export class CanvasExtract implements ISystem, IExtract
             else
             {
                 renderTexture = renderer.generateTexture(target, {
+                    region: frame,
                     resolution: renderer.resolution
                 });
+                frame = undefined;
             }
         }
 

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -178,7 +178,7 @@ export class CanvasExtract implements ISystem, IExtract
         const height = Math.round(frame.height * resolution);
 
         const canvasBuffer = new utils.CanvasRenderTarget(width, height, 1);
-        const canvasData = context.getImageData(x, y, width, height);
+        const canvasData = context.getImageData(x, y, width || 1, height || 1);
 
         canvasBuffer.context.putImageData(canvasData, 0, 0);
 
@@ -253,7 +253,7 @@ export class CanvasExtract implements ISystem, IExtract
         const width = Math.round(frame.width * resolution);
         const height = Math.round(frame.height * resolution);
 
-        return context.getImageData(x, y, width, height).data;
+        return context.getImageData(x, y, width || 1, height || 1).data.subarray(0, 4 * width * height);
     }
 
     /** Destroys the extract */

--- a/packages/canvas-extract/src/CanvasExtract.ts
+++ b/packages/canvas-extract/src/CanvasExtract.ts
@@ -143,7 +143,13 @@ export class CanvasExtract implements ISystem, IExtract
                     region: frame,
                     resolution: renderer.resolution
                 });
-                frame = undefined;
+
+                if (frame)
+                {
+                    TEMP_RECT.width = frame.width;
+                    TEMP_RECT.height = frame.height;
+                    frame = TEMP_RECT;
+                }
             }
         }
 
@@ -213,7 +219,13 @@ export class CanvasExtract implements ISystem, IExtract
                     region: frame,
                     resolution: renderer.resolution
                 });
-                frame = undefined;
+
+                if (frame)
+                {
+                    TEMP_RECT.width = frame.width;
+                    TEMP_RECT.height = frame.height;
+                    frame = TEMP_RECT;
+                }
             }
         }
 

--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -1,7 +1,7 @@
 import { CanvasExtract } from '@pixi/canvas-extract';
 import { CanvasGraphicsRenderer } from '@pixi/canvas-graphics';
 import { CanvasRenderer } from '@pixi/canvas-renderer';
-import { RenderTexture, Texture } from '@pixi/core';
+import { Rectangle, RenderTexture, Texture } from '@pixi/core';
 import { Graphics } from '@pixi/graphics';
 import { Sprite } from '@pixi/sprite';
 import '@pixi/canvas-display';
@@ -401,5 +401,45 @@ describe('CanvasExtract', () =>
         renderer.destroy();
         renderTexture.destroy();
         sprite.destroy();
+    });
+
+    it('should extract from object with frame correctly', async () =>
+    {
+        const renderer = new CanvasRenderer({ width: 2, height: 2 });
+
+        renderer.plugins.graphics = new CanvasGraphicsRenderer(renderer);
+
+        const graphics = new Graphics()
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
+        const extract = renderer.extract;
+
+        const pixels = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixels00 = extract.pixels(graphics, new Rectangle(0, 0, 1, 1));
+        const pixels10 = extract.pixels(graphics, new Rectangle(1, 0, 1, 1));
+        const pixels01 = extract.pixels(graphics, new Rectangle(0, 1, 1, 1));
+        const pixels11 = extract.pixels(graphics, new Rectangle(1, 1, 1, 1));
+
+        expect(pixels).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+        expect(pixels00).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+        expect(pixels10).toEqual(new Uint8ClampedArray([0, 255, 0, 255]));
+        expect(pixels01).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));
+        expect(pixels11).toEqual(new Uint8ClampedArray([255, 255, 0, 255]));
+
+        graphics.destroy();
+        renderer.destroy();
     });
 });

--- a/packages/canvas-extract/test/CanvasExtract.tests.ts
+++ b/packages/canvas-extract/test/CanvasExtract.tests.ts
@@ -424,16 +424,18 @@ describe('CanvasExtract', () =>
             .endFill();
         const extract = renderer.extract;
 
-        const pixels = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixelsA = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixelsB = extract.pixels(graphics, new Rectangle(0, 0, 0, 0));
         const pixels00 = extract.pixels(graphics, new Rectangle(0, 0, 1, 1));
         const pixels10 = extract.pixels(graphics, new Rectangle(1, 0, 1, 1));
         const pixels01 = extract.pixels(graphics, new Rectangle(0, 1, 1, 1));
         const pixels11 = extract.pixels(graphics, new Rectangle(1, 1, 1, 1));
 
-        expect(pixels).toEqual(new Uint8ClampedArray([
+        expect(pixelsA).toEqual(new Uint8ClampedArray([
             255, 0, 0, 255, 0, 255, 0, 255,
             0, 0, 255, 255, 255, 255, 0, 255
         ]));
+        expect(pixelsB).toEqual(new Uint8ClampedArray([]));
         expect(pixels00).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
         expect(pixels10).toEqual(new Uint8ClampedArray([0, 255, 0, 255]));
         expect(pixels01).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));

--- a/packages/core/src/renderTexture/GenerateTextureSystem.ts
+++ b/packages/core/src/renderTexture/GenerateTextureSystem.ts
@@ -1,14 +1,14 @@
 import { extensions, ExtensionType } from '@pixi/extensions';
-import { Matrix, Transform } from '@pixi/math';
+import { Matrix, Rectangle, Transform } from '@pixi/math';
 import { RenderTexture } from './RenderTexture';
 
 import type { MSAA_QUALITY, SCALE_MODES } from '@pixi/constants';
 import type { ExtensionMetadata } from '@pixi/extensions';
-import type { Rectangle } from '@pixi/math';
 import type { IRenderableContainer, IRenderableObject, IRenderer } from '../IRenderer';
 import type { ISystem } from '../system/ISystem';
 
 const tempTransform = new Transform();
+const tempRect = new Rectangle();
 
 // TODO could this just be part of extract?
 export interface IGenerateTextureOptions
@@ -63,7 +63,8 @@ export class GenerateTextureSystem implements ISystem
     {
         const { region: manualRegion, ...textureOptions } = options || {};
 
-        const region = manualRegion || (displayObject as IRenderableContainer).getLocalBounds(null, true);
+        const region = manualRegion?.copyTo(tempRect)
+            || (displayObject as IRenderableContainer).getLocalBounds(tempRect, true);
 
         // minimum texture size is 1x1, 0x0 will throw an error
         if (region.width === 0) region.width = 1;

--- a/packages/core/test/GenerateTextureSystem.tests.ts
+++ b/packages/core/test/GenerateTextureSystem.tests.ts
@@ -1,4 +1,4 @@
-import { Renderer } from '@pixi/core';
+import { Rectangle, Renderer } from '@pixi/core';
 import { Sprite } from '@pixi/sprite';
 
 describe('GenerateTextureSystem', () =>
@@ -10,6 +10,22 @@ describe('GenerateTextureSystem', () =>
         const renderTexture = renderer.generateTexture(sprite);
 
         expect(renderer.renderTexture.current).toBe(renderTexture);
+
+        renderTexture.destroy(true);
+        renderer.destroy();
+    });
+
+    it('should not mutate region argument', () =>
+    {
+        const renderer = new Renderer();
+        const sprite = new Sprite();
+        const region = new Rectangle(0.3, 0.2, 0.1, 0);
+        const renderTexture = renderer.generateTexture(sprite, { region });
+
+        expect(region.x).toBe(0.3);
+        expect(region.y).toBe(0.2);
+        expect(region.width).toBe(0.1);
+        expect(region.height).toBe(0);
 
         renderTexture.destroy(true);
         renderer.destroy();

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -213,10 +213,16 @@ export class Extract implements ISystem, IExtract
                 renderTexture = renderer.generateTexture(target, {
                     region: frame,
                     resolution: renderer.resolution,
-                    multisample: renderer.multisample,
+                    multisample: renderer.multisample
                 });
-                frame = undefined;
                 generated = true;
+
+                if (frame)
+                {
+                    TEMP_RECT.width = frame.width;
+                    TEMP_RECT.height = frame.height;
+                    frame = TEMP_RECT;
+                }
             }
         }
 

--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -211,9 +211,11 @@ export class Extract implements ISystem, IExtract
             else
             {
                 renderTexture = renderer.generateTexture(target, {
+                    region: frame,
                     resolution: renderer.resolution,
-                    multisample: renderer.multisample
+                    multisample: renderer.multisample,
                 });
+                frame = undefined;
                 generated = true;
             }
         }

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -336,16 +336,18 @@ describe('Extract', () =>
             .endFill();
         const extract = renderer.extract;
 
-        const pixels = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixelsA = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixelsB = extract.pixels(graphics, new Rectangle(0, 0, 0, 0));
         const pixels00 = extract.pixels(graphics, new Rectangle(0, 0, 1, 1));
         const pixels10 = extract.pixels(graphics, new Rectangle(1, 0, 1, 1));
         const pixels01 = extract.pixels(graphics, new Rectangle(0, 1, 1, 1));
         const pixels11 = extract.pixels(graphics, new Rectangle(1, 1, 1, 1));
 
-        expect(pixels).toEqual(new Uint8Array([
+        expect(pixelsA).toEqual(new Uint8Array([
             255, 0, 0, 255, 0, 255, 0, 255,
             0, 0, 255, 255, 255, 255, 0, 255
         ]));
+        expect(pixelsB).toEqual(new Uint8Array([]));
         expect(pixels00).toEqual(new Uint8Array([255, 0, 0, 255]));
         expect(pixels10).toEqual(new Uint8Array([0, 255, 0, 255]));
         expect(pixels01).toEqual(new Uint8Array([0, 0, 255, 255]));

--- a/packages/extract/test/Extract.tests.ts
+++ b/packages/extract/test/Extract.tests.ts
@@ -318,6 +318,43 @@ describe('Extract', () =>
         sprite.destroy();
     });
 
+    it('should extract from object with frame correctly', async () =>
+    {
+        const renderer = new Renderer({ width: 2, height: 2 });
+        const graphics = new Graphics()
+            .beginFill(0xFF0000)
+            .drawRect(0, 0, 1, 1)
+            .endFill()
+            .beginFill(0x00FF00)
+            .drawRect(1, 0, 1, 1)
+            .endFill()
+            .beginFill(0x0000FF)
+            .drawRect(0, 1, 1, 1)
+            .endFill()
+            .beginFill(0xFFFF00)
+            .drawRect(1, 1, 1, 1)
+            .endFill();
+        const extract = renderer.extract;
+
+        const pixels = extract.pixels(graphics, new Rectangle(0, 0, 2, 2));
+        const pixels00 = extract.pixels(graphics, new Rectangle(0, 0, 1, 1));
+        const pixels10 = extract.pixels(graphics, new Rectangle(1, 0, 1, 1));
+        const pixels01 = extract.pixels(graphics, new Rectangle(0, 1, 1, 1));
+        const pixels11 = extract.pixels(graphics, new Rectangle(1, 1, 1, 1));
+
+        expect(pixels).toEqual(new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 0, 255
+        ]));
+        expect(pixels00).toEqual(new Uint8Array([255, 0, 0, 255]));
+        expect(pixels10).toEqual(new Uint8Array([0, 255, 0, 255]));
+        expect(pixels01).toEqual(new Uint8Array([0, 0, 255, 255]));
+        expect(pixels11).toEqual(new Uint8Array([255, 255, 0, 255]));
+
+        graphics.destroy();
+        renderer.destroy();
+    });
+
     it('should unpremultiply alpha correctly', () =>
     {
         const pixels1 = new Uint8Array(4);


### PR DESCRIPTION
##### Description of change

No need to make the generated render texture larger than it needs to be.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
