### PR TITLE
v8 fix a bunch of small issues

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -588,6 +588,8 @@ export class EventBoundary
 
         if (container.effects && container.effects.length)
         {
+            let hit = false;
+
             for (let i = 0; i < container.effects.length; i++)
             {
                 const effect = container.effects[i];
@@ -598,10 +600,12 @@ export class EventBoundary
                     {
                         return false;
                     }
+
+                    hit = true;
                 }
             }
 
-            return true;
+            return hit;
         }
 
         return false;

--- a/src/filters/shockwave/ShockwaveFilter.ts
+++ b/src/filters/shockwave/ShockwaveFilter.ts
@@ -1,0 +1,189 @@
+import { Filter } from '../../rendering/filters/Filter';
+import { GlProgram } from '../../rendering/renderers/gl/shader/GlProgram';
+import { GpuProgram } from '../../rendering/renderers/gpu/shader/GpuProgram';
+import { UniformGroup } from '../../rendering/renderers/shared/shader/UniformGroup';
+import fragment from './shockwave.frag';
+import vertex from './shockwave.vert';
+import source from './shockwave.wgsl';
+
+import type { PointData } from '../../maths/PointData';
+import type { FilterSystem } from '../../rendering/filters/shared/FilterSystem';
+import type { RenderSurface } from '../../rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem';
+import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
+
+export interface ShockwaveFilterOptions
+{
+    /**
+     * The `x` and `y` center coordinates to change the position of the center of the circle of effect.
+     * @default [0,0]
+     */
+    center?: PointData;
+    /**
+     * The speed about the shockwave ripples out. The unit is `pixel-per-second`
+     * @default 500
+     */
+    speed?: number;
+    /**
+     * The amplitude of the shockwave
+     * @default 30
+     */
+    amplitude?: number;
+    /**
+     * The wavelength of the shockwave
+     * @default 160
+     */
+    wavelength?: number;
+    /**
+     * The brightness of the shockwave
+     * @default 1
+     */
+    brightness?: number;
+    /**
+     * The maximum radius of shockwave. less than `0` means the max is an infinite distance
+     * @default -1
+     */
+    radius?: number;
+}
+
+/**
+ * A Noise effect filter.
+ *
+ * original filter: https://github.com/evanw/glfx.js/blob/master/src/filters/adjust/noise.js
+ * @memberof PIXI.filters
+ * @author Vico @vicocotea
+ */
+export class ShockwaveFilter extends Filter
+{
+    static readonly DEFAULT: ShockwaveFilterOptions = {
+        center: { x: 0, y: 0 },
+        speed: 500,
+        amplitude: 30,
+        wavelength: 160,
+        brightness: 1,
+        radius: -1,
+    };
+
+    public uniforms: {
+        uTime: number;
+        uCenter: PointData;
+        uSpeed: number;
+        uWave: Float32Array;
+    };
+
+    time: number;
+
+    /**
+     * @param options
+     */
+    constructor(options: ShockwaveFilterOptions = {})
+    {
+        options = { ...ShockwaveFilter.DEFAULT, ...options };
+
+        const gpuProgram = new GpuProgram({
+            vertex: {
+                source,
+                entryPoint: 'mainVertex',
+            },
+            fragment: {
+                source,
+                entryPoint: 'mainFragment',
+            },
+        });
+
+        const glProgram = new GlProgram({
+            vertex,
+            fragment,
+            name: 'shockwave-filter'
+        });
+
+        super({
+            gpuProgram,
+            glProgram,
+            resources: {
+                shockwaveUniforms: new UniformGroup({
+                    uTime: { value: 0, type: 'f32' },
+                    uCenter: { value: options.center, type: 'vec2<f32>' },
+                    uSpeed: { value: options.speed, type: 'f32' },
+                    uWave: { value: new Float32Array(4), type: 'vec4<f32>' },
+                })
+            },
+            resolution: 1,
+        });
+
+        this.time = 0;
+
+        this.uniforms = this.resources.shockwaveUniforms.uniforms;
+
+        Object.assign(this, options);
+    }
+
+    public override apply(
+        filterManager: FilterSystem,
+        input: Texture,
+        output: RenderSurface,
+        clearMode: boolean
+    ): void
+    {
+        // There is no set/get of `time`, for performance.
+        // Because in the most real cases, `time` will be changed in ever game tick.
+        // Use set/get will take more function-call.
+        this.uniforms.uTime = this.time;
+        filterManager.applyFilter(this, input, output, clearMode);
+    }
+
+    /**
+     * The `x` and `y` center coordinates to change the position of the center of the circle of effect.
+     * @default [0,0]
+     */
+    get center(): PointData { return this.uniforms.uCenter; }
+    set center(value: PointData) { this.uniforms.uCenter = value; }
+
+    /**
+     * Sets the center of the effect in normalized screen coords on the `x` axis
+     * @default 0
+     */
+    get centerX(): number { return this.uniforms.uCenter.x; }
+    set centerX(value: number) { this.uniforms.uCenter.x = value; }
+
+    /**
+     * Sets the center of the effect in normalized screen coords on the `y` axis
+     * @default 0
+     */
+    get centerY(): number { return this.uniforms.uCenter.y; }
+    set centerY(value: number) { this.uniforms.uCenter.y = value; }
+
+    /**
+     * The speed about the shockwave ripples out. The unit is `pixel-per-second`
+     * @default 500
+     */
+    get speed(): number { return this.uniforms.uSpeed; }
+    set speed(value: number) { this.uniforms.uSpeed = value; }
+
+    /**
+     * The amplitude of the shockwave
+     * @default 30
+     */
+    get amplitude(): number { return this.uniforms.uWave[0]; }
+    set amplitude(value: number) { this.uniforms.uWave[0] = value; }
+
+    /**
+     * The wavelength of the shockwave
+     * @default 160
+     */
+    get wavelength(): number { return this.uniforms.uWave[1]; }
+    set wavelength(value: number) { this.uniforms.uWave[1] = value; }
+
+    /**
+     * The brightness of the shockwave
+     * @default 1
+     */
+    get brightness(): number { return this.uniforms.uWave[2]; }
+    set brightness(value: number) { this.uniforms.uWave[2] = value; }
+
+    /**
+     * The maximum radius of shockwave. less than `0` means the max is an infinite distance
+     * @default -1
+     */
+    get radius(): number { return this.uniforms.uWave[3]; }
+    set radius(value: number) { this.uniforms.uWave[3] = value; }
+}

