### PR TITLE
Fix: Remove the asset from the asset cache and the loader promise cache when the texture is destroyed

### DIFF
--- a/packages/assets/src/cache/Cache.ts
+++ b/packages/assets/src/cache/Cache.ts
@@ -145,8 +145,6 @@ class CacheClass
      */
     public remove(key: string): void
     {
-        this._cacheMap.get(key);
-
         if (!this._cacheMap.has(key))
         {
             // #if _DEBUG

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -9,7 +9,7 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
     const texture = new Texture(base);
 
     // remove the promise from the loader and the url from the cache when the texture is destroyed
-    texture.baseTexture.once('destroy', () =>
+    texture.baseTexture.once('destroyed', () =>
     {
         delete loader.promiseCache[url];
         Cache.remove(url);

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -1,4 +1,5 @@
 import { Texture } from '@pixi/core';
+import { Cache } from '../../../../cache/Cache';
 
 import type { BaseTexture } from '@pixi/core';
 import type { Loader } from '../../../Loader';
@@ -8,9 +9,10 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
     const texture = new Texture(base);
 
     // make sure to nuke the promise if a texture is destroyed..
-    texture.baseTexture.on('dispose', () =>
+    texture.baseTexture.on('destroy', () =>
     {
         delete loader.promiseCache[url];
+        Cache.remove(url);
     });
 
     return texture;

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -12,7 +12,11 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
     texture.baseTexture.once('destroyed', () =>
     {
         delete loader.promiseCache[url];
-        Cache.remove(url);
+
+        if (Cache.has(url))
+        {
+            Cache.remove(url);
+        }
     });
 
     return texture;

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -8,8 +8,8 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
 {
     const texture = new Texture(base);
 
-    // make sure to nuke the promise if a texture is destroyed..
-    texture.baseTexture.on('destroy', () =>
+    // remove the promise from the loader and the url from the cache when the texture is destroyed
+    texture.baseTexture.once('destroy', () =>
     {
         delete loader.promiseCache[url];
         Cache.remove(url);

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -495,4 +495,29 @@ describe('Assets', () =>
         Assets.setPreferences({ preferWorkers: true });
         expect(loadTextures.config.preferWorkers).toBe(true);
     });
+
+    it('should remove the asset from the cache when destroyed', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const url = 'textures/bunny.png';
+        const texture1 = await Assets.load(url);
+
+        expect(Assets.cache.has(url)).toBeTrue();
+
+        texture1.destroy(true);
+
+        expect(Assets.cache.has(url)).toBeFalse();
+
+        const texture2 = await Assets.load(url);
+
+        expect(Assets.cache.has(url)).toBeTrue();
+        expect(texture2).not.toBe(texture1);
+
+        texture2.destroy(true);
+
+        expect(Assets.cache.has(url)).toBeFalse();
+    });
 });

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -583,7 +583,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
      * Destroys this base texture.
      * The method stops if resource doesn't want this texture to be destroyed.
      * Removes texture from all caches.
-     * @fires PIXI.BaseTexture#destroy
+     * @fires PIXI.BaseTexture#destroyed
      */
     destroy(): void
     {
@@ -614,7 +614,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
         this.textureCacheIds = null;
 
         this.destroyed = true;
-        this.emit('destroy', this);
+        this.emit('destroyed', this);
     }
 
     /**

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -583,6 +583,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
      * Destroys this base texture.
      * The method stops if resource doesn't want this texture to be destroyed.
      * Removes texture from all caches.
+     * @fires PIXI.BaseTexture#destroy
      */
     destroy(): void
     {
@@ -613,6 +614,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
         this.textureCacheIds = null;
 
         this.destroyed = true;
+        this.emit('destroy', this);
     }
 
     /**


### PR DESCRIPTION
We do not want to remove the asset from the cache when the texture is disposed. A texture could be disposed without being destroyed.

We also need to remove the asset from the asset cache. 