### PR TITLE
Core/destroy-mesh

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -39,6 +39,7 @@ export class Batch
 export interface BatchableObject
 {
     indexStart: number;
+
     packAttributes: (
         float32View: Float32Array,
         uint32View: Uint32Array,

--- a/src/rendering/graphics/shared/Graphics.ts
+++ b/src/rendering/graphics/shared/Graphics.ts
@@ -3,7 +3,6 @@ import { GraphicsContext } from './GraphicsContext';
 import { GraphicsView } from './GraphicsView';
 
 import type { ContainerOptions } from '../../scene/Container';
-import type { DestroyOptions } from '../../scene/destroyTypes';
 
 export interface GraphicsOptions extends ContainerOptions<GraphicsView>
 {
@@ -34,24 +33,5 @@ export class Graphics extends Container<GraphicsView>
     set context(context: GraphicsContext)
     {
         this.view.context = context;
-    }
-
-    /**
-     * Destroys this graphics and optionally its context and children.
-     * Do not use a Graphics after calling `destroy`.
-     * @param options - Options parameter. A boolean will act as if all options
-     *  have been set to that value
-     * @param {boolean} [options.children=false] - if set to true, all the children will have their destroy
-     *  method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should destroy the texture of the graphics or of any child sprite
-     * @param {boolean} [options.textureSource=false] - Should destroy the texture source of the graphics or of
-     * any child sprite
-     * @param {boolean} [options.context=false] - Should destroy the context of the child graphics
-     */
-    public destroy(options: DestroyOptions = false): void
-    {
-        super.destroy(options);
-
-        this.view.destroy(options);
     }
 }

--- a/src/rendering/graphics/shared/GraphicsContext.ts
+++ b/src/rendering/graphics/shared/GraphicsContext.ts
@@ -121,6 +121,9 @@ export class GraphicsContext
 
     customShader?: Shader;
 
+    onGraphicsContextUpdate = new Runner('onGraphicsContextUpdate');
+    onGraphicsContextDestroy = new Runner('onGraphicsContextDestroy');
+
     private _transform: Matrix = new Matrix();
 
     private _fillStyle: FillStyle = { ...GraphicsContext.defaultFillStyle };
@@ -129,8 +132,6 @@ export class GraphicsContext
     private _strokeStyle: StrokeStyle = { ...GraphicsContext.defaultStrokeStyle };
     private _strokeStyleOriginal: FillStyleInputs = 0xffffff;
     private _stateStack: { fillStyle: FillStyle; strokeStyle: StrokeStyle, transform: Matrix }[] = [];
-
-    onGraphicsContextUpdate = new Runner('onGraphicsContextUpdate');
 
     private _tick = 0;
 
@@ -801,6 +802,18 @@ export class GraphicsContext
 
         this._fillStyle = null;
         this._strokeStyle = null;
+
+        this.instructions = null;
+        this.activePath = null;
+        this._bounds = null;
+        this._stateStack = null;
+        this.transformMatrix = null;
+        this.customShader = null;
+        this._transform = null;
+
+        this.onGraphicsContextDestroy.emit(this);
+        this.onGraphicsContextDestroy.removeAll();
+        this.onGraphicsContextDestroy = null;
     }
 }
 

--- a/src/rendering/graphics/shared/GraphicsPipe.ts
+++ b/src/rendering/graphics/shared/GraphicsPipe.ts
@@ -7,11 +7,10 @@ import type { ExtensionMetadata } from '../../../extensions/Extensions';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { Instruction } from '../../renderers/shared/instructions/Instruction';
 import type { InstructionSet } from '../../renderers/shared/instructions/InstructionSet';
-import type { RenderPipe } from '../../renderers/shared/instructions/RenderPipe';
+import type { BatchPipe, RenderPipe } from '../../renderers/shared/instructions/RenderPipe';
 import type { Renderable } from '../../renderers/shared/Renderable';
 import type { Shader } from '../../renderers/shared/shader/Shader';
-import type { Renderer } from '../../renderers/types';
-import type { GpuGraphicsContext } from './GraphicsContextSystem';
+import type { GpuGraphicsContext, GraphicsContextSystem } from './GraphicsContextSystem';
 import type { GraphicsView } from './GraphicsView';
 
 export interface GraphicsAdaptor
@@ -25,6 +24,15 @@ export interface GraphicsInstruction extends Instruction
     type: 'graphics';
     renderable: Renderable<GraphicsView>;
 }
