### PR TITLE
Add `BufferResource.unpackAlignment`

### DIFF
--- a/packages/compressed-textures/src/resources/BlobResource.ts
+++ b/packages/compressed-textures/src/resources/BlobResource.ts
@@ -1,12 +1,14 @@
 import { BufferResource, ViewableBuffer } from '@pixi/core';
 
-import type { BufferType } from '@pixi/core';
+import type { BufferType, IBufferResourceOptions } from '@pixi/core';
 
-interface IBlobOptions
+/**
+ * Constructor options for BlobResource.
+ * @memberof PIXI
+ */
+export interface IBlobResourceOptions extends IBufferResourceOptions
 {
     autoLoad?: boolean;
-    width: number;
-    height: number;
 }
 
 /**
@@ -33,13 +35,14 @@ export abstract class BlobResource extends BufferResource
 
     /**
      * @param source - The buffer/URL of the texture file.
-     * @param {PIXI.IBlobOptions} [options]
+     * @param {PIXI.IBlobResourceOptions} [options]
      * @param {boolean} [options.autoLoad=false] - Whether to fetch the data immediately;
      *  you can fetch it later via {@link PIXI.BlobResource#load}.
      * @param {number} [options.width=1] - The width in pixels.
      * @param {number} [options.height=1] - The height in pixels.
+     * @param {1|2|4|8} [options.unpackAlignment=4] - The alignment of the pixel rows.
      */
