### PR TITLE
Chore/destroy buffers

### DIFF
--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -65,7 +65,7 @@ export class GlBufferSystem implements ISystem
     /** Sets up the renderer context and necessary buffers. */
     protected contextChange(): void
     {
-        this.disposeAll(true);
+        this.destroyAll(true);
 
         this.gl = this.renderer.gl;
     }
@@ -169,7 +169,7 @@ export class GlBufferSystem implements ISystem
      * dispose all WebGL resources of all managed buffers
      * @param {boolean} [contextLost=false] - If context was lost, we suppress `gl.delete` calls
      */
-    disposeAll(contextLost?: boolean): void
+    destroyAll(contextLost?: boolean): void
     {
         const gl = this.gl;
 

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -38,11 +38,7 @@ export class GlBufferSystem implements ISystem
 
     private gl: GlRenderingContext;
 
-    private readonly _glBuffers: {[key: number]: GlBuffer} = {};
-
-    // TODO make sure to manage these! also for the GPU stuff
-    /** Cache for all buffers by id, used in case renderer gets destroyed or for profiling */
-    readonly managedBuffers: {[key: number]: Buffer};
+    private _gpuBuffers: {[key: number]: GlBuffer} = {};
 
     /** Cache keeping track of the base bound buffer bases */
     private readonly boundBufferBases: {[key: number]: Buffer};
@@ -55,7 +51,6 @@ export class GlBufferSystem implements ISystem
     constructor(renderer: WebGLRenderer)
     {
         this.renderer = renderer;
-        this.managedBuffers = {};
         this.boundBufferBases = {};
     }
 
@@ -77,7 +72,7 @@ export class GlBufferSystem implements ISystem
 
     getGlBuffer(buffer: Buffer): GlBuffer
     {
-        return this._glBuffers[buffer.uid] || this.createGLBuffer(buffer);
+        return this._gpuBuffers[buffer.uid] || this.createGLBuffer(buffer);
     }
 
     /**
@@ -171,49 +166,41 @@ export class GlBufferSystem implements ISystem
     }
 
     /**
-     * Disposes buffer
-     * @param {PIXI.Buffer} _buffer - buffer with data
-     * @param {boolean} [_contextLost=false] - If context was lost, we suppress deleteVertexArray
+     * dispose all WebGL resources of all managed buffers
+     * @param {boolean} [contextLost=false] - If context was lost, we suppress `gl.delete` calls
      */
-    dispose(_buffer: Buffer, _contextLost?: boolean): void
+    disposeAll(contextLost?: boolean): void
     {
-        // if (!this.managedBuffers[buffer.id])
-        // {
-        //     return;
-        // }
+        const gl = this.gl;
 
-        // delete this.managedBuffers[buffer.id];
+        if (!contextLost)
+        {
+            for (const id in this._gpuBuffers)
+            {
+                gl.deleteBuffer(this._gpuBuffers[id].buffer);
+            }
+        }
 
-        // const glBuffer = this.getGlBuffer(buffer);
-        // const gl = this.gl;
-
-        // // buffer.disposeRunner.remove(this);
-
-        // if (!glBuffer)
-        // {
-        //     return;
-        // }
-
-        // if (!contextLost)
-        // {
-        //     gl.deleteBuffer(glBuffer.buffer);
-        // }
-
-        // delete this._glBuffers[buffer.UID];
+        this._gpuBuffers = {};
     }
 
     /**
-     * dispose all WebGL resources of all managed buffers
-     * @param {boolean} [_contextLost=false] - If context was lost, we suppress `gl.delete` calls
+     * Disposes buffer
+     * @param {Buffer} buffer - buffer with data
+     * @param {boolean} [contextLost=false] - If context was lost, we suppress deleteVertexArray
      */
-    disposeAll(_contextLost?: boolean): void
+    protected onBufferDestroy(buffer: Buffer, contextLost?: boolean): void
     {
-        // const all: any[] = Object.keys(this.managedBuffers);
+        const glBuffer = this._gpuBuffers[buffer.uid];
 
-        // for (let i = 0; i < all.length; i++)
-        // {
-        //     this.dispose(this.managedBuffers[all[i]], contextLost);
-        // }
+        const gl = this.gl;
+
+        if (!contextLost)
+        {
+            gl.deleteBuffer(glBuffer.buffer);
+        }
+
+        this._gpuBuffers[buffer.uid] = null;
     }
 
     /**
@@ -238,10 +225,9 @@ export class GlBufferSystem implements ISystem
 
         const glBuffer = new GlBuffer(gl.createBuffer(), type);
 
-        this._glBuffers[buffer.uid] = glBuffer;
+        this._gpuBuffers[buffer.uid] = glBuffer;
 
-        // TODO dispose runners!
-        //  buffer.disposeRunner.add(this);
+        buffer.onDestroy.add(this);
 
         return glBuffer;
     }

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -88,10 +88,22 @@ export class GlProgram
         this.key = `${this.vertex}:${this.fragment}`;
     }
 
+    destroy(): void
+    {
+        this.fragment = null;
+        this.vertex = null;
+
+        this.attributeData = null;
+        this.uniformData = null;
+        this.uniformBlockData = null;
+
+        this.transformFeedbackVaryings = null;
+    }
+
     static programCached: Record<string, GlProgram> = {};
     static from(options: GlProgramOptions): GlProgram
     {
-        const key = `${options.vertex}:${options.fragment}:${options.name}`;
+        const key = `${options.vertex}:${options.fragment}`;
 
         if (!GlProgram.programCached[key])
         {

--- a/src/rendering/renderers/gpu/WebGPUSystems.ts
+++ b/src/rendering/renderers/gpu/WebGPUSystems.ts
@@ -37,7 +37,6 @@ export interface GPURenderSystems extends SharedRenderSystems, PixiMixins.GPURen
 export interface GPURenderPipes extends SharedRenderPipes, PixiMixins.GPURenderPipes
 {
     uniformBatch: UniformBatchPipe,
-    scissorMask: GpuScissorMaskPipe,
 }
 
 export const WebGPUSystemsExtensions = [

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -60,7 +60,7 @@ export class BufferSystem implements ISystem
     }
 
     /** dispose all WebGL resources of all managed buffers */
-    disposeAll(): void
+    destroyAll(): void
     {
         for (const id in this._gpuBuffers)
         {
@@ -102,7 +102,7 @@ export class BufferSystem implements ISystem
      * Disposes buffer
      * @param buffer - buffer with data
      */
-    protected onBufferDestroy(buffer: Buffer): void
+    onBufferDestroy(buffer: Buffer): void
     {
         const gpuBuffer = this._gpuBuffers[buffer.uid];
 

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -20,7 +20,7 @@ export class BufferSystem implements ISystem
 
     readonly renderer: WebGPURenderer;
     protected CONTEXT_UID: number;
-    private readonly _gpuBuffers: { [key: number]: GPUBuffer } = {};
+    private _gpuBuffers: { [key: number]: GPUBuffer } = {};
 
     private gpu: GPU;
 
@@ -59,6 +59,17 @@ export class BufferSystem implements ISystem
         return gpuBuffer;
     }
 
+    /** dispose all WebGL resources of all managed buffers */
+    disposeAll(): void
+    {
+        for (const id in this._gpuBuffers)
+        {
+            this._gpuBuffers[id].destroy();
+        }
+
+        this._gpuBuffers = {};
+    }
+
     createGPUBuffer(buffer: Buffer): GPUBuffer
     {
         const gpuBuffer = this.gpu.device.createBuffer(buffer.descriptor);
@@ -76,6 +87,7 @@ export class BufferSystem implements ISystem
         this._gpuBuffers[buffer.uid] = gpuBuffer;
 
         buffer.onUpdate.add(this);
+        buffer.onDestroy.add(this);
 
         return gpuBuffer;
     }
@@ -84,6 +96,19 @@ export class BufferSystem implements ISystem
     {
         // just upload that...
         this.updateBuffer(buffer);
+    }
+
+    /**
+     * Disposes buffer
+     * @param buffer - buffer with data
+     */
+    protected onBufferDestroy(buffer: Buffer): void
+    {
+        const gpuBuffer = this._gpuBuffers[buffer.uid];
+
+        gpuBuffer.destroy();
+
+        this._gpuBuffers[buffer.uid] = null;
     }
 
     destroy(): void

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -64,6 +64,17 @@ export class GpuProgram
         this.gpuLayout = gpuLayout ?? generateGpuLayoutGroups(structsAndGroups);
     }
 
+    destroy(): void
+    {
+        this._gpuLayout = null;
+        this.gpuLayout = null;
+        this.layout = null;
+        this.structsAndGroups = null;
+        this.fragment = null;
+        this.vertex = null;
+        this.compute = null;
+    }
+
     static programCached: Record<string, GpuProgram> = {};
     static from(options: GpuProgramOptions): GpuProgram
     {

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -52,7 +52,7 @@ export class Buffer implements BindResource
 
         this._data = data as TypedArray;
 
-        size = size ?? (data as TypedArray).byteLength;
+        size = size ?? (data as TypedArray)?.byteLength;
 
         const mappedAtCreation = !!data;
 

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -42,6 +42,7 @@ export class Geometry
     _bufferLayout: Record<number, Buffer>;
 
     onUpdate = new Runner('onGeometryUpdate');
+    onDestroy = new Runner('onGeometryDestroy');
     tick = 0;
 
     instanced: boolean;
@@ -68,9 +69,12 @@ export class Geometry
             }
         }
 
-        this.indexBuffer = ensureIsBuffer(indexBuffer, true);
+        if (indexBuffer)
+        {
+            this.indexBuffer = ensureIsBuffer(indexBuffer, true);
 
-        this.buffers.push(this.indexBuffer);
+            this.buffers.push(this.indexBuffer);
+        }
 
         this.topology = topology || 'triangle-list';
     }
