### PR TITLE
Feature/nine slice

### DIFF
--- a/src/mesh-extras/NineSlicePlane.ts
+++ b/src/mesh-extras/NineSlicePlane.ts
@@ -1,11 +1,12 @@
 import { MeshView } from '../rendering/mesh/shared/MeshView';
 import { Texture } from '../rendering/renderers/shared/texture/Texture';
 import { Container } from '../rendering/scene/Container';
+import { deprecation } from '../utils/logging/deprecation';
 import { NineSliceGeometry } from './NineSliceGeometry';
 
 import type { ContainerOptions } from '../rendering/scene/Container';
 
-export interface NineSlicePlaneOptions extends ContainerOptions<MeshView<NineSliceGeometry>>
+export interface NineSliceSpriteOptions extends ContainerOptions<MeshView<NineSliceGeometry>>
 {
     texture: Texture;
     leftWidth?: number;
@@ -41,9 +42,9 @@ export interface NineSlicePlaneOptions extends ContainerOptions<MeshView<NineSli
  * const plane9 = new NineSlicePlane(Texture.from('BoxWithRoundedCorners.png'), 15, 15, 15, 15);
  * @memberof PIXI
  */
-export class NineSlicePlane extends Container<MeshView<NineSliceGeometry>>
+export class NineSliceSprite extends Container<MeshView<NineSliceGeometry>>
 {
-    static defaultOptions: NineSlicePlaneOptions = {
+    static defaultOptions: NineSliceSpriteOptions = {
         texture: Texture.EMPTY,
         leftWidth: 10,
         topHeight: 10,
@@ -63,14 +64,14 @@ export class NineSlicePlane extends Container<MeshView<NineSliceGeometry>>
      * @param options.height - Height of the NineSlicePlane,
      * setting this will actually modify the vertices and not UV's of this plane.
      */
-    constructor(options: NineSlicePlaneOptions | Texture)
+    constructor(options: NineSliceSpriteOptions | Texture)
     {
         if ((options instanceof Texture))
         {
             options = { texture: options };
         }
 
-        options = { ...NineSlicePlane.defaultOptions, ...options };
+        options = { ...NineSliceSprite.defaultOptions, ...options };
 
         const texture = options.texture;
 
@@ -188,3 +189,14 @@ export class NineSlicePlane extends Container<MeshView<NineSliceGeometry>>
         this.view.texture = value;
     }
 }
+
+class NineSlicePlane extends NineSliceSprite
+{
+    constructor(options: NineSliceSpriteOptions | Texture)
+    {
+        deprecation('v8', 'NineSlicePlane is deprecated. Use NineSliceSprite instead.');
+        super(options);
+    }
+}
+
+export { NineSlicePlane };

--- a/src/mesh-extras/NineSlicePlane.ts
+++ b/src/mesh-extras/NineSlicePlane.ts
@@ -190,7 +190,7 @@ export class NineSliceSprite extends Container<MeshView<NineSliceGeometry>>
     }
 }
 
-class NineSlicePlane extends NineSliceSprite
+export class NineSlicePlane extends NineSliceSprite
 {
     constructor(options: NineSliceSpriteOptions | Texture)
     {
@@ -198,5 +198,3 @@ class NineSlicePlane extends NineSliceSprite
         super(options);
     }
 }
-
-export { NineSlicePlane };

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -17,7 +17,7 @@ export type TextStyleTextBaseline = 'alphabetic' | 'top' | 'hanging' | 'middle' 
 export type TextStyleWhiteSpace = 'normal' | 'pre' | 'pre-line';
 
 export type TextDropShadow = {
-    /** Set alpha for the drop shadow */
+    /** Set alpha for the drop shadow  */
     alpha: number;
     /** Set a angle of the drop shadow */
     angle: number;


### PR DESCRIPTION
little rename! 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8d51956</samp>

### Summary
🛠️🚚🗑️

<!--
1.  🛠️ for fixing a linting error
2.  🚚 for renaming a type and related interface and options
3.  🗑️ for adding a deprecated alias for the old name
-->
Renamed `NineSlicePlane` to `NineSliceSprite` to better match its functionality and usage, and fixed a minor linting issue in `TextStyle.ts`.

> _`NineSlicePlane` gone_
> _A new sprite name emerges_
> _Fall of legacy_

### Walkthrough
*  Rename `NineSlicePlane` class and interface to `NineSliceSprite` to avoid confusion and better reflect functionality ([link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL4-R9), [link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL44-R47), [link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL66-R67), [link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL73-R74), [link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cR192-R200))
  * Add deprecated alias for `NineSlicePlane` to maintain backward compatibility and warn users to migrate ([link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cR192-R200))
  * Update constructor parameter and default options to match new interface name ([link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL66-R67), [link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cL73-R74))
* Fix linting error by adding whitespace after comment for `alpha` property of `TextDropShadow` type ([link](https://github.com/pixijs/pixijs/pull/9510/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL20-R20))

