### PR TITLE
fix up visible check when executing stand alone renderables

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,9 +1,5 @@
 {
   "buildCommand": "codesandbox-ci",
-  "packages": [
-    "bundles/*",
-    "packages/*"
-  ],
   "sandboxes": ["/.codesandbox/sandbox"],
   "node": "18"
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,4 +8,5 @@ if [ -n "$staged_files" ]; then
   #log files
   echo 'linting the following commited files:' $staged_files
   npx eslint --ext .ts --max-warnings 0 $staged_files
+  npm run test:types
 fi

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "docs:webdoc": "webdoc -R README.md",
     "lint": "eslint --ext .js --ext .ts ./ --ignore-path .gitignore --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
-    "codesandbox-ci": "run-s build prepublish-ci",
+    "codesandbox-ci": "run-s build",
     "prerelease": "run-s clean:build test dist",
     "release": "ts-node ./scripts/release.ts",
     "publish-ci": "npm publish"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "docs:webdoc": "webdoc -R README.md",
     "lint": "eslint --ext .js --ext .ts ./ --ignore-path .gitignore --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
-    "codesandbox-ci": "run-s build build:types prepublish-ci",
+    "codesandbox-ci": "run-s build prepublish-ci",
     "prerelease": "run-s clean:build test dist",
     "release": "ts-node ./scripts/release.ts",
     "publish-ci": "npm publish"

--- a/src/rendering/graphics/shared/GraphicsPipe.ts
+++ b/src/rendering/graphics/shared/GraphicsPipe.ts
@@ -117,7 +117,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
 
     execute({ renderable }: GraphicsInstruction)
     {
-        if (renderable.layerVisibleRenderable < 0b11) return;
+        if (!renderable.isRenderable) return;
 
         this.adaptor.execute(this, renderable);
     }

--- a/src/rendering/mesh/shared/MeshPipe.ts
+++ b/src/rendering/mesh/shared/MeshPipe.ts
@@ -161,7 +161,7 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
 
     execute({ renderable }: MeshInstruction)
     {
-        if (renderable.layerVisibleRenderable < 0b11) return;
+        if (!renderable.isRenderable) return;
 
         this.adaptor.execute(this, renderable);
     }

--- a/src/rendering/renderers/shared/LayerRenderable.ts
+++ b/src/rendering/renderers/shared/LayerRenderable.ts
@@ -45,4 +45,9 @@ export class LayerRenderable<T extends View = View> implements Renderable<T>
         this.didViewUpdate = true;
         this.original.layerGroup.onChildViewUpdate(this);
     }
+
+    get isRenderable()
+    {
+        return this.original.isRenderable;
+    }
 }

--- a/src/rendering/renderers/shared/ProxyRenderable.ts
+++ b/src/rendering/renderers/shared/ProxyRenderable.ts
@@ -34,4 +34,9 @@ export class ProxyRenderable<T extends View = View> implements Renderable<T>
     {
         return this.original.layerVisibleRenderable;
     }
+
+    get isRenderable()
+    {
+        return this.original.isRenderable;
+    }
 }

--- a/src/rendering/renderers/shared/Renderable.ts
+++ b/src/rendering/renderers/shared/Renderable.ts
@@ -12,4 +12,5 @@ export interface Renderable<VIEW extends View = View>
     layerColor: number;
     layerBlendMode: BLEND_MODES;
     layerVisibleRenderable: number;
+    isRenderable: boolean;
 }

--- a/src/rendering/scene/Container.ts
+++ b/src/rendering/scene/Container.ts
@@ -691,6 +691,13 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
         this.onUpdate();
     }
 
+    get isRenderable(): boolean
+    {
+        const worldAlpha = ((this.layerColor >> 24) & 0xFF);
+
+        return (this.localVisibleRenderable === 0b11 && worldAlpha > 0);
+    }
+
     updateIsSimple()
     {
         this.isSimple = !(this.isLayerRoot) && (this.effects.length === 0);

--- a/src/rendering/scene/LayerGroup.ts
+++ b/src/rendering/scene/LayerGroup.ts
@@ -246,6 +246,13 @@ export class LayerGroup implements Instruction
         childrenToUpdate.index--;
     }
 
+    get isRenderable(): boolean
+    {
+        const worldAlpha = ((this.worldColor >> 24) & 0xFF);
+
+        return (this.root.localVisibleRenderable === 0b11 && worldAlpha > 0);
+    }
+
     onRenderContainers: Container[] = [];
 
     /**

--- a/src/rendering/scene/LayerPipe.ts
+++ b/src/rendering/scene/LayerPipe.ts
@@ -34,6 +34,8 @@ export class LayerPipe implements InstructionPipe<LayerGroup>
 
     execute(layerGroup: LayerGroup)
     {
+        if (!layerGroup.isRenderable) return;
+
         this.renderer.globalUniforms.push({
             projectionMatrix: this.renderer.renderTarget.renderTarget.projectionMatrix,
             worldTransformMatrix: layerGroup.worldTransform,


### PR DESCRIPTION
fix up visible check when executing stand alone renderables

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b31965d</samp>

### Summary
🎨🔬🚫

<!--
1.  🎨 - This emoji represents the change in the color-related logic of the `isRenderable` property, which now takes into account the alpha component of the `layerColor` and `worldColor` properties.
2.  🔬 - This emoji represents the change in the visibility-related logic of the `isRenderable` property, which now uses the `localVisibleRenderable` property instead of the `layerVisibleRenderable` property, and also checks the `root` property of the layer group.
3.  🚫 - This emoji represents the change in the pipe execution logic, which now skips the renderable objects that have the `isRenderable` property set to false.
-->
This pull request simplifies and unifies the logic of checking the visibility and transparency of renderable objects in different types of pipes. It introduces the `isRenderable` property to the `Renderable` interface and its subclasses, and replaces the usage of the `layerVisibleRenderable` property in the `GraphicsPipe` and `MeshPipe` classes.

> _`isRenderable`_
> _simplifies pipe logic_
> _a clear winter sky_

### Walkthrough
*  Simplify and unify the logic of checking whether a renderable object should be executed by a pipe or not by using the `isRenderable` property instead of the `layerVisibleRenderable` property ([link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-69c7d514fec768a7b06cdb20beb89725d25f1bed5ec8f70e8cff6c92d30e1517L120-R120), [link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-0570a5977ff7601f6bd7334b6862ff6af98b6f04c4b96434e367d3128a8b12b0L164-R164), [link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-a2814763080c95ca7c6fe2e672bbd348be4719f464349303982cea4230bb62e3R37-R38))
*  Add the `isRenderable` property to the `Renderable` interface and implement it in the subclasses `Container` and `LayerGroup` ([link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-2da2b159323892fe7677dff65957fab1452d82cc033d076c0892a3da3adb1af8R15), [link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R694-R700), [link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaR249-R255))
*  The `isRenderable` property returns true if the renderable object and its parent are visible and not fully transparent, based on the `localVisibleRenderable`, `layerColor`, `root`, and `worldColor` properties ([link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R694-R700), [link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaR249-R255))
*  The `worldColor` property of a `LayerGroup` is the result of multiplying the `layerColor` property of the layer group and its ancestors ([link](https://github.com/pixijs/pixijs/pull/9461/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaR249-R255))