+
+export interface GraphicsSystem
+{
+    graphicsContext: GraphicsContextSystem;
+    renderPipes: {
+        batch: BatchPipe
+    }
+}
+
 export class GraphicsPipe implements RenderPipe<GraphicsView>
 {
     /** @ignore */
@@ -37,7 +45,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
         name: 'graphics',
     };
 
-    renderer: Renderer;
+    renderer: GraphicsSystem;
     shader: Shader;
     state: State = State.for2d();
 
@@ -45,7 +53,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
     private renderableBatchesHash: Record<number, BatchableGraphics[]> = {};
     private adaptor: GraphicsAdaptor;
 
-    constructor(renderer: Renderer, adaptor: GraphicsAdaptor)
+    constructor(renderer: GraphicsSystem, adaptor: GraphicsAdaptor)
     {
         this.renderer = renderer;
 
@@ -132,12 +140,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
 
         if (wasBatched)
         {
-            this.renderableBatchesHash[renderable.uid].forEach((batch) =>
-            {
-                BigPool.return(batch as PoolItem);
-            });
-
-            this.renderableBatchesHash[renderable.uid] = null;
+            this.removeBatchForRenderable(renderable);
         }
 
         if (gpuContext.isBatchable)
@@ -189,6 +192,27 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
 
         this.renderableBatchesHash[renderable.uid] = batches;
 
+        // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
+        renderable.onDestroyed = () =>
+        {
+            this.destroyRenderable(renderable);
+        };
+
         return batches;
+    }
+
+    destroyRenderable(renderable: Renderable<GraphicsView>)
+    {
+        this.removeBatchForRenderable(renderable);
+    }
+
+    private removeBatchForRenderable(renderable: Renderable<GraphicsView>)
+    {
+        this.renderableBatchesHash[renderable.uid].forEach((batch) =>
+        {
+            BigPool.return(batch as PoolItem);
+        });
+
+        this.renderableBatchesHash[renderable.uid] = null;
     }
 }

--- a/src/rendering/graphics/shared/GraphicsPipe.ts
+++ b/src/rendering/graphics/shared/GraphicsPipe.ts
@@ -193,10 +193,10 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
         this.renderableBatchesHash[renderable.uid] = batches;
 
         // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
-        renderable.onDestroyed = () =>
+        renderable.on('destroyed', () =>
         {
             this.destroyRenderable(renderable);
-        };
+        });
 
         return batches;
     }

--- a/src/rendering/graphics/shared/GraphicsView.ts
+++ b/src/rendering/graphics/shared/GraphicsView.ts
@@ -82,5 +82,7 @@ export class GraphicsView implements View
         {
             this._context.destroy(options);
         }
+
+        this._context = null;
     }
 }

--- a/src/rendering/mesh/shared/BatchableMesh.ts
+++ b/src/rendering/mesh/shared/BatchableMesh.ts
@@ -15,6 +15,14 @@ export class BatchableMesh implements BatchableObject
 
     get blendMode() { return this.renderable.layerBlendMode; }
 
+    reset()
+    {
+        this.renderable = null;
+        this.texture = null;
+        this.batcher = null;
+        this.batch = null;
+    }
+
     packIndex(indexBuffer: Uint32Array, index: number, indicesOffset: number)
     {
         const indices = this.renderable.view.geometry.indices;

--- a/src/rendering/mesh/shared/MeshView.ts
+++ b/src/rendering/mesh/shared/MeshView.ts
@@ -6,6 +6,7 @@ import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { Texture } from '../../renderers/shared/texture/Texture';
 import type { View } from '../../renderers/shared/View';
 import type { Bounds } from '../../scene/bounds/Bounds';
+import type { DestroyOptions } from '../../scene/destroyTypes';
 import type { MeshGeometry } from './MeshGeometry';
 
 let UID = 0;
@@ -162,6 +163,28 @@ export class MeshView<GEOMETRY extends MeshGeometry = MeshGeometry>implements Vi
         }
 
         return this._geometry.batchMode === 'batch';
+    }
+
+    /**
+     * Destroys this sprite renderable and optionally its texture.
+     * @param options - Options parameter. A boolean will act as if all options
+     *  have been set to that value
+     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the renderable as well
+     * @param {boolean} [options.textureSource=false] - Should it destroy the textureSource of the renderable as well
+     */
+    destroy(options: DestroyOptions = false): void
+    {
+        const destroyTexture = typeof options === 'boolean' ? options : options?.texture;
+
+        if (destroyTexture)
+        {
+            const destroyTextureSource = typeof options === 'boolean' ? options : options?.textureSource;
+
+            this._texture.destroy(destroyTextureSource);
+        }
+
+        this._geometry = null;
+        this._shader = null;
     }
 
     protected onGeometryUpdate()

