### PR TITLE
Add warn for large expanse of text

### DIFF
--- a/packages/text-html/src/HTMLText.ts
+++ b/packages/text-html/src/HTMLText.ts
@@ -161,10 +161,12 @@ export class HTMLText extends Sprite
 
         const { width, height } = contentBounds;
 
+        // #if _DEBUG
         if (width > this.maxWidth || height > this.maxHeight)
         {
             console.warn('[HTMLText] Large expanse of text, increase HTMLText.maxWidth or HTMLText.maxHeight property.');
         }
+        // #endif
 
         const contentWidth = Math.min(this.maxWidth, Math.ceil(width));
         const contentHeight = Math.min(this.maxHeight, Math.ceil(height));

--- a/packages/text-html/src/HTMLText.ts
+++ b/packages/text-html/src/HTMLText.ts
@@ -159,8 +159,15 @@ export class HTMLText extends Sprite
 
         this._svgRoot.remove();
 
-        const contentWidth = Math.min(this.maxWidth, Math.ceil(contentBounds.width));
-        const contentHeight = Math.min(this.maxHeight, Math.ceil(contentBounds.height));
+        const { width, height } = contentBounds;
+
+        if (width > this.maxWidth || height > this.maxHeight)
+        {
+            console.warn('[HTMLText] Large expanse of text, increase HTMLText.maxWidth or HTMLText.maxHeight property.');
+        }
+
+        const contentWidth = Math.min(this.maxWidth, Math.ceil(width));
+        const contentHeight = Math.min(this.maxHeight, Math.ceil(height));
 
         this._svgRoot.setAttribute('width', contentWidth.toString());
         this._svgRoot.setAttribute('height', contentHeight.toString());

--- a/packages/text-html/test/HTMLText.tests.ts
+++ b/packages/text-html/test/HTMLText.tests.ts
@@ -91,5 +91,24 @@ describe('HTMLText', () =>
             expect(style2Id).toBe(style.styleID);
             text.destroy();
         });
+
+        it('should warn user when large expanse of text is found', () =>
+        {
+            const text = new HTMLText('Lorem ipsum dolor sit amet, consectetur adipiscing elit, '
+                + 'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. '
+                + 'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi '
+                + 'ut aliquip ex ea commodo consequat. '
+                + 'Duis aute irure dolor in reprehenderit in voluptate velit esse '
+                + 'cillum dolore eu fugiat nulla pariatur. '
+                + 'Excepteur sint occaecat cupidatat non proident, sunt in culpa '
+                + 'qui officia deserunt mollit anim id est laborum.');
+
+            const warn = jest.spyOn(console, 'warn').mockImplementation();
+
+            text.measureText({ resolution: 10 });
+            expect(warn).toBeCalled();
+            warn.mockReset();
+            text.destroy();
+        });
     });
 });


### PR DESCRIPTION
##### Description of change
Added console warn for situations when text bounds width or height is larger then defaultMaxWidth or defaultMaxHeight parameter

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