@@ -142,6 +146,25 @@ export class Geometry
         }
 
         return 0;
+    }
+
+    destroy(destroyBuffers = false): void
+    {
+        this.onDestroy.emit(this);
+
+        this.onDestroy.destroy();
+        this.onUpdate.destroy();
+
+        this.onDestroy = null;
+        this.onUpdate = null;
+
+        if (destroyBuffers)
+        {
+            this.buffers.forEach((buffer) => buffer.destroy());
+        }
+
+        this.attributes = null;
+        this.buffers = null;
     }
 }
 

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -1,4 +1,5 @@
 import { BindGroup } from '../../gpu/shader/BindGroup';
+import { Runner } from '../runner/Runner';
 
 import type { GlProgram } from '../../gl/shader/GlProgram';
 import type { GpuProgram } from '../../gpu/shader/GpuProgram';
@@ -38,6 +39,8 @@ export class Shader
     resources: Record<string, any>;
 
     uniformBindMap: Record<number, Record<number, string>> = {};
+
+    onDestroy = new Runner('onShaderDestroy');
 
     constructor({ gpuProgram, glProgram, resources }: ShaderWithResourcesDescriptor);
     constructor({ gpuProgram, glProgram, groups, groupMap }: ShaderWithGroupsDescriptor);
@@ -177,5 +180,28 @@ export class Shader
         }
 
         return uniformsOut;