--- a/src/rendering/renderers/shared/LayerRenderable.ts
+++ b/src/rendering/renderers/shared/LayerRenderable.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'eventemitter3';
 import { Matrix } from '../../../maths/Matrix';
 import { getRenderableUID } from '../../scene/Container';
 
@@ -13,7 +14,7 @@ import type { View } from './View';
  * This proxy allows us to override the values. This saves us a lot of extra if statements in the core loop
  * for what is normally a very rare use case!
  */
-export class LayerRenderable<T extends View = View> implements Renderable<T>
+export class LayerRenderable<T extends View = View> extends EventEmitter implements Renderable<T>
 {
     uid = getRenderableUID();
     view: T;
@@ -26,6 +27,8 @@ export class LayerRenderable<T extends View = View> implements Renderable<T>
 
     constructor({ original, view }: { original: Container<View>; view: T; })
     {
+        super();
+
         this.view = view;
         this.original = original;
         this.layerTransform = new Matrix();

--- a/src/rendering/renderers/shared/ProxyRenderable.ts
+++ b/src/rendering/renderers/shared/ProxyRenderable.ts
@@ -1,10 +1,11 @@
+import EventEmitter from 'eventemitter3';
 import { getRenderableUID } from '../../scene/Container';
 
 import type { Matrix } from '../../../maths/Matrix';
 import type { Renderable } from './Renderable';
 import type { View } from './View';
 
-export class ProxyRenderable<T extends View = View> implements Renderable<T>
+export class ProxyRenderable<T extends View = View> extends EventEmitter implements Renderable<T>
 {
     uid = getRenderableUID();
     view: T;
@@ -15,6 +16,8 @@ export class ProxyRenderable<T extends View = View> implements Renderable<T>
 
     constructor({ original, view }: { original: Renderable<any>; view: T; })
     {
+        super();
+
         this.view = view;
         this.original = original;
         this.layerTransform = original.layerTransform;

--- a/src/rendering/renderers/shared/Renderable.ts
+++ b/src/rendering/renderers/shared/Renderable.ts
@@ -13,4 +13,6 @@ export interface Renderable<VIEW extends View = View>
     layerBlendMode: BLEND_MODES;
     layerVisibleRenderable: number;
     isRenderable: boolean;
+    // called when the renderable is destroyed..
+    onDestroyed?: () => void;
 }

--- a/src/rendering/renderers/shared/Renderable.ts
+++ b/src/rendering/renderers/shared/Renderable.ts
@@ -1,8 +1,9 @@
+import type EventEmitter from 'eventemitter3';
 import type { Matrix } from '../../../maths/Matrix';
 import type { BLEND_MODES } from './state/const';
 import type { View } from './View';
 
-export interface Renderable<VIEW extends View = View>
+export interface Renderable<VIEW extends View = View> extends EventEmitter
 {
     uid: number;
     view: VIEW;
@@ -13,6 +14,4 @@ export interface Renderable<VIEW extends View = View>
     layerBlendMode: BLEND_MODES;
     layerVisibleRenderable: number;
     isRenderable: boolean;
-    // called when the renderable is destroyed..
-    onDestroyed?: () => void;
 }

--- a/src/rendering/renderers/shared/View.ts
+++ b/src/rendering/renderers/shared/View.ts
@@ -1,5 +1,6 @@
 import type { Point } from '../../../maths/Point';
 import type { Bounds } from '../../scene/bounds/Bounds';
+import type { DestroyOptions } from '../../scene/destroyTypes';
 
 export interface ViewObserver
 {
@@ -26,5 +27,7 @@ export interface View
 
     addBounds: (bounds: Bounds) => void;
     containsPoint: (point: Point) => boolean;
+
+    destroy<DESTROY_OPTIONS = DestroyOptions>(options: DESTROY_OPTIONS): void;
 }
 

--- a/src/rendering/renderers/shared/instructions/RenderPipe.ts
+++ b/src/rendering/renderers/shared/instructions/RenderPipe.ts
@@ -23,6 +23,7 @@ export interface RenderPipe<VIEW extends View = View>
 {
     addRenderable: (renderable: Renderable<VIEW>, instructionSet: InstructionSet) => void;
     updateRenderable: (renderable: Renderable<VIEW>, instructionSet?: InstructionSet) => void;
+    destroyRenderable?: (renderable: Renderable<VIEW>) => void;
 }
 
 export interface BatchPipe

--- a/src/rendering/scene/Container.ts
+++ b/src/rendering/scene/Container.ts
@@ -2,7 +2,6 @@ import EventEmitter from 'eventemitter3';
 import { DEG_TO_RAD, RAD_TO_DEG } from '../../maths/const';
 import { Matrix } from '../../maths/Matrix';
 import { ObservablePoint } from '../../maths/ObservablePoint';
-import { NOOP } from '../../utils/NOOP';
 import { BLEND_MODES } from '../renderers/shared/state/const';
 import { childrenHelperMixin } from './container-mixins/childrenHelperMixin';
 import { effectsMixin } from './container-mixins/effectsMixin';
@@ -174,8 +173,6 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
     /// /// EFFECTS and masks etc...
 
     effects: Effect[] = [];
-
-    onDestroyed = NOOP;
 
     addEffect(effect: Effect)
     {
@@ -738,7 +735,6 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
 
         this.emit('destroyed');
 
-        this.onDestroyed();
         this.removeAllListeners();
 
         const destroyChildren = typeof options === 'boolean' ? options : options?.children;
@@ -751,6 +747,12 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
             {
                 oldChildren[i].destroy(options);
             }
+        }
+
+        if (this.view)
+        {
+            this.view.destroy(options);
+            this.view.owner = null;
         }
     }
 }

--- a/src/rendering/scene/Container.ts
+++ b/src/rendering/scene/Container.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'eventemitter3';
 import { DEG_TO_RAD, RAD_TO_DEG } from '../../maths/const';
 import { Matrix } from '../../maths/Matrix';
 import { ObservablePoint } from '../../maths/ObservablePoint';
+import { NOOP } from '../../utils/NOOP';
 import { BLEND_MODES } from '../renderers/shared/state/const';
 import { childrenHelperMixin } from './container-mixins/childrenHelperMixin';
 import { effectsMixin } from './container-mixins/effectsMixin';
@@ -173,6 +174,8 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
     /// /// EFFECTS and masks etc...
 
     effects: Effect[] = [];
+
+    onDestroyed = NOOP;
 
     addEffect(effect: Effect)
     {
@@ -734,6 +737,8 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
         this._skew = null;
 
         this.emit('destroyed');
+
+        this.onDestroyed();
         this.removeAllListeners();
 
         const destroyChildren = typeof options === 'boolean' ? options : options?.children;

--- a/src/rendering/sprite/shared/BatchableSprite.ts
+++ b/src/rendering/sprite/shared/BatchableSprite.ts
@@ -106,4 +106,13 @@ export class BatchableSprite implements BatchableObject
         indexBuffer[index++] = indicesOffset + 2;
         indexBuffer[index++] = indicesOffset + 3;
     }
+
+    reset()
+    {
+        this.sprite = null;
+        this.texture = null;
+        this.batcher = null;
+        this.batch = null;
+        this.bounds = null;
+    }
 }

