### PR TITLE
Destroy pipes

### DIFF
--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -64,4 +64,10 @@ export class GlBatchAdaptor implements BatcherAdaptor
 
         renderer.geometry.draw('triangle-list', batch.size, batch.start);
     }
+
+    destroy(): void
+    {
+        this.shader.destroy(true);
+        this.shader = null;
+    }
 }

--- a/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
+++ b/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
@@ -65,4 +65,10 @@ export class GpuBatchAdaptor implements BatcherAdaptor
         // TODO move this to a draw function on the pipe!
         encoder.renderPassEncoder.drawIndexed(batch.size, 1, batch.start);
     }
+
+    destroy(): void
+    {
+        this.shader.destroy(true);
+        this.shader = null;
+    }
 }

--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -34,6 +34,12 @@ export class Batch
 
     canBundle = true;
     batchParent: { geometry: Geometry, batcher: Batcher };
+
+    destroy()
+    {
+        this.textures = null;
+        this.batchParent = null;
+    }
 }
 
 export interface BatchableObject
@@ -80,7 +86,6 @@ export class Batcher
     vertexSize = 6;
 
     textureBatcher = new TextureBatcher();
-    computeBuffer: ViewableBuffer;
     elements: BatchableObject[] = [];
     updateIndex: boolean;
     currentBlendMode: number;
@@ -338,5 +343,31 @@ export class Batcher
         fastCopy(indexBuffer.buffer, newIndexBuffer.buffer);
 
         this.indexBuffer = newIndexBuffer;
+    }
+
+    destroy()
+    {
+        for (let i = 0; i < this.batches.length; i++)
+        {
+            this.batches[i].destroy();
+        }
+
+        this.batches = null;
+
+        for (let i = 0; i < this.elements.length; i++)
+        {
+            this.elements[i].batch = null;
+        }
+
+        this.elements = null;
+
+        this.indexBuffer = null;
+
+        this.attributeBuffer.destroy();
+        this.attributeBuffer = null;
+
+        this.textureBatcher.destroy();
+
+        this.boundTextures = null;
     }
 }

--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -14,6 +14,7 @@ export interface BatcherAdaptor
 {
     init(): void;
     execute(batchPipe: BatcherPipe, batch: Batch): void
+    destroy(): void;
 }
 
 // eslint-disable-next-line max-len
@@ -132,5 +133,26 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
     execute(batch: Batch)
     {
         this.adaptor.execute(this, batch);
+    }
+
+    destroy()
+    {
+        this.toUpdate = null;
+        this.instructionSet = null;
+        this.activeBatcher = null;
+        this.state = null;
+        this._batches = null;
+        this.renderer = null;
+
+        this.adaptor.destroy();
+        this.adaptor = null;
+
+        for (const i in this._batches)
+        {
+            const batchData = this._batches[i];
+
+            batchData.batcher.destroy();
+            batchData.geometry.destroy();
+        }
     }
 }

--- a/src/rendering/batcher/shared/TextureBatcher.ts
+++ b/src/rendering/batcher/shared/TextureBatcher.ts
@@ -82,4 +82,10 @@ export class TextureBatcher
 
         return true;
     }
+
+    destroy()
+    {
+        this.output = null;
+        this.textureTicks = null;
+    }
 }

--- a/src/rendering/filters/FilterEffect.ts
+++ b/src/rendering/filters/FilterEffect.ts
@@ -12,6 +12,16 @@ export class FilterEffect implements Effect
         this.filters = options?.filters;
     }
 
+    destroy(): void
+    {
+        for (let i = 0; i < this.filters.length; i++)
+        {
+            this.filters[i].destroy();
+        }
+
+        this.filters = null;
+    }
+
     // addBounds(_bounds: Bounds): void
     // {
     //     // TODO do we take into account padding?

--- a/src/rendering/filters/shared/FilterPipe.ts
+++ b/src/rendering/filters/shared/FilterPipe.ts
@@ -74,4 +74,10 @@ export class FilterPipe implements InstructionPipe<FilterInstruction>
             this.renderer.filter.pop();
         }
     }
+
+    destroy(): void
+    {
+        this.renderer = null;
+        this.filterGlobalUniforms = null;
+    }
 }

--- a/src/rendering/graphics/gl/GlGraphicsAdaptor.ts
+++ b/src/rendering/graphics/gl/GlGraphicsAdaptor.ts
@@ -96,4 +96,10 @@ export class GlGraphicsAdaptor implements GraphicsAdaptor
             }
         }
     }
+
+    destroy(): void
+    {
+        this.shader.destroy(true);
+        this.shader = null;
+    }
 }

--- a/src/rendering/graphics/gpu/GpuGraphicsAdaptor.ts
+++ b/src/rendering/graphics/gpu/GpuGraphicsAdaptor.ts
@@ -101,4 +101,10 @@ export class GpuGraphicsAdaptor implements GraphicsAdaptor
             encoder.renderPassEncoder.drawIndexed(batch.size, 1, batch.start);
         }
     }
+
+    destroy(): void
+    {
+        this.shader.destroy(true);
+        this.shader = null;
+    }
 }

--- a/src/rendering/mask/shared/AlphaMask.ts
+++ b/src/rendering/mask/shared/AlphaMask.ts
@@ -69,6 +69,11 @@ export class AlphaMask implements Effect, PoolItem
         return false;
     }
 
+    destroy(): void
+    {
+        this.reset();
+    }
+
     static test(mask: any): boolean
     {
         return mask instanceof Sprite;

--- a/src/rendering/mask/shared/AlphaMaskPipe.ts
+++ b/src/rendering/mask/shared/AlphaMaskPipe.ts
@@ -229,4 +229,11 @@ export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
             BigPool.return(maskData.filterEffect);
         }
     }