+    }
+
+    destroy(destroyProgram = false): void
+    {
+        this.onDestroy.emit(this);
+
+        if (destroyProgram)
+        {
+            this.gpuProgram?.destroy();
+            this.glProgram?.destroy();
+        }
+
+        this.gpuProgram = null;
+        this.glProgram = null;
+
+        this.groups = null;
+
+        this.onDestroy.destroy();
+        this.onDestroy = null;
+
+        this.uniformBindMap = null;
+
+        this.resources = null;
     }
 }

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -54,7 +54,7 @@ describe('Buffer', () =>
 
         renderer.buffer.updateBuffer(buffer);
 
-        renderer.buffer.disposeAll();
+        renderer.buffer.destroyAll();
 
         expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeUndefined();
     });

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -1,0 +1,61 @@
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { getRenderer } from '../utils/getRenderer';
+
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+describe('Buffer', () =>
+{
+    it('should destroyed', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        buffer.destroy();
+
+        expect(buffer.data).toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.buffer.updateBuffer(buffer);
+
+        buffer.destroy();
+
+        expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeNull();
+    });
+
+    it('should set a cast data correctly', () =>
+    {
+        const buffer = new Buffer({
+            data: [1, 2, 3],
+            usage: 1,
+        });
+
+        expect(buffer.data).toBeInstanceOf(Float32Array);
+    });
+
+    it('should dispose all on the BufferSystem', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.buffer.updateBuffer(buffer);
+
+        renderer.buffer.disposeAll();
+
+        expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeUndefined();
+    });
+});

