### PR TITLE
fix Container.parent type

### DIFF
--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -90,7 +90,7 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
      * Will get automatically set to true if a new child is added, or if a child's zIndex changes.
      */
     public sortDirty: boolean;
-    public parent: Container;
+    public parent?: Container;
     public containerUpdateTransform: () => void;
 
     protected _width: number;


### PR DESCRIPTION
##### Description of change
Fix incorrect `Container.parent` type to include optionality.

This makes it compatible with strict TypeScript (i.e. `noUncheckedIndexedAccess` and `strictNullChecks`).

Currently this triggers the [@typescript-eslint/no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition) eslint rule because the typing is incorrect.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included - **N/A** type inference change
- [x] Documentation is changed or added - **N/A** self-documenting
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