+
+    destroy(): void
+    {
+        this.renderer = null;
+
+        this.activeMaskStage = null;
+    }
 }

--- a/src/rendering/mask/shared/ColorMask.ts
+++ b/src/rendering/mask/shared/ColorMask.ts
@@ -25,6 +25,11 @@ export class ColorMask implements Effect, PoolItem
         this.mask = mask;
     }
 
+    destroy(): void
+    {
+        // nothing to destroy
+    }
+
     static test(mask: any): boolean
     {
         return typeof mask === 'number';

--- a/src/rendering/mask/shared/ColorMaskPipe.ts
+++ b/src/rendering/mask/shared/ColorMaskPipe.ts
@@ -1,12 +1,9 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
 import type { ExtensionMetadata } from '../../../extensions/Extensions';
-import type { MaskFilter } from '../../filters/mask/MaskFilter';
 import type { Instruction } from '../../renderers/shared/instructions/Instruction';
 import type { InstructionSet } from '../../renderers/shared/instructions/InstructionSet';
 import type { InstructionPipe } from '../../renderers/shared/instructions/RenderPipe';
-import type { RenderTarget } from '../../renderers/shared/renderTarget/RenderTarget';
-import type { Texture } from '../../renderers/shared/texture/Texture';
 import type { Renderer } from '../../renderers/types';
 import type { Container } from '../../scene/Container';
 import type { ColorMask } from './ColorMask';
@@ -15,14 +12,6 @@ export interface ColorMaskInstruction extends Instruction
 {
     type: 'colorMask',
     colorMask: number,
-}
-
-export interface ColorMaskData
-{
-    previousRenderTarget: RenderTarget,
-    filter: [MaskFilter],
-    container: Container,
-    filterTexture: Texture,
 }
 
 export class ColorMaskPipe implements InstructionPipe<ColorMaskInstruction>
@@ -108,5 +97,10 @@ export class ColorMaskPipe implements InstructionPipe<ColorMaskInstruction>
         const renderer = this.renderer;
 
         renderer.colorMask.setMask(instruction.colorMask);
+    }
+
+    destroy()
+    {
+        this.colorStack = null;
     }
 }

--- a/src/rendering/mask/shared/ScissorMask.ts
+++ b/src/rendering/mask/shared/ScissorMask.ts
@@ -44,4 +44,15 @@ export class ScissorMask implements Effect
 
         return false;
     }
+
+    reset()
+    {
+        this.mask.measurable = true;
+        this.mask = null;
+    }
+
+    destroy(): void
+    {
+        this.reset();
+    }
 }

--- a/src/rendering/mask/shared/StencilMask.ts
+++ b/src/rendering/mask/shared/StencilMask.ts
@@ -61,6 +61,11 @@ export class StencilMask implements Effect, PoolItem
         return false;
     }
 
+    destroy(): void
+    {
+        this.reset();
+    }
+
     static test(mask: any): boolean
     {
         return mask instanceof Container;

--- a/src/rendering/mask/shared/StencilMaskPipe.ts
+++ b/src/rendering/mask/shared/StencilMaskPipe.ts
@@ -184,4 +184,11 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
 
         this.maskStackHash[currentRenderTargetUid] = maskStackIndex;
     }
+
+    destroy()
+    {
+        this.renderer = null;
+        this.maskStackHash = null;
+        this.maskHash = null;
+    }
 }

--- a/src/rendering/mesh/shared/MeshPipe.ts
+++ b/src/rendering/mesh/shared/MeshPipe.ts
@@ -168,7 +168,6 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
 
         const gpuMesh = this.gpuBatchableMeshHash[renderable.uid];
 
-        // TODO consider adding reset to the BatchableObject interface? Could force pooling of them?
         BigPool.return(gpuMesh as PoolItem);
 
         this.gpuBatchableMeshHash[renderable.uid] = null;
@@ -221,5 +220,30 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
         gpuMesh.renderable = renderable;
 
         return gpuMesh;
+    }
+
+    destroy()
+    {
+        for (const i in this.gpuBatchableMeshHash)
+        {
+            if (this.gpuBatchableMeshHash[i])
+            {
+                BigPool.return(this.gpuBatchableMeshHash[i] as PoolItem);
+            }
+        }
+
+        this.gpuBatchableMeshHash = null;
+        this.renderableHash = null;
+
+        this.localUniforms = null;
+        this.localUniformsBindGroup = null;
+
+        this.meshShader.destroy();
+        this.meshShader = null;
+
+        this.adaptor = null;
+
+        this.renderer = null;
+        this.state = null;
     }
 }

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -65,7 +65,7 @@ export class GlBufferSystem implements ISystem
     /** Sets up the renderer context and necessary buffers. */
     protected contextChange(): void
     {
-        this.disposeAll(true);
+        this.destroyAll(true);
 
         this.gl = this.renderer.gl;
     }
@@ -169,7 +169,7 @@ export class GlBufferSystem implements ISystem
      * dispose all WebGL resources of all managed buffers
      * @param {boolean} [contextLost=false] - If context was lost, we suppress `gl.delete` calls
      */
