### PR TITLE
fix: force strict check for group variable in UniformGroup

### DIFF
--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -63,7 +63,7 @@ export class Shader
         {
             const uniform = group.uniforms[i];
 
-            if (uniform.group)
+            if (uniform.group === true)
             {
                 if (this.checkUniformExists(name, uniform))
                 {

--- a/packages/core/src/shader/utils/generateUniformsSync.ts
+++ b/packages/core/src/shader/utils/generateUniformsSync.ts
@@ -229,7 +229,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Dict<any>
 
         if (!data)
         {
-            if (group.uniforms[i]?.group)
+            if (group.uniforms[i]?.group === true)
             {
                 if (group.uniforms[i].ubo)
                 {

--- a/packages/unsafe-eval/src/syncUniforms.ts
+++ b/packages/unsafe-eval/src/syncUniforms.ts
@@ -106,7 +106,7 @@ export function syncUniforms(group: UniformGroup, uniformData: {[x: string]: IUn
 
         if (!data)
         {
-            if (gu.group)
+            if (gu.group === true)
             {
                 renderer.shader.syncUniformGroup(uvi);
             }


### PR DESCRIPTION
##### Description of change
This aims to solve #9414 where safari invented the group method in arrays and that made it so arrays now were detected as UniformGroups.

I achieved this by trying to find every place that a UniformGroup is used and where we check for the `group` variable and forced an strict check with true. By doing this, truthy values are not enough, we must have that value set to true.

I would like for somebody with more knowledge on UniformGroup code to see if I missed anything and if my solution makes sense.