### PR TITLE
added isRenderingToScreen

### DIFF
--- a/src/rendering/renderers/gl/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/GlRenderTargetSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { Matrix } from '../../../maths/Matrix';
+import { isRenderingToScreen } from '../shared/renderTarget/isRenderingToScreen';
 import { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import { SystemRunner } from '../shared/system/SystemRunner';
 import { Texture } from '../shared/texture/Texture';
@@ -23,6 +24,7 @@ export class GlRenderTargetSystem implements System
     } as const;
 
     rootProjectionMatrix: Matrix;
+    renderingToScreen: boolean;
     rootRenderTarget: RenderTarget;
     renderTarget: RenderTarget;
 
@@ -68,6 +70,9 @@ export class GlRenderTargetSystem implements System
         const renderTarget = this.getRenderTarget(rootRenderSurface);
 
         this.rootRenderTarget = renderTarget;
+
+        this.renderingToScreen = isRenderingToScreen(this.rootRenderTarget);
+
         this.rootProjectionMatrix = renderTarget.projectionMatrix;
 
         this.push(renderTarget, clear, clearColor);

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { Matrix } from '../../../../maths/Matrix';
+import { isRenderingToScreen } from '../../shared/renderTarget/isRenderingToScreen';
 import { RenderTarget } from '../../shared/renderTarget/RenderTarget';
 import { SystemRunner } from '../../shared/system/SystemRunner';
 import { TextureSource } from '../../shared/texture/sources/TextureSource';
@@ -28,6 +29,7 @@ export class GpuRenderTargetSystem implements System
     } as const;
 
     rootRenderTarget: RenderTarget;
+    renderingToScreen: boolean;
     rootProjectionMatrix = new Matrix();
     renderTarget: RenderTarget;
     onRenderTargetChange = new SystemRunner('onRenderTargetChange');
@@ -61,6 +63,8 @@ export class GpuRenderTargetSystem implements System
 
         this.rootRenderTarget = this.getRenderTarget(target);
         this.rootProjectionMatrix = this.rootRenderTarget.projectionMatrix;
+
+        this.renderingToScreen = isRenderingToScreen(this.rootRenderTarget);
 
         this.renderTargetStack.length = 0;
 