-    disposeAll(contextLost?: boolean): void
+    destroyAll(contextLost?: boolean): void
     {
         const gl = this.gl;
 

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -38,11 +38,7 @@ export class GlBufferSystem implements ISystem
 
     private gl: GlRenderingContext;
 
-    private readonly _glBuffers: {[key: number]: GlBuffer} = {};
-
-    // TODO make sure to manage these! also for the GPU stuff
-    /** Cache for all buffers by id, used in case renderer gets destroyed or for profiling */
-    readonly managedBuffers: {[key: number]: Buffer};
+    private _gpuBuffers: {[key: number]: GlBuffer} = {};
 
     /** Cache keeping track of the base bound buffer bases */
     private readonly boundBufferBases: {[key: number]: Buffer};
@@ -55,7 +51,6 @@ export class GlBufferSystem implements ISystem
     constructor(renderer: WebGLRenderer)
     {
         this.renderer = renderer;
-        this.managedBuffers = {};
         this.boundBufferBases = {};
     }
 
@@ -77,7 +72,7 @@ export class GlBufferSystem implements ISystem
 
     getGlBuffer(buffer: Buffer): GlBuffer
     {
-        return this._glBuffers[buffer.uid] || this.createGLBuffer(buffer);
+        return this._gpuBuffers[buffer.uid] || this.createGLBuffer(buffer);
     }
 
     /**
@@ -171,49 +166,41 @@ export class GlBufferSystem implements ISystem
     }
 
     /**
-     * Disposes buffer
-     * @param {PIXI.Buffer} _buffer - buffer with data
-     * @param {boolean} [_contextLost=false] - If context was lost, we suppress deleteVertexArray
+     * dispose all WebGL resources of all managed buffers
+     * @param {boolean} [contextLost=false] - If context was lost, we suppress `gl.delete` calls
      */
-    dispose(_buffer: Buffer, _contextLost?: boolean): void
+    disposeAll(contextLost?: boolean): void
     {
-        // if (!this.managedBuffers[buffer.id])
-        // {
-        //     return;
-        // }
+        const gl = this.gl;
 
-        // delete this.managedBuffers[buffer.id];
+        if (!contextLost)
+        {
+            for (const id in this._gpuBuffers)
+            {
+                gl.deleteBuffer(this._gpuBuffers[id].buffer);
+            }
+        }
 
-        // const glBuffer = this.getGlBuffer(buffer);
-        // const gl = this.gl;
-
-        // // buffer.disposeRunner.remove(this);
-
-        // if (!glBuffer)
-        // {
-        //     return;
-        // }
-
-        // if (!contextLost)
-        // {
-        //     gl.deleteBuffer(glBuffer.buffer);
-        // }
-
-        // delete this._glBuffers[buffer.UID];
+        this._gpuBuffers = {};
     }
 
     /**
-     * dispose all WebGL resources of all managed buffers
-     * @param {boolean} [_contextLost=false] - If context was lost, we suppress `gl.delete` calls
+     * Disposes buffer
+     * @param {Buffer} buffer - buffer with data
+     * @param {boolean} [contextLost=false] - If context was lost, we suppress deleteVertexArray
      */
-    disposeAll(_contextLost?: boolean): void
+    protected onBufferDestroy(buffer: Buffer, contextLost?: boolean): void
     {
-        // const all: any[] = Object.keys(this.managedBuffers);
+        const glBuffer = this._gpuBuffers[buffer.uid];
 
-        // for (let i = 0; i < all.length; i++)
-        // {
-        //     this.dispose(this.managedBuffers[all[i]], contextLost);
-        // }
+        const gl = this.gl;
+
+        if (!contextLost)
+        {
+            gl.deleteBuffer(glBuffer.buffer);
+        }
+
+        this._gpuBuffers[buffer.uid] = null;
     }
 
     /**
@@ -238,10 +225,9 @@ export class GlBufferSystem implements ISystem
 
         const glBuffer = new GlBuffer(gl.createBuffer(), type);
 
-        this._glBuffers[buffer.uid] = glBuffer;
+        this._gpuBuffers[buffer.uid] = glBuffer;
 
-        // TODO dispose runners!
-        //  buffer.disposeRunner.add(this);
+        buffer.onDestroy.add(this);
 
         return glBuffer;
     }

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -88,10 +88,22 @@ export class GlProgram
         this.key = `${this.vertex}:${this.fragment}`;
     }
 
+    destroy(): void
+    {
+        this.fragment = null;
+        this.vertex = null;
+
+        this.attributeData = null;
+        this.uniformData = null;
+        this.uniformBlockData = null;
+
+        this.transformFeedbackVaryings = null;
+    }
+
     static programCached: Record<string, GlProgram> = {};
     static from(options: GlProgramOptions): GlProgram
     {
-        const key = `${options.vertex}:${options.fragment}:${options.name}`;
+        const key = `${options.vertex}:${options.fragment}`;
 
         if (!GlProgram.programCached[key])
         {

--- a/src/rendering/renderers/gpu/WebGPUSystems.ts
+++ b/src/rendering/renderers/gpu/WebGPUSystems.ts
@@ -37,7 +37,6 @@ export interface GPURenderSystems extends SharedRenderSystems, PixiMixins.GPURen
 export interface GPURenderPipes extends SharedRenderPipes, PixiMixins.GPURenderPipes
 {
     uniformBatch: UniformBatchPipe,
-    scissorMask: GpuScissorMaskPipe,
 }
 
 export const WebGPUSystemsExtensions = [

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -60,7 +60,7 @@ export class BufferSystem implements ISystem
     }
 
     /** dispose all WebGL resources of all managed buffers */
-    disposeAll(): void
+    destroyAll(): void
     {
         for (const id in this._gpuBuffers)
         {
@@ -102,7 +102,7 @@ export class BufferSystem implements ISystem
      * Disposes buffer
      * @param buffer - buffer with data
      */
-    protected onBufferDestroy(buffer: Buffer): void
+    onBufferDestroy(buffer: Buffer): void
     {
         const gpuBuffer = this._gpuBuffers[buffer.uid];
 

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -20,7 +20,7 @@ export class BufferSystem implements ISystem
 
     readonly renderer: WebGPURenderer;
     protected CONTEXT_UID: number;
-    private readonly _gpuBuffers: { [key: number]: GPUBuffer } = {};
+    private _gpuBuffers: { [key: number]: GPUBuffer } = {};
 
     private gpu: GPU;
 
@@ -59,6 +59,17 @@ export class BufferSystem implements ISystem
         return gpuBuffer;
     }
 
+    /** dispose all WebGL resources of all managed buffers */
+    disposeAll(): void
+    {
+        for (const id in this._gpuBuffers)
+        {
+            this._gpuBuffers[id].destroy();
+        }
+
+        this._gpuBuffers = {};
+    }
+
     createGPUBuffer(buffer: Buffer): GPUBuffer
     {
         const gpuBuffer = this.gpu.device.createBuffer(buffer.descriptor);
@@ -76,6 +87,7 @@ export class BufferSystem implements ISystem
         this._gpuBuffers[buffer.uid] = gpuBuffer;
 
         buffer.onUpdate.add(this);
+        buffer.onDestroy.add(this);
 
         return gpuBuffer;
     }
@@ -84,6 +96,19 @@ export class BufferSystem implements ISystem
     {
         // just upload that...
         this.updateBuffer(buffer);
+    }
+
+    /**
+     * Disposes buffer
+     * @param buffer - buffer with data
+     */
+    protected onBufferDestroy(buffer: Buffer): void
+    {
+        const gpuBuffer = this._gpuBuffers[buffer.uid];
+
+        gpuBuffer.destroy();
+
+        this._gpuBuffers[buffer.uid] = null;
     }
 
     destroy(): void

--- a/src/rendering/renderers/gpu/buffer/UniformBufferBatch.ts
+++ b/src/rendering/renderers/gpu/buffer/UniformBufferBatch.ts
@@ -55,4 +55,12 @@ export class UniformBufferBatch
     {
         // TODO
     }
+
+    destroy()
+    {
+        this.buffer.destroy();
+        this.buffer = null;
+
+        this.data = null;
+    }
 }

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -64,6 +64,17 @@ export class GpuProgram
         this.gpuLayout = gpuLayout ?? generateGpuLayoutGroups(structsAndGroups);
     }
 
+    destroy(): void
+    {
+        this._gpuLayout = null;
+        this.gpuLayout = null;
+        this.layout = null;
+        this.structsAndGroups = null;
+        this.fragment = null;
+        this.vertex = null;
+        this.compute = null;
+    }
+
     static programCached: Record<string, GpuProgram> = {};
     static from(options: GpuProgramOptions): GpuProgram
     {

--- a/src/rendering/renderers/shared/BlendModePipe.ts
+++ b/src/rendering/renderers/shared/BlendModePipe.ts
@@ -174,4 +174,17 @@ export class BlendModePipe implements InstructionPipe<AdvancedBlendInstruction>
             this.endAdvancedBlendMode(instructionSet);
         }
     }