--- a/tests/renderering/Geometry.test.ts
+++ b/tests/renderering/Geometry.test.ts
@@ -1,52 +1,10 @@
-import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
 import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
 import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+import { getGeometry } from '../utils/getGeometry';
+import { getGlProgram } from '../utils/getGlProgram';
 import { getRenderer } from '../utils/getRenderer';
 
 import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
-
-function getGlProgram()
-{
-    return new GlProgram({
-        vertex: `
-            
-            in vec2 aVertexPosition;
-            
-            void main(void)
-            {
-                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
-            }
-        `,
-
-        fragment: `
-
-            out vec4 fragColor;
-
-            void main(void)
-            {
-                fragColor = vec4(1.0);
-            }
-        `,
-    });
-}
-
-function getGeometry()
-{
-    return new Geometry({
-        attributes: {
-            aVertexPosition: {
-                buffer: new Buffer({
-                    data: new Float32Array([1, 2, 3]),
-                    usage: 1,
-                }),
-                shaderLocation: 0,
-                format: 'float32x2',
-                stride: 2 * 4,
-                offset: 0,
-            }
-        }
-    });
-}
 
 describe('Geometry', () =>
 {

--- a/tests/renderering/Geometry.test.ts
+++ b/tests/renderering/Geometry.test.ts
@@ -1,0 +1,131 @@
+import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+import { getRenderer } from '../utils/getRenderer';
+
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+function getGlProgram()
+{
+    return new GlProgram({
+        vertex: `
+            
+            in vec2 aVertexPosition;
+            
+            void main(void)
+            {
+                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
+            }
+        `,
+
+        fragment: `
+
+            out vec4 fragColor;
+
+            void main(void)
+            {
+                fragColor = vec4(1.0);
+            }
+        `,
+    });
+}
+
+function getGeometry()
+{
+    return new Geometry({
+        attributes: {
+            aVertexPosition: {
+                buffer: new Buffer({
+                    data: new Float32Array([1, 2, 3]),
+                    usage: 1,
+                }),
+                shaderLocation: 0,
+                format: 'float32x2',
+                stride: 2 * 4,
+                offset: 0,
+            }
+        }
+    });
+}
+
+describe('Geometry', () =>
+{
+    it('should create correctly', () =>
+    {
+        const geometry = getGeometry();
+
+        expect(geometry).toBeInstanceOf(Geometry);
+
+        expect(geometry.buffers).toHaveLength(1);
+    });
+
+    it('should destroyed', () =>
+    {
+        const geometry = getGeometry();
+
+        geometry.destroy();
+
+        expect(geometry.buffers).toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const buffer = geometry.buffers[0];
+
+        geometry.destroy();
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(buffer.data).not.toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent is destroyBuffers is true', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const buffer = geometry.buffers[0];
+
+        geometry.destroy(true);
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(buffer.data).toBeNull();
+    });
+
+    it('should set a cast data correctly', () =>
+    {
+        const buffer = new Buffer({
+            data: [1, 2, 3],
+            usage: 1,
+        });
+
+        expect(buffer.data).toBeInstanceOf(Float32Array);
+    });
+
+    it('should dispose all on the GeometrySystem', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        renderer.geometry.destroyAll();
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+    });
+});

--- a/tests/renderering/Shader.test.ts
+++ b/tests/renderering/Shader.test.ts
@@ -1,0 +1,41 @@
+import { Shader } from '../../src/rendering/renderers/shared/shader/Shader';
+import { getGlProgram } from '../utils/getGlProgram';
+
+describe('Shader', () =>
+{
+    it('should create correctly', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        expect(shader).toBeInstanceOf(Shader);
+    });
+
+    it('should destroyed', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        shader.destroy();
+
+        expect(shader.glProgram).toBeNull();
+    });
+
+    it('should destroy programs if specified', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        const glProgram = shader.glProgram;
+
+        shader.destroy(true);
+
+        expect(glProgram.attributeData).toBeNull();
+    });
+});

