### PR TITLE
Fix: Text being cropped when leading is not 0

### DIFF
--- a/packages/text/src/TextMetrics.ts
+++ b/packages/text/src/TextMetrics.ts
@@ -278,7 +278,8 @@ export class TextMetrics
         }
 
         const lineHeight = style.lineHeight || fontProperties.fontSize + style.strokeThickness;
-        let height = Math.max(lineHeight, fontProperties.fontSize + (style.strokeThickness * 2))
+        let height
+            = Math.max(lineHeight, fontProperties.fontSize + (style.strokeThickness * 2)) + style.leading
             + ((lines.length - 1) * (lineHeight + style.leading));
 
         if (style.dropShadow)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

#### Description of change
<!-- Provide a description of the change below this comment. -->

An extra `leading` need to be added to `TextMetrics`' height to get the correct result.

- Before: <https://pixiplayground.com/#/edit/aK-uHfQkxW1Tr2bxI0c6n>
- After: <https://pixiplayground.com/#/edit/eHg-yNE0Gq2GE8YCbdAMe>

Fixes #9410.

#### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
