### PR TITLE
Replace `url` dependency with modern URL API

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -74,6 +74,7 @@ export { default as earcut } from 'earcut';
  * @memberof PIXI.utils
  * @name url
  * @member {object}
+ * @deprecated since 7.3.0
  */
 export * from './url';
 

--- a/packages/utils/src/network/determineCrossOrigin.ts
+++ b/packages/utils/src/network/determineCrossOrigin.ts
@@ -21,10 +21,8 @@ export function determineCrossOrigin(url: string, loc: Location = globalThis.loc
 
     const parsedUrl = new URL(url, document.baseURI);
 
-    const samePort = (!parsedUrl.port && loc.port === '') || (parsedUrl.port === loc.port);
-
     // if cross origin
-    if (parsedUrl.hostname !== loc.hostname || !samePort || parsedUrl.protocol !== loc.protocol)
+    if (parsedUrl.hostname !== loc.hostname || parsedUrl.port !== loc.port || parsedUrl.protocol !== loc.protocol)
     {
         return 'anonymous';
     }

--- a/packages/utils/src/network/determineCrossOrigin.ts
+++ b/packages/utils/src/network/determineCrossOrigin.ts
@@ -1,7 +1,3 @@
-import { url as _url } from '../url';
-
-let tempAnchor: HTMLAnchorElement | undefined;
-
 /**
  * Sets the `crossOrigin` property for this resource based on if the url
  * for this resource is cross-origin. If crossOrigin was manually set, this
@@ -23,16 +19,7 @@ export function determineCrossOrigin(url: string, loc: Location = globalThis.loc
     // default is window.location
     loc = loc || globalThis.location;
 
-    if (!tempAnchor)
-    {
-        tempAnchor = document.createElement('a');
-    }
-
-    // let the browser determine the full href for the url of this resource and then
-    // parse with the node url lib, we can't use the properties of the anchor element
-    // because they don't work in IE9 :(
-    tempAnchor.href = url;
-    const parsedUrl = _url.parse(tempAnchor.href);
+    const parsedUrl = new URL(url, document.baseURI);
 
     const samePort = (!parsedUrl.port && loc.port === '') || (parsedUrl.port === loc.port);
 

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -6,6 +6,7 @@
  */
 
 import { format as _format, parse as _parse, resolve as _resolve } from 'url';
+import { deprecation } from './logging/deprecation';
 
 interface ParsedUrlQuery
 {
@@ -80,7 +81,37 @@ type ResolveFunction = {
 };
 
 export const url = {
-    parse: _parse as ParseFunction,
-    format: _format as FormatFunction,
-    resolve: _resolve as ResolveFunction,
+    /**
+     * @deprecated since 7.3.0
+     */
+    get parse()
+    {
+        // #if _DEBUG
+        deprecation('7.3.0', 'utils.url.parse is deprecated, use native URL API instead.');
+        // #endif
+
+        return _parse as ParseFunction;
+    },
+    /**
+     * @deprecated since 7.3.0
+     */
+    get format()
+    {
+        // #if _DEBUG
+        deprecation('7.3.0', 'utils.url.format is deprecated, use native URL API instead.');
+        // #endif
+
+        return _format as FormatFunction;
+    },
+    /**
+     * @deprecated since 7.3.0
+     */
+    get resolve()
+    {
+        // #if _DEBUG
+        deprecation('7.3.0', 'utils.url.resolve is deprecated, use native URL API instead.');
+        // #endif
+
+        return _resolve as ResolveFunction;
+    }
 };


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This is related to #9413, where I proposed to replace `url` dependency with native API.

<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