--- a/src/filters/shockwave/shockwave.frag
+++ b/src/filters/shockwave/shockwave.frag
@@ -1,0 +1,75 @@
+
+in vec2 vTextureCoord;
+in vec4 vColor;
+
+uniform vec4 inputSize;
+uniform vec4 inputClamp;
+
+out vec4 fragColor;
+
+uniform vec2 uCenter;
+uniform float uTime;
+uniform float uSpeed;
+uniform vec4 uWave;
+
+uniform sampler2D myTexture;
+
+
+const float PI = 3.14159;
+
+void main()
+{
+    float uAmplitude = uWave[0];
+    float uWavelength = uWave[1];
+    float uBrightness = uWave[2];
+    float uRadius = uWave[3];
+
+    float halfWavelength = uWavelength * 0.5 / inputSize.x;
+    float maxRadius = uRadius / inputSize.x;
+    float currentRadius = uTime * uSpeed / inputSize.x;
+
+    float fade = 1.0;
+
+    if (maxRadius > 0.0) {
+        if (currentRadius > maxRadius) {
+            fragColor = texture(myTexture, vTextureCoord);
+            return;
+        }
+        fade = 1.0 - pow(currentRadius / maxRadius, 2.0);
+    }
+
+    vec2 dir = vec2(vTextureCoord - uCenter / inputSize.xy);
+    dir.y *= inputSize.y / inputSize.x;
+    float dist = length(dir);
+
+    if (dist <= 0.0 || dist < currentRadius - halfWavelength || dist > currentRadius + halfWavelength) {
+        fragColor = texture(myTexture, vTextureCoord);
+        return;
+    }
+
+    vec2 diffUV = normalize(dir);
+
+    float diff = (dist - currentRadius) / halfWavelength;
+
+    float p = 1.0 - pow(abs(diff), 2.0);
+
+    // float powDiff = diff * pow(p, 2.0) * ( amplitude * fade );
+    float powDiff = 1.25 * sin(diff * PI) * p * ( uAmplitude * fade );
+
+    vec2 offset = diffUV * powDiff / inputSize.xy;
+
+    // Do clamp :
+    vec2 coord = vTextureCoord + offset;
+    vec2 clampedCoord = clamp(coord, inputClamp.xy, inputClamp.zw);
+    vec4 color = texture(myTexture, clampedCoord);
+    if (coord != clampedCoord) {
+        color *= max(0.0, 1.0 - length(coord - clampedCoord));
+    }
+
+    // No clamp :
+    // fragColor = texture(myTexture, vTextureCoord + offset);
+
+    color.rgb *= 1.0 + (uBrightness - 1.0) * p * fade;
+
+    fragColor = color;
+}

--- a/src/filters/shockwave/shockwave.vert
+++ b/src/filters/shockwave/shockwave.vert
@@ -1,0 +1,28 @@
+in vec2 aPosition;
+out vec2 vTextureCoord;
+
+uniform globalUniforms {
+  mat3 projectionMatrix;
+  mat3 worldTransformMatrix;
+  float worldAlpha;
+};
+
+uniform vec4 inputSize;
+uniform vec4 outputFrame;
+
+vec4 filterVertexPosition( void )
+{
+    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    return vec4((projectionMatrix * vec3(position, 1.0)).xy, 0.0, 1.0);
+}
+
+vec2 filterTextureCoord( void )
+{
+    return aPosition * (outputFrame.zw * inputSize.zw);
+}
+
+void main(void)
+{
+    gl_Position = filterVertexPosition();
+    vTextureCoord = filterTextureCoord();
+}

--- a/src/filters/shockwave/shockwave.wgsl
+++ b/src/filters/shockwave/shockwave.wgsl
@@ -132,4 +132,4 @@ fn boolVec2(x: vec2<f32>, y: vec2<f32>) -> bool
     return false;
 }
 
-const PI: f32 = 3.14159265358979323846264;";
+const PI: f32 = 3.14159265358979323846264;