--- a/src/rendering/sprite/shared/Sprite.ts
+++ b/src/rendering/sprite/shared/Sprite.ts
@@ -4,7 +4,6 @@ import { Container } from '../../scene/Container';
 import { SpriteView } from './SpriteView';
 
 import type { ContainerOptions } from '../../scene/Container';
-import type { DestroyOptions } from '../../scene/destroyTypes';
 
 export interface SpriteOptions extends ContainerOptions<SpriteView>
 {
@@ -52,24 +51,5 @@ export class Sprite extends Container<SpriteView>
     set texture(value: Texture)
     {
         this.view.texture = value;
-    }
-
-    /**
-     * Destroys this sprite and optionally its texture and children.
-     * Do not use a Sprite after calling `destroy`.
-     * @param options - Options parameter. A boolean will act as if all options
-     *  have been set to that value
-     * @param {boolean} [options.children=false] - if set to true, all the children will have their destroy
-     *  method called as well. 'options' will be passed on to those calls.
-     * @param {boolean} [options.texture=false] - Should it destroy the current texture of the sprite as well
-     * @param {boolean} [options.textureSource=false] - Should it destroy the textureSource of the sprite as well
-     * @param {boolean} [options.context=false] - Only used for children with graphicsContexts e.g. Graphics.
-     * If options.children is set to true it should destroy the context of the child graphics
-     */
-    public destroy(options: DestroyOptions = false): void
-    {
-        super.destroy(options);
-
-        this.view.destroy(options);
     }
 }

