### PR TITLE
misc little v8 fixes

### DIFF
--- a/src/rendering/mesh/shared/MeshPipe.ts
+++ b/src/rendering/mesh/shared/MeshPipe.ts
@@ -214,6 +214,7 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
         const gpuMesh: BatchableMesh = BigPool.get(BatchableMesh);
 
         gpuMesh.renderable = renderable;
+        gpuMesh.texture = renderable.view._texture;
 
         this.gpuBatchableMeshHash[renderable.uid] = gpuMesh;
 

--- a/src/rendering/scene/LayerGroup.ts
+++ b/src/rendering/scene/LayerGroup.ts
@@ -1,8 +1,8 @@
 import { Matrix } from '../../maths/Matrix';
 import { InstructionSet } from '../renderers/shared/instructions/InstructionSet';
-import { LayerRenderable } from '../renderers/shared/LayerRenderable';
 
 import type { Instruction } from '../renderers/shared/instructions/Instruction';
+import type { LayerRenderable } from '../renderers/shared/LayerRenderable';
 import type { Renderable } from '../renderers/shared/Renderable';
 import type { View } from '../renderers/shared/View';
 import type { Container } from './Container';
@@ -46,16 +46,6 @@ export class LayerGroup implements Instruction
     constructor(root: Container)
     {
         this.root = root;
-
-        const view = root.view;
-
-        if (view)
-        {
-            this.proxyRenderable = new LayerRenderable({
-                original: root,
-                view,
-            });
-        }
 
         this.addChild(root);
     }

