### PR TITLE
Fix: `LineStyle.reset()` does not reset `cap`, `join`, and `miterLimit`

### DIFF
--- a/packages/graphics/src/styles/LineStyle.ts
+++ b/packages/graphics/src/styles/LineStyle.ts
@@ -64,5 +64,8 @@ export class LineStyle extends FillStyle
         this.alignment = 0.5;
         this.width = 0;
         this.native = false;
+        this.cap = LINE_CAP.BUTT;
+        this.join = LINE_JOIN.MITER;
+        this.miterLimit = 10;
     }
 }

--- a/packages/graphics/test/Graphics.tests.ts
+++ b/packages/graphics/test/Graphics.tests.ts
@@ -58,6 +58,9 @@ describe('Graphics', () =>
                 color: 0xff0000,
                 alignment: 1,
                 native: true,
+                cap: LINE_CAP.ROUND,
+                join: LINE_JOIN.ROUND,
+                miterLimit: 20,
             });
 
             expect(graphics.line.width).toEqual(1);
@@ -66,6 +69,9 @@ describe('Graphics', () =>
             expect(graphics.line.alpha).toEqual(0.5);
             expect(graphics.line.native).toEqual(true);
             expect(graphics.line.visible).toEqual(true);
+            expect(graphics.line.cap).toEqual(LINE_CAP.ROUND);
+            expect(graphics.line.join).toEqual(LINE_JOIN.ROUND);
+            expect(graphics.line.miterLimit).toEqual(20);
 
             graphics.lineStyle();
 
@@ -75,6 +81,9 @@ describe('Graphics', () =>
             expect(graphics.line.alpha).toEqual(1);
             expect(graphics.line.native).toEqual(false);
             expect(graphics.line.visible).toEqual(false);
+            expect(graphics.line.cap).toEqual(LINE_CAP.BUTT);
+            expect(graphics.line.join).toEqual(LINE_JOIN.MITER);
+            expect(graphics.line.miterLimit).toEqual(10);
 
             graphics.destroy();
         });


### PR DESCRIPTION
##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
