### PR TITLE
update TextStyle

### DIFF
--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -103,17 +103,23 @@ export class AbstractRenderer<PIPES, OPTIONS>
      * @param options.container - The container to render.
      * @param [options.target] - The target to render to.
      */
-    public render(options: RenderOptions): void
+    public render(options: RenderOptions | Container): void
     {
         if (options instanceof Container)
         {
-            deprecation('8', 'passing Container as argument is deprecated, please use render options instead');
+            options = { container: options };
 
             // eslint-disable-next-line prefer-rest-params
-            options = { container: options, target: arguments[1] };
+            if (arguments[1])
+            {
+                deprecation('8', 'passing target as a second argument is deprecated, please use render options instead');
+
+                // eslint-disable-next-line prefer-rest-params
+                options.target = arguments[1];
+            }
         }
 
-        options.target = options.target || this.view.texture;
+        options.target ||= this.view.texture;
 
         // TODO get rid of this
         this._lastObjectRendered = options.container;

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -104,20 +104,20 @@ export interface TextStyleOptions
 }
 
 const valuesToIterateForKeys = [
-    'fontFamily',
-    'fontStyle',
-    'fontVariant',
-    'fontWeight',
-    'breakWords',
-    'align',
-    'leading',
-    'letterSpacing',
-    'lineHeight',
-    'textBaseline',
-    'whiteSpace',
-    'wordWrap',
-    'wordWrapWidth',
-    'padding',
+    '_fontFamily',
+    '_fontStyle',
+    '_fontVariant',
+    '_fontWeight',
+    '_breakWords',
+    '_align',
+    '_leading',
+    '_letterSpacing',
+    '_lineHeight',
+    '_textBaseline',
+    '_whiteSpace',
+    '_wordWrap',
+    '_wordWrapWidth',
+    '_padding',
 ];
 
 export class TextStyle extends EventEmitter<{
@@ -208,26 +208,26 @@ export class TextStyle extends EventEmitter<{
     _stroke: StrokeStyle;
     _originalStroke: FillStyleInputs | StrokeStyle;
 
-    dropShadow: TextDropShadow;
+    private _dropShadow: TextDropShadow;
 
-    fontFamily: string | string[];
-    fontSize: number;
-    fontStyle: TextStyleFontStyle;
-    fontVariant: TextStyleFontVariant;
-    fontWeight: TextStyleFontWeight;
+    private _fontFamily: string | string[];
+    private _fontSize: number;
+    private _fontStyle: TextStyleFontStyle;
+    private _fontVariant: TextStyleFontVariant;
+    private _fontWeight: TextStyleFontWeight;
 
-    breakWords: boolean;
-    align: TextStyleAlign;
-    leading: number;
-    letterSpacing: number;
-    lineHeight: number;
+    private _breakWords: boolean;
+    private _align: TextStyleAlign;
+    private _leading: number;
+    private _letterSpacing: number;
+    private _lineHeight: number;
 
-    textBaseline: TextStyleTextBaseline;
-    whiteSpace: TextStyleWhiteSpace;
-    wordWrap: boolean;
-    wordWrapWidth: number;
+    private _textBaseline: TextStyleTextBaseline;
+    private _whiteSpace: TextStyleWhiteSpace;
+    private _wordWrap: boolean;
+    private _wordWrapWidth: number;
 
-    padding: number;
+    private _padding: number;
 
     private _styleKey: string;
 
@@ -282,6 +282,67 @@ export class TextStyle extends EventEmitter<{
         this.update();
     }
 
+    get align(): TextStyleAlign { return this._align; }
+    set align(value: TextStyleAlign) { this._align = value; this.update(); }
+    get breakWords(): boolean { return this._breakWords; }
+    set breakWords(value: boolean) { this._breakWords = value; this.update(); }
+    get dropShadow(): TextDropShadow { return this._dropShadow; }
+    set dropShadow(value: TextDropShadow) { this._dropShadow = value; this.update(); }
+    get fontFamily(): string | string[] { return this._fontFamily; }
+    set fontFamily(value: string | string[]) { this._fontFamily = value; this.update(); }
+    get fontSize(): number { return this._fontSize; }
+    set fontSize(value: number) { this._fontSize = value; this.update(); }
+    get fontStyle(): TextStyleFontStyle { return this._fontStyle; }
+    set fontStyle(value: TextStyleFontStyle) { this._fontStyle = value; this.update(); }
+    get fontVariant(): TextStyleFontVariant { return this._fontVariant; }
+    set fontVariant(value: TextStyleFontVariant) { this._fontVariant = value; this.update(); }
+    get fontWeight(): TextStyleFontWeight { return this._fontWeight; }
+    set fontWeight(value: TextStyleFontWeight) { this._fontWeight = value; this.update(); }
+    get leading(): number { return this._leading; }
+    set leading(value: number) { this._leading = value; this.update(); }
+    get letterSpacing(): number { return this._letterSpacing; }
+    set letterSpacing(value: number) { this._letterSpacing = value; this.update(); }
+    get lineHeight(): number { return this._lineHeight; }
+    set lineHeight(value: number) { this._lineHeight = value; this.update(); }
+    get padding(): number { return this._padding; }
+    set padding(value: number) { this._padding = value; this.update(); }
+    get textBaseline(): TextStyleTextBaseline { return this._textBaseline; }
+    set textBaseline(value: TextStyleTextBaseline) { this._textBaseline = value; this.update(); }
+    get whiteSpace(): TextStyleWhiteSpace { return this._whiteSpace; }
+    set whiteSpace(value: TextStyleWhiteSpace) { this._whiteSpace = value; this.update(); }
+    get wordWrap(): boolean { return this._wordWrap; }
+    set wordWrap(value: boolean) { this._wordWrap = value; this.update(); }
+    get wordWrapWidth(): number { return this._wordWrapWidth; }
+    set wordWrapWidth(value: number) { this._wordWrapWidth = value; this.update(); }
+
+    get fill(): FillStyleInputs
+    {
+        return this._originalFill;
+    }
+
+    set fill(value: FillStyleInputs)
+    {
+        if (value === this._originalFill) return;
+
+        this._originalFill = value;
+        this._fill = convertFillInputToFillStyle(value, GraphicsContext.defaultFillStyle);
+        this.update();
+    }
+
+    get stroke(): FillStyleInputs | StrokeStyle
+    {
+        return this._originalStroke;
+    }
+
+    set stroke(value: FillStyleInputs | StrokeStyle)
+    {
+        if (value === this._originalFill) return;
+
+        this._originalFill = value;
+        this._stroke = convertFillInputToFillStyle(value, GraphicsContext.defaultStrokeStyle);
+        this.update();
+    }
+
     generateKey(): string
     {
         const key = [];
@@ -307,34 +368,6 @@ export class TextStyle extends EventEmitter<{
     {
         this._styleKey = null;
         this.emit('update', this);
-    }
-
-    get fill(): FillStyleInputs
-    {
-        return this._originalFill;
-    }
-
-    set fill(value: FillStyleInputs)
-    {
-        if (value === this._fill) return;
-
-        this._originalFill = value;
-
-        this._fill = convertFillInputToFillStyle(value, GraphicsContext.defaultFillStyle);
-    }
-
-    get stroke(): FillStyleInputs | StrokeStyle
-    {
-        return this._originalStroke;
-    }
-
-    set stroke(value: FillStyleInputs | StrokeStyle)
-    {
-        if (value === this._fill) return;
-
-        this._originalFill = value;
-
-        this._stroke = convertFillInputToFillStyle(value, GraphicsContext.defaultStrokeStyle);
     }
 
     get styleKey()


### PR DESCRIPTION
- tweak text style so update is. triggered when setting the properties (like v7)
- render function can now accept a container or renderOptions

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3659b9c</samp>

### Summary
🔄🎨🔒

<!--
1.  🔄 - This emoji represents the refactoring aspect of the changes, which aim to improve the code quality, readability, and maintainability without changing the functionality or behavior. The clockwise arrows suggest a circular motion of reorganizing or rearranging the code.
2.  🎨 - This emoji represents the rendering aspect of the changes, which affect how the graphics and text are drawn on the screen. The paintbrush and palette suggest a creative or artistic process of creating visual output.
3.  🔒 - This emoji represents the private properties aspect of the changes, which enhance the security and integrity of the data and prevent unwanted access or modification. The lock suggests a protection or restriction mechanism.
-->
This pull request refactors the text rendering and the render API of pixijs. It uses private properties, getters, and setters to improve the `TextStyle` class and its options. It also simplifies the `render` method of the `AbstractRenderer` class and makes it more flexible and type-safe by accepting different kinds of arguments.

> _We're refactoring the code, me hearties, yo ho ho_
> _We're making it more simple and consistent as we go_
> _We're passing `RenderOptions` or `Container` to `render`_
> _And using private properties for `TextStyle`, one, two, heave!_

### Walkthrough
*  Simplify the render API and make it more consistent and type-safe by allowing either a `RenderOptions` or a `Container` object as the first argument of the `render` method of the `AbstractRenderer` class and deprecating the second argument ([link](https://github.com/pixijs/pixijs/pull/9522/files?diff=unified&w=0#diff-27fa29afe053bf0bbdb6c29016c4da0abb00506b5b31c3e689aa84f35867aa42L106-R122))
* Encapsulate the internal state of the `TextStyle` class and provide getters and setters for the public properties by renaming the private properties with a leading underscore and making them private ([link](https://github.com/pixijs/pixijs/pull/9522/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL107-R120), [link](https://github.com/pixijs/pixijs/pull/9522/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL211-R230))
* Improve the performance and usability of the `TextStyle` class by updating the internal state and invalidating the style when the public properties are changed ([link](https://github.com/pixijs/pixijs/pull/9522/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bR285-R345))
* Simplify the code and avoid duplication by removing the redundant getters and setters for the `fill` and `stroke` properties of the `TextStyle` class that are already defined by the `FillStyle` and `StrokeStyle` interfaces ([link](https://github.com/pixijs/pixijs/pull/9522/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL312-L339))



