### PR TITLE
Fix: Update `VideoResource` on `seeked`

### DIFF
--- a/packages/core/src/textures/resources/BaseImageResource.ts
+++ b/packages/core/src/textures/resources/BaseImageResource.ts
@@ -85,7 +85,7 @@ export class BaseImageResource extends Resource
         }
         else if (typeof HTMLVideoElement !== 'undefined' && source instanceof HTMLVideoElement)
         {
-            if (source.readyState <= 1 && source.buffered.length === 0)
+            if (source.readyState <= 1)
             {
                 return false;
             }

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -144,6 +144,9 @@ export class VideoResource extends BaseImageResource
         // Bind for listeners
         this._onCanPlay = this._onCanPlay.bind(this);
         this._onError = this._onError.bind(this);
+        this._onPlayStart = this._onPlayStart.bind(this);
+        this._onPlayStop = this._onPlayStop.bind(this);
+        this._onSeeked = this._onSeeked.bind(this);
 
         if (options.autoLoad !== false)
         {
@@ -209,8 +212,9 @@ export class VideoResource extends BaseImageResource
             (source as any).complete = true;
         }
 
-        source.addEventListener('play', this._onPlayStart.bind(this));
-        source.addEventListener('pause', this._onPlayStop.bind(this));
+        source.addEventListener('play', this._onPlayStart);
+        source.addEventListener('pause', this._onPlayStop);
+        source.addEventListener('seeked', this._onSeeked);
 
         if (!this._isSourceReady())
         {
@@ -298,6 +302,15 @@ export class VideoResource extends BaseImageResource
         this._configureAutoUpdate();
     }
 
+    /** Fired when the video is completed seeking to the current playback position. */
+    private _onSeeked(): void
+    {
+        if (this._autoUpdate && !this._isSourcePlaying())
+        {
+            this.update();
+        }
+    }
+
     /** Fired when the video is loaded and ready to play. */
     private _onCanPlay(): void
     {
@@ -337,6 +350,11 @@ export class VideoResource extends BaseImageResource
 
         if (source)
         {
+            source.removeEventListener('play', this._onPlayStart);
+            source.removeEventListener('pause', this._onPlayStop);
+            source.removeEventListener('seeked', this._onSeeked);
+            source.removeEventListener('canplay', this._onCanPlay);
+            source.removeEventListener('canplaythrough', this._onCanPlay);
             source.removeEventListener('error', this._onError, true);
             source.pause();
             source.src = '';

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -307,7 +307,9 @@ export class VideoResource extends BaseImageResource
     {
         if (this._autoUpdate && !this._isSourcePlaying())
         {
+            this._msToNextUpdate = 0;
             this.update();
+            this._msToNextUpdate = 0;
         }
     }
 


### PR DESCRIPTION
Reverted #8806: The fix doesn't work in Firefox. It spams a bunch of warnings and produces flickering black frames when the `currentTime` is changed. Open the example provided by #8806 (https://codesandbox.io/s/stoic-grass-rkhxl3?file=/src/index.js) in Firefox to observe this issue.
```
WebGL warning: tex(Sub)Image[23]D: Resource has no data (yet?). Uploading zeros.
WebGL warning: drawElementsInstanced: TEXTURE_2D at unit 0 is incomplete: The dimensions of `level_base` are not all positive. 
```

Instead I added a `seeked` event handler that updates the resource. Note though that the example provided by #8806 does not work after this change because the `currentTime` is updated so fast (every frame) that the `readyState` is 1 in `upload` even though in the previous `seeked` event the `readyState` was 4. I cannot observe any other events on the source in between. Maybe the reason is that the seeks don't finish within a frame and then next seek is requested and they start to overlap (?). If there's enough time in between the seeks it works as expected. Seeking every frame is probably something that isn't really supported by videos.