### PR TITLE
NPE on INT/destroyed texture

### DIFF
--- a/packages/core/src/textures/TextureSystem.ts
+++ b/packages/core/src/textures/TextureSystem.ts
@@ -264,7 +264,7 @@ export class TextureSystem implements ISystem
             {
                 const glTexture = tex._glTextures[CONTEXT_UID];
 
-                if (glTexture.samplerType !== SAMPLER_TYPES.FLOAT)
+                if (!glTexture || glTexture.samplerType !== SAMPLER_TYPES.FLOAT)
                 {
                     this.renderer.texture.unbind(tex);
                 }


### PR DESCRIPTION
Here is NPE when one bound texture is INT, and another is destroyed.