+
+    destroy()
+    {
+        this.renderer = null;
+        this.renderableList = null;
+
+        for (const i in this.filterHash)
+        {
+            this.filterHash[i as any as BLEND_MODES].destroy();
+        }
+
+        this.filterHash = null;
+    }
 }

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -52,7 +52,7 @@ export class Buffer implements BindResource
 
         this._data = data as TypedArray;
 
-        size = size ?? (data as TypedArray).byteLength;
+        size = size ?? (data as TypedArray)?.byteLength;
 
         const mappedAtCreation = !!data;
 

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -12,7 +12,7 @@ export class BufferResource implements BindResource
     // this really means ths the buffer resource cannot be updated!
     resourceId = this.uid;
 
-    readonly buffer: Buffer;
+    buffer: Buffer;
     readonly offset: number;
     readonly size: number;
     readonly bufferResource = true;
@@ -22,5 +22,15 @@ export class BufferResource implements BindResource
         this.buffer = buffer;
         this.offset = offset;
         this.size = size;
+    }
+
+    destroy(destroyBuffer = false): void
+    {
+        if (destroyBuffer)
+        {
+            this.buffer.destroy();
+        }
+
+        this.buffer = null;
     }
 }

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -42,6 +42,7 @@ export class Geometry
     _bufferLayout: Record<number, Buffer>;
 
     onUpdate = new Runner('onGeometryUpdate');
+    onDestroy = new Runner('onGeometryDestroy');
     tick = 0;
 
     instanced: boolean;
@@ -68,9 +69,12 @@ export class Geometry
             }
         }
 
-        this.indexBuffer = ensureIsBuffer(indexBuffer, true);
+        if (indexBuffer)
+        {
+            this.indexBuffer = ensureIsBuffer(indexBuffer, true);
 
-        this.buffers.push(this.indexBuffer);
+            this.buffers.push(this.indexBuffer);
+        }
 
         this.topology = topology || 'triangle-list';
     }
@@ -142,6 +146,25 @@ export class Geometry
         }
 
         return 0;
+    }
+
+    destroy(destroyBuffers = false): void
+    {
+        this.onDestroy.emit(this);
+
+        this.onDestroy.destroy();
+        this.onUpdate.destroy();
+
+        this.onDestroy = null;
+        this.onUpdate = null;
+
+        if (destroyBuffers)
+        {
+            this.buffers.forEach((buffer) => buffer.destroy());
+        }
+
+        this.attributes = null;
+        this.buffers = null;
     }
 }
 