--- a/src/rendering/sprite/shared/SpriteView.ts
+++ b/src/rendering/sprite/shared/SpriteView.ts
@@ -204,7 +204,6 @@ export class SpriteView implements View
     public destroy(options: TypeOrBool<TextureDestroyOptions> = false)
     {
         this.anchor = null;
-        this.owner = null;
 
         const destroyTexture = typeof options === 'boolean' ? options : options?.texture;
 

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -1,18 +1,68 @@
 import { Graphics } from '../../../src/rendering/graphics/shared/Graphics';
+import { WebGLRenderer } from '../../../src/rendering/renderers/gl/WebGLRenderer';
+import { Container } from '../../../src/rendering/scene/Container';
+
+import type { Renderer } from '../../../src/rendering/renderers/types';
+
+async function getRenderer(): Promise<Renderer>
+{
+    const renderer = new WebGLRenderer();
+
+    await renderer.init({
+        width: 100,
+        height: 100,
+    });
+
+    return renderer;
+}
 
 describe('Graphics', () =>
 {
     it('should not throw when destroyed', () =>
     {
-        const sprite = new Graphics();
+        const graphics = new Graphics();
 
-        expect(() => sprite.destroy()).not.toThrow();
+        expect(() => graphics.destroy()).not.toThrow();
     });
 
     it('should not throw when destroying it context', () =>
     {
-        const sprite = new Graphics();
+        const graphics = new Graphics();
 
-        expect(() => sprite.destroy(true)).not.toThrow();
+        expect(() => graphics.destroy(true)).not.toThrow();
+    });
+
+    it('should clean up correctly on the pipe and system when destroyed', async () =>
+    {
+        const renderer = await getRenderer();
+
+        const container = new Container();
+
+        const graphics = new Graphics();
+
+        graphics.context.rect(0, 0, 100, 100).fill(0xFF0000);
+
+        container.addChild(graphics);
+
+        renderer.render(container);
+
+        // we will lose this ref once its destroyed:
+        const context = graphics.context;
+
+        graphics.destroy();
+
+        expect(graphics.context).toBeNull();
+
+        expect(renderer.renderPipes.graphics['renderableBatchesHash'][graphics.uid]).toBeNull();
+
+        expect(renderer.graphicsContext['gpuContextHash'][context.uid]).not.toBeNull();
+        expect(renderer.graphicsContext['gpuContextHash'][context.uid]).not.toBeNull();
+
+        context.destroy(true);
+
+        expect(renderer.graphicsContext['gpuContextHash'][context.uid]).toBeNull();
+        expect(renderer.graphicsContext['gpuContextHash'][context.uid]).toBeNull();
+
+        expect(context.instructions).toBeNull();
     });
 });

--- a/tests/renderering/mesh/Mesh.test.ts
+++ b/tests/renderering/mesh/Mesh.test.ts
@@ -1,0 +1,98 @@
+import { Mesh } from '../../../src/rendering/mesh/shared/Mesh';
+import { MeshGeometry } from '../../../src/rendering/mesh/shared/MeshGeometry';
+import { WebGLRenderer } from '../../../src/rendering/renderers/gl/WebGLRenderer';
+import { ImageSource } from '../../../src/rendering/renderers/shared/texture/sources/ImageSource';
+import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+import { Container } from '../../../src/rendering/scene/Container';
+
+import type { Renderer } from '../../../src/rendering/renderers/types';
+
+async function getRenderer(): Promise<Renderer>
+{
+    const renderer = new WebGLRenderer();
+
+    await renderer.init({
+        width: 100,
+        height: 100,
+    });
+
+    return renderer;
+}
+
+function getTexture()
+{
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 20;
+    canvas.height = 20;
+
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+
+    // fill canvas with white
+    context.fillStyle = '#FFFFFF';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    const defaultTexture = new Texture({
+        source: new ImageSource({
+            resource: canvas
+        })
+    });
+
+    defaultTexture.label = 'defaultTexture';
+
+    return defaultTexture;
+}
+
+function getMesh()
+{
+    const size = 10;
+
+    const quadGeometry = new MeshGeometry({
+        positions: new Float32Array([-size, -size, size, -size, size, size, -size, size]),
+        uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]),
+        indices: new Uint32Array([0, 1, 2, 0, 2, 3]), // triangle 1);
+    });
+
+    const mesh = new Mesh({
+        texture: getTexture(),
+        geometry: quadGeometry
+    });
+
+    return mesh;
+}
+
+describe('Mesh', () =>
+{
+    it('should not throw when destroyed', () =>
+    {
+        const mesh = getMesh();
+
+        expect(() => mesh.destroy()).not.toThrow();
+    });
+
+    it('should clean up correctly on the pipe when destroyed', async () =>
+    {
+        const renderer = await getRenderer();
+
+        const container = new Container();
+
+        const mesh = getMesh();
+
+        container.addChild(mesh);
+
+        renderer.render(container);
+
+        const gpuMesh = renderer.renderPipes.mesh['gpuBatchableMeshHash'][mesh.uid];
+
+        mesh.destroy();
+
+        expect(mesh.geometry).toBeNull();
+        expect(mesh.texture).toBeNull();
+        expect(mesh.view.owner).toBeNull();
+
+        expect(renderer.renderPipes.mesh['renderableHash'][mesh.uid]).toBeNull();
+        expect(renderer.renderPipes.mesh['gpuBatchableMeshHash'][mesh.uid]).toBeNull();
+
+        expect(gpuMesh.renderable).toBeNull();
+    });
+});

