### PR TITLE
Add ownsImageBitmap for ImageBitmapResource

### DIFF
--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -61,7 +61,7 @@ export class ImageBitmapResource extends BaseImageResource
      * Whether the underlying ImageBitmap is owned by the ImageBitmapResource.
      * @see PIXI.IImageBitmapResourceOptions.ownsImageBitmap
      */
-    ownsImageBitmap: boolean;
+    private ownsImageBitmap: boolean;
 
     /**
      * Promise when loading.

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -7,6 +7,10 @@ import type { Renderer } from '../../Renderer';
 import type { BaseTexture } from '../BaseTexture';
 import type { GLTexture } from '../GLTexture';
 
+/**
+ * Options for ImageBitmapResource.
+ * @memberof PIXI
+ */
 export interface IImageBitmapResourceOptions
 {
     /** Start loading process automatically when constructed. */
@@ -17,6 +21,17 @@ export interface IImageBitmapResourceOptions
 
     /** Alpha mode used when creating the ImageBitmap. */
     alphaMode?: ALPHA_MODES;
+
+    /**
+     * Whether the underlying ImageBitmap is owned by the {@link PIXI.ImageBitmapResource}. When set to `true`,
+     * the underlying ImageBitmap will be disposed automatically when disposing {@link PIXI.ImageBitmapResource}.
+     * If this option is not set, whether it owns the underlying ImageBitmap is determained by the type of `source`
+     * used when constructing {@link PIXI.ImageBitmapResource}:
+     * - When `source` is `ImageBitmap`, the underlying ImageBitmap is not owned by default.
+     * - When `source` is `string` (a URL), the underlying ImageBitmap is owned by default.
+     * @see PIXI.ImageBitmapResource.ownsImageBitmap
+     */
+    ownsImageBitmap?: boolean;
 }
 
 /**
@@ -43,17 +58,20 @@ export class ImageBitmapResource extends BaseImageResource
     alphaMode: ALPHA_MODES | null;
 
     /**
+     * Whether the underlying ImageBitmap is owned by the ImageBitmapResource.
+     * @see PIXI.IImageBitmapResourceOptions.ownsImageBitmap
+     */
+    ownsImageBitmap: boolean;
+
+    /**
      * Promise when loading.
      * @default null
      */
     private _load: Promise<this>;
 
     /**
-     * @param source - ImageBitmap or URL to use
-     * @param options
-     * @param {boolean} [options.autoLoad=true] - Start loading process automatically when constructed.
-     * @param {boolean} [options.crossOrigin=true] - Load image using cross origin.
-     * @param {PIXI.ALPHA_MODES} [options.alphaMode=null] - Alpha mode used when creating the ImageBitmap.
+     * @param source - ImageBitmap or URL to use.
+     * @param options - Options to use.
      */
     constructor(source: ImageBitmap | string, options?: IImageBitmapResourceOptions)
     {
@@ -61,16 +79,19 @@ export class ImageBitmapResource extends BaseImageResource
 
         let baseSource;
         let url;
+        let ownsImageBitmap;
 
         if (typeof source === 'string')
         {
             baseSource = ImageBitmapResource.EMPTY;
             url = source;
+            ownsImageBitmap = true;
         }
         else
         {
             baseSource = source;
             url = null;
+            ownsImageBitmap = false;
         }
         // Using super() in if() can cause transpilation problems in some cases, so take it out of if().
         // See https://github.com/pixijs/pixijs/pull/9093 for details.
@@ -79,6 +100,7 @@ export class ImageBitmapResource extends BaseImageResource
 
         this.crossOrigin = options.crossOrigin ?? true;
         this.alphaMode = typeof options.alphaMode === 'number' ? options.alphaMode : null;
+        this.ownsImageBitmap = options.ownsImageBitmap ?? ownsImageBitmap;
 
         this._load = null;
 
@@ -167,7 +189,7 @@ export class ImageBitmapResource extends BaseImageResource
     /** Destroys this resource. */
     override dispose(): void
     {
-        if (this.source instanceof ImageBitmap)
+        if (this.ownsImageBitmap && this.source instanceof ImageBitmap)
         {
             this.source.close();
         }

--- a/packages/core/src/textures/resources/ImageBitmapResource.ts
+++ b/packages/core/src/textures/resources/ImageBitmapResource.ts
@@ -143,7 +143,12 @@ export class ImageBitmapResource extends BaseImageResource
                         ? 'premultiply' : 'none',
                 });
 
