### PR TITLE
Backport: Add skipKerning option to BitmapFont in v6

### DIFF
--- a/packages/text-bitmap/src/BitmapFont.ts
+++ b/packages/text-bitmap/src/BitmapFont.ts
@@ -53,6 +53,13 @@ export interface IBitmapFontOptions
      * @default 512
      */
     textureHeight?: number;
+
+    /**
+     * Skip generation of kerning information for the BitmapFont.
+     * If true, this could potentially increase the performance, but may impact the rendered text appearance.
+     * @default false
+     */
+    skipKerning?: boolean;
 }
 
 /**
@@ -492,27 +499,30 @@ export class BitmapFont
             positionX = Math.ceil(positionX);
         }
 
-        // Brute-force kerning info, this can be expensive b/c it's an O(n²),
-        // but we're using measureText which is native and fast.
-        for (let i = 0, len = charsList.length; i < len; i++)
+        if (!options?.skipKerning)
         {
-            const first = charsList[i];
-
-            for (let j = 0; j < len; j++)
+            // Brute-force kerning info, this can be expensive b/c it's an O(n²),
+            // but we're using measureText which is native and fast.
+            for (let i = 0, len = charsList.length; i < len; i++)
             {
-                const second = charsList[j];
-                const c1 = context.measureText(first).width;
-                const c2 = context.measureText(second).width;
-                const total = context.measureText(first + second).width;
-                const amount = total - (c1 + c2);
+                const first = charsList[i];
 
-                if (amount)
+                for (let j = 0; j < len; j++)
                 {
-                    fontData.kerning.push({
-                        first: extractCharCode(first),
-                        second: extractCharCode(second),
-                        amount,
-                    });
+                    const second = charsList[j];
+                    const c1 = context.measureText(first).width;
+                    const c2 = context.measureText(second).width;
+                    const total = context.measureText(first + second).width;
+                    const amount = total - (c1 + c2);
+
+                    if (amount)
+                    {
+                        fontData.kerning.push({
+                            first: extractCharCode(first),
+                            second: extractCharCode(second),
+                            amount,
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request backports the changes introduced in #9496 to the v6 branch.

The original pull request, [#9496](https://github.com/pixijs/pixijs/pull/9496), added an option to skip kerning generation in the `BitmapFont.from` method. This feature provides a performance enhancement by reducing the computational overhead when generating bitmap fonts, particularly in scenarios where the kerning information isn't required.

The changes involve introducing a new 'skipKerning' property in the `IBitmapFontOptions` interface. When this property is set to `true`, the kerning calculation loop is bypassed, resulting in a performance gain.

This backport is important for users who are still on the v6 version of PixiJS and could benefit from the performance improvements.

##### Pre-Merge Checklist

- [ ❌ ] Tests and/or benchmarks are included
- [ ✅ ] Documentation is changed or added
- [ ✅ ] Lint process passed (`npm run lint`)
- [ ✅  ] Tests passed (`npm run test`)
