### PR TITLE
fix nine slice rendering for rotated textures

### DIFF
--- a/src/mesh-extras/NineSliceGeometry.ts
+++ b/src/mesh-extras/NineSliceGeometry.ts
@@ -103,39 +103,48 @@ export class NineSliceGeometry extends PlaneGeometry
 
         const textureMatrix = this._textureMatrix;
 
-        const a = textureMatrix.a;
-        const b = textureMatrix.b;
-        const c = textureMatrix.c;
-        const d = textureMatrix.d;
-        const tx = textureMatrix.tx;
-        const ty = textureMatrix.ty;
-
         const uvs = this.uvs;
 
-        let x = 0;
-        let y = 0;
+        uvs[0] = uvs[8] = uvs[16] = uvs[24] = 0;
+        uvs[1] = uvs[3] = uvs[5] = uvs[7] = 0;
 
-        uvs[0] = uvs[8] = uvs[16] = uvs[24] = (a * x) + (c * y) + tx;
-        uvs[1] = uvs[3] = uvs[5] = uvs[7] = (b * x) + (d * y) + ty;
+        uvs[6] = uvs[14] = uvs[22] = uvs[30] = 1;
+        uvs[25] = uvs[27] = uvs[29] = uvs[31] = 1;
 
-        x = this._originalWidth;
-        y = this._originalHeight;
+        const _uvw = 1.0 / this._originalWidth;
+        const _uvh = 1.0 / this._originalHeight;
 
-        uvs[6] = uvs[14] = uvs[22] = uvs[30] = (a * x) + (c * y) + tx;
-        uvs[25] = uvs[27] = uvs[29] = uvs[31] = (b * x) + (d * y) + ty;
+        uvs[2] = uvs[10] = uvs[18] = uvs[26] = _uvw * this._leftWidth;
+        uvs[9] = uvs[11] = uvs[13] = uvs[15] = _uvh * this._topHeight;
 
-        x = this._leftWidth;
-        y = this._topHeight;
+        uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (_uvw * this._rightWidth);
+        uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (_uvh * this._bottomHeight);
 
-        uvs[2] = uvs[10] = uvs[18] = uvs[26] = (a * x) + (c * y) + tx;
-        uvs[9] = uvs[11] = uvs[13] = uvs[15] = (b * x) + (d * y) + ty;
-
-        x = this._originalWidth - this._rightWidth;
-        y = this._originalHeight - this._bottomHeight;
-
-        uvs[4] = uvs[12] = uvs[20] = uvs[28] = (a * x) + (c * y) + tx;
-        uvs[17] = uvs[19] = uvs[21] = uvs[23] = (b * x) + (d * y) + ty;
+        multiplyUvs(textureMatrix, uvs);
 
         this.getBuffer('aUV').update();
     }
+}
+
+function multiplyUvs(matrix: Matrix, uvs: Float32Array, out?: Float32Array)
+{
+    out ??= uvs;
+
+    const a = matrix.a;
+    const b = matrix.b;
+    const c = matrix.c;
+    const d = matrix.d;
+    const tx = matrix.tx;
+    const ty = matrix.ty;
+
+    for (let i = 0; i < uvs.length; i += 2)
+    {
+        const x = uvs[i];
+        const y = uvs[i + 1];
+
+        out[i] = (x * a) + (y * c) + tx;
+        out[i + 1] = (x * b) + (y * d) + ty;
+    }
+
+    return out;
 }

--- a/src/mesh-extras/NineSlicePlane.ts
+++ b/src/mesh-extras/NineSlicePlane.ts
@@ -1,4 +1,3 @@
-import { Matrix } from '../maths/Matrix';
 import { MeshView } from '../rendering/mesh/shared/MeshView';
 import { Texture } from '../rendering/renderers/shared/texture/Texture';
 import { Container } from '../rendering/scene/Container';
@@ -75,19 +74,16 @@ export class NineSlicePlane extends Container<MeshView<NineSliceGeometry>>
 
         const texture = options.texture;
 