-    constructor(source: string | BufferType, options: IBlobOptions = { width: 1, height: 1, autoLoad: true })
+    constructor(source: string | BufferType, options: IBlobResourceOptions = { width: 1, height: 1, autoLoad: true })
     {
         let origin: string | null;
         let data: BufferType;

--- a/packages/compressed-textures/src/resources/CompressedTextureResource.ts
+++ b/packages/compressed-textures/src/resources/CompressedTextureResource.ts
@@ -149,6 +149,8 @@ export class CompressedTextureResource extends BlobResource
             return false;
         }
 
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+
         for (let i = 0, j = this.levels; i < j; i++)
         {
             const { levelID, levelWidth, levelHeight, levelBuffer } = this._levelBuffers[i];

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -9,7 +9,7 @@ import type { MSAA_QUALITY } from '@pixi/constants';
 import type { ICanvas } from '@pixi/settings';
 import type { GLTexture } from './GLTexture';
 import type { IAutoDetectOptions } from './resources/autoDetectResource';
-import type { BufferType } from './resources/BufferResource';
+import type { BufferType, IBufferResourceOptions } from './resources/BufferResource';
 
 const defaultBufferOptions = {
     scaleMode: SCALE_MODES.NEAREST,
@@ -704,11 +704,11 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
      * @returns - The resulting new BaseTexture
      */
     static fromBuffer(buffer: BufferType, width: number, height: number,
-        options?: IBaseTextureOptions): BaseTexture<BufferResource>
+        options?: IBaseTextureOptions<IBufferResourceOptions>): BaseTexture<BufferResource>
     {
         buffer = buffer || new Float32Array(width * height * 4);
 
-        const resource = new BufferResource(buffer, { width, height });
+        const resource = new BufferResource(buffer, Object.assign({ width, height }, options?.resourceOptions));
         let format: FORMATS;
         let type: TYPES;
 

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -708,7 +708,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
     {
         buffer = buffer || new Float32Array(width * height * 4);
 
-        const resource = new BufferResource(buffer, Object.assign({ width, height }, options?.resourceOptions));
+        const resource = new BufferResource(buffer, { width, height, ...options?.resourceOptions });
         let format: FORMATS;
         let type: TYPES;
 

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -5,9 +5,9 @@ import { BaseTexture } from './BaseTexture';
 import { ImageResource } from './resources/ImageResource';
 import { TextureUvs } from './TextureUvs';
 
-import type { IPointData, ISize } from '@pixi/math';
+import type { IPointData } from '@pixi/math';
 import type { IBaseTextureOptions, ImageSource } from './BaseTexture';
-import type { BufferResource, BufferType } from './resources/BufferResource';
+import type { BufferResource, BufferType, IBufferResourceOptions } from './resources/BufferResource';
 import type { CanvasResource } from './resources/CanvasResource';
 import type { Resource } from './resources/Resource';
 import type { TextureMatrix } from './TextureMatrix';
@@ -481,7 +481,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
      * @returns - The resulting new BaseTexture
      */
     static fromBuffer(buffer: BufferType, width: number, height: number,
-        options?: IBaseTextureOptions<ISize>): Texture<BufferResource>
+        options?: IBaseTextureOptions<IBufferResourceOptions>): Texture<BufferResource>
     {
         return new Texture(BaseTexture.fromBuffer(buffer, width, height, options));
     }

--- a/packages/core/src/textures/resources/BufferResource.ts
+++ b/packages/core/src/textures/resources/BufferResource.ts
@@ -10,6 +10,15 @@ export type BufferType = null | Int8Array | Uint8Array | Uint8ClampedArray
 | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array;
 
 /**
+ * Constructor options for BufferResource.
+ * @memberof PIXI
+ */
+export interface IBufferResourceOptions extends ISize
+{
+    unpackAlignment?: 1 | 2 | 4 | 8
+}
+
+/**
  * Buffer resource with data of typed array.
  * @memberof PIXI
  */
@@ -18,13 +27,17 @@ export class BufferResource extends Resource
     /** The data of this resource. */
     public data: BufferType;
 
+    /** The alignment of the rows in the data. */
+    public unpackAlignment: 1 | 2 | 4 | 8;
+
     /**
      * @param source - Source buffer
      * @param options - Options
      * @param {number} options.width - Width of the texture
      * @param {number} options.height - Height of the texture
+     * @param {1|2|4|8} [options.unpackAlignment=4] - The alignment of the pixel rows.
      */
-    constructor(source: BufferType, options: ISize)
+    constructor(source: BufferType, options: IBufferResourceOptions)
     {
         const { width, height } = options || {};
 
@@ -36,6 +49,7 @@ export class BufferResource extends Resource
         super(width, height);
 
         this.data = source;
+        this.unpackAlignment = options.unpackAlignment ?? 4;
     }
 
     /**
@@ -49,6 +63,7 @@ export class BufferResource extends Resource
     {
         const gl = renderer.gl;
 
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, this.unpackAlignment);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, baseTexture.alphaMode === ALPHA_MODES.UNPACK);
 
         const width = baseTexture.realWidth;

--- a/packages/core/test/BufferResource.tests.ts
+++ b/packages/core/test/BufferResource.tests.ts
@@ -1,0 +1,37 @@
+import { BaseTexture, BufferResource, FORMATS, Renderer, TYPES } from '@pixi/core';
+
+describe('BufferResource', () =>
+{
+    it('should set UNPACK_ALIGNMENT on upload', () =>
+    {
+        const renderer = new Renderer();
+        const texture1 = new BaseTexture(
+            new BufferResource(new Uint8Array(1 * 2), { width: 1, height: 2, unpackAlignment: 1 }),
+            {
+                format: FORMATS.RED,
+                type: TYPES.UNSIGNED_BYTE
+            }
+        );
+
+        renderer.gl.pixelStorei(renderer.gl.UNPACK_ALIGNMENT, 4);
+        renderer.texture.bind(texture1);
+
+        expect(renderer.gl.getError()).toBe(renderer.gl.NONE);
+
+        const texture2 = new BaseTexture(
+            new BufferResource(new Uint8Array(1 * 2), { width: 1, height: 2 }),
+            {
+                format: FORMATS.RED,
+                type: TYPES.UNSIGNED_BYTE
+            }
+        );
+
+        renderer.texture.bind(texture2);
+
+        expect(renderer.gl.getError()).not.toBe(renderer.gl.NONE);
+
+        texture1.destroy();
+        texture2.destroy();
+        renderer.destroy();
+    });
+});


### PR DESCRIPTION
##### Description of change

Without control over the unpack alignment, we cannot upload a buffer resource that has a pixel row size in bytes isn't a multiple of 4, which is the default unpack alignment.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
