### PR TITLE
Use `requestVideoFrameCallback` to auto update `VideoResource` if possible

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -166,13 +166,14 @@ export class VideoResource extends BaseImageResource
         }
     }
 
-    private _videoFrameRequestCallback(_now: DOMHighResTimeStamp, _metadata: VideoFrameCallbackMetadata): void
+    private _videoFrameRequestCallback(): void
     {
         this.update();
 
         if (!this.destroyed)
         {
-            this._videoFrameRequestCallbackHandle = this.source.requestVideoFrameCallback(this._videoFrameRequestCallback);
+            this._videoFrameRequestCallbackHandle = (this.source as any).requestVideoFrameCallback(
+                this._videoFrameRequestCallback);
         }
         else
         {
@@ -363,7 +364,7 @@ export class VideoResource extends BaseImageResource
     {
         if (this._autoUpdate && this._isSourcePlaying())
         {
-            if (!this._updateFPS && this.source.requestVideoFrameCallback)
+            if (!this._updateFPS && (this.source as any).requestVideoFrameCallback)
             {
                 if (this._isConnectedToTicker)
                 {
@@ -374,7 +375,7 @@ export class VideoResource extends BaseImageResource
 
                 if (this._videoFrameRequestCallbackHandle === null)
                 {
-                    this._videoFrameRequestCallbackHandle = this.source.requestVideoFrameCallback(
+                    this._videoFrameRequestCallbackHandle = (this.source as any).requestVideoFrameCallback(
                         this._videoFrameRequestCallback);
                 }
             }
@@ -382,7 +383,7 @@ export class VideoResource extends BaseImageResource
             {
                 if (this._videoFrameRequestCallbackHandle !== null)
                 {
-                    this.source.cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
+                    (this.source as any).cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
                     this._videoFrameRequestCallbackHandle = null;
                 }
 
@@ -398,7 +399,7 @@ export class VideoResource extends BaseImageResource
         {
             if (this._videoFrameRequestCallbackHandle !== null)
             {
-                this.source.cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
+                (this.source as any).cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
                 this._videoFrameRequestCallbackHandle = null;
             }
 

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -40,6 +40,8 @@ export class VideoResource extends BaseImageResource
     protected _updateFPS: number;
     protected _msToNextUpdate: number;
 
+    private _videoFrameRequestCallbackHandle: number | null;
+
     /**
      * When set to true will automatically play videos used by this texture once
      * they are loaded. If false, it will not modify the playing state.
@@ -124,6 +126,9 @@ export class VideoResource extends BaseImageResource
         this._msToNextUpdate = 0;
         this.autoPlay = options.autoPlay !== false;
 
+        this._videoFrameRequestCallback = this._videoFrameRequestCallback.bind(this);
+        this._videoFrameRequestCallbackHandle = null;
+
         this._load = null;
         this._resolve = null;
 
@@ -145,15 +150,33 @@ export class VideoResource extends BaseImageResource
     {
         if (!this.destroyed)
         {
-            // account for if video has had its playbackRate changed
-            const elapsedMS = Ticker.shared.elapsedMS * (this.source as HTMLVideoElement).playbackRate;
+            if (this._updateFPS)
+            {
+                // account for if video has had its playbackRate changed
+                const elapsedMS = Ticker.shared.elapsedMS * (this.source as HTMLVideoElement).playbackRate;
 
-            this._msToNextUpdate = Math.floor(this._msToNextUpdate - elapsedMS);
+                this._msToNextUpdate = Math.floor(this._msToNextUpdate - elapsedMS);
+            }
+
             if (!this._updateFPS || this._msToNextUpdate <= 0)
             {
                 super.update(/* deltaTime*/);
                 this._msToNextUpdate = this._updateFPS ? Math.floor(1000 / this._updateFPS) : 0;
             }
+        }
+    }
+
+    private _videoFrameRequestCallback(_now: DOMHighResTimeStamp, _metadata: VideoFrameCallbackMetadata): void
+    {
+        this.update();
+
+        if (!this.destroyed)
+        {
+            this._videoFrameRequestCallbackHandle = this.source.requestVideoFrameCallback(this._videoFrameRequestCallback);
+        }
+        else
+        {
+            this._videoFrameRequestCallbackHandle = null;
         }
     }
 
@@ -248,21 +271,13 @@ export class VideoResource extends BaseImageResource
             this._onCanPlay();
         }
 
-        if (this.autoUpdate && !this._isConnectedToTicker)
-        {
-            Ticker.shared.add(this.update, this);
-            this._isConnectedToTicker = true;
-        }
+        this._configureAutoUpdate();
     }
 
     /** Fired when a pause event is triggered, stops the update loop. */
     private _onPlayStop(): void
     {
-        if (this._isConnectedToTicker)
-        {
-            Ticker.shared.remove(this.update, this);
-            this._isConnectedToTicker = false;
-        }
+        this._configureAutoUpdate();
     }
 
     /** Fired when the video is loaded and ready to play. */
@@ -297,11 +312,7 @@ export class VideoResource extends BaseImageResource
     /** Destroys this texture. */
     dispose(): void
     {
-        if (this._isConnectedToTicker)
-        {
-            Ticker.shared.remove(this.update, this);
-            this._isConnectedToTicker = false;
-        }
+        this._configureAutoUpdate();
 
         const source = this.source as HTMLVideoElement;
 
@@ -326,17 +337,7 @@ export class VideoResource extends BaseImageResource
         if (value !== this._autoUpdate)
         {
             this._autoUpdate = value;
-
-            if (!this._autoUpdate && this._isConnectedToTicker)
-            {
-                Ticker.shared.remove(this.update, this);
-                this._isConnectedToTicker = false;
-            }
-            else if (this._autoUpdate && !this._isConnectedToTicker && this._isSourcePlaying())
-            {
-                Ticker.shared.add(this.update, this);
-                this._isConnectedToTicker = true;
-            }
+            this._configureAutoUpdate();
         }
     }
 
@@ -354,6 +355,59 @@ export class VideoResource extends BaseImageResource
         if (value !== this._updateFPS)
         {
             this._updateFPS = value;
+            this._configureAutoUpdate();
+        }
+    }
+
+    private _configureAutoUpdate(): void
+    {
+        if (this._autoUpdate && this._isSourcePlaying())
+        {
+            if (!this._updateFPS && this.source.requestVideoFrameCallback)
+            {
+                if (this._isConnectedToTicker)
+                {
+                    Ticker.shared.remove(this.update, this);
+                    this._isConnectedToTicker = false;
+                    this._msToNextUpdate = 0;
+                }
+
+                if (this._videoFrameRequestCallbackHandle === null)
+                {
+                    this._videoFrameRequestCallbackHandle = this.source.requestVideoFrameCallback(
+                        this._videoFrameRequestCallback);
+                }
+            }
+            else
+            {
+                if (this._videoFrameRequestCallbackHandle !== null)
+                {
+                    this.source.cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
+                    this._videoFrameRequestCallbackHandle = null;
+                }
+
+                if (!this._isConnectedToTicker)
+                {
+                    Ticker.shared.add(this.update, this);
+                    this._isConnectedToTicker = true;
+                    this._msToNextUpdate = 0;
+                }
+            }
+        }
+        else
+        {
+            if (this._videoFrameRequestCallbackHandle !== null)
+            {
+                this.source.cancelVideoFrameCallback(this._videoFrameRequestCallbackHandle);
+                this._videoFrameRequestCallbackHandle = null;
+            }
+
+            if (this._isConnectedToTicker)
+            {
+                Ticker.shared.remove(this.update, this);
+                this._isConnectedToTicker = false;
+                this._msToNextUpdate = 0;
+            }
         }
     }
 


### PR DESCRIPTION
[`requestVideoFrameCallback`](https://wicg.github.io/video-rvfc/) isn't available everywhere unfortunately: https://caniuse.com/?search=requestVideoFrameCallback. If it is, we should use it to avoid unnecessary uploads each frame.
##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
