### PR TITLE
Add Spritesheet type inference

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -114,13 +114,13 @@ export interface ISpritesheetData
  * supported by TexturePacker.
  * @memberof PIXI
  */
-export class Spritesheet
+export class Spritesheet<S extends ISpritesheetData = ISpritesheetData>
 {
     /** The maximum number of Textures to build per process. */
     static readonly BATCH_SIZE = 1000;
 
     /** For multi-packed spritesheets, this contains a reference to all the other spritesheets it depends on. */
-    public linkedSheets: Spritesheet[] = [];
+    public linkedSheets: Spritesheet<S>[] = [];
 
     /** Reference to ths source texture. */
     public baseTexture: BaseTexture;
@@ -133,7 +133,7 @@ export class Spritesheet
      *
      * new Sprite(sheet.textures['image.png']);
      */
-    public textures: utils.Dict<Texture>;
+    public textures: Record<keyof S['frames'], Texture>;
 
     /**
      * A map containing the textures for each animation.
@@ -143,13 +143,13 @@ export class Spritesheet
      *
      * new AnimatedSprite(sheet.animations['anim_name']);
      */
-    public animations: utils.Dict<Texture[]>;
+    public animations: Record<keyof S['animations'], Texture[]>;
 
     /**
      * Reference to the original JSON data.
      * @type {object}
      */
-    public data: ISpritesheetData;
+    public data: S;
 
     /** The resolution of the spritesheet. */
     public resolution: number;
@@ -164,10 +164,10 @@ export class Spritesheet
      * Map of spritesheet frames.
      * @type {object}
      */
-    private _frames: utils.Dict<ISpritesheetFrameData>;
+    private _frames: S['frames'];
 
     /** Collection of frame names. */
-    private _frameKeys: string[];
+    private _frameKeys: (keyof S['frames'])[];
 
     /** Current batch index being processed. */
     private _batchIndex: number;
@@ -185,12 +185,12 @@ export class Spritesheet
      *        the resolution of the spritesheet. If not provided, the imageUrl will
      *        be used on the BaseTexture.
      */
-    constructor(texture: BaseTexture | Texture, data: ISpritesheetData, resolutionFilename: string = null)
+    constructor(texture: BaseTexture | Texture, data: S, resolutionFilename: string = null)
     {
         this._texture = texture instanceof Texture ? texture : null;
         this.baseTexture = texture instanceof BaseTexture ? texture : this._texture.baseTexture;
-        this.textures = {};
-        this.animations = {};
+        this.textures = {} as Record<keyof S['frames'], Texture>;
+        this.animations = {} as Record<keyof S['animations'], Texture[]>;
         this.data = data;
 
         const resource = this.baseTexture.resource as ImageResource;
@@ -327,7 +327,7 @@ export class Spritesheet
                 );
 
                 // lets also add the frame to pixi's global cache for 'from' and 'fromLoader' functions
-                Texture.addToCache(this.textures[i], i);
+                Texture.addToCache(this.textures[i], i.toString());
             }
 
             frameIndex++;
@@ -341,7 +341,7 @@ export class Spritesheet
 
         for (const animName in animations)
         {
-            this.animations[animName] = [];
+            this.animations[animName as keyof S['animations']] = [];
             for (let i = 0; i < animations[animName].length; i++)
             {
                 const frameName = animations[animName][i];

--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -131,7 +131,7 @@ export const spritesheetAsset = {
 
             if (Array.isArray(multiPacks))
             {
-                const promises: Promise<Spritesheet>[] = [];
+                const promises: Promise<Spritesheet<SpriteSheetJson>>[] = [];
 
                 for (const item of multiPacks)
                 {
@@ -150,7 +150,7 @@ export const spritesheetAsset = {
 
                     itemUrl = copySearchParams(itemUrl, options.src);
 
-                    promises.push(loader.load<Spritesheet>({
+                    promises.push(loader.load<Spritesheet<SpriteSheetJson>>({
                         src: itemUrl,
                         data: {
                             ignoreMultiPack: true,


### PR DESCRIPTION
##### Description of change
Add type inference for the Spritesheet atlas data. It makes using Spritesheets much easier for those using plain objects as an atlas.

- `.toString()` in line 330 is explained at the end of [this](https://www.typescriptlang.org/docs/handbook/2/keyof-types.html) section of the TypeScript docs.
- `S` for the type parameter following existing code style https://github.com/pixijs/pixijs/blob/356abaaad852b248f0aa3f6873f5d7d2a56e3a50/packages/core/src/textures/BaseTexture.ts#L49
##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