--- a/tests/renderering/sprite/Sprite.test.ts
+++ b/tests/renderering/sprite/Sprite.test.ts
@@ -1,0 +1,78 @@
+import { Graphics } from '../../../src/rendering/graphics/shared/Graphics';
+import { WebGLRenderer } from '../../../src/rendering/renderers/gl/WebGLRenderer';
+import { ImageSource } from '../../../src/rendering/renderers/shared/texture/sources/ImageSource';
+import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+import { Container } from '../../../src/rendering/scene/Container';
+import { Sprite } from '../../../src/rendering/sprite/shared/Sprite';
+
+import type { Renderer } from '../../../src/rendering/renderers/types';
+
+async function getRenderer(): Promise<Renderer>
+{
+    const renderer = new WebGLRenderer();
+
+    await renderer.init({
+        width: 100,
+        height: 100,
+    });
+
+    return renderer;
+}
+
+function getTexture()
+{
+    const canvas = document.createElement('canvas');
+
+    canvas.width = 20;
+    canvas.height = 20;
+
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+
+    // fill canvas with white
+    context.fillStyle = '#FFFFFF';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    const defaultTexture = new Texture({
+        source: new ImageSource({
+            resource: canvas
+        })
+    });
+
+    defaultTexture.label = 'defaultTexture';
+
+    return defaultTexture;
+}
+
+describe('Sprite', () =>
+{
+    it('should not throw when destroyed', () =>
+    {
+        const sprite = new Graphics();
+
+        expect(() => sprite.destroy()).not.toThrow();
+    });
+
+    it('should not throw when destroying it context', () =>
+    {
+        const sprite = new Graphics();
+
+        expect(() => sprite.destroy(true)).not.toThrow();
+    });
+
+    it('should clean up correctly on the pipe and system when destroyed', async () =>
+    {
+        const renderer = await getRenderer();
+
+        const container = new Container();
+
+        const sprite = new Sprite(getTexture());
+
+        container.addChild(sprite);
+
+        renderer.render(container);
+
+        sprite.destroy();
+
+        expect(renderer.renderPipes.sprite['gpuSpriteHash'][sprite.uid]).toBeNull();
+    });
+});

--- a/tests/scene/DummyView.ts
+++ b/tests/scene/DummyView.ts
@@ -1,8 +1,10 @@
+import EventEmitter from 'eventemitter3';
+
 import type { Point } from '../../src/maths/Point';
 import type { View, ViewObserver } from '../../src/rendering/renderers/shared/View';
 import type { Bounds } from '../../src/rendering/scene/bounds/Bounds';
 
-export class DummyView implements View
+export class DummyView extends EventEmitter implements View
 {
     owner: ViewObserver;
     uid: number;
@@ -15,4 +17,5 @@ export class DummyView implements View
         bounds.addFrame(0, 0, 100, 100);
     };
     containsPoint: (point: Point) => boolean;
+    destroy: () => void;
 }


### PR DESCRIPTION
- hook into events for `destroyed`
- renamed sprite to renderable in sprite pipe (for consistency with the other pipes)
- make `Container` call `view.destroy` rather than overriding in the renderable class
- make Renderable extend `EventEmitter`
- fixed up the 'Sprite' destroy cycle
- fixed up the 'Mesh' destroy cycle
- fixed up the 'graphics` destroy cycle