### PR TITLE
Add option to skip kerning generation in BitmapFont

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -523,7 +523,8 @@ export class BitmapFont
             positionX = Math.ceil(positionX);
         }
 
-        if (!options?.skipKerning) {
+        if (!options?.skipKerning)
+        {
             // Brute-force kerning info, this can be expensive b/c it's an O(n²),
             // but we're using measureText which is native and fast.
             for (let i = 0, len = charsList.length; i < len; i++)

--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -81,6 +81,13 @@ export interface IBitmapFontOptions extends BaseOptions
      * @default PIXI.BaseTexture.defaultOptions.alphaMode
      */
     alphaMode?: ALPHA_MODES;
+
+    /**
+     * Skip generation of kerning information for the BitmapFont.
+     * If true, this could potentially increase the performance, but may impact the rendered text appearance.
+     * @default false
+     */
+    skipKerning?: boolean;
 }
 
 /**
@@ -516,27 +523,29 @@ export class BitmapFont
             positionX = Math.ceil(positionX);
         }
 
-        // Brute-force kerning info, this can be expensive b/c it's an O(n²),
-        // but we're using measureText which is native and fast.
-        for (let i = 0, len = charsList.length; i < len; i++)
-        {
-            const first = charsList[i];
-
-            for (let j = 0; j < len; j++)
+        if (!options?.skipKerning) {
+            // Brute-force kerning info, this can be expensive b/c it's an O(n²),
+            // but we're using measureText which is native and fast.
+            for (let i = 0, len = charsList.length; i < len; i++)
             {
-                const second = charsList[j];
-                const c1 = context.measureText(first).width;
-                const c2 = context.measureText(second).width;
-                const total = context.measureText(first + second).width;
-                const amount = total - (c1 + c2);
+                const first = charsList[i];
 
-                if (amount)
+                for (let j = 0; j < len; j++)
                 {
-                    fontData.kerning.push({
-                        first: extractCharCode(first),
-                        second: extractCharCode(second),
-                        amount,
-                    });
+                    const second = charsList[j];
+                    const c1 = context.measureText(first).width;
+                    const c2 = context.measureText(second).width;
+                    const total = context.measureText(first + second).width;
+                    const amount = total - (c1 + c2);
+
+                    if (amount)
+                    {
+                        fontData.kerning.push({
+                            first: extractCharCode(first),
+                            second: extractCharCode(second),
+                            amount,
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request addresses the suggestion in issue [#8246](https://github.com/pixijs/pixijs/issues/8246), adding an option to skip the generation of kernings in the `BitmapFont.from` method.

The brute force kerning method was introduced in PR [#6888](https://github.com/pixijs/pixijs/pull/6888). This method can be computationally intensive, especially for larger character sets. 

By adding an option to bypass this step, developers can reduce the computational overhead when generating bitmap fonts, particularly in cases where the kerning information isn't required.

The changes involve adding a new property in the `IBitmapFontOptions` interface to allow skipping the kerning generation step. If this option is set to `true`, the method will bypass the kerning calculation loop, resulting in a performance gain.


##### Pre-Merge Checklist

- [ ❌ ] Tests and/or benchmarks are included
- [ ✅ ] Documentation is changed or added ( if jsdoc is accounted for documentation ) 
- [ ✅ ] Lint process passed (`npm run lint`)
- [ ✅ ] Tests passed (`npm run test`)