--- a/src/rendering/renderers/shared/instructions/UniformBatchPipe.ts
+++ b/src/rendering/renderers/shared/instructions/UniformBatchPipe.ts
@@ -33,7 +33,7 @@ export class UniformBatchPipe implements InstructionPipe<UniformInstruction>
 
     private renderer: WebGPURenderer;
 
-    private hash: Record<number, BindGroup> = {};
+    private bindGroupHash: Record<number, BindGroup> = {};
     private batchBuffer: UniformBufferBatch;
 
     // number of buffers..
@@ -71,16 +71,16 @@ export class UniformBatchPipe implements InstructionPipe<UniformInstruction>
 
     private resetBindGroups()
     {
-        this.hash = {};
+        this.bindGroupHash = {};
         this.batchBuffer.clear();
     }
 
     // just works for single bind groups for now
     getUniformBindGroup(group: UniformGroup<any>, duplicate: boolean): BindGroup
     {
-        if (!duplicate && this.hash[group.uid])
+        if (!duplicate && this.bindGroupHash[group.uid])
         {
-            return this.hash[group.uid];
+            return this.bindGroupHash[group.uid];
         }
 
         // update the data..
@@ -91,9 +91,9 @@ export class UniformBatchPipe implements InstructionPipe<UniformInstruction>
 
         const offset = this.batchBuffer.addGroup(data);
 
-        this.hash[group.uid] = this.getBindGroup(offset / minUniformOffsetAlignment);
+        this.bindGroupHash[group.uid] = this.getBindGroup(offset / minUniformOffsetAlignment);
 
-        return this.hash[group.uid];
+        return this.bindGroupHash[group.uid];
     }
 
     getUniformBufferResource(group: UniformGroup<any>): BufferResource
@@ -198,6 +198,30 @@ export class UniformBatchPipe implements InstructionPipe<UniformInstruction>
 
     destroy()
     {
-        // BOOM!
+        for (let i = 0; i < this.bindGroups.length; i++)
+        {
+            this.bindGroups[i].destroy();
+        }
+
+        this.bindGroups = null;
+        this.bindGroupHash = null;
+
+        for (let i = 0; i < this.buffers.length; i++)
+        {
+            this.buffers[i].destroy();
+        }
+        this.buffers = null;
+
+        for (let i = 0; i < this.bufferResources.length; i++)
+        {
+            this.bufferResources[i].destroy();
+        }
+
+        this.bufferResources = null;
+
+        this.batchBuffer.destroy();
+        this.bindGroupHash = null;
+
+        this.renderer = null;
     }
 }

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -1,4 +1,5 @@
 import { BindGroup } from '../../gpu/shader/BindGroup';
+import { Runner } from '../runner/Runner';
 
 import type { GlProgram } from '../../gl/shader/GlProgram';
 import type { GpuProgram } from '../../gpu/shader/GpuProgram';
@@ -38,6 +39,8 @@ export class Shader
     resources: Record<string, any>;
 
     uniformBindMap: Record<number, Record<number, string>> = {};
+
+    onDestroy = new Runner('onShaderDestroy');
 
     constructor({ gpuProgram, glProgram, resources }: ShaderWithResourcesDescriptor);
     constructor({ gpuProgram, glProgram, groups, groupMap }: ShaderWithGroupsDescriptor);
@@ -177,5 +180,28 @@ export class Shader
         }
 
         return uniformsOut;
+    }
+
+    destroy(destroyProgram = false): void
+    {
+        this.onDestroy.emit(this);
+
+        if (destroyProgram)
+        {
+            this.gpuProgram?.destroy();
+            this.glProgram?.destroy();
+        }
+
+        this.gpuProgram = null;
+        this.glProgram = null;
+
+        this.groups = null;
+
+        this.onDestroy.destroy();
+        this.onDestroy = null;
+
+        this.uniformBindMap = null;
+
+        this.resources = null;
     }
 }

--- a/src/rendering/scene/Effect.ts
+++ b/src/rendering/scene/Effect.ts
@@ -9,6 +9,7 @@ export interface Effect
     addBounds?(bounds: Bounds, skipUpdateTransform?: boolean): void
     addLocalBounds?(bounds: Bounds, localRoot: Container): void
     containsPoint?(point: PointData): boolean
+    destroy(): void
 }
 
 export interface EffectConstructor

--- a/src/rendering/scene/LayerPipe.ts
+++ b/src/rendering/scene/LayerPipe.ts
@@ -49,4 +49,9 @@ export class LayerPipe implements InstructionPipe<LayerGroup>
 
         // now render a quad..
     }
+
+    destroy(): void
+    {
+        this.renderer = null;
+    }
 }

--- a/src/rendering/sprite/shared/SpritePipe.ts
+++ b/src/rendering/sprite/shared/SpritePipe.ts
@@ -109,4 +109,15 @@ export class SpritePipe implements RenderPipe<SpriteView>
 
         return batchableSprite;
     }
+
+    destroy()
+    {
+        for (const i in this.gpuSpriteHash)
+        {
+            BigPool.return(this.gpuSpriteHash[i] as PoolItem);
+        }
+
+        this.gpuSpriteHash = null;
+        this.renderer = null;
+    }
 }

--- a/src/rendering/text/bitmap/BitmapTextPipe.ts
+++ b/src/rendering/text/bitmap/BitmapTextPipe.ts
@@ -80,8 +80,13 @@ export class BitmapTextPipe implements RenderPipe<TextView>
 
     destroyRenderable(renderable: Renderable<TextView>)
     {
-        BigPool.return(this.gpuBitmapText[renderable.uid]);
-        this.gpuBitmapText[renderable.uid] = null;
+        this.destroyRenderableByUid(renderable.uid);
+    }
+
+    private destroyRenderableByUid(renderableUid: number)
+    {
+        BigPool.return(this.gpuBitmapText[renderableUid]);
+        this.gpuBitmapText[renderableUid] = null;
     }
 
     updateRenderable(renderable: Renderable<TextView>)
