### PR TITLE
Fix up assets tree shaking

### DIFF
--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -1,18 +1,8 @@
-import { extensions, ExtensionType } from '../extensions/Extensions';
-
+import type { ExtensionType } from '../extensions/Extensions';
 import type { CacheParser } from './cache/CacheParser';
 import type { FormatDetectionParser } from './detections/types';
 import type { LoaderParser } from './loader/parsers/LoaderParser';
 import type { ResolveURLParser } from './resolver/types';
-
-const assetKeyMap = {
-    loader: ExtensionType.LoadParser,
-    resolver: ExtensionType.ResolveParser,
-    cache: ExtensionType.CacheParser,
-    detection: ExtensionType.DetectionParser,
-};
-
-type AssetType = keyof typeof assetKeyMap;
 
 /**
  * This developer convenience object allows developers to group
@@ -27,28 +17,5 @@ interface AssetExtension<ASSET = any, META_DATA = any>
     cache?: Partial<CacheParser<ASSET>>,
     detection?: Partial<FormatDetectionParser>,
 }
-
-// Split the Asset extension into it's various parts
-// these are handled in the Assets.ts file
-extensions.handle(ExtensionType.Asset, (extension) =>
-{
-    const ref = extension.ref as AssetExtension;
-
-    Object.entries(assetKeyMap)
-        .filter(([key]) => !!ref[key as AssetType])
-        .forEach(([key, type]) => extensions.add(Object.assign(
-            ref[key as AssetType],
-            // Allow the function to optionally define it's own
-            // ExtensionMetadata, the use cases here is priority for LoaderParsers
-            { extension: ref[key as AssetType].extension ?? type },
-        )));
-}, (extension) =>
-{
-    const ref = extension.ref as AssetExtension;
-
-    Object.keys(assetKeyMap)
-        .filter((key) => !!ref[key as AssetType])
-        .forEach((key) => extensions.remove(ref[key as AssetType]));
-});
 
 export type { AssetExtension };

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -195,7 +195,7 @@ export class GpuEncoderSystem implements ISystem
         {
             const resource = bindGroup.resources[j];
 
-            if ((resource as UniformGroup).group)
+            if ((resource as UniformGroup).isUniformGroup)
             {
                 this.renderer.uniformBuffer.updateUniformGroup(resource as UniformGroup);
             }

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -38,7 +38,7 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
 
     isStatic: boolean;
     // to identify this as a uniform group
-    readonly group = true;
+    readonly isUniformGroup = true;
 
     dirtyId = 0;
 


### PR DESCRIPTION
- Fix up assets tree shaking
- rename `group` to `isUniformGroup` to avoid clash with new iOS property

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a010dd</samp>

### Summary
🔧🚚🌟

<!--
1.  🔧 - This emoji represents a change that fixes or improves something, such as renaming a property or simplifying a file.
2.  🚚 - This emoji represents a change that moves or relocates something, such as moving code or types between files or modules.
3.  🌟 - This emoji represents a change that adds or enhances a feature, such as adding support for `Asset` extensions in the assets system.
-->
This pull request refactors some code related to `Asset` extensions and `UniformGroup` classes. It simplifies the `AssetExtension.ts` file and the assets system initialization, and renames the `group` property of the `UniformGroup` class to `isUniformGroup` for clarity and consistency.

> _We are the uniform group, we have the power_
> _We use the `is` prefix to show our type_
> _We move the code around, we optimize the bundle_
> _We handle the extensions in the init of the night_

### Walkthrough
*  Refactor `AssetExtension` class and its usage ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL1-R1), [link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL8-L16), [link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL31-L53), [link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637L1-R1), [link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637R17-R18), [link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637R42-R73))
  - Use `import type` syntax for `extensions` and `ExtensionType` in `src/assets/AssetExtension.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL1-R1))
  - Move `assetKeyMap` and `AssetType` from `src/assets/AssetExtension.ts` to `src/assets/init.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL8-L16))
  - Move code that handles `Asset` extensions from `src/assets/AssetExtension.ts` to `src/assets/init.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-896735af3e540ebb12dfc736afbde5b13fd90a82bd24b5e253f600fa976984dcL31-L53))
  - Move imports of `extensions`, `ExtensionType`, `bitmapFontCachePlugin`, `xmlBitmapFontLoader`, and `cacheTextureArray` from `src/assets/init.ts` to `src/assets/AssetExtension.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637L1-R1))
  - Add import of `AssetExtension` type to `src/assets/init.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637R17-R18))
  - Split and register `Asset` extension parts with `extensions` system in `src/assets/init.ts` ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-41601471c7da101c0d0a14d041884178b9cd59380245826d583a9efe5e2a3637R42-R73))
* Rename `group` property to `isUniformGroup` in `UniformGroup` class ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-984b1c73264c64684bfdb732d9172f4ea5e637483fdc6d6d45e313e7e08f52b7L41-R41))
  - Update `GpuEncoderSystem` to use `isUniformGroup` property instead of `group` property ([link](https://github.com/pixijs/pixijs/pull/9478/files?diff=unified&w=0#diff-a9bb4356e83dae8c3e504b589c7f4e577ce26084d096a36b735369da50942bd1L198-R198))