-                if (this.destroyed) return;
+                if (this.destroyed)
+                {
+                    imageBitmap.close();
+
+                    return;
+                }
 
                 this.source = imageBitmap;
                 this.update();

--- a/packages/core/test/ImageBitmapResource.tests.ts
+++ b/packages/core/test/ImageBitmapResource.tests.ts
@@ -4,6 +4,11 @@ import type { BaseTexture } from '@pixi/core';
 
 describe('ImageBitmapResource', () =>
 {
+    // 1x1 white PNG data URL
+    const IMAGE_URL
+        = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42m'
+        + 'P8/x8AAwMCAO+ip1sAAAAASUVORK5CYII=';
+
     it('should create new dimension-less resource', async () =>
     {
         const canvas = document.createElement('canvas');
@@ -67,5 +72,77 @@ describe('ImageBitmapResource', () =>
 
         resource.unbind(baseTexture as unknown as BaseTexture);
         resource.destroy();
+    });
+
+    it('should not dispose underlying ImageBitmap when source is ImageBitmap', async () =>
+    {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 100;
+        canvas.height = 200;
+
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap);
+
+        expect(bitmap.width).toEqual(100);
+        expect(bitmap.height).toEqual(200);
+
+        resource.destroy();
+
+        expect(bitmap.width).toEqual(100);
+        expect(bitmap.height).toEqual(200);
+    });
+
+    it('should not dispose underlying ImageBitmap when source is string', async () =>
+    {
+        const resource = new ImageBitmapResource(IMAGE_URL);
+
+        await resource.load();
+
+        const bitmap = resource.source as ImageBitmap;
+
+        expect(bitmap.width).toEqual(1);
+        expect(bitmap.height).toEqual(1);
+
+        resource.destroy();
+
+        expect(bitmap.width).toEqual(0);
+        expect(bitmap.height).toEqual(0);
+    });
+
+    it('should dispose underlying ImageBitmap when ownImageBitmap is true', async () =>
+    {
+        const canvas = document.createElement('canvas');
+
+        canvas.width = 100;
+        canvas.height = 200;
+
+        const bitmap = await createImageBitmap(canvas);
+        const resource = new ImageBitmapResource(bitmap, { ownsImageBitmap: true });
+
+        expect(bitmap.width).toEqual(100);
+        expect(bitmap.height).toEqual(200);
+
+        resource.destroy();
+
+        expect(bitmap.width).toEqual(0);
+        expect(bitmap.height).toEqual(0);
+    });
+
+    it('should not dispose underlying ImageBitmap when ownImageBitmap is false', async () =>
+    {
+        const resource = new ImageBitmapResource(IMAGE_URL, { ownsImageBitmap: false });
+
+        await resource.load();
+
+        const bitmap = resource.source as ImageBitmap;
+
+        expect(bitmap.width).toEqual(1);
+        expect(bitmap.height).toEqual(1);
+
+        resource.destroy();
+
+        expect(bitmap.width).toEqual(1);
+        expect(bitmap.height).toEqual(1);
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

Add `ownsImageBitmap` for `ImageBitmapResource` and `IImageBitmapResourceOptions`. When it is `true`, the `ImageBitmapResource`'s underlying `ImageBitmap` will be disposed (`this.source.close()` is called); otherwise the `ImageBitmap` will not be disposed.

If the `ownsImageBitmap` option is not set by user:
- When `source` is `ImageBitmap`, `ownsImageBitmap` will be `false` by default.
- When `source` is `string` (a URL), `ownsImageBitmap` will be `true` by default.

`loadTextures` is also updated: when `loadTextures` is using `ImageBitmap`, the `resourceOptions.ownsImageBitmap` will be set to `true` when creating the `BaseTexture` if this option is not set by user.

Fixes #9403.
- Before (disposed): <https://www.pixiplayground.com/#/edit/cW1MglcpTHTH_ViEEj4YJ>
- After (not disposed): <https://www.pixiplayground.com/#/edit/qkDMDCYVMtO4wsVv-RCLp>

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