@@ -212,6 +217,21 @@ export class BitmapTextPipe implements RenderPipe<TextView>
         const distance = worldScale * dynamicFont.distanceField.distanceRange * (1 / fontScale) * resolution;
 
         context.customShader.resources.localUniforms.uniforms.distance = distance;
+    }
+
+    destroy()
+    {
+        for (const uid in this.gpuBitmapText)
+        {
+            this.destroyRenderableByUid(uid as any as number);
+        }
+
+        this.gpuBitmapText = null;
+
+        this.sdfShader?.destroy(true);
+        this.sdfShader = null;
+
+        this.renderer = null;
     }
 }
 

--- a/src/rendering/text/canvas/CanvasTextPipe.ts
+++ b/src/rendering/text/canvas/CanvasTextPipe.ts
@@ -101,13 +101,18 @@ export class CanvasTextPipe implements RenderPipe<TextView>
 
     destroyRenderable(renderable: Renderable<TextView>)
     {
-        const gpuText = this.gpuText[renderable.uid];
+        this.destroyRenderableById(renderable.uid);
+    }
+
+    private destroyRenderableById(renderableUid: number)
+    {
+        const gpuText = this.gpuText[renderableUid];
 
         this.renderer.canvasText.decreaseReferenceCount(gpuText.currentKey);
 
         BigPool.return(gpuText.batchableSprite);
 
-        this.gpuText[renderable.uid] = null;
+        this.gpuText[renderableUid] = null;
     }
 
     private updateText(renderable: Renderable<TextView>)
@@ -183,6 +188,17 @@ export class CanvasTextPipe implements RenderPipe<TextView>
         });
 
         return gpuTextData;
+    }
+
+    destroy()
+    {
+        for (const i in this.gpuText)
+        {
+            this.destroyRenderableById(i as any as number);
+        }
+
+        this.gpuText = null;
+        this.renderer = null;
     }
 }
 

--- a/src/tiling-sprite/TilingSpritePipe.ts
+++ b/src/tiling-sprite/TilingSpritePipe.ts
@@ -334,6 +334,15 @@ export class TilingSpritePipe implements RenderPipe<TilingSpriteView>
 
         applyMatrix(uvs, 2, 0, textureMatrix);
     }
+
+    destroy()
+    {
+        this.renderableHash = null;
+        this.gpuTilingSprite = null;
+        this.gpuBatchedTilingSprite = null;
+
+        this.renderer = null;
+    }
 }
 
 // TODO - move to a shared location

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -54,7 +54,7 @@ describe('Buffer', () =>
 
         renderer.buffer.updateBuffer(buffer);
 
-        renderer.buffer.disposeAll();
+        renderer.buffer.destroyAll();
 
         expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeUndefined();
     });

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -1,0 +1,61 @@
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { getRenderer } from '../utils/getRenderer';
+
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+describe('Buffer', () =>
+{
+    it('should destroyed', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        buffer.destroy();
+
+        expect(buffer.data).toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.buffer.updateBuffer(buffer);
+
+        buffer.destroy();
+
+        expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeNull();
+    });
+
+    it('should set a cast data correctly', () =>
+    {
+        const buffer = new Buffer({
+            data: [1, 2, 3],
+            usage: 1,
+        });
+
+        expect(buffer.data).toBeInstanceOf(Float32Array);
+    });
+
+    it('should dispose all on the BufferSystem', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.buffer.updateBuffer(buffer);
+
+        renderer.buffer.disposeAll();
+
+        expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeUndefined();
+    });
+});

--- a/tests/renderering/Geometry.test.ts
+++ b/tests/renderering/Geometry.test.ts
@@ -1,52 +1,10 @@
-import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
 import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
 import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+import { getGeometry } from '../utils/getGeometry';
+import { getGlProgram } from '../utils/getGlProgram';
 import { getRenderer } from '../utils/getRenderer';
 
 import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