--- a/src/rendering/renderers/shared/renderTarget/isRenderingToScreen.ts
+++ b/src/rendering/renderers/shared/renderTarget/isRenderingToScreen.ts
@@ -1,0 +1,14 @@
+import type { RenderTarget } from './RenderTarget';
+
+/**
+ * Checks if the render target is viewable on the screen
+ * Basically, is it a canvas element and is that canvas element in the DOM
+ * @param renderTarget - the render target to check
+ * @returns true if the render target is viewable on the screen
+ */
+export function isRenderingToScreen(renderTarget: RenderTarget): boolean
+{
+    const resource = renderTarget.colorTexture.source.resource;
+
+    return (resource instanceof HTMLCanvasElement && document.body.contains(resource));
+}

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -180,8 +180,9 @@ export class AbstractRenderer<PIPES, OPTIONS>
      */
     get renderingToScreen(): boolean
     {
-        // is this really BAD code??
-        return (this as any as {renderTarget: {renderingToScreen: boolean}}).renderTarget.renderingToScreen;
+        const renderer = this as unknown as Renderer;
+
+        return renderer.renderTarget.renderingToScreen;
     }
 
     /**

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -180,7 +180,8 @@ export class AbstractRenderer<PIPES, OPTIONS>
      */
     get renderingToScreen(): boolean
     {
-        return true; // TODO: this._renderingToScreen;
+        // is this really BAD code??
+        return (this as any as {renderTarget: {renderingToScreen: boolean}}).renderTarget.renderingToScreen;
     }
 
     /**

--- a/tests/renderering/render-target/RenderTarget.test.ts
+++ b/tests/renderering/render-target/RenderTarget.test.ts
@@ -1,0 +1,57 @@
+import { isRenderingToScreen } from '../../../src/rendering/renderers/shared/renderTarget/isRenderingToScreen';
+import { RenderTarget } from '../../../src/rendering/renderers/shared/renderTarget/RenderTarget';
+import { CanvasSource } from '../../../src/rendering/renderers/shared/texture/sources/CanvasSource';
+import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+
+import type { ICanvas } from '../../../src/settings/adapter/ICanvas';
+
+function makeTextureFromResource(resource: HTMLCanvasElement)
+{
+    return new Texture({
+        source: new CanvasSource({
+            resource: (resource as ICanvas),
+        }),
+    });
+}
+
+describe('isRenderingToScreen', () =>
+{
+    it('returns true for a canvas attached to the dom', () =>
+    {
+        const canvas = document.createElement('canvas');
+
+        document.body.appendChild(canvas);
+
+        const renderTarget = new RenderTarget({
+            colorTextures: [
+                makeTextureFromResource(canvas)
+            ]
+        });
+
+        expect(isRenderingToScreen(renderTarget)).toBe(true);
+    });
+
+    it('returns false for canvas not attached to the dom', () =>
+    {
+        const canvas = document.createElement('canvas');
+
+        const renderTarget = new RenderTarget({
+            colorTextures: [
+                makeTextureFromResource(canvas)
+            ]
+        });
+
+        expect(isRenderingToScreen(renderTarget)).toBe(false);
+    });
+
+    it('returns false if the texture is not a canvas', () =>
+    {
+        const renderTarget = new RenderTarget({
+            colorTextures: [
+                Texture.EMPTY
+            ]
+        });
+
+        expect(isRenderingToScreen(renderTarget)).toBe(false);
+    });
+});


### PR DESCRIPTION
adds renderingToScreen property back to the renderer

A bit different to v7 as it could be we are rendering to multiple places on the screen!

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f522a7b</samp>

### Summary
🖥️🧪🛠️

<!--
1.  🖥️ - This emoji represents the screen or monitor, which is relevant to the concept of rendering to the screen or to an offscreen texture. It also suggests the visual aspect of the changes, which affect how the renderers display the graphics.
2.  🧪 - This emoji represents a test or experiment, which is relevant to the addition of the test file and the test cases for the new function. It also suggests the quality aspect of the changes, which aim to ensure the correctness and reliability of the function.
3.  🛠️ - This emoji represents a tool or a fix, which is relevant to the modification of the `renderingToScreen` getter and the use of the new function in the render target systems. It also suggests the improvement aspect of the changes, which aim to enhance the performance and functionality of the renderers.
-->
This pull request improves the detection of whether a renderer is rendering to the screen or to an offscreen texture, using a shared utility function `isRenderingToScreen`. This function is used by the `GlRenderTargetSystem` and the `GpuRenderTargetSystem` classes, and accessed by the `AbstractRenderer` class. The pull request also adds a test file `RenderTarget.test.ts` for the function.

> _`isRenderingToScreen`_
> _checks canvas in the dom_
> _a winter feature_

### Walkthrough
*  Add `isRenderingToScreen` function to check if a render target is viewable on the screen ([link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-699302eb8f23ffd7d7af461eb6ca086315206e146f35119dfe9e3fe65e9e49f6R1-R14))
*  Import and use `isRenderingToScreen` function in `GlRenderTargetSystem` and `GpuRenderTargetSystem` classes ([link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-44089baf2a412137289b97057757debedd8e1db280102cc76cfb5a69b712cf7fR3), [link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-44089baf2a412137289b97057757debedd8e1db280102cc76cfb5a69b712cf7fR27), [link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-44089baf2a412137289b97057757debedd8e1db280102cc76cfb5a69b712cf7fR73-R75), [link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-cc30907ceac12da16aac42e68a3be36849cc7e433a623667b9e8327f6e7dc229R3), [link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-cc30907ceac12da16aac42e68a3be36849cc7e433a623667b9e8327f6e7dc229R32), [link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-cc30907ceac12da16aac42e68a3be36849cc7e433a623667b9e8327f6e7dc229R67-R68))
*  Update `renderingToScreen` getter in `AbstractRenderer` class to access render target system property ([link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-27fa29afe053bf0bbdb6c29016c4da0abb00506b5b31c3e689aa84f35867aa42L183-R184))
*  Add test cases for `isRenderingToScreen` function in `RenderTarget.test.ts` file ([link](https://github.com/pixijs/pixijs/pull/9509/files?diff=unified&w=0#diff-3c0b0f60975eaad691091df443eb1720595f32da5d6ddf6ff958174fccd1c788R1-R57))

