### PR TITLE
Mini updates

### DIFF
--- a/src/rendering/RenderingMixins.d.ts
+++ b/src/rendering/RenderingMixins.d.ts
@@ -72,9 +72,10 @@ declare namespace PixiMixins
     type MeasureMixin = import('./scene/container-mixins/measureMixin').MeasureMixin;
     type EffectsMixin = import('./scene/container-mixins/effectsMixin').EffectsMixin;
     type FindMixin = import('./scene/container-mixins/getByLabelMixin').GetByLabelMixin;
+    type SortMixin = import('./scene/container-mixins/sortMixin').SortMixin;
 
     // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface Container extends LocalGlobal, ChildrenHelper, OnRenderMixin, MeasureMixin, EffectsMixin, FindMixin
+    interface Container extends LocalGlobal, ChildrenHelper, OnRenderMixin, MeasureMixin, EffectsMixin, FindMixin, SortMixin
     {
 
     }

--- a/src/rendering/graphics/shared/GraphicsContext.ts
+++ b/src/rendering/graphics/shared/GraphicsContext.ts
@@ -112,6 +112,7 @@ export class GraphicsContext extends EventEmitter<{
     uid = UID++;
     usage = 0;
 
+    label: string;
     dirty = true;
 
     batchMode: BatchMode = 'auto';

--- a/src/rendering/graphics/shared/GraphicsContextSystem.ts
+++ b/src/rendering/graphics/shared/GraphicsContextSystem.ts
@@ -177,6 +177,9 @@ export class GraphicsContextSystem implements System
         // this mean we don't have to creating new Batchers for each graphics items
         geometry.buffers[0].data = batcher.attributeBuffer.float32View;
 
+        geometry.indexBuffer.update(batcher.indexSize * 4);
+        geometry.buffers[0].update(batcher.attributeSize * 4);
+
         const drawBatches = batcher.batches;
 
         for (let i = 0; i < drawBatches.length; i++)

--- a/src/rendering/mesh/shared/MeshView.ts
+++ b/src/rendering/mesh/shared/MeshView.ts
@@ -18,19 +18,19 @@ export interface TextureShader extends Shader
     texture: Texture;
 }
 
-export interface MeshRenderableTextureOptions
+export interface MeshViewTextureOptions
 {
     geometry: MeshGeometry;
     texture: Texture;
 }
 
-export interface MeshRenderableShaderOptions
+export interface MeshViewShaderOptions
 {
     geometry: MeshGeometry;
     shader: TextureShader;
 }
 