-
-function getGlProgram()
-{
-    return new GlProgram({
-        vertex: `
-            
-            in vec2 aVertexPosition;
-            
-            void main(void)
-            {
-                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
-            }
-        `,
-
-        fragment: `
-
-            out vec4 fragColor;
-
-            void main(void)
-            {
-                fragColor = vec4(1.0);
-            }
-        `,
-    });
-}
-
-function getGeometry()
-{
-    return new Geometry({
-        attributes: {
-            aVertexPosition: {
-                buffer: new Buffer({
-                    data: new Float32Array([1, 2, 3]),
-                    usage: 1,
-                }),
-                shaderLocation: 0,
-                format: 'float32x2',
-                stride: 2 * 4,
-                offset: 0,
-            }
-        }
-    });
-}
 
 describe('Geometry', () =>
 {

--- a/tests/renderering/Geometry.test.ts
+++ b/tests/renderering/Geometry.test.ts
@@ -1,0 +1,131 @@
+import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+import { getRenderer } from '../utils/getRenderer';
+
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+function getGlProgram()
+{
+    return new GlProgram({
+        vertex: `
+            
+            in vec2 aVertexPosition;
+            
+            void main(void)
+            {
+                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
+            }
+        `,
+
+        fragment: `
+
+            out vec4 fragColor;
+
+            void main(void)
+            {
+                fragColor = vec4(1.0);
+            }
+        `,
+    });
+}
+
+function getGeometry()
+{
+    return new Geometry({
+        attributes: {
+            aVertexPosition: {
+                buffer: new Buffer({
+                    data: new Float32Array([1, 2, 3]),
+                    usage: 1,
+                }),
+                shaderLocation: 0,
+                format: 'float32x2',
+                stride: 2 * 4,
+                offset: 0,
+            }
+        }
+    });
+}
+
+describe('Geometry', () =>
+{
+    it('should create correctly', () =>
+    {
+        const geometry = getGeometry();
+
+        expect(geometry).toBeInstanceOf(Geometry);
+
+        expect(geometry.buffers).toHaveLength(1);
+    });
+
+    it('should destroyed', () =>
+    {
+        const geometry = getGeometry();
+
+        geometry.destroy();
+
+        expect(geometry.buffers).toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const buffer = geometry.buffers[0];
+
+        geometry.destroy();
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(buffer.data).not.toBeNull();
+    });
+
+    it('should destroyed its gpu equivalent is destroyBuffers is true', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const buffer = geometry.buffers[0];
+
+        geometry.destroy(true);
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(buffer.data).toBeNull();
+    });
+
+    it('should set a cast data correctly', () =>
+    {
+        const buffer = new Buffer({
+            data: [1, 2, 3],
+            usage: 1,
+        });
+
+        expect(buffer.data).toBeInstanceOf(Float32Array);
+    });
+
+    it('should dispose all on the GeometrySystem', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        renderer.geometry.destroyAll();
+
+        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+    });
+});

--- a/tests/renderering/Shader.test.ts
+++ b/tests/renderering/Shader.test.ts
@@ -1,0 +1,41 @@
+import { Shader } from '../../src/rendering/renderers/shared/shader/Shader';
+import { getGlProgram } from '../utils/getGlProgram';
+
+describe('Shader', () =>
+{
+    it('should create correctly', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        expect(shader).toBeInstanceOf(Shader);
+    });
+
+    it('should destroyed', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        shader.destroy();
+
+        expect(shader.glProgram).toBeNull();
+    });
+
+    it('should destroy programs if specified', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        const glProgram = shader.glProgram;
+
+        shader.destroy(true);
+
+        expect(glProgram.attributeData).toBeNull();
+    });
+});

--- a/tests/scene/DummyEffect.ts
+++ b/tests/scene/DummyEffect.ts
@@ -21,4 +21,9 @@ export class DummyEffect implements Effect
     {
         return false;
     }
+
+    destroy(): void
+    {
+        // nothing to destroy
+    }
 }

--- a/tests/utils/getGeometry.ts
+++ b/tests/utils/getGeometry.ts
@@ -1,7 +1,8 @@
 import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
 import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
 