--- a/src/rendering/scene/bounds/getGlobalBounds.ts
+++ b/src/rendering/scene/bounds/getGlobalBounds.ts
@@ -14,6 +14,7 @@ export function getGlobalBounds(target: Container, skipUpdateTransform: boolean,
     {
         if (!skipUpdateTransform)
         {
+            // TODO new Matrix.. EEEWW! pooling..
             parentTransform = updateTransformBackwards(target, new Matrix());
         }
         else
@@ -63,6 +64,15 @@ export function _getGlobalBounds(
         worldTransform = target.worldTransform;
     }
 
+    const parentBounds = bounds;
+    const preserveBounds = !!target.effects.length;
+
+    if (preserveBounds)
+    {
+        // TODO - cloning bounds is slow, we should have a pool (its on the todo list!)
+        bounds = bounds.clone();
+    }
+
     if (target.view)
     {
         bounds.setMatrix(worldTransform);
@@ -75,9 +85,14 @@ export function _getGlobalBounds(
         _getGlobalBounds(target.children[i], bounds, worldTransform, skipUpdateTransform);
     }
 
-    for (let i = 0; i < target.effects.length; i++)
+    if (preserveBounds)
     {
-        target.effects[i].addBounds?.(bounds);
+        for (let i = 0; i < target.effects.length; i++)
+        {
+            target.effects[i].addBounds?.(bounds);
+        }
+
+        parentBounds.addBounds(bounds);
     }
 }
 

--- a/src/rendering/scene/container-mixins/effectsMixin.ts
+++ b/src/rendering/scene/container-mixins/effectsMixin.ts
@@ -52,7 +52,7 @@ export const effectsMixin: Partial<Container> = {
 
     set filters(value: Filter | Filter[])
     {
-        if (!Array.isArray(value)) value = [value];
+        if (!Array.isArray(value) && value !== null) value = [value];
 
         // TODO - not massively important, but could optimise here
         // by reusing the same effect.. rather than adding and removing from the pool!
@@ -67,11 +67,11 @@ export const effectsMixin: Partial<Container> = {
             this._filters.effect = null;
         }
 
-        this._filters.filters = value;
+        this._filters.filters = value as Filter[];
 
         if (!value) return;
 
-        const effect = getFilterEffect(value);
+        const effect = getFilterEffect(value as Filter[]);
 
         this._filters.effect = effect;
 

--- a/src/tiling-sprite/TilingSpriteView.ts
+++ b/src/tiling-sprite/TilingSpriteView.ts
@@ -101,8 +101,8 @@ export class TilingSpriteView implements View
 
         bounds.addFrame(
             _bounds[0],
-            _bounds[1],
             _bounds[2],
+            _bounds[1],
             _bounds[3],
         );
     }

--- a/src/utils/pool/Pool.ts
+++ b/src/utils/pool/Pool.ts
@@ -3,7 +3,7 @@ export class Pool<T extends PoolItem>
     public readonly _classType: PoolItemConstructor<T>;
     private readonly _pool: T[] = [];
     private _count = 0;
-    private _nextAvailableIndex = 0;
+    private _index = 0;
 
     constructor(ClassType: PoolItemConstructor<T>, initialSize?: number)
     {
@@ -19,7 +19,7 @@ export class Pool<T extends PoolItem>
     {
         for (let i = 0; i < total; i++)
         {
-            this._pool.push(new this._classType());
+            this._pool[this._index++] = new this._classType();
         }
 
         this._count += total;
@@ -27,13 +27,16 @@ export class Pool<T extends PoolItem>
 
     public get(data?: unknown): T
     {
-        if (this._nextAvailableIndex >= this._count)
-        {
-            this._pool[this._count] = new this._classType();
-            this._count++;
-        }
+        let item;
 
-        const item = this._pool[this._nextAvailableIndex];
+        if (this._index > 0)
+        {
+            item = this._pool[--this._index];
+        }
+        else
+        {
+            item = new this._classType();
+        }
 
         item.init?.(data);
 
@@ -43,8 +46,8 @@ export class Pool<T extends PoolItem>
     public return(item: T): void
     {
         item.reset?.();
-        this._nextAvailableIndex--;
-        this._pool[this._nextAvailableIndex] = item;
+
+        this._pool[this._index++] = item;
     }
 
     get totalSize(): number

--- a/tests/Pool.test.ts
+++ b/tests/Pool.test.ts
@@ -1,0 +1,81 @@
+import { Pool } from '../src/utils/pool/Pool';
+
+class TestItem
+{
+    public value: number;
+
+    constructor()
+    {
+        this.value = 0;
+    }
+
+    public init(data?: unknown)
+    {
+        this.value = data as number || 0;
+    }
+
+    public reset()
+    {
+        this.value = 0;
+    }
+}
+
+describe('Pool', () =>
+{
+    it('should create a pool with the specified initial size', () =>
+    {
+        const pool = new Pool(TestItem, 5);
+
+        expect(pool['_count']).toBe(5);
+        expect(pool['_pool'].length).toBe(5);
+    });
+
+    it('should create a pool with no initial size', () =>
+    {
+        const pool = new Pool(TestItem);
+
+        expect(pool['_count']).toBe(0);
+        expect(pool['_pool'].length).toBe(0);
+    });
+
+    it('should prepopulate the pool with the specified number of items', () =>
+    {
+        const pool = new Pool(TestItem);
+
+        pool.prepopulate(5);
+
+        expect(pool['_count']).toBe(5);
+        expect(pool['_pool'].length).toBe(5);
+    });
+
+    it('should get an item from the pool', () =>
+    {
+        const pool = new Pool(TestItem);
+        const item = pool.get(10);
+
+        expect(item.value).toBe(10);
+    });
+
+    it('should return an item to the pool', () =>
+    {
+        const pool = new Pool(TestItem);
+        const item = pool.get(10);
+
+        pool.return(item);
+
+        expect(item.value).toBe(0);
+    });
+
+    it('should reuse returned items', () =>
+    {
+        const pool = new Pool(TestItem);
+        const item1 = pool.get(10);
+
+        pool.get(20);
+
+        pool.return(item1);
+        const item3 = pool.get(30);
+
+        expect(item3).toBe(item1);
+    });
+});

--- a/tests/scene/DummyView.ts
+++ b/tests/scene/DummyView.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'eventemitter3';
-import { Rectangle } from '../../src';
+import { Rectangle } from '../../src/maths/shapes/Rectangle';
 
 import type { Point } from '../../src/maths/Point';
 import type { View, ViewObserver } from '../../src/rendering/renderers/shared/View';

--- a/tests/scene/DummyView.ts
+++ b/tests/scene/DummyView.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'eventemitter3';
+import { Rectangle } from '../../src';
 
 import type { Point } from '../../src/maths/Point';
 import type { View, ViewObserver } from '../../src/rendering/renderers/shared/View';
@@ -14,8 +15,14 @@ export class DummyView extends EventEmitter implements View
     onUpdate: () => void;
     addBounds = (bounds: Bounds) =>
     {
-        bounds.addFrame(0, 0, 100, 100);
+        bounds.addFrame(this.size.x, this.size.y, this.size.width, this.size.height);
     };
     containsPoint: (point: Point) => boolean;
     destroy: () => void;
+    size: Rectangle;
+    constructor(x = 0, y = 0, width = 100, height = 100)
+    {
+        super();
+        this.size = new Rectangle(x, y, width, height);
+    }
 }

--- a/tests/scene/getGlobalBounds.tests.ts
+++ b/tests/scene/getGlobalBounds.tests.ts
@@ -225,8 +225,6 @@ describe('getGlobalBounds', () =>
 
         getGlobalBounds(container, false, bounds);
 
-        console.log(bounds);
-
         expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500, maxY: 500 });
     });
 

--- a/tests/scene/getGlobalBounds.tests.ts
+++ b/tests/scene/getGlobalBounds.tests.ts
@@ -199,6 +199,37 @@ describe('getGlobalBounds', () =>
         expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 100, maxY: 100 });
     });
 
