### PR TITLE
Don't GC textures that don't have a resource

### DIFF
--- a/packages/core/src/textures/TextureGCSystem.ts
+++ b/packages/core/src/textures/TextureGCSystem.ts
@@ -137,7 +137,7 @@ export class TextureGCSystem implements ISystem
             const texture = managedTextures[i];
 
             // Only supports non generated textures at the moment!
-            if (!(texture as any).framebuffer && this.count - texture.touched > this.maxIdle)
+            if (texture.resource && this.count - texture.touched > this.maxIdle)
             {
                 tm.destroyTexture(texture, true);
                 managedTextures[i] = null;


### PR DESCRIPTION
##### Description of change

If a texture doesn't have a resource, we shouldn't GC it, because we cannot reupload it. Only textures that are rendered to don't have a resource, but they don't have to be `BaseRenderTexture`s necessarily. For example, textures added to a framebuffer with `addColorTexture`/`addDepthTexture` aren't.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
