### PR TITLE
Add endLine() convenience method to Graphics, in parallel with endFill()

### DIFF
--- a/packages/graphics/src/Graphics.ts
+++ b/packages/graphics/src/Graphics.ts
@@ -700,6 +700,19 @@ export class Graphics extends Container
     }
 
     /**
+     * Applies a line style to the lines and shapes that were added since the last call to the lineStyle() method.
+     * @returns - This Graphics object. Good for chaining method calls
+     */
+    public endLine(): this
+    {
+        this.finishPoly();
+
+        this._lineStyle.reset();
+
+        return this;
+    }
+
+    /**
      * Draws a rectangle shape.
      * @param x - The X coord of the top-left of the rectangle
      * @param y - The Y coord of the top-left of the rectangle


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add an `endLine()` convenience method to the `Graphics` class, which parallels `endFill()`. I encounter a situation like this frequently in my project:

```js
graphics.beginFill(0xff0000, 1)
	.lineStyle(1, 0)
	.drawRect(this.x - this.w / 2, this.y - this.h / 2, this.w, this.h)
	.endFill()
	._lineStyle.reset();
```

The `._lineStyle.reset()` is certainly not very pleasing to look at compared to:

```js
graphics.beginFill(0xff00000, 1)
	.lineStyle(1, 0)
	.drawRect(this.x - this.w / 2, this.y - this.h / 2, this.w, this.h)
	.endFill()
	.endLine();
```

Which allows one to visualize the "scope" in which the `beginFill` and `lineStyle` functions apply.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