--- a/tests/utils/getGeometry.ts
+++ b/tests/utils/getGeometry.ts
@@ -1,7 +1,8 @@
 import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
 import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
 
-export function getGeometry() {
+export function getGeometry()
+{
     return new Geometry({
         attributes: {
             aVertexPosition: {

--- a/tests/utils/getGeometry.ts
+++ b/tests/utils/getGeometry.ts
@@ -1,0 +1,19 @@
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+
+export function getGeometry() {
+    return new Geometry({
+        attributes: {
+            aVertexPosition: {
+                buffer: new Buffer({
+                    data: new Float32Array([1, 2, 3]),
+                    usage: 1,
+                }),
+                shaderLocation: 0,
+                format: 'float32x2',
+                stride: 2 * 4,
+                offset: 0,
+            }
+        }
+    });
+}

--- a/tests/utils/getGlProgram.ts
+++ b/tests/utils/getGlProgram.ts
@@ -1,6 +1,7 @@
 import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
 
-export function getGlProgram() {
+export function getGlProgram()
+{
     return new GlProgram({
         vertex: `
             

--- a/tests/utils/getGlProgram.ts
+++ b/tests/utils/getGlProgram.ts
@@ -1,0 +1,25 @@
+import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
+
+export function getGlProgram() {
+    return new GlProgram({
+        vertex: `
+            
+            in vec2 aVertexPosition;
+            
+            void main(void)
+            {
+                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
+            }
+        `,
+
+        fragment: `
+
+            out vec4 fragColor;
+
+            void main(void)
+            {
+                fragColor = vec4(1.0);
+            }
+        `,
+    });
+}


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0b80612</samp>

### Summary
🧹🧪🔧

<!--
1.  🧹 - This emoji represents the cleanup and destruction of resources and memory that was added to several classes, such as `GlProgram`, `GpuProgram`, `Buffer`, `Geometry`, and `Shader`. It also signifies the removal of unused or redundant code and properties, such as the `name` property from the `GlProgram` cache key, and the `disposeGeometry` and `disposeBuffer` methods from the `GlGeometrySystem` class.
2.  🧪 - This emoji represents the addition of unit tests for the `Buffer`, `Geometry`, and `Shader` classes using the Jest framework. It also signifies the creation of helper functions to mock the `Geometry` and `GlProgram` instances for testing purposes. These tests help to ensure the functionality and correctness of the rendering classes and their methods.
3.  🔧 - This emoji represents the refactoring and improvement of some classes and methods, such as the `GlGeometrySystem` class using a hash map to store and manage the vertex array objects, the `BufferSystem` class handling the destruction of GPU buffers, the `Buffer` class supporting number arrays as input, and the `Geometry` class accepting geometries without an index buffer. These changes enhance the performance, flexibility, and clarity of the rendering code.
-->
This pull request improves the memory management and performance of the rendering system by adding methods and events to handle the destruction of buffers, geometries, and shaders, and by refactoring some classes to use hash maps and typed arrays. It also adds unit tests for the `Buffer`, `Geometry`, and `Shader` classes using Jest.

> _We're cleaning up the code, me hearties, yo ho ho_
> _We're freeing up the memory and letting garbage go_
> _We're testing all the classes, from `Buffer` to `Shader`_
> _We're heaving on the ropes, me lads, and raising up the `GlProgram`_

### Walkthrough
*  Rename `_glBuffers` to `_gpuBuffers` and remove `managedBuffers` and `dispose` methods in `GlBufferSystem` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L41-R42), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L58), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L174-R203))
*  Rename `disposeAll` to `destroyAll` and update `getGlBuffer` and `createGLBuffer` methods to use `_gpuBuffers` and `onDestroy` runner in `GlBufferSystem` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L73-R68), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L80-R75), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L241-R230))
*  Add `destroy` method to `GlProgram` class to nullify shader source and data properties ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-b772f53b85be24e5a235f9c85c1450af5bb61962a9cfcc3b889517a4d7f81a5cL91-R106))
*  Change `_gpuBuffers` from `readonly` to `private` and add `destroyAll` and `onBufferDestroy` methods to `BufferSystem` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-2cccb4dd45cb130829c2c15e61bdee87e0398381774b67b908973c865bc3869fL23-R23), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-2cccb4dd45cb130829c2c15e61bdee87e0398381774b67b908973c865bc3869fR62-R72), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-2cccb4dd45cb130829c2c15e61bdee87e0398381774b67b908973c865bc3869fR101-R113))
*  Update `updateBuffer` method to use `onDestroy` runner in `BufferSystem` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-2cccb4dd45cb130829c2c15e61bdee87e0398381774b67b908973c865bc3869fR90))
*  Add `destroy` method to `GpuProgram` class to nullify shader source and layout properties ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-e6669c0dd094ec387f9d28583429fcb3dbbf70b8ca33cb0251d64cf7afbde828R67-R77))
*  Add `onDestroy` runner and `destroy` method to `Buffer` class and cast number array to `Float32Array` in constructor ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bfbce9e754c1022cf2c1c1319cd2e81b8b3cb4f81baacb5686e64ac9e375d92fL14-R14), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bfbce9e754c1022cf2c1c1319cd2e81b8b3cb4f81baacb5686e64ac9e375d92fL31-R38), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bfbce9e754c1022cf2c1c1319cd2e81b8b3cb4f81baacb5686e64ac9e375d92fL45-R56), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bfbce9e754c1022cf2c1c1319cd2e81b8b3cb4f81baacb5686e64ac9e375d92fR89-R102))
*  Add `onDestroy` runner and `destroy` method to `Geometry` class and handle geometries without index buffer in constructor ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bb72d736afd670e355371121f4285fd28af37dce4038265c101a2798bc429c1fR45), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bb72d736afd670e355371121f4285fd28af37dce4038265c101a2798bc429c1fL71-R77), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-bb72d736afd670e355371121f4285fd28af37dce4038265c101a2798bc429c1fR150-R168))
*  Add `onDestroy` runner and `destroy` method to `Shader` class and import `Runner` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-30ea8df9df32c8dec2534ad4a827462b35261d36345318791ff197d078c5746eR2), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-30ea8df9df32c8dec2534ad4a827462b35261d36345318791ff197d078c5746eR43-R44), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-30ea8df9df32c8dec2534ad4a827462b35261d36345318791ff197d078c5746eR184-R206))
*  Update `bind` method to use `_geometryVaoHash` and `onDestroy` runner and remove `disposeGeometry` and `disposeAll` methods in `GlGeometrySystem` class ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L237-R245), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L311-L315), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L328-R392))
*  Add unit tests for `Buffer` class in `Buffer.test.ts` file ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-9081f3a9577f1fbe67432a3c0bd32e23efb580c7f24da4dfeff0a65b17cff6dcR1-R61))
*  Add unit tests for `Geometry` class in `Geometry.test.ts` file ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-c1ca615d3004a5c6c66d5530c28ea87f60f97d6072395a15c14c7e0bf9c17130R1-R89))
*  Add unit tests for `Shader` class in `Shader.test.ts` file ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-4f77f5d58ee7f800a52b5372075ed359c33784d8bd58b8a880fc98a716205165R1-R41))
*  Add helper functions to create mock geometry and WebGL program instances in `getGeometry.ts` and `getGlProgram.ts` files ([link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-fa9d935b48bb408d2681b9168416a9135606fdac20472f62e26710ac2398600dR1-R19), [link](https://github.com/pixijs/pixijs/pull/9467/files?diff=unified&w=0#diff-252f71b19da3bc3ade21f1fad945f524f463f79ebbe4578c96ddf037599ab415R1-R25))

