### PR TITLE
Add option 'strict' to Assets to optionally avoid expensive detection methods

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -52,6 +52,11 @@ export interface AssetInitOptions
          * ['avif', 'webp', 'png', 'jpg', 'jpeg', 'webm', 'mp4', 'm4v', 'ogv']
          */
         format?: ArrayOr<string>;
+        /**
+         * If true, don't attempt to detect whether browser has preferred formats available.
+         * May result in increased performance as it skips detection step.
+         */
+        strict?: boolean;
     };
 
     /** advanced - override how bundlesIds are generated */
@@ -301,14 +306,17 @@ export class AssetsClass
         {
             const formatPref = options.texturePreference?.format;
 
-            formats = (typeof formatPref === 'string') ? [formatPref] : formatPref;
+            formats = typeof formatPref === 'string' ? [formatPref] : formatPref;
 
-            // we should remove any formats that are not supported by the browser
-            for (const detection of this._detections)
+            if (!options.texturePreference?.strict)
             {
-                if (!await detection.test())
+                // we should remove any formats that are not supported by the browser
+                for (const detection of this._detections)
                 {
-                    formats = await detection.remove(formats);
+                    if (!(await detection.test()))
+                    {
+                        formats = await detection.remove(formats);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

New 'strict' option to the AssetInitOptions.texturePreferences object added, which will skip expensive calls to detect file formats.


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Still working on the above, having some trouble setting up my dev environment. :pray: 