+    it('should addMaskBounds correctly with existing bounds', async () =>
+    {
+        const bounds = new Bounds();
+
+        bounds.set(0, 0, 100, 100);
+        bounds.pad(10);
+
+        // | - container
+        //     | - bg
+        //     | - maskedContainer
+        //     | - mask
+
+        const container = new Container();
+
+        const bg = new Container({ label: 'bg', view: new DummyView(0, 0, 500, 500) });
+
+        const maskedContainer = new Container({ label: 'maskedContainer', view: new DummyView(50, 50, 200, 200) });
+
+        const mask = new Container({ label: 'mask', view: new DummyView(100, 100, 100, 100) });
+
+        container.addChild(bg, maskedContainer, mask);
+
+        maskedContainer.mask = mask;
+
+        getGlobalBounds(container, false, bounds);
+
+        console.log(bounds);
+
+        expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500, maxY: 500 });
+    });
+
     it('should get global bounds correctly with a layer', async () =>
     {
         const container = new Container({ label: 'container', layer: true });

--- a/tests/tiling-sprite/TilingSprite.test.ts
+++ b/tests/tiling-sprite/TilingSprite.test.ts
@@ -1,3 +1,5 @@
+import { Bounds } from '../../src/rendering/scene/bounds/Bounds';
+import { getGlobalBounds } from '../../src/rendering/scene/bounds/getGlobalBounds';
 import { Container } from '../../src/rendering/scene/Container';
 import { TilingSprite } from '../../src/tiling-sprite/TilingSprite';
 import { getRenderer } from '../utils/getRenderer';
@@ -43,5 +45,19 @@ describe('TilingSprite', () =>
         expect(renderer.renderPipes.tilingSprite['gpuBatchedTilingSprite'][sprite.uid]).toBeNull();
 
         expect(sprite.view.texture).toBeNull();
+    });
+
+    it('should global bounds to be correct', async () =>
+    {
+        const sprite = new TilingSprite({
+            texture: getTexture({ width: 256, height: 256 })
+        });
+
+        const bounds = getGlobalBounds(sprite, true, new Bounds());
+
+        expect(bounds.minX).toBe(0);
+        expect(bounds.maxX).toBe(256);
+        expect(bounds.minY).toBe(0);
+        expect(bounds.maxY).toBe(256);
     });
 });


### PR DESCRIPTION
- fix mask bounds measure bug
- fix tiling sprite measure
- fix circular dep
- fix mesh bug with texture

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37f272d</samp>

### Summary
🐛🎨🧪

<!--
1.  🐛 - This emoji represents the bug fix in the `TilingSpriteView` class, which is a common symbol for software errors or defects.
2.  🎨 - This emoji represents the refactor and performance improvements in the `MeshPipe` and `LayerGroup` classes, which are related to the rendering and graphics aspects of the project.
3.  🧪 - This emoji represents the new test cases added to the `getGlobalBounds.tests.ts` and `TilingSprite.test.ts` modules, which are related to testing and verification of the code functionality.
-->
This pull request improves the scene graph rendering and bounds calculation in `pixijs/pixijs`. It refactors the `LayerGroup` and `MeshPipe` classes, fixes bugs in the `TilingSpriteView` and `effectsMixin` modules, adds a comment for a possible optimization in the `getGlobalBounds` function, and adds new test cases for the `TilingSprite` and `getGlobalBounds` modules.