-export function getGeometry() {
+export function getGeometry()
+{
     return new Geometry({
         attributes: {
             aVertexPosition: {

--- a/tests/utils/getGeometry.ts
+++ b/tests/utils/getGeometry.ts
@@ -1,0 +1,19 @@
+import { Buffer } from '../../src/rendering/renderers/shared/buffer/Buffer';
+import { Geometry } from '../../src/rendering/renderers/shared/geometry/Geometry';
+
+export function getGeometry() {
+    return new Geometry({
+        attributes: {
+            aVertexPosition: {
+                buffer: new Buffer({
+                    data: new Float32Array([1, 2, 3]),
+                    usage: 1,
+                }),
+                shaderLocation: 0,
+                format: 'float32x2',
+                stride: 2 * 4,
+                offset: 0,
+            }
+        }
+    });
+}

--- a/tests/utils/getGlProgram.ts
+++ b/tests/utils/getGlProgram.ts
@@ -1,6 +1,7 @@
 import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
 
-export function getGlProgram() {
+export function getGlProgram()
+{
     return new GlProgram({
         vertex: `
             

--- a/tests/utils/getGlProgram.ts
+++ b/tests/utils/getGlProgram.ts
@@ -1,0 +1,25 @@
+import { GlProgram } from '../../src/rendering/renderers/gl/shader/GlProgram';
+
+export function getGlProgram() {
+    return new GlProgram({
+        vertex: `
+            
+            in vec2 aVertexPosition;
+            
+            void main(void)
+            {
+                gl_Position = vec4(aVertexPosition, 0.0, 1.0);
+            }
+        `,
+
+        fragment: `
+
+            out vec4 fragColor;
+
+            void main(void)
+            {
+                fragColor = vec4(1.0);
+            }
+        `,
+    });
+}


### PR DESCRIPTION
All Pipes now get destroyed.

Going to provide fleshed out destroy tests in the next PR!

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3946b60</samp>

### Summary
🧹🚀🛠️

<!--
1.  🧹 - This emoji represents the cleaning up of resources and references, as well as the removal of unused or outdated code, which are common themes in these changes.
2.  🚀 - This emoji represents the improvement of performance and efficiency, as well as the simplification of the code, which are also common goals in these changes.
3.  🛠️ - This emoji represents the refactoring and fixing of bugs, as well as the addition of new features, which are also part of these changes.
-->
This pull request improves the memory management and performance of the rendering system by adding `destroy` methods to various classes that handle WebGL, GPU, and batching resources. It also fixes a bug in the `GraphicsPipe` class and refactors some classes to simplify and optimize the code. The affected classes are `Batcher`, `BatcherPipe`, `BatcherAdaptor`, `FilterPipe`, `FilterEffect`, `GraphicsPipe`, `GraphicsAdaptor`, `MeshPipe`, `GlBufferSystem`, `GlGeometrySystem`, `GlBatchAdaptor`, `GpuBatchAdaptor`, `TextureBatcher`, `GlGraphicsAdaptor`, `GpuGraphicsAdaptor`, `AlphaMask`, `AlphaMaskPipe`, `ColorMask`, `ColorMaskPipe`, `ScissorMask`, `StencilMask`, and `StencilMaskPipe`. The affected files are `src/rendering/batcher/shared/Batcher.ts`, `src/rendering/batcher/shared/BatcherPipe.ts`, `src/rendering/graphics/shared/GraphicsPipe.ts`, `src/rendering/mask/shared/ColorMaskPipe.ts`, `src/rendering/mesh/shared/MeshPipe.ts`, `src/rendering/renderers/gl/buffer/GlBufferSystem.ts`, `src/rendering/renderers/gl/geometry/GlGeometrySystem.ts`, `src/rendering/batcher/gl/GlBatchAdaptor.ts`, `src/rendering/batcher/gpu/GpuBatchAdaptor.ts`, `src/rendering/batcher/shared/TextureBatcher.ts`, `src/rendering/filters/FilterEffect.ts`, `src/rendering/filters/shared/FilterPipe.ts`, `src/rendering/graphics/gl/GlGraphicsAdaptor.ts`, `src/rendering/graphics/gpu/GpuGraphicsAdaptor.ts`, `src/rendering/mask/shared/AlphaMask.ts`, `src/rendering/mask/shared/AlphaMaskPipe.ts`, `src/rendering/mask/shared/ColorMask.

> _To render elements with flair_
> _They added `destroy` methods everywhere_
> _They cleaned up the code_
> _And fixed some bugs that showed_
> _And improved the performance and memory care_

### Walkthrough
*  Add `destroy` methods to various classes and interfaces to free up resources and references and avoid leaks ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-71719a370a41477b6b10f352b538614bc2982d420ca5c2c2bdd23365aeed69ccR67-R72), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-a0f3f9b4b6542d13dbae01459e1936d490c982d65be81867d1257e05996b0a19R68-R73), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341R37-R42), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341R347-R372), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-89625f6f630aefb661146d12dc5859848581a3df90cbcf736ec1094c4c97d3a8R17), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-89625f6f630aefb661146d12dc5859848581a3df90cbcf736ec1094c4c97d3a8R137-R157), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-98ae7086fcff6302228d24a15e44544a433dd8d66b6a8f8ebe07331b120fdd9bR85-R90), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-f9c813b9c10442ffc84191d129543df2c4f273cbb3e9d856e206e677f26119c7R15-R24), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-61d7fdef7161f2057ec024f9344ecc6d73e7d65bbcc95c5ad30c702cd8528b25R77-R82), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-14bd1620e6b7489cde9efeef0340aee91d4d4dc2aa30e28b830eeaf96e70540fR99-R104), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-618a2c2547372d596e6ead870e518ecba11e8c00252da84286d711f9d09ca8caR104-R109), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-69c7d514fec768a7b06cdb20beb89725d25f1bed5ec8f70e8cff6c92d30e1517R20), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-69c7d514fec768a7b06cdb20beb89725d25f1bed5ec8f70e8cff6c92d30e1517L206-R236), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-96493e5cbc50eff010b7ab5c5f44c905e8c24f7198e61b9332d22e968ef79efdR72-R76), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-4655eeccfe796ba8b03e92090e6563e30fb3e7e0ec109cee7bde8306a4ebb26cR232-R238), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-6382f350943b02cd9ed3b55a507e12dc8214d9731fc7ebb7676d2ff08760c3b6R28-R32), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-8c80ec9a55424681a663c564daf25b7098ce3099a881d44d38fea2cfe7a26437R101-R105), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-2217c41125a01a1a625deb54f4f7b3b5b28312b374e445df1314e9b78ee27318R47-R57), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-3f7b98bb8e4c0d56041933982c7a80912a5dca21c2b8414e29ecb3984457cf3cR64-R68), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-64fa83836f89d14f27a7e04699adc6f3f2dd7ae28843385470001dfc52d6d7e2R187-R193), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-0570a5977ff7601f6bd7334b6862ff6af98b6f04c4b96434e367d3128a8b12b0R224-R248))
*  Rename and remove some properties and methods in `GlBufferSystem` and `GlGeometrySystem` to match the naming convention and the refactored buffer and geometry systems ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L41-R42), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L58), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L73-R68), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L80-R75), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L174-R203), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-b36174f27080567f12c7bb824a375818926aed007e5c1561ab5b46457c50f234L241-R230), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L237-R245), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L328-R392))
*  Fix a bug in `Batcher` where the `removeBatchForRenderable` method was expecting a renderable object instead of a renderable uid ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341L83))
*  Remove some unused imports and interfaces from `ColorMaskPipe` that were related to the `MaskFilter` class, which is no longer used by the color mask system ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-8c80ec9a55424681a663c564daf25b7098ce3099a881d44d38fea2cfe7a26437L4-R6), [link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-8c80ec9a55424681a663c564daf25b7098ce3099a881d44d38fea2cfe7a26437L20-L27))
*  Remove a TODO comment from `MeshPipe` that was no longer relevant after the refactoring of the batching system ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-0570a5977ff7601f6bd7334b6862ff6af98b6f04c4b96434e367d3128a8b12b0L171))
*  Remove some commented out code from `GlGeometrySystem` that was no longer relevant after the refactoring of the buffer system ([link](https://github.com/pixijs/pixijs/pull/9468/files?diff=unified&w=0#diff-f834685033233eba7e061ce000d5887c092cb98924d9a26096426470b29e1509L311-L315))