--- a/src/filters/shockwave/shockwave.wgsl
+++ b/src/filters/shockwave/shockwave.wgsl
@@ -1,0 +1,135 @@
+struct GlobalUniforms {
+    projectionMatrix:mat3x3<f32>,
+    worldTransformMatrix:mat3x3<f32>,
+    worldAlpha: f32
+}
+
+struct GlobalFilterUniforms {
+    inputSize:vec4<f32>,
+    inputPixel:vec4<f32>,
+    inputClamp:vec4<f32>,
+    outputFrame:vec4<f32>,
+    backgroundFrame:vec4<f32>,
+    globalFrame:vec4<f32>,
+};
+
+struct ShockWaveUniforms {
+    uTime: f32,
+    uOffset: vec2<f32>,
+    uSpeed: f32,
+    uWave: vec4<f32>,
+};
+@group(0) @binding(0) var<uniform> globalUniforms : GlobalUniforms;
+@group(1) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
+@group(1) @binding(1) var myTexture: texture_2d<f32>;
+@group(1) @binding(2) var mySampler : sampler;
+@group(1) @binding(3) var backTexture: texture_2d<f32>;
+@group(2) @binding(0) var<uniform> shockwaveUniforms : ShockWaveUniforms;
+
+struct VSOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv : vec2<f32>,
+    @location(1) backgroundUv : vec2<f32>,
+};
+
+fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
+{
+    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    return vec4((globalUniforms.projectionMatrix * vec3(position, 1.0)).xy, 0.0, 1.0);
+}
+
+fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
+{
+    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+}
+
+fn filterBackgroundTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
+{
+    return aPosition * gfu.backgroundFrame.zw;
+}
+
+fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
+{
+    return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+}
+fn getSize() -> vec2<f32>
+{
+    return gfu.globalFrame.zw;
+}
+
+@vertex
+fn mainVertex(
+    @location(0) aPosition : vec2<f32>, 
+) -> VSOutput {
+    return VSOutput(
+        filterVertexPosition(aPosition),
+        filterTextureCoord(aPosition),
+        filterBackgroundTextureCoord(aPosition),
+    );
+}
+
+@fragment
+fn mainFragment(
+    @location(0) uv: vec2<f32>,
+    @location(1) backgroundUv: vec2<f32>,
+    @builtin(position) position: vec4<f32>
+) -> @location(0) vec4<f32> {
+
+    let uTime = shockwaveUniforms.uTime;
+    let uOffset = shockwaveUniforms.uOffset;
+    let uSpeed = shockwaveUniforms.uSpeed;
+    let uAmplitude = shockwaveUniforms.uWave[0];
+    let uWavelength = shockwaveUniforms.uWave[1];
+    let uBrightness = shockwaveUniforms.uWave[2];
+    let uRadius = shockwaveUniforms.uWave[3];
+    let halfWavelength: f32 = uWavelength * 0.5 / gfu.inputSize.x;
+    let maxRadius: f32 = uRadius / gfu.inputSize.x;
+    let currentRadius: f32 = uTime * uSpeed / gfu.inputSize.x;
+    var fade: f32 = 1.0;
+    var returnColorOnly: bool = false;
+    
+    if (maxRadius > 0.0) {
+        if (currentRadius > maxRadius) {
+            returnColorOnly = true;
+        }
+        fade = 1.0 - pow(currentRadius / maxRadius, 2.0);
+    }
+    var dir: vec2<f32> = vec2<f32>(uv - uOffset / gfu.inputSize.xy);
+    dir.y *= gfu.inputSize.y / gfu.inputSize.x;
+
+    let dist:f32 = length(dir);
+
+    if (dist <= 0.0 || dist < currentRadius - halfWavelength || dist > currentRadius + halfWavelength) {
+        returnColorOnly = true;
+    }
+
+    let diffUV: vec2<f32> = normalize(dir);
+    let diff: f32 = (dist - currentRadius) / halfWavelength;
+    let p: f32 = 1.0 - pow(abs(diff), 2.0);
+    let powDiff: f32 = 1.25 * sin(diff * PI) * p * ( uAmplitude * fade );
+    let offset: vec2<f32> = diffUV * powDiff / gfu.inputSize.xy;
+    // Do clamp :
+    let coord: vec2<f32> = uv + offset;
+    let clampedCoord: vec2<f32> = clamp(coord, gfu.inputClamp.xy, gfu.inputClamp.zw);
+
+    var clampedColor: vec4<f32> = textureSample(myTexture, mySampler, clampedCoord);
+    
+    if (boolVec2(coord, clampedCoord)) 
+    {
+        clampedColor *= max(0.0, 1.0 - length(coord - clampedCoord));
+    }
+    // No clamp :
+    return select(clampedColor * vec4<f32>(vec3<f32>(1.0 + (uBrightness - 1.0) * p * fade), clampedColor.a), textureSample(myTexture, mySampler, uv), returnColorOnly);
+}
+
+fn boolVec2(x: vec2<f32>, y: vec2<f32>) -> bool
+{
+    if (x.x == y.x && x.y == y.y)
+    {
+        return true;
+    }
+    
+    return false;
+}
+
+const PI: f32 = 3.14159265358979323846264;";

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -111,7 +111,7 @@ export class Ellipse implements ShapePrimitive
     // #if _DEBUG
     public toString(): string
     {
-        return `[@pixi/math:Ellipse x=${this.x} y=${this.y} width=${this.halfWidth} height=${this.halfHeight}]`;
+        return `[@pixi/math:Ellipse x=${this.x} y=${this.y} halfWidth=${this.halfWidth} halfHeight=${this.halfHeight}]`;
     }
     // #endif
 }

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -15,10 +15,10 @@ export class Ellipse implements ShapePrimitive
     public y: number;
 
     /** @default 0 */