-export type MeshViewOptions = MeshRenderableTextureOptions | MeshRenderableShaderOptions;
+export type MeshViewOptions = MeshViewTextureOptions | MeshViewShaderOptions;
 
 export class MeshView<GEOMETRY extends MeshGeometry = MeshGeometry>implements View
 {
@@ -53,11 +53,11 @@ export class MeshView<GEOMETRY extends MeshGeometry = MeshGeometry>implements Vi
 
     constructor(options: MeshViewOptions)
     {
-        this.shader = (options as MeshRenderableShaderOptions).shader;
+        this.shader = (options as MeshViewShaderOptions).shader;
 
-        if ((options as MeshRenderableTextureOptions).texture)
+        if ((options as MeshViewTextureOptions).texture)
         {
-            this.texture = (options as MeshRenderableTextureOptions).texture;
+            this.texture = (options as MeshViewTextureOptions).texture;
         }
 
         this._geometry = options.geometry as GEOMETRY;

--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -49,7 +49,7 @@ export async function autoDetectRenderer(options: Partial<AutoDetectOptions>): P
     {
         const rendererType = preferredOrder[i];
 
-        if (rendererType === 'webgpu' && isWebGPUSupported())
+        if (rendererType === 'webgpu' && (await isWebGPUSupported()))
         {
             const { WebGPURenderer } = await import('./gpu/WebGPURenderer');
 

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -30,9 +30,14 @@ export class Texture extends EventEmitter<{
     update: Texture
 }> implements BindableTexture
 {
-    static from(id: string): Texture
+    static from(id: string | TextureSource): Texture
     {
-        return Cache.get(id);
+        if (typeof id === 'string')
+        {
+            return Cache.get(id);
+        }
+
+        return new Texture({ source: id });
     }
 
     public label?: string;

--- a/src/rendering/scene/container-mixins/childrenHelperMixin.ts
+++ b/src/rendering/scene/container-mixins/childrenHelperMixin.ts
@@ -184,6 +184,8 @@ export const childrenHelperMixin: Partial<Container> = {
             this.layerGroup.addChild(child);
         }
 
+        if (this.depthSort) this.depthSortDirty = true;
+
         this.emit('childAdded', child, this, index);
         child.emit('added', this);
 

--- a/src/rendering/scene/container-mixins/childrenHelperMixin.ts
+++ b/src/rendering/scene/container-mixins/childrenHelperMixin.ts
@@ -184,7 +184,7 @@ export const childrenHelperMixin: Partial<Container> = {
             this.layerGroup.addChild(child);
         }
 
-        if (this.depthSort) this.depthSortDirty = true;
+        if (this.sortChildren) this.sortDirty = true;
 
         this.emit('childAdded', child, this, index);
         child.emit('added', this);

--- a/src/rendering/scene/container-mixins/sortMixin.ts
+++ b/src/rendering/scene/container-mixins/sortMixin.ts
@@ -1,0 +1,54 @@
+import type { Container } from '../Container';
+
+export interface SortMixin
+{
+    _depth: 0;
+    depth: number;
+    sortDirty: boolean;
+    sortChildren: boolean;
+
+    sortChildrenDepth: () => void;
+}
+
+export const sortMixin: Partial<Container> = {
+
+    _depth: 0,
+    sortDirty: false,
+    sortChildren: false,
+
+    get depth()
+    {
+        return this._depth;
+    },
+
+    /** The depth of the object. Setting this value, will automatically set the parent to be sortable */
+    set depth(value)
+    {
+        if (this._depth === value) return;
+
+        this._depth = value;
+
+        if (this.layerGroup && !this.isLayerRoot)
+        {
+            this.parent.sortChildren = true;
+            this.parent.sortDirty = true;
+
+            this.layerGroup.structureDidChange = true;
+        }
+    },
+
+    sortChildrenDepth()
+    {
+        if (!this.sortDirty) return;
+
+        this.sortDirty = false;
+
+        this.children.sort(sortChildren);
+    }
+
+} as Container;
+
+function sortChildren(a: Container, b: Container): number
+{
+    return a._depth - b._depth;
+}

--- a/src/rendering/scene/utils/buildInstructions.ts
+++ b/src/rendering/scene/utils/buildInstructions.ts
@@ -33,7 +33,7 @@ export function buildInstructions(layerGroup: LayerGroup, renderPipes: RenderPip
         }
     }
 
-    if (root.depthSort)
+    if (root.sortChildren)
     {
         root.sortChildrenDepth();
     }
@@ -62,7 +62,7 @@ export function collectAllRenderables(
 
     if (container.layerVisibleRenderable < 0b11 || !container.includeInBuild) return;
 
-    if (container.depthSort)
+    if (container.sortChildren)
     {
         container.sortChildrenDepth();
     }

--- a/src/rendering/scene/utils/buildInstructions.ts
+++ b/src/rendering/scene/utils/buildInstructions.ts
@@ -33,6 +33,11 @@ export function buildInstructions(layerGroup: LayerGroup, renderPipes: RenderPip
         }
     }
 
+    if (root.depthSort)
+    {
+        root.sortChildrenDepth();
+    }
+
     const children = root.children;
 
     const length = children.length;
@@ -56,6 +61,11 @@ export function collectAllRenderables(
     // if there is 0b01 or 0b10 the return value
 
     if (container.layerVisibleRenderable < 0b11 || !container.includeInBuild) return;
+
+    if (container.depthSort)
+    {
+        container.sortChildrenDepth();
+    }
 
     if (container.isSimple)
     {

--- a/src/utils/browser/isWebGPUSupported.ts
+++ b/src/utils/browser/isWebGPUSupported.ts
@@ -2,11 +2,30 @@ import { settings } from '../../settings/settings';
 
 /**
  * Helper for checking for WebGPU support.
+ * @param options
  * @memberof PIXI.utils
  * @function isWebGPUSupported
  * @returns Is WebGPU supported.
  */
-export function isWebGPUSupported()
+export async function isWebGPUSupported(options: GPURequestAdapterOptions = {}): Promise<boolean>
 {
-    return !!settings.ADAPTER.getNavigator().gpu;
+    // try to create get the gpu
+
+    const gpu = settings.ADAPTER.getNavigator().gpu;
+
+    if (!gpu) return false;
+
+    try
+    {
+        const adapter = await navigator.gpu.requestAdapter(options);
+        // TODO and one of these!
+
+        await adapter.requestDevice();
+
+        return true;
+    }
+    catch (e)
+    {
+        return false;
+    }
 }

--- a/tests/scene/Container.tests.ts
+++ b/tests/scene/Container.tests.ts
@@ -157,17 +157,17 @@ describe('Container Tests', () =>
 
         root.layerGroup.structureDidChange = false;
 
-        expect(root.depthSort).toEqual(false);
+        expect(root.sortChildren).toEqual(false);
 
         container1.depth = 1;
 
-        expect(root.depthSortDirty).toEqual(true);
+        expect(root.sortDirty).toEqual(true);
         expect(root.layerGroup.structureDidChange).toEqual(true);
 
         root.sortChildrenDepth();
 
-        expect(root.depthSortDirty).toEqual(false);
-        expect(root.depthSort).toEqual(true);
+        expect(root.sortDirty).toEqual(false);
+        expect(root.sortChildren).toEqual(true);
         expect(root.children).toEqual([container2, container3, container1]);
     });
 });

--- a/tests/scene/Container.tests.ts
+++ b/tests/scene/Container.tests.ts
@@ -131,6 +131,45 @@ describe('Container Tests', () =>
         expect(child.toLocal({ x: 0, y: 0 }, otherContainer, null, true)).toEqual({ x: -20, y: -20 });
         //   expect(container.getBounds()).toEqual({ x: 10, y: 10, width: 0, height: 0 });
     });
+
+    it('should update the depth of a container if depth is modified', async () =>
+    {
+        const root = new Container({
+            label: 'root',
+            layer: true,
+        });
+
+        const container1 = new Container({
+            label: 'container1',
+        });
+
+        const container2 = new Container({
+            label: 'container2',
+        });
+
+        const container3 = new Container({
+            label: 'container3',
+        });
+
+        root.addChild(container1);
+        root.addChild(container2);
+        root.addChild(container3);
+
+        root.layerGroup.structureDidChange = false;
+
+        expect(root.depthSort).toEqual(false);
+
+        container1.depth = 1;
+
+        expect(root.depthSortDirty).toEqual(true);
+        expect(root.layerGroup.structureDidChange).toEqual(true);
+
+        root.sortChildrenDepth();
+
+        expect(root.depthSortDirty).toEqual(false);
+        expect(root.depthSort).toEqual(true);
+        expect(root.children).toEqual([container2, container3, container1]);
+    });
 });
 
 // Test to cover


