### PR TITLE
fix(events): allow custom events while maintaining typescript suggestions

### DIFF
--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -46,4 +46,7 @@ export type FederatedEventEmitterTypes = {
     [K in keyof FederatedEventMap as K | `${K}capture`]: [event: FederatedEventMap[K]];
 } & {
     [K in keyof GlobalFederatedEventMap]: [event: GlobalFederatedEventMap[K]];
+} & {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    [x: ({} & string) | ({} & symbol)]: any;
 };

--- a/packages/events/src/FederatedEventMap.ts
+++ b/packages/events/src/FederatedEventMap.ts
@@ -47,6 +47,18 @@ export type FederatedEventEmitterTypes = {
 } & {
     [K in keyof GlobalFederatedEventMap]: [event: GlobalFederatedEventMap[K]];
 } & {
+
+    // The following is a hack to allow any custom event while maintaining type safety.
+    // For some reason, the tsc compiler gets angry about error TS1023
+    // "An index signature parameter type must be either 'string' or 'number'."
+    // This is really odd since ({}&string) should interpret as string, but then again
+    // there is some black magic behind why this works in the first place.
+    // Closest thing to an explanation:
+    // https://stackoverflow.com/questions/70144348/why-does-a-union-of-type-literals-and-string-cause-ide-code-completion-wh
+    //
+    // Side note, we disable @typescript-eslint/ban-types since {}&string is the only syntax that works.
+    // Nor of the Record/unknown/never alternatives work.
+    // @ts-expect-error This syntax is a hack
     // eslint-disable-next-line @typescript-eslint/ban-types
-    [x: ({} & string) | ({} & symbol)]: any;
+    [K: ({} & string) | ({} & symbol)]: any;
 };


### PR DESCRIPTION
##### Description of change
Fixes #8957 

This is not the super strongly typed fix we wanted, but the quick fix we deserved.

All credits to @djmisterjon for knowing this arcane typescript syntax.

Explanation on how this works:
https://stackoverflow.com/questions/70144348/why-does-a-union-of-type-literals-and-string-cause-ide-code-completion-wh

---

##### Resulting ergonomics

All string and symbol events are now valid syntax while still auto-completing the FederatedEvent event keys.

![image](https://github.com/pixijs/pixijs/assets/15253010/3d643da2-f6ea-44b2-b80f-551b22816026)

---

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c3f38b</samp>

> _`FederatedEventMap`_
> _Index signature added_
> _No more TypeScript errors_