### PR TITLE
Fix: Update resource on load

### DIFF
--- a/packages/core/src/textures/resources/AbstractMultiResource.ts
+++ b/packages/core/src/textures/resources/AbstractMultiResource.ts
@@ -197,6 +197,7 @@ export abstract class AbstractMultiResource extends Resource
                 const { realWidth, realHeight } = this.items[0];
 
                 this.resize(realWidth, realHeight);
+                this.update();
 
                 return Promise.resolve(this);
             }

--- a/packages/core/src/textures/resources/ImageResource.ts
+++ b/packages/core/src/textures/resources/ImageResource.ts
@@ -148,7 +148,7 @@ export class ImageResource extends BaseImageResource
                 source.onload = null;
                 source.onerror = null;
 
-                this.resize(source.width, source.height);
+                this.update();
                 this._load = null;
 
                 if (this.createBitmap)

--- a/packages/core/src/textures/resources/SVGResource.ts
+++ b/packages/core/src/textures/resources/SVGResource.ts
@@ -84,7 +84,7 @@ export class SVGResource extends BaseImageResource
             // Save this until after load is finished
             this._resolve = (): void =>
             {
-                this.resize(this.source.width, this.source.height);
+                this.update();
                 resolve(this);
             };
 

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -308,7 +308,9 @@ export class VideoResource extends BaseImageResource
 
         const valid = this.valid;
 
-        this.resize(source.videoWidth, source.videoHeight);
+        this._msToNextUpdate = 0;
+        this.update();
+        this._msToNextUpdate = 0;
 
         // prevent multiple loaded dispatches..
         if (!valid && this._resolve)


### PR DESCRIPTION
Only `resize` on load does not emit an update if the width and height of the resource have already been set correctly. In this case the texture is not updated and may remain blank.

Example: View in Firefox. Once #9441 is merged, the before will fail in Chrome as expected too.
- Before: https://pixiplayground.com/#/edit/OeZYTU7uvEGa06eBnbFe2 (first frame is not loaded)
- After: https://pixiplayground.com/#/edit/1ct9gCmWuOfIinadRTpgX (first frame is loaded)