### PR TITLE
Fix: Mark resources of loaded textures as internal so that they are destroyed when unloaded

### DIFF
--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -5,6 +5,9 @@ import type { Loader } from '../../../Loader';
 
 export function createTexture(base: BaseTexture, loader: Loader, url: string)
 {
+    // make sure the resource is destroyed when the base texture is destroyed
+    base.resource.internal = true;
+
     const texture = new Texture(base);
 
     // make sure to nuke the promise if a texture is destroyed..

--- a/packages/assets/test/loadVideo.tests.ts
+++ b/packages/assets/test/loadVideo.tests.ts
@@ -1,5 +1,5 @@
 import { Assets } from '@pixi/assets';
-import { Texture } from '@pixi/core';
+import { BaseTexture, Texture, VideoResource } from '@pixi/core';
 import { basePath } from './basePath';
 
 describe('loadVideo', () =>
@@ -157,5 +157,32 @@ describe('loadVideo', () =>
         expect(ogv).toBeInstanceOf(Texture);
         expect(ogv.width).toBe(1);
         expect(ogv.height).toBe(1);
+    });
+
+    it('should destroy texture, base texture, and resource on unload', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const texture = await Assets.load('videos/white.mp4');
+
+        expect(texture).toBeInstanceOf(Texture);
+        expect(texture.width).toBe(1);
+        expect(texture.height).toBe(1);
+
+        const baseTexture = texture.baseTexture;
+
+        expect(baseTexture).toBeInstanceOf(BaseTexture);
+
+        const resource = baseTexture.resource;
+
+        expect(resource).toBeInstanceOf(VideoResource);
+
+        await Assets.unload('videos/white.mp4');
+
+        expect(texture.baseTexture).toBeNull();
+        expect(baseTexture.destroyed).toBeTrue();
+        expect(resource.destroyed).toBeTrue();
     });
 });

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -748,6 +748,8 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
             type = TYPES.UNSIGNED_BYTE;
         }
 
+        resource.internal = true;
+
         return new BaseTexture(resource, Object.assign({}, defaultBufferOptions, { type, format }, options));
     }
 

--- a/packages/core/test/BaseTexture.tests.ts
+++ b/packages/core/test/BaseTexture.tests.ts
@@ -1,5 +1,6 @@
 import {
     BaseTexture,
+    BufferResource,
     ImageResource,
     RenderTexture,
     SCALE_MODES,
@@ -271,5 +272,17 @@ describe('BaseTexture', () =>
         expect(baseTexture.type).toBe(TYPES.FLOAT);
 
         baseTexture.destroy();
+    });
+
+    it('should destroy the resource of the texture that was created with fromBuffer', () =>
+    {
+        const baseTexture = BaseTexture.fromBuffer(new Float32Array(2 * 3 * 4), 2, 3);
+        const resource = baseTexture.resource;
+
+        expect(resource).toBeInstanceOf(BufferResource);
+
+        baseTexture.destroy();
+
+        expect(resource.destroyed).toBeTrue();
     });
 });


### PR DESCRIPTION
Resources of loaded SVGs and videos are not destroyed currently because the resource is created outside of `BaseTexture`. The same is true for the `BufferResource` created in `BaseTexture.fromBuffer`.