-    public width: number;
+    public halfWidth: number;
 
     /** @default 0 */
-    public height: number;
+    public halfHeight: number;
 
     /**
      * The type of the object, mainly used to avoid `instanceof` checks
@@ -36,8 +36,8 @@ export class Ellipse implements ShapePrimitive
     {
         this.x = x;
         this.y = y;
-        this.width = halfWidth;
-        this.height = halfHeight;
+        this.halfWidth = halfWidth;
+        this.halfHeight = halfHeight;
     }
 
     /**
@@ -46,7 +46,7 @@ export class Ellipse implements ShapePrimitive
      */
     public clone(): Ellipse
     {
-        return new Ellipse(this.x, this.y, this.width, this.height);
+        return new Ellipse(this.x, this.y, this.halfWidth, this.halfHeight);
     }
 
     /**
@@ -57,14 +57,14 @@ export class Ellipse implements ShapePrimitive
      */
     public contains(x: number, y: number): boolean
     {
-        if (this.width <= 0 || this.height <= 0)
+        if (this.halfWidth <= 0 || this.halfHeight <= 0)
         {
             return false;
         }
 
         // normalize the coords to an ellipse with center 0,0
-        let normx = ((x - this.x) / this.width);
-        let normy = ((y - this.y) / this.height);
+        let normx = ((x - this.x) / this.halfWidth);
+        let normy = ((y - this.y) / this.halfHeight);
 
         normx *= normx;
         normy *= normy;
@@ -78,7 +78,7 @@ export class Ellipse implements ShapePrimitive
      */
     public getBounds(): Rectangle
     {
-        return new Rectangle(this.x - this.width, this.y - this.height, this.width, this.height);
+        return new Rectangle(this.x - this.halfWidth, this.y - this.halfHeight, this.halfWidth * 2, this.halfHeight * 2);
     }
 
     /**
@@ -90,8 +90,8 @@ export class Ellipse implements ShapePrimitive
     {
         this.x = ellipse.x;
         this.y = ellipse.y;
-        this.width = ellipse.width;
-        this.height = ellipse.height;
+        this.halfWidth = ellipse.halfWidth;
+        this.halfHeight = ellipse.halfHeight;
 
         return this;
     }
@@ -111,7 +111,7 @@ export class Ellipse implements ShapePrimitive
     // #if _DEBUG
     public toString(): string
     {
-        return `[@pixi/math:Ellipse x=${this.x} y=${this.y} width=${this.width} height=${this.height}]`;
+        return `[@pixi/math:Ellipse x=${this.x} y=${this.y} width=${this.halfWidth} height=${this.halfHeight}]`;
     }
     // #endif
 }

--- a/src/rendering/graphics/shared/buildCommands/buildCircle.ts
+++ b/src/rendering/graphics/shared/buildCommands/buildCircle.ts
@@ -43,8 +43,8 @@ export const buildCircle: ShapeBuildCommand<RoundedThing> = {
 
             x = ellipse.x;
             y = ellipse.y;
-            rx = ellipse.width;
-            ry = ellipse.height;
+            rx = ellipse.halfWidth;
+            ry = ellipse.halfHeight;
             dx = dy = 0;
         }
         else

--- a/src/rendering/mask/shared/StencilMaskPipe.ts
+++ b/src/rendering/mask/shared/StencilMaskPipe.ts
@@ -95,14 +95,12 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
 
         maskData.instructionsLength = instructionsLength;
 
-        const currentRenderTargetUid = renderer.renderTarget.renderTarget.uid;
-
-        if (!this.maskStackHash[currentRenderTargetUid])
+        if (this.maskStackHash[_container.uid] === undefined)
         {
-            this.maskStackHash[currentRenderTargetUid] = 0;
+            this.maskStackHash[_container.uid] = 0;
         }
 
-        this.maskStackHash[currentRenderTargetUid]++;
+        this.maskStackHash[_container.uid]++;
     }
 
     pop(mask: StencilMask, _container: Container, instructionSet: InstructionSet): void
@@ -110,9 +108,8 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
         const renderer = this.renderer;
 
         // stencil is stored based on current render target..
-        const currentRenderTargetUid = renderer.renderTarget.renderTarget.uid;
 
-        this.maskStackHash[currentRenderTargetUid]--;
+        this.maskStackHash[_container.uid]--;
 
         renderer.renderPipes.batch.break(instructionSet);
 
@@ -124,7 +121,7 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
 
         const maskData = this.maskHash.get(mask);
 
-        if (this.maskStackHash[currentRenderTargetUid])
+        if (this.maskStackHash[_container.uid])
         {
             for (let i = 0; i < maskData.instructionsLength; i++)
             {
@@ -145,7 +142,7 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
         const renderer = this.renderer;
         const currentRenderTargetUid = renderer.renderTarget.renderTarget.uid;
 
-        let maskStackIndex = this.maskStackHash[currentRenderTargetUid];
+        let maskStackIndex = this.maskStackHash[currentRenderTargetUid] ?? 0;
 
         if (instruction.action === 'pushMaskBegin')
         {

--- a/src/rendering/mesh/shared/MeshView.ts
+++ b/src/rendering/mesh/shared/MeshView.ts
@@ -124,7 +124,7 @@ export class MeshView<GEOMETRY extends MeshGeometry = MeshGeometry>implements Vi
     {
         const { x, y } = point;
 
-        const vertices = this.geometry.getBuffer('aVertexPosition').data;
+        const vertices = this.geometry.getBuffer('aPosition').data;
 
         const points = tempPolygon.points;
         const indices = this.geometry.getIndex().data;

--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -54,7 +54,7 @@ export class GlBackBufferSystem implements ISystem
     backBufferTexture: Texture;
     renderer: WebGLRenderer;
     targetTexture: Texture;
-    useBackBuffer = true;
+    useBackBuffer = false;
 
     constructor(renderer: WebGLRenderer)
     {

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '../../../extensions/Extensions';
+import { sayHello } from '../../../utils/sayHello';
 import { SharedDefaultRendererOptions, SharedRendererExtensions } from '../shared/system/SharedSystems';
 import { SystemManager } from '../shared/system/SystemManager';
 import { getCanvasTexture } from '../shared/texture/utils/getCanvasTexture';
@@ -77,6 +78,8 @@ export class WebGLRenderer extends SystemManager<WebGLRenderer> implements GLRen
         });
 
         this.setup(systemConfig);
+
+        sayHello(this.type);
     }
 
     /**

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -1,5 +1,4 @@
 import { extensions, ExtensionType } from '../../../extensions/Extensions';
-import { sayHello } from '../../../utils/sayHello';
 import { SharedDefaultRendererOptions, SharedRendererExtensions } from '../shared/system/SharedSystems';
 import { SystemManager } from '../shared/system/SystemManager';
 import { getCanvasTexture } from '../shared/texture/utils/getCanvasTexture';
@@ -78,8 +77,6 @@ export class WebGLRenderer extends SystemManager<WebGLRenderer> implements GLRen
         });
 
         this.setup(systemConfig);
-
-        sayHello(this.type);
     }
 
     /**

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -1,5 +1,4 @@
 import { extensions, ExtensionType } from '../../../extensions/Extensions';
-import { sayHello } from '../../../utils/sayHello';
 import { SharedDefaultRendererOptions, SharedRendererExtensions } from '../shared/system/SharedSystems';
 import { SystemManager } from '../shared/system/SystemManager';
 import { getCanvasTexture } from '../shared/texture/utils/getCanvasTexture';
@@ -76,8 +75,6 @@ export class WebGPURenderer extends SystemManager<WebGPURenderer> implements GPU
         });
 
         this.setup(systemConfig);
-
-        sayHello(this.type);
     }
 
     set resolution(value: number)

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '../../../extensions/Extensions';
+import { sayHello } from '../../../utils/sayHello';
 import { SharedDefaultRendererOptions, SharedRendererExtensions } from '../shared/system/SharedSystems';
 import { SystemManager } from '../shared/system/SystemManager';
 import { getCanvasTexture } from '../shared/texture/utils/getCanvasTexture';
@@ -75,6 +76,8 @@ export class WebGPURenderer extends SystemManager<WebGPURenderer> implements GPU
         });
 
         this.setup(systemConfig);
+
+        sayHello(this.type);
     }
 
     set resolution(value: number)

--- a/src/rendering/renderers/shared/View.ts
+++ b/src/rendering/renderers/shared/View.ts
@@ -1,5 +1,6 @@
 import type { Point } from '../../../maths/Point';
 import type { Bounds } from '../../scene/bounds/Bounds';
+import type { DestroyOptions } from '../../scene/destroyTypes';
 
 export interface ViewObserver
 {
@@ -27,6 +28,6 @@ export interface View
     addBounds: (bounds: Bounds) => void;
     containsPoint: (point: Point) => boolean;
 
-    destroy(options?: unknown): void;
+    destroy(options?: DestroyOptions): void;
 }
 

--- a/src/rendering/renderers/shared/View.ts
+++ b/src/rendering/renderers/shared/View.ts
@@ -1,6 +1,5 @@
 import type { Point } from '../../../maths/Point';
 import type { Bounds } from '../../scene/bounds/Bounds';
-import type { DestroyOptions } from '../../scene/destroyTypes';
 
 export interface ViewObserver
 {
@@ -28,6 +27,6 @@ export interface View
     addBounds: (bounds: Bounds) => void;
     containsPoint: (point: Point) => boolean;
 
-    destroy<DESTROY_OPTIONS = DestroyOptions>(options: DESTROY_OPTIONS): void;
+    destroy(options?: unknown): void;
 }
 

--- a/src/rendering/renderers/shared/startup/StartupSystem.ts
+++ b/src/rendering/renderers/shared/startup/StartupSystem.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
+import { sayHello } from '../../../../utils/sayHello';
 
 import type { ExtensionMetadata } from '../../../../extensions/Extensions';
 import type { Renderer } from '../../types';
@@ -62,7 +63,7 @@ export interface StartupSystemOptions
         if (options.hello)
         {
             // eslint-disable-next-line no-console
-            console.log(`PixiJS ${'$_VERSION'} - ${renderer.rendererLogId} - https://pixijs.com`);
+            sayHello(renderer.type);
         }
 
         // TODO: screen doesn't exist on renderer yet

--- a/src/rendering/scene/LayerGroup.ts
+++ b/src/rendering/scene/LayerGroup.ts
@@ -138,10 +138,10 @@ export class LayerGroup implements Instruction
                 return;
             }
         }
-
         else
         {
             child.layerGroup = this;
+            child.didChange = true;
         }
 
         const children = child.children;

--- a/src/rendering/scene/bounds/getLocalBounds.ts
+++ b/src/rendering/scene/bounds/getLocalBounds.ts
@@ -25,7 +25,7 @@ export function getLocalBounds(target: Container, bounds: Bounds, relativeMatrix
 
     for (let i = 0; i < target.children.length; i++)
     {
-        _getLocalBounds(target.children[i], bounds, relativeMatrix || new Matrix(), target);
+        _getLocalBounds(target.children[i], bounds, relativeMatrix, target);
     }
 
     if (!bounds.isValid)

--- a/src/rendering/sprite/shared/SpritePipe.ts
+++ b/src/rendering/sprite/shared/SpritePipe.ts
@@ -59,7 +59,7 @@ export class SpritePipe implements RenderPipe<SpriteView>
 
         if (gpuSprite.texture._source !== texture._source)
         {
-            return gpuSprite.batcher.checkAndUpdateTexture(gpuSprite, texture);
+            return !gpuSprite.batcher.checkAndUpdateTexture(gpuSprite, texture);
         }
 
         return false;

--- a/src/rendering/sprite/shared/SpriteView.ts
+++ b/src/rendering/sprite/shared/SpriteView.ts
@@ -168,7 +168,7 @@ export class SpriteView implements View
     {
         this.didUpdate = true;
 
-        this.boundsDirty = true;
+        this.sourceBoundsDirty = this.boundsDirty = true;
 
         this.owner.onViewUpdate();
     }

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -3,7 +3,7 @@ import { TextView } from './TextView';
 
 import type { ContainerOptions } from '../scene/Container';
 import type { TextStyle } from './TextStyle';
-import type { TextViewOptions } from './TextView';
+import type { TextString, TextViewOptions } from './TextView';
 
 export type TextOptions = ContainerOptions<TextView> & TextViewOptions;
 
@@ -23,7 +23,7 @@ export class Text extends Container<TextView>
         return this.view.anchor;
     }
 
-    set text(value: string)
+    set text(value: TextString)
     {
         this.view.text = value;
     }

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -39,9 +39,9 @@ export interface TextStyleOptions
      * Alignment for multiline text, does not affect single line text
      * @type {'left'|'center'|'right'|'justify'}
      */
-    align: TextStyleAlign;
+    align?: TextStyleAlign;
     /** Indicates if lines can be wrapped within words, it needs wordWrap to be set to true */
-    breakWords: boolean;
+    breakWords?: boolean;
     /** Set a drop shadow for the text */
     dropShadow?: boolean | TextDropShadow;
     /**
@@ -50,57 +50,57 @@ export interface TextStyleOptions
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle|MDN}
      * @type {string|string[]|number|number[]|CanvasGradient|CanvasPattern}
      */
-    fill: FillStyleInputs;
+    fill?: FillStyleInputs;
     /** The font family, can be a single font name, or a list of names where the first is the preferred font. */
-    fontFamily: string | string[];
+    fontFamily?: string | string[];
     /** The font size (as a number it converts to px, but as a string, equivalents are '26px','20pt','160%' or '1.6em') */
-    fontSize: number | string;
+    fontSize?: number | string;
     /**
      * The font style.
      * @type {'normal'|'italic'|'oblique'}
      */
-    fontStyle: TextStyleFontStyle;
+    fontStyle?: TextStyleFontStyle;
     /**
      * The font variant.
      * @type {'normal'|'small-caps'}
      */
-    fontVariant: TextStyleFontVariant;
+    fontVariant?: TextStyleFontVariant;
     /**
      * The font weight.
      * @type {'normal'|'bold'|'bolder'|'lighter'|'100'|'200'|'300'|'400'|'500'|'600'|'700'|'800'|'900'}
      */
-    fontWeight: TextStyleFontWeight;
+    fontWeight?: TextStyleFontWeight;
     /** The height of the line, a number that represents the vertical space that a letter uses. */
-    leading: number;
+    leading?: number;
     /** The amount of spacing between letters, default is 0 */
-    letterSpacing: number;
+    letterSpacing?: number;
     /** The line height, a number that represents the vertical space that a letter uses */
-    lineHeight: number;
+    lineHeight?: number;
     /**
      * Occasionally some fonts are cropped. Adding some padding will prevent this from
      * happening by adding padding to all sides of the text.
      */
-    padding: number;
+    padding?: number;
     /** A canvas fillstyle that will be used on the text stroke, e.g., 'blue', '#FCFF00' */
-    stroke: StrokeStyle | FillStyleInputs;
+    stroke?: StrokeStyle | FillStyleInputs;
     /**
      * The baseline of the text that is rendered.
      * @type {'alphabetic'|'top'|'hanging'|'middle'|'ideographic'|'bottom'}
      */
-    textBaseline: TextStyleTextBaseline;
+    textBaseline?: TextStyleTextBaseline;
     /** See {@link PIXI.TextStyle.trim} */
-    trim: false,
+    trim?: false,
     /**
      * Determines whether newlines & spaces are collapsed or preserved "normal"
      * (collapse, collapse), "pre" (preserve, preserve) | "pre-line" (preserve,
      * collapse). It needs wordWrap to be set to true.
      * @type {'normal'|'pre'|'pre-line'}
      */
-    whiteSpace: TextStyleWhiteSpace;
+    whiteSpace?: TextStyleWhiteSpace;
     /** Indicates if word wrap should be used */
-    wordWrap: boolean;
+    wordWrap?: boolean;
     /** The width at which text will wrap, it needs wordWrap to be set to true */
-    wordWrapWidth: number;
+    wordWrapWidth?: number;
 }
 
 const valuesToIterateForKeys = [

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -248,14 +248,14 @@ export class TextStyle extends EventEmitter<{
 
         this.dropShadow = null;
 
-        if (typeof style.fill === 'string')
+        if (typeof fullStyle.fill === 'string')
         {
             // eg '34px' to number
-            this.fontSize = parseInt(style.fontSize as string, 10);
+            this.fontSize = parseInt(fullStyle.fontSize as string, 10);
         }
         else
         {
-            this.fontSize = style.fontSize as number;
+            this.fontSize = fullStyle.fontSize as number;
         }
 
         if (style.dropShadow)

--- a/src/rendering/text/TextView.ts
+++ b/src/rendering/text/TextView.ts
@@ -14,7 +14,7 @@ import type { TextStyleOptions } from './TextStyle';
 let uid = 0;
 
 type Filter<T> = { [K in keyof T]: {
-    text?: string;
+    text?: TextString;
     renderMode?: K;
     resolution?: number;
     style?: T[K]
@@ -33,6 +33,8 @@ const map = {
     html: 'text',
     bitmap: 'bitmapText',
 };
+
+export type TextString = string | number | {toString: () => string};
 
 export class TextView implements View
 {
@@ -64,7 +66,7 @@ export class TextView implements View
 
     constructor(options: TextViewOptions)
     {
-        this._text = options.text;
+        this.text = options.text ?? '';
         this._style = options.style instanceof TextStyle ? options.style : new TextStyle(options.style);
 
         const renderMode = options.renderMode ?? this.detectRenderType(this._style);
@@ -76,14 +78,14 @@ export class TextView implements View
         this._resolution = options.resolution ?? TextView.defaultResolution;
     }
 
-    set text(value: string)
+    set text(value: TextString)
     {
         // check its a string
         value = value.toString();
 
         if (this._text === value) return;
 
-        this._text = value;
+        this._text = value as string;
         this.onUpdate();
     }
 

--- a/src/rendering/text/canvas/CanvasTextSystem.ts
+++ b/src/rendering/text/canvas/CanvasTextSystem.ts
@@ -283,7 +283,7 @@ export class CanvasTextSystem implements ISystem
                     );
                 }
 
-                if (style._fill)
+                if (style._fill !== undefined)
                 {
                     this.drawLetterSpacing(
                         lines[i],

--- a/src/tiling-sprite/TilingSpritePipe.ts
+++ b/src/tiling-sprite/TilingSpritePipe.ts
@@ -191,7 +191,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSpriteView>
 
             const matrix = view.tileTransform.matrix;
 
-            const uTextureTransform = Matrix.shared;
+            const uTextureTransform = tilingUniforms.uniforms.uTextureTransform;
 
             uTextureTransform.set(
                 matrix.a * tilingSpriteWidth / originalWidth,

--- a/src/tiling-sprite/shader/TilingSpriteShader.ts
+++ b/src/tiling-sprite/shader/TilingSpriteShader.ts
@@ -49,7 +49,7 @@ export class TilingSpriteShader extends Shader implements TextureShader
             uClampFrame: { value: new Float32Array([0, 0, 1, 1]), type: 'vec4<f32>' },
             uClampOffset: { value: new Float32Array([0, 0]), type: 'vec2<f32>' },
             uTextureTransform: { value: new Matrix(), type: 'mat3x3<f32>' },
-            uSizeAnchor: { value: new Float32Array([100, 200, 0.5, 0.5]), type: 'vec2<f32>' },
+            uSizeAnchor: { value: new Float32Array([100, 200, 0.5, 0.5]), type: 'vec4<f32>' },
         });
 
         super({

--- a/src/tiling-sprite/shader/tiling-sprite.wgsl
+++ b/src/tiling-sprite/shader/tiling-sprite.wgsl
@@ -40,7 +40,6 @@ fn mainVertex(
 
     var modifiedPosition = (aPosition - tilingUniforms.uSizeAnchor.zw) * tilingUniforms.uSizeAnchor.xy;
   
-  
     var  mvpMatrix = globalUniforms.projectionMatrix * globalUniforms.worldTransformMatrix * localUniforms.transformMatrix;
 
     var  colorOut = localUniforms.color;

--- a/src/utils/sayHello.ts
+++ b/src/utils/sayHello.ts
@@ -1,4 +1,4 @@
-import { settings } from '..';
+import { settings } from '../settings/settings';
 
 let saidHello = false;
 

--- a/src/utils/sayHello.ts
+++ b/src/utils/sayHello.ts
@@ -1,0 +1,34 @@
+import { settings } from '..';
+
+let saidHello = false;
+
+export const VERSION = '$_VERSION';
+
+export function sayHello(type: string): void
+{
+    if (saidHello)
+    {
+        return;
+    }
+
+    if (settings.ADAPTER.getNavigator().userAgent.toLowerCase().indexOf('chrome') > -1)
+    {
+        const args = [
+            `%c  %c  %c  %c  %c PixiJS %c v${VERSION} (${type}) http://www.pixijs.com/\n\n`,
+            'background: #E72264; padding:5px 0;',
+            'background: #6CA2EA; padding:5px 0;',
+            'background: #B5D33D; padding:5px 0;',
+            'background: #FED23F; padding:5px 0;',
+            'color: #FFFFFF; background: #E72264; padding:5px 0;',
+            'color: #E72264; background: #FFFFFF; padding:5px 0;',
+        ];
+
+        globalThis.console.log(...args);
+    }
+    else if (globalThis.console)
+    {
+        globalThis.console.log(`PixiJS ${VERSION} - ${type} - http://www.pixijs.com/`);
+    }
+
+    saidHello = true;
+}

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -1,4 +1,7 @@
+import { Matrix } from '../../../src/maths/Matrix';
 import { Graphics } from '../../../src/rendering/graphics/shared/Graphics';
+import { Bounds } from '../../../src/rendering/scene/bounds/Bounds';
+import { getLocalBounds } from '../../../src/rendering/scene/bounds/getLocalBounds';
 import { Container } from '../../../src/rendering/scene/Container';
 import { getRenderer } from '../../utils/getRenderer';
 
@@ -50,5 +53,18 @@ describe('Graphics', () =>
         expect(renderer.graphicsContext['gpuContextHash'][context.uid]).toBeNull();
 
         expect(context.instructions).toBeNull();
+    });
+
+    it('should measure an ellipse correctly', async () =>
+    {
+        const g = new Graphics();
+
+        g.context
+            .ellipse(0, 0, 100, 50)
+            .fill(0xFF0000);
+
+        const bounds = getLocalBounds(g, new Bounds(), new Matrix());
+
+        expect(bounds.rectangle.width).toBe(200);
     });
 });


### PR DESCRIPTION
- fix issues with measuring mesh
- fix layer group reparenting issue
- fix textStyle '0' color issue
- fix tilingSprite matrix issue
- fix tiling sprite anchor issue (webGPU)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 311ec56</samp>

### Summary
🔄🚫➕

<!--
1.  🔄 - This emoji represents a change in the naming or format of a variable, attribute, parameter, or uniform, such as `aVertexPosition` to `aPosition` or `vec2<f32>` to `vec4<f32>`.
2.  🚫 - This emoji represents a removal of a default value, an empty line, or a condition that is no longer needed, such as the default value for `relativeMatrix`, the empty line in the shader code, or the `style._fill` condition.
3.  ➕ - This emoji represents an addition of a new property, variable, or object, such as the `didChange` property, the `fullStyle` variable, or the `tilingUniforms` object.
-->
This pull request updates the mesh, text, and tiling sprite rendering systems to use the new WebGPU shader format and naming conventions. It also improves the performance and readability of some code by avoiding unnecessary object creation, variable confusion, and empty lines.

> _`style` and `aPosition`_
> _Renamed for clarity - kireji_
> _Winter of refactoring_

### Walkthrough
*  Rename vertex position attribute to match new shader convention ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-1d342e14a5fa9b47e0e30c31361244ae97e3baa7c19f0dc3af9f19750136a552L127-R127))
*  Remove default matrix value to avoid unnecessary object creation ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-1cd21e663358872d0530cf047d6780fa25cac642c9d729bed2ce9e8eb72ba164L28-R28))
*  Add `didChange` property to display object to track transform and geometry changes ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaL141-R144))
*  Change fill style condition to handle falsy values correctly ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-8393c735ac09d32cf2441068d3711a155f4ef1c6aa0c82017316af90c00c486cL286-R286))
*  Rename style object variable to avoid confusion with local variable ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL251-R258))
*  Remove empty line in `tiling-sprite.wgsl` for code consistency ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-0b39a6696cc14b877918b64394e8046d75699831256faf6ba9def4d63f75a586L43))
*  Access texture transform matrix from tiling uniforms object in `TilingSpritePipe.ts` ([link](https://github.com/pixijs/pixijs/pull/9488/files?diff=unified&w=0#diff-50bd5bfa1f824856f8471c41605e2e3bd533518043209829c486043b1a8a249eL194-R194))

