### PR TITLE
Replace TouchEvent with PixiTouch interface

### DIFF
--- a/packages/events/src/EventBoundary.ts
+++ b/packages/events/src/EventBoundary.ts
@@ -651,7 +651,7 @@ export class EventBoundary
         // call the `on${type}` for the current target if it exists
         const handlerKey = `on${type}` as keyof IFederatedDisplayObject;
 
-        (e.currentTarget[handlerKey] as FederatedEventHandler<FederatedEvent<UIEvent>>)?.(e);
+        (e.currentTarget[handlerKey] as FederatedEventHandler<FederatedEvent>)?.(e);
 
         const key = e.eventPhase === e.CAPTURING_PHASE || e.eventPhase === e.AT_TARGET ? `${type}capture` : type;
 

--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -6,6 +6,7 @@ import { FederatedWheelEvent } from './FederatedWheelEvent';
 
 import type { ExtensionMetadata, IPointData, IRenderer, ISystem } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
+import type { PixiTouch } from './FederatedEvent';
 import type { EventMode } from './FederatedEventTarget';
 import type { FederatedMouseEvent } from './FederatedMouseEvent';
 
@@ -840,28 +841,6 @@ interface PixiPointerEvent extends PointerEvent
     pressure: number;
     twist: number;
     tangentialPressure: number;
-    isNormalized: boolean;
-    type: string;
-}
-
-interface PixiTouch extends Touch
-{
-    button: number;
-    buttons: number;
-    isPrimary: boolean;
-    width: number;
-    height: number;
-    tiltX: number;
-    tiltY: number;
-    pointerType: string;
-    pointerId: number;
-    pressure: number;
-    twist: number;
-    tangentialPressure: number;
-    layerX: number;
-    layerY: number;
-    offsetX: number;
-    offsetY: number;
     isNormalized: boolean;
     type: string;
 }

--- a/packages/events/src/FederatedEvent.ts
+++ b/packages/events/src/FederatedEvent.ts
@@ -3,13 +3,35 @@ import { Point } from '@pixi/core';
 import type { EventBoundary } from './EventBoundary';
 import type { FederatedEventTarget } from './FederatedEventTarget';
 
+export interface PixiTouch extends Touch
+{
+    button: number;
+    buttons: number;
+    isPrimary: boolean;
+    width: number;
+    height: number;
+    tiltX: number;
+    tiltY: number;
+    pointerType: string;
+    pointerId: number;
+    pressure: number;
+    twist: number;
+    tangentialPressure: number;
+    layerX: number;
+    layerY: number;
+    offsetX: number;
+    offsetY: number;
+    isNormalized: boolean;
+    type: string;
+}
+
 /**
  * An DOM-compatible synthetic event implementation that is "forwarded" on behalf of an original
  * FederatedEvent or native {@link https://dom.spec.whatwg.org/#event Event}.
  * @memberof PIXI
  * @typeParam N - The type of native event held.
  */
-export class FederatedEvent<N extends UIEvent = UIEvent> implements UIEvent
+export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch> implements UIEvent
 {
     /** Flags whether this event bubbles. This will take effect only if it is set before propagation. */
     public bubbles = true;

--- a/packages/events/src/FederatedMouseEvent.ts
+++ b/packages/events/src/FederatedMouseEvent.ts
@@ -3,13 +3,14 @@ import { FederatedEvent } from './FederatedEvent';
 
 import type { IPointData } from '@pixi/core';
 import type { DisplayObject } from '@pixi/display';
+import type { PixiTouch } from './FederatedEvent';
 
 /**
  * A {@link PIXI.FederatedEvent} for mouse events.
  * @memberof PIXI
  */
 export class FederatedMouseEvent extends FederatedEvent<
-MouseEvent | PointerEvent | TouchEvent
+MouseEvent | PointerEvent | PixiTouch
 > implements MouseEvent
 {
     /** Whether the "alt" key was pressed when this mouse event occurred. */


### PR DESCRIPTION
Fixes #9407 

I've replaced the `TouchEvent` for the `PixiTouch` interface which is what actually gets passed as the `nativeEvent`