### PR TITLE
Fixed up the uniform buffers 

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -1,0 +1,92 @@
+# WebGL / WebGPU and Canvas separation
+
+- Shaders are the only area that overlap with WebGL and WebGPU. This is really about convenience! We could split them out but who wants a different blur shader for webGL and WebGPU?
+- Any renderable should not have any render logic in it. For example a NiceSlicePlane should not extend mesh, as it will be rendered in canvas a unique way. Its ok behind the scenes to render them as a mesh for WebGL and WebGPU, but the renderable should not know about it.
+- Be mindful of imports, webGL and WebGPU should not know about each other (shaders excepted). This will make for very smart code splitting when we load in the correct renderer.
+ 
+# Shader conventions
+property names
+- uniform buffers `ub` eg `ubFilterUniforms`
+- attribute, prefix `a` eg. `aPosition`
+
+# Class constructors
+Where possible, favour options object over multiple parameters.
+
+Use a static `defaultOptions` property to hold the default options that a user can easily override.
+
+eg:
+```
+export interface PersonOptions {
+    name:string,
+    age:number,
+}
+
+class Person {
+    static defaultOptions:PersonOptions = {
+        name:'person`,
+        age:23
+    }
+
+    constructor(options:PersonOptions)
+    {
+        options = {...Person.defaultOptions, ...options}
+        // ... code
+    }
+}
+```
+
+
+# Enums and types 
+- where possible prefer a string type over a const. This is a more modern approach and makes code easier to read. Type safety also makes this work well, eg: 
+```
+export type TEXTURE_DIMENSIONS =
+    | '1d'
+    | '2d'
+    | '3d';
+```
+
+Use enums if the information held in the property is important. An example would be WebGPU buffer usage. Each property represents a single bit that can be combined, so strings wont work here!
+
+```
+export enum BufferUsage
+{
+    MAP_READ = 0x0001,
+    MAP_WRITE = 0x0002,
+    COPY_SRC = 0x0004,
+    COPY_DST = 0x0008,
+    INDEX = 0x0010,
+    VERTEX = 0x0020,
+    UNIFORM = 0x0040,
+    STORAGE = 0x0080,
+    INDIRECT = 0x0100,
+    QUERY_RESOLVE = 0x0200,
+    STATIC = 0x0400
+}
+
+const usage = BufferUsage.MAP_READ | BufferUsage.COPY_SRC
+```
+
+# Singleton, System or RenderPipe?
+
+Singleton:
+I something is managed at a global level where it does not need to know about the renderer, it should be a singleton. An example of this is the Loader and the Cache classes. We only need one of them, and as a texture can be used across multiple renderers. Other examples are the TexturePool.
+
+System:
+A system is used to modify and manage one aspect of WebGL or GPU. An example would be the TextureSystem, it is only responsible for managing textures.
+
+RenderPipes:
+A RenderPipe is what is used by the renderer when building and executing its instruction set. An example would be the SpritePipe. This is responsible for adding a Sprite to the renderables list.
+
+# Mats scrappy notes (ignore)
+uniforms
+- updated and shader bind time 
+
+textures
+- updated the moment they are updated
+- maybe move this to the sync check?
+
+containers and renderables
+- added to a toUpdate queue
+- this is triggered before a render
+
+graphics context

--- a/src/rendering/renderers/gpu/GpuUniformBufferPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBufferPipe.ts
@@ -1,0 +1,80 @@
+import { ExtensionType } from '../../../extensions/Extensions';
+import { BigPool } from '../../../utils/pool/PoolGroup';
+import { Buffer } from '../shared/buffer/Buffer';
+import { BufferUsage } from '../shared/buffer/const';
+import { BindGroup } from './shader/BindGroup';
+
+import type { ExtensionMetadata } from '../../../extensions/Extensions';
+import type { PoolItem } from '../../../utils/pool/Pool';
+import type { UniformGroup } from '../shared/shader/UniformGroup';
+import type { WebGPURenderer } from './WebGPURenderer';
+
+class UniformBindGroup extends BindGroup
+{
+    constructor()
+    {
+        super({
+            0: new Buffer({
+                data: new Float32Array(128),
+                usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+            }),
+        });
+    }
+
+    get buffer(): Buffer
+    {
+        return this.resources[0] as Buffer;
+    }
+
+    get data(): Float32Array
+    {
+        return (this.resources[0] as Buffer).data as Float32Array;
+    }
+}
+
+export class GpuUniformBufferPipe
+{
+    /** @ignore */
+    static extension: ExtensionMetadata = {
+        type: [
+            ExtensionType.WebGPURendererPipes,
+        ],
+        name: 'uniformBuffer',
+    };
+
+    private activeBindGroups: BindGroup[] = [];
+    private activeBindGroupIndex = 0;
+    private renderer: WebGPURenderer;
+
+    constructor(renderer: WebGPURenderer)
+    {
+        this.renderer = renderer;
+    }
+
+    getUniformBindGroup(uniformGroup: UniformGroup)
+    {
+        const renderer = this.renderer;
+
+        renderer.uniformBuffer.ensureUniformGroup(uniformGroup);
+
+        const bindGroup = BigPool.get(UniformBindGroup);
+
+        renderer.uniformBuffer.syncUniformGroup(uniformGroup, bindGroup.data, 0);
+
+        bindGroup.buffer.update(uniformGroup.buffer.data.byteLength);
+
+        this.activeBindGroups[this.activeBindGroupIndex++] = bindGroup;
+
+        return bindGroup;
+    }
+
+    renderEnd()
+    {
+        for (let i = 0; i < this.activeBindGroupIndex; i++)
+        {
+            BigPool.return(this.activeBindGroups[i] as PoolItem);
+        }
+
+        this.activeBindGroupIndex = 0;
+    }
+}

--- a/src/rendering/renderers/gpu/WebGPUSystems.ts
+++ b/src/rendering/renderers/gpu/WebGPUSystems.ts
@@ -1,15 +1,15 @@
 // RenderSystems
 import { GpuBatchAdaptor } from '../../batcher/gpu/GpuBatchAdaptor';
 import { GpuGraphicsAdaptor } from '../../graphics/gpu/GpuGraphicsAdaptor';
-import { GpuScissorMaskPipe } from '../../mask/gpu/GpuScissorMaskPipe';
 import { GpuMeshAdapter } from '../../mesh/gpu/GpuMeshAdapter';
-import { UniformBatchPipe } from '../shared/instructions/UniformBatchPipe';
 import { BindGroupSystem } from './BindGroupSystem';
 import { BufferSystem } from './buffer/GpuBufferSystem';
 import { GpuColorMaskSystem } from './GpuColorMaskSystem';
 import { GpuDeviceSystem } from './GpuDeviceSystem';
 import { GpuEncoderSystem } from './GpuEncoderSystem';
 import { GpuStencilSystem } from './GpuStencilSystem';
+import { GpuUniformBatchPipe } from './GpuUniformBatchPipe';
+import { GpuUniformBufferPipe } from './GpuUniformBufferPipe';
 import { PipelineSystem } from './pipeline/PipelineSystem';
 import { GpuRenderTargetSystem } from './renderTarget/GpuRenderTargetSystem';
 import { GpuShaderSystem } from './shader/GpuShaderSystem';
@@ -36,7 +36,8 @@ export interface GPURenderSystems extends SharedRenderSystems, PixiMixins.GPURen
 
 export interface GPURenderPipes extends SharedRenderPipes, PixiMixins.GPURenderPipes
 {
-    uniformBatch: UniformBatchPipe,
+    uniformBatch: GpuUniformBatchPipe,
+    uniformBuffer: GpuUniformBufferPipe,
 }
 
 export const WebGPUSystemsExtensions = [
@@ -53,8 +54,8 @@ export const WebGPUSystemsExtensions = [
     GpuStencilSystem,
     BindGroupSystem,
     // Pipes
-    UniformBatchPipe,
-    GpuScissorMaskPipe,
+    GpuUniformBatchPipe,
+    GpuUniformBufferPipe,
     // Adapters
     GpuBatchAdaptor,
     GpuMeshAdapter,

--- a/src/rendering/renderers/gpu/buffer/UniformBufferBatch.ts
+++ b/src/rendering/renderers/gpu/buffer/UniformBufferBatch.ts
@@ -19,17 +19,17 @@ export class UniformBufferBatch
         this.byteIndex = 0;
     }
 
-    addGroup(array: Float32Array): number
+    addEmptyGroup(size: number): number
     {
         // update the buffer.. only float32 for now!
-        if (array.length > this.minUniformOffsetAlignment / 4)
+        if (size > this.minUniformOffsetAlignment / 4)
         {
-            throw new Error(`UniformBufferBatch: array is too large: ${array.byteLength}`);
+            throw new Error(`UniformBufferBatch: array is too large: ${size * 4}`);
         }
 
         const start = this.byteIndex;
 
-        let newSize = start + (array.length * 4);
+        let newSize = start + (size * 4);
 
         newSize = Math.ceil(newSize / this.minUniformOffsetAlignment) * this.minUniformOffsetAlignment;
 
@@ -41,14 +41,21 @@ export class UniformBufferBatch
             throw new Error('UniformBufferBatch: ubo batch got too big');
         }
 
-        for (let i = 0; i < array.length; i++)
-        {
-            this.data[(start / 4) + i] = array[i];
-        }
-
         this.byteIndex = newSize;
 
         return start;
+    }
+
+    addGroup(array: Float32Array): number
+    {
+        const offset = this.addEmptyGroup(array.length);
+
+        for (let i = 0; i < array.length; i++)
+        {
+            this.data[(offset / 4) + i] = array[i];
+        }
+
+        return offset;
     }
 
     upload()

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -44,7 +44,7 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
 
     readonly signature: string;
 
-    _syncFunction?: (uniforms: UNIFORMS, data: Float32Array) => void;
+    _syncFunction?: (uniforms: UNIFORMS, data: Float32Array, offset: number) => void;
 
     constructor(uniformStructures: UNIFORMS, options?: UniformGroupOptions)
     {

--- a/src/rendering/scene/LayerSystem.ts
+++ b/src/rendering/scene/LayerSystem.ts
@@ -106,6 +106,7 @@ export class LayerSystem implements ISystem
         if ((renderPipes as GPURenderPipes).uniformBatch)
         {
             (renderPipes as GPURenderPipes).uniformBatch.renderEnd();
+            (renderPipes as GPURenderPipes).uniformBuffer.renderEnd();
         }
     }
 

--- a/tests/renderering/UniformBatch.test.ts
+++ b/tests/renderering/UniformBatch.test.ts
@@ -1,4 +1,4 @@
-import { UniformBatchPipe } from '../../src/rendering/renderers/shared/instructions/UniformBatchPipe';
+import { GpuUniformBatchPipe } from '../../src/rendering/renderers/gpu/GpuUniformBatchPipe';
 
 import type { WebGPURenderer } from '../../src/rendering/renderers/gpu/WebGPURenderer';
 
@@ -6,7 +6,7 @@ describe('UniformBatch', () =>
 {
     it('should get a bind group correctly', () =>
     {
-        const uniformBatchPipe = new UniformBatchPipe({} as any as WebGPURenderer);
+        const uniformBatchPipe = new GpuUniformBatchPipe({} as any as WebGPURenderer);
 
         const bufferResource = uniformBatchPipe.getArrayBufferResource(new Float32Array(32));
 


### PR DESCRIPTION
- renamed UniformBatchPipe to gpuUniformBatchPipe
- create GpuUniformBufferPipe
- optimised uniform batching - by copying straight to buffer

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d49b8e1</samp>

### Summary
📝🚀🛠️

<!--
1.  📝 - This emoji represents the documentation and clarity notes added to the code.
2.  🚀 - This emoji represents the performance and compatibility improvements made to the uniform buffer handling and the WebGPU renderer.
3.  🛠️ - This emoji represents the bug fixes, refactoring and optimization done to the code.
-->
This pull request improves the performance and compatibility of the uniform data handling in the WebGL / WebGPU renderer by introducing new classes, methods, and parameters for creating and managing uniform bind groups and buffers. It also fixes some bugs, updates the tests, and adds some documentation notes. The main files affected are `UniformBufferBatch.ts`, `GpuUniformBatchPipe.ts`, `WebGPUSystems.ts`, `UniformBufferSystem.ts`, `createUniformBufferSync.ts`, `GpuUniformBufferPipe.ts`, `UniformGroup.ts`, and `LayerSystem.ts`.

> _We're working on the WebGPU renderer_
> _We're syncing up the uniform data_
> _We're using pipes and buffers and groups_
> _We're heaving on the count of three_

### Walkthrough
*  Rename and move `UniformBatchPipe` class to `GpuUniformBatchPipe` and update its methods to improve performance and flexibility for WebGPU renderer ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-68f95193456a7a3565f8d093ebc2445bc55fd25178677335f82097304934cf90L1-R16), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-68f95193456a7a3565f8d093ebc2445bc55fd25178677335f82097304934cf90L74-R70), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-68f95193456a7a3565f8d093ebc2445bc55fd25178677335f82097304934cf90L86-R89), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-3ffe4d1d1650a14cf95e1f264b259a6cf786587a959875cd98b10203ba69d472L1-R1), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-3ffe4d1d1650a14cf95e1f264b259a6cf786587a959875cd98b10203ba69d472L9-R9))
* Add new `GpuUniformBufferPipe` class to handle uniform bind groups with single buffers for WebGPU renderer ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-c9892f9bf41cabe3fd1bd689dd29c643816b4f6798f3815be1cf857dd5c6f8a0R1-R80))
* Remove unused imports and add new imports of `GpuUniformBatchPipe` and `GpuUniformBufferPipe` in `WebGPUSystems.ts` file ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-2789661bb4a191141796d32e59a53423b9852a2d76ad9a677e91e9a96b43f5d1L4-R4), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-2789661bb4a191141796d32e59a53423b9852a2d76ad9a677e91e9a96b43f5d1R11-R12))
* Modify `GPURenderPipes` interface and `WebGPUSystemsExtensions` value to include `GpuUniformBufferPipe` and replace `UniformBatchPipe` with `GpuUniformBatchPipe` ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-2789661bb4a191141796d32e59a53423b9852a2d76ad9a677e91e9a96b43f5d1L39-R40), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-2789661bb4a191141796d32e59a53423b9852a2d76ad9a677e91e9a96b43f5d1L56-R58))
* Add new methods `ensureUniformGroup` and `syncUniformGroup` to `UniformBufferSystem` class and modify `updateUniformGroup` method to use them ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-32bd5aafe934ed5702790d3c8f090b3d7de0daeebdd3250e70001b38a7d40af4L31-R31), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-32bd5aafe934ed5702790d3c8f090b3d7de0daeebdd3250e70001b38a7d40af4R39-R46), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-32bd5aafe934ed5702790d3c8f090b3d7de0daeebdd3250e70001b38a7d40af4R77-R88), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-32bd5aafe934ed5702790d3c8f090b3d7de0daeebdd3250e70001b38a7d40af4L74-R98))
* Modify `UniformGroup` class to include `offset` parameter in `_syncFunction` type ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-984b1c73264c64684bfdb732d9172f4ea5e637483fdc6d6d45e313e7e08f52b7L47-R47))
* Modify `generateUniformBufferSync` function to use `offset` variable and add offset difference to sync function code ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427R94-R95), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427R103), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427L108-R114), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427L126-R135), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427L146-R163), [link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-20bc4079319d916453e58673fff57610c247ffbbfc27e968f90d98c113b7c427R172))
* Modify `addGroup` method of `UniformBufferBatch` class to rename parameter and expect a number instead of a Float32Array ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-fec98b48dd168cac55b7482e37f92b131c627641870bf35b345af2e8a7e66cfdL22-R32))
* Add new `addGroup` method to `UniformBufferBatch` class that takes a Float32Array and calls the other `addGroup` method ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-fec98b48dd168cac55b7482e37f92b131c627641870bf35b345af2e8a7e66cfdL44-R58))
* Add call to `renderEnd` method of `uniformBuffer` pipe in `renderEnd` method of `LayerSystem` class ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-501f1fe6a661d748538b32d16f4419c27bfe4479186f97915a5c1a2d65aa0c58R109))
* Add notes about design principles and conventions in `Notes.md` file ([link](https://github.com/pixijs/pixijs/pull/9475/files?diff=unified&w=0#diff-a20e5e0a5faee06daa084bfd1421b092f247fbb9e477d28cf102325c12d156ddL1-R91))