> _This pull request has many changes_
> _To render sprites with different ranges_
> _It fixes some bugs_
> _And adds some new tests_
> _And refactors the `MeshPipe` stages_

### Walkthrough
*  Refactor texture assignment for mesh rendering ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-0570a5977ff7601f6bd7334b6862ff6af98b6f04c4b96434e367d3128a8b12b0R217))
   * Move import statements from `LayerGroup.ts` to `MeshPipe.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaL3-R5))
   * Set `gpuMesh.texture` to `renderable.view._texture` in `MeshPipe.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-0570a5977ff7601f6bd7334b6862ff6af98b6f04c4b96434e367d3128a8b12b0R217))
*  Optimize and fix global bounds calculation ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8R17), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8R67-R75), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8L78-R95), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-62a8655c74299291ea404ee6788b468263c30cbd80c48d2788bb715810b65488L104-R105), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3663c15c632bae8313bf0f19857df15b0e30289d5b090dffd9aeb067c90876c1R202-R232), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-d7b428b680f5ded572a45bf64a4181139d8a8dc73998afd3d0c825ca32f1fe9fR49-R62))
   * Add comment about using a pool of `Matrix` objects in `getGlobalBounds.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8R17))
   * Clone and apply effects to bounds in `getGlobalBounds.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8R67-R75), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-22fea8a83107b05480683032cf57976215890e5a09ae0c11f8c9c8013088a2a8L78-R95))
   * Fix argument order for `bounds.addFrame` in `TilingSpriteView.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-62a8655c74299291ea404ee6788b468263c30cbd80c48d2788bb715810b65488L104-R105))
   * Add test cases for mask bounds and tiling sprite bounds in `getGlobalBounds.tests.ts` and `TilingSprite.test.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3663c15c632bae8313bf0f19857df15b0e30289d5b090dffd9aeb067c90876c1R202-R232), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-d7b428b680f5ded572a45bf64a4181139d8a8dc73998afd3d0c825ca32f1fe9fR49-R62))
*  Allow setting filters to null in `effectsMixin.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-85b0f715f0e69d273c792574068e09cd765f528e91c060cb6d2f42352b855e38L55-R55), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-85b0f715f0e69d273c792574068e09cd765f528e91c060cb6d2f42352b855e38L70-R74))
   * Add null check to `filters` setter in `effectsMixin.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-85b0f715f0e69d273c792574068e09cd765f528e91c060cb6d2f42352b855e38L55-R55))
   * Add type assertion to `filters` setter in `effectsMixin.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-85b0f715f0e69d273c792574068e09cd765f528e91c060cb6d2f42352b855e38L70-R74))
*  Create proxy renderable lazily for layer groups ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaL50-L59), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR1-R2), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL21-R33), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR152-R164))
   * Remove proxy renderable creation from `LayerGroup.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-ed831278ea825367c70b7f2674e0b5d0c3159e4cee387f2d0f674a73280beddaL50-L59))
   * Add import statement for `LayerRenderable` in `buildInstructions.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR1-R2))
   * Check view and create proxy renderable in `buildInstructions.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL21-R33))
   * Add helper function `initProxyRenderable` in `buildInstructions.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR152-R164))
*  Add size property and constructor to `DummyView.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3c83be602de870e87478f69eb60753c00aa14086b3f0e40b98a6ac263718f5d4R2), [link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3c83be602de870e87478f69eb60753c00aa14086b3f0e40b98a6ac263718f5d4L17-R27))
   * Add import statement for `Rectangle` in `DummyView.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3c83be602de870e87478f69eb60753c00aa14086b3f0e40b98a6ac263718f5d4R2))
   * Add size property and constructor to `DummyView.ts` ([link](https://github.com/pixijs/pixijs/pull/9504/files?diff=unified&w=0#diff-3c83be602de870e87478f69eb60753c00aa14086b3f0e40b98a6ac263718f5d4L17-R27))

