### PR TITLE
Fix typo in Extract.base64 documentation

### DIFF
--- a/packages/extract/src/Extract.ts
+++ b/packages/extract/src/Extract.ts
@@ -77,7 +77,7 @@ export class Extract implements ISystem, IExtract
 
     /**
      * Will return a base64 encoded string of this target. It works by calling
-     *  `Extract.getCanvas` and then running toDataURL on that.
+     *  `Extract.canvas` and then running toDataURL on that.
      * @param target - A displayObject or renderTexture
      *  to convert. If left empty will use the main renderer
      * @param format - Image format, e.g. "image/jpeg" or "image/webp".


### PR DESCRIPTION
##### Description of change
Changed base64 method documentation to match method name "Extract.canvas", not nonexistent "Extract.getCanvas" method.
