### PR TITLE
fix(application): prevent read property of null if the application is destroyed

### DIFF
--- a/packages/app/src/Application.ts
+++ b/packages/app/src/Application.ts
@@ -97,7 +97,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      */
     get view(): VIEW
     {
-        return this.renderer.view;
+        return this.renderer?.view;
     }
 
     /**
@@ -107,7 +107,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      */
     get screen(): Rectangle
     {
-        return this.renderer.screen;
+        return this.renderer?.screen;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
If the application is destroyed, the reading view or screen will cause an error, read property of null. The error is fixed by optional chaining. This PR should not affect any other features. 


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