### PR DESCRIPTION
- Added `depth` to `Container`
- Beed up the `autoDetect`
- optimised graphics a lttle bit when uploading
- added label to `GraphicsContext`
- `Texture.from` an can now be a `TextureSource`

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 785f625</samp>

### Summary
🏷️🎨🔢

<!--
1.  🏷️ - This emoji represents the addition of the `label` property to the `GraphicsContext` class, which is a tag or a name for the context.
2.  🎨 - This emoji represents the changes to the rendering functions and classes, such as the `GraphicsContextSystem`, the `autoDetectRenderer`, the `Texture`, and the `MeshView`. These changes affect the appearance or the performance of the graphics output.
3.  🔢 - This emoji represents the addition and modification of the depth sorting feature to the `Container` class and the related functions. This feature involves sorting the nodes by their numerical depth values.
-->
This pull request adds depth sorting functionality to the `Container` class and its related rendering functions, refactors some interfaces and types for the `MeshView` class, adds a `label` property to the `GraphicsContext` class, adds an overload to the `Texture.from` method, and updates the `isWebGPUSupported` function to be async. It also adds a test case for the depth sorting feature and fixes some minor bugs.

> _Oh we are the coders of the WebGPU_
> _We make the graphics fast and smooth_
> _We sort the `depth` of the `Container`s_
> _And we `await` the `isWebGPUSupported`_

### Walkthrough
*  Add depth sorting feature to `Container` class and its helper functions ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R46), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7L214-R215), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R237-R238), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R284-R285), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R496-R529), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7R806-R810), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-8374d58f18a0707ea59f0ae963bf8638a25bff01b09b4bb3a2d272cb7c9948d1R187-R188), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR36-R40), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aR65-R69))
* Add `label` property to `GraphicsContext` class for debugging purposes ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-664798958690d98707000cb8a5ba95ea62f0f61eea7d7d6cac67bb0aab175d70R115))
* Add `Texture.from` overload to accept either string id or texture source object ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-fba1e43ab937e0a6b728c704fc451a45a8cf334495d7a1ab521b60e26c6bea80L33-R40))
* Rename `MeshRenderableTextureOptions` and `MeshRenderableShaderOptions` interfaces to `MeshViewTextureOptions` and `MeshViewShaderOptions` for consistency ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-1d342e14a5fa9b47e0e30c31361244ae97e3baa7c19f0dc3af9f19750136a552L21-R21), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-1d342e14a5fa9b47e0e30c31361244ae97e3baa7c19f0dc3af9f19750136a552L27-R27), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-1d342e14a5fa9b47e0e30c31361244ae97e3baa7c19f0dc3af9f19750136a552L33-R33), [link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-1d342e14a5fa9b47e0e30c31361244ae97e3baa7c19f0dc3af9f19750136a552L56-R60))
* Update `GraphicsContextSystem` class to update index buffer and attribute buffer of geometry object for batcher ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-faee89d0d8c9e904b7ee9c935e8909e023f99ca35c19ac29f565790f6fffa2baR180-R182))
* Add `await` keyword to `autoDetectRenderer` function to call `isWebGPUSupported` async function ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-5d3582d9a575e4f9d3eed5d15273716980a0763ccc16b1c80e219fbfbadff242L52-R52))
* Make `isWebGPUSupported` function async and add optional parameter for GPU request adapter options ([link](https://github.com/pixijs/pixijs/pull/9520/files?diff=unified&w=0#diff-1067dfac46cfc9cb1cdea8325cbd3e1aa19c6e7fb1eb3eaea44bd3c5b9e815f8L5-R30))