-        // calculate the matrix..
-        const textureMatrix = textureMatrixFromTexture(texture, Matrix.shared);
-
         const nineSliceGeometry = new NineSliceGeometry({
-            width: texture.frameWidth,
-            height: texture.frameHeight,
-            originalWidth: texture.frameWidth,
-            originalHeight: texture.frameHeight,
+            width: texture.width,
+            height: texture.height,
+            originalWidth: texture.width,
+            originalHeight: texture.height,
             leftWidth: options.leftWidth,
             topHeight: options.topHeight,
             rightWidth: options.rightWidth,
             bottomHeight: options.bottomHeight,
-            textureMatrix,
+            textureMatrix: texture.textureMatrix.mapCoord,
         });
 
         super({
@@ -183,28 +179,12 @@ export class NineSlicePlane extends Container<MeshView<NineSliceGeometry>>
         if (value === this.view.texture) return;
 
         // // calculate the matrix..
-        const textureMatrix = textureMatrixFromTexture(value, Matrix.shared);
-
         this.view.geometry.updateUvs({
-            originalWidth: value.frameWidth,
-            originalHeight: value.frameHeight,
-            textureMatrix,
+            originalWidth: value.width,
+            originalHeight: value.height,
+            textureMatrix: value.textureMatrix.mapCoord,
         });
 
         this.view.texture = value;
     }
-}
-
-function textureMatrixFromTexture(texture: Texture, out: Matrix): Matrix
-{
-    const layout = texture.layout;
-
-    // normalise...
-    out.scale(1.0 / texture.frameWidth, 1.0 / texture.frameHeight);
-    // apply frame size
-    out.scale(layout.frame.width, layout.frame.height);
-    // apply frame position
-    out.translate(-layout.frame.x, -layout.frame.y);
-
-    return out;
 }

--- a/src/rendering/renderers/shared/texture/TextureMatrix.ts
+++ b/src/rendering/renderers/shared/texture/TextureMatrix.ts
@@ -101,15 +101,10 @@ export class TextureMatrix
     {
         if (this.texture === value) return;
 
-        this._texture?.removeListener('update', this.onTextureUpdate, this);
+        this._texture?.removeListener('update', this.update, this);
         this._texture = value;
-        this._texture.addListener('update', this.onTextureUpdate, this);
+        this._texture.addListener('update', this.update, this);
 
-        this.update();
-    }
-
-    onTextureUpdate(): void
-    {
         this.update();
     }
 


### PR DESCRIPTION
fixed some inccorect maths for texture transforms in nineslice geometry. Working like a champ now!

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b1e51f7</samp>

### Summary
🛠️🗑️🐛

<!--
1.  🛠️ - This emoji represents the optimization and refactoring of the UV calculation logic, which is a kind of improvement or enhancement to the existing code.
2.  🗑️ - This emoji represents the removal of unnecessary or redundant code, such as the `onTextureUpdate` method, which is a kind of cleanup or simplification of the code.
3.  🐛 - This emoji represents the bug fix for the texture coordinate handling, which is a kind of correction or resolution of an existing issue or error.
-->
This pull request improves the performance and accuracy of the `NineSlicePlane` class and its related classes. It simplifies the texture coordinate calculations, avoids unnecessary matrix operations, and fixes potential issues with rotated or trimmed textures. It also makes the code more readable and consistent by refactoring some common logic and removing redundant methods.

> _`NineSlicePlane` fixed_
> _Texture matrix simplified_
> _Winter code is clear_

### Walkthrough
*  Simplify and optimize UV calculation for nine-slice geometry by using normalized values and matrix multiplication ([link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-3911e291a84e466bd3618c5588c1cbc3d1c4d0d7c824a713528351fe84d01bf9L106-R149))
*  Use texture width and height instead of frame values for nine-slice plane constructor and texture setter, and pass texture matrix mapCoord property ([link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL78-R86), [link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL186-R185))
*  Remove unused import of Matrix class from `NineSlicePlane.ts` ([link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL1))
*  Remove unnecessary textureMatrixFromTexture function from `NineSlicePlane.ts` ([link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL197-L210))
*  Simplify texture update event listener registration and removal in `TextureMatrix.ts` by using update method directly ([link](https://github.com/pixijs/pixijs/pull/9482/files?diff=unified&w=0#diff-f67ba822b98c017f9458d270851c20a0516907a84f1f8dc0c793307d4a14f1ddL104-R110))

