### PR TITLE
Experimental Constructor Options

### DIFF
--- a/packages/accessibility/global.d.ts
+++ b/packages/accessibility/global.d.ts
@@ -5,4 +5,10 @@ declare namespace GlobalMixins
     {
 
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IDisplayObjectOptions extends Partial<import('@pixi/accessibility').IAccessibleOptions>
+    {
+
+    }
 }

--- a/packages/accessibility/src/AccessibilityManager.ts
+++ b/packages/accessibility/src/AccessibilityManager.ts
@@ -1,14 +1,14 @@
 import { extensions, ExtensionType, utils } from '@pixi/core';
 import { DisplayObject } from '@pixi/display';
 import { FederatedEvent } from '@pixi/events';
-import { accessibleTarget } from './accessibleTarget';
+import { accessibleOptions, accessibleTarget } from './accessibleTarget';
 
 import type { ExtensionMetadata, IRenderer, Rectangle } from '@pixi/core';
 import type { Container } from '@pixi/display';
 import type { IAccessibleHTMLElement } from './accessibleTarget';
 
 // add some extra variables to the container..
-DisplayObject.mixin(accessibleTarget);
+DisplayObject.mixin(accessibleTarget, accessibleOptions);
 
 const KEY_CODE_TAB = 9;
 

--- a/packages/accessibility/src/accessibleTarget.ts
+++ b/packages/accessibility/src/accessibleTarget.ts
@@ -12,17 +12,21 @@ export type PointerEvents = 'auto'
 | 'all'
 | 'inherit';
 
-export interface IAccessibleTarget
+export interface IAccessibleOptions
 {
     accessible: boolean;
     accessibleTitle: string;
     accessibleHint: string;
     tabIndex: number;
-    _accessibleActive: boolean;
-    _accessibleDiv: IAccessibleHTMLElement;
     accessibleType: string;
     accessiblePointerEvents: PointerEvents;
     accessibleChildren: boolean;
+}
+
+export interface IAccessibleTarget extends IAccessibleOptions
+{
+    _accessibleActive: boolean;
+    _accessibleDiv: IAccessibleHTMLElement;
     renderId: number;
 }
 
@@ -31,6 +35,44 @@ export interface IAccessibleHTMLElement extends HTMLElement
     type?: string;
     displayObject?: DisplayObject;
 }
+
+export const accessibleOptions: IAccessibleOptions = {
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessible
+     */
+    accessible: false,
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessibleTitle
+     */
+    accessibleTitle: null as string,
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessibleHint
+     */
+    accessibleHint: null as string,
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#tabIndex
+     */
+    tabIndex: 0,
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessibleType
+     */
+    accessibleType: 'button' as string,
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessiblePointerEvents
+     */
+    accessiblePointerEvents: 'auto',
+    /**
+     * @memberof PIXI.IDisplayObjectOptions
+     * @see PIXI.DisplayObject#accessibleChildren
+     */
+    accessibleChildren: true,
+};
 
 /**
  * Default property values of accessible objects
@@ -57,7 +99,7 @@ export const accessibleTarget: IAccessibleTarget = {
     /**
      * Sets the title attribute of the shadow div
      * If accessibleTitle AND accessibleHint has not been this will default to 'displayObject [tabIndex]'
-     * @member {?string}
+     * @member {string}
      * @memberof PIXI.DisplayObject#
      */
     accessibleTitle: null,

--- a/packages/display/global.d.ts
+++ b/packages/display/global.d.ts
@@ -18,6 +18,12 @@ declare namespace GlobalMixins
 
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IDisplayObjectOptions
+    {
+
+    }
+
     interface Settings
     {
         /** @deprecated since 7.1.0 */

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -26,7 +26,7 @@ export interface IContainerOptions
     /** @see PIXI.Container#sortableChildren */
     sortableChildren: boolean;
     /** @see PIXI.Container#children */
-    children: DisplayObject[];
+    children?: DisplayObject[];
     /** @see PIXI.Container#sortDirty */
     sortDirty: boolean;
     /** @see PIXI.Container#width */
@@ -117,12 +117,6 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
 
     /** Default container options */
     public static defaultContainerOptions: IContainerOptions = {
-        /**
-         * See {@link PIXI.Container#children}
-         * @type {DisplayObject[]}
-         * @default []
-         */
-        children: [],
         /** See {@link PIXI.Container#sortableChildren} */
         sortableChildren: false,
         /** See {@link PIXI.Container#sortDirty} */
@@ -134,7 +128,7 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
 
     constructor(options?: Partial<IContainerOptions & IDisplayObjectOptions>)
     {
-        super({ ...Container.defaultContainerOptions, ...options });
+        super({ ...Container.defaultContainerOptions, children: [], ...options });
 
         /**
          * Fired when a DisplayObject is added to this Container.

--- a/packages/display/src/Container.ts
+++ b/packages/display/src/Container.ts
@@ -126,9 +126,9 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
     protected _width: number;
     protected _height: number;
 
-    constructor(options?: Partial<IContainerOptions & IDisplayObjectOptions>)
+    constructor({ children, ...options }: Partial<IContainerOptions & IDisplayObjectOptions> = {})
     {
-        super({ ...Container.defaultContainerOptions, children: [], ...options });
+        super({ ...Container.defaultContainerOptions, ...options });
 
         /**
          * Fired when a DisplayObject is added to this Container.
@@ -145,6 +145,9 @@ export class Container<T extends DisplayObject = DisplayObject> extends DisplayO
          * @param {PIXI.Container} container - The container that removed the child.
          * @param {number} index - The former children's index of the removed child.
          */
+
+        this.children = [];
+        children?.forEach((child) => this.addChild(child as any));
     }
 
     /**

--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -20,6 +20,51 @@ export interface DisplayObjectEvents extends GlobalMixins.DisplayObjectEvents
     removed: [container: Container];
 }
 
+/**
+ * Constructor options use for DisplayObject instances.
+ * @see PIXI.DisplayObject
+ * @memberof PIXI
+ */
+export interface IDisplayObjectOptions extends GlobalMixins.IDisplayObjectOptions
+{
+    /** @see PIXI.DisplayObject#alpha */
+    alpha: number;
+    /** @see PIXI.DisplayObject#angle */
+    angle?: number;
+    /** @see PIXI.DisplayObject#cullable */
+    cullable: boolean;
+    /** @see PIXI.DisplayObject#cullArea */
+    cullArea: Rectangle;
+    /** @see PIXI.DisplayObject#filters */
+    filters: Filter[] | null;
+    /** @see PIXI.DisplayObject#filterArea */
+    filterArea: Rectangle;
+    /** @see PIXI.DisplayObject#mask */
+    mask?: Container | MaskData | null;
+    /** @see PIXI.DisplayObject#parent */
+    parent: Container;
+    /** @see PIXI.DisplayObject#renderable */
+    renderable: boolean;
+    /** @see PIXI.DisplayObject#rotation */
+    rotation?: number;
+    /** @see PIXI.DisplayObject#scale */
+    scale?: IPointData;
+    /** @see PIXI.DisplayObject#pivot */
+    pivot?: IPointData;
+    /** @see PIXI.DisplayObject#position */
+    position?: IPointData;
+    /** @see PIXI.DisplayObject#skew */
+    skew?: IPointData;
+    /** @see PIXI.DisplayObject#visible */
+    visible: boolean;
+    /** @see PIXI.DisplayObject#x */
+    x?: number;
+    /** @see PIXI.DisplayObject#y */
+    y?: number;
+    /** @see PIXI.DisplayObject#zIndex */
+    zIndex: number;
+}
+
 export interface DisplayObject
     extends Omit<GlobalMixins.DisplayObject, keyof utils.EventEmitter<DisplayObjectEvents>>,
     utils.EventEmitter<DisplayObjectEvents> {}
@@ -332,8 +377,9 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
     /**
      * Mixes all enumerable properties and methods from a source object to DisplayObject.
      * @param source - The source of properties and methods to mix in.
+     * @param options
      */
-    static mixin(source: utils.Dict<any>): void
+    static mixin(source: utils.Dict<any>, options: Record<string, any>): void
     {
         // in ES8/ES2017, this would be really easy:
         // Object.defineProperties(DisplayObject.prototype, Object.getOwnPropertyDescriptors(source));
@@ -353,9 +399,49 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
                 Object.getOwnPropertyDescriptor(source, propertyName)
             );
         }
+
+        Object.assign(DisplayObject.defaultDisplayObjectOptions, options);
     }
 
-    constructor()
+    /** Default constructor options */
+    public static defaultDisplayObjectOptions: IDisplayObjectOptions = {
+        /** See {@link PIXI.DisplayObject#alpha} */
+        alpha: 1,
+        /** See {@link PIXI.DisplayObject#cullable} */
+        cullable: false,
+        /**
+         * See {@link PIXI.DisplayObject#cullArea}
+         * @default null
+         */
+        cullArea: null,
+        /**
+         * See {@link PIXI.DisplayObject#filters}
+         * @default null
+         */
+        filters: null,
+        /**
+         * See {@link PIXI.DisplayObject#filterArea}
+         * @default null
+         */
+        filterArea: null,
+        /**
+         * See {@link PIXI.DisplayObject#parent}
+         * @default null
+         */
+        parent: null,
+        /** See {@link PIXI.DisplayObject#renderable} */
+        renderable: true,
+        /** See {@link PIXI.DisplayObject#visible} */
+        visible: true,
+        /** See {@link PIXI.DisplayObject#zIndex} */
+        zIndex: 0,
+    };
+
+    /**
+     * Create a new DisplayObject instance.
+     * @param options - The options for this DisplayObject
+     */
+    constructor(options?: Partial<IDisplayObjectOptions>)
     {
         super();
 
@@ -363,22 +449,12 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
 
         // TODO: need to create Transform from factory
         this.transform = new Transform();
-        this.alpha = 1;
-        this.visible = true;
-        this.renderable = true;
-        this.cullable = false;
-        this.cullArea = null;
 
-        this.parent = null;
         this.worldAlpha = 1;
-
         this._lastSortedIndex = 0;
         this._zIndex = 0;
 
-        this.filterArea = null;
-        this.filters = null;
         this._enabledFilters = null;
-
         this._bounds = new Bounds();
         this._localBounds = null;
         this._boundsID = 0;
@@ -390,6 +466,8 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
 
         this.isSprite = false;
         this.isMask = false;
+
+        Object.assign(this, DisplayObject.defaultDisplayObjectOptions, options);
     }
 
     /**

--- a/packages/events/global.d.ts
+++ b/packages/events/global.d.ts
@@ -16,6 +16,12 @@ declare namespace GlobalMixins
 
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IDisplayObjectOptions extends Partial<import('@pixi/events').FederatedOptions>
+    {
+
+    }
+
     interface IRenderer
     {
         readonly events: import('@pixi/events').EventSystem;

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -64,46 +64,16 @@ export type FederatedEventHandler<T= FederatedPointerEvent> = (event: T) => void
  */
 export type EventMode = 'none' | 'passive' | 'auto' | 'static' | 'dynamic';
 
-/**
- * Describes the shape for a {@link PIXI.FederatedEvent}'s' `eventTarget`.
- * @memberof PIXI
- */
-export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
+export interface FederatedOptions
 {
     /** The cursor preferred when the mouse pointer is hovering over. */
     cursor: Cursor | string;
-
-    /** The parent of this event target. */
-    readonly parent?: FederatedEventTarget;
-
-    /** The children of this event target. */
-    readonly children?: ReadonlyArray<FederatedEventTarget>;
-
-    /** Whether this event target should fire UI events. */
-    interactive: boolean
-    _internalInteractive: boolean;
     /** The mode of interaction for this object */
     eventMode: EventMode;
-    _internalEventMode: EventMode;
-
-    /** Returns true if the DisplayObject has interactive 'static' or 'dynamic' */
-    isInteractive: () => boolean;
-
     /** Whether this event target has any children that need UI events. This can be used optimize event propagation. */
     interactiveChildren: boolean;
-
     /** The hit-area specifies the area for which pointer events should be captured by this event target. */
     hitArea: IHitArea | null;
-
-    // In Angular projects, zone.js is monkey patching the `EventTarget`
-    // by adding its own `removeAllListeners(event?: string): void;` method,
-    // so we have to override this signature when extending both `EventTarget` and `utils.EventEmitter`
-    // to make it compatible with Angular projects
-    // @see https://github.com/pixijs/pixijs/issues/8794
-
-    /** Remove all listeners, or those of the specified event. */
-    removeAllListeners(event?: string | symbol): this;
-
     /** Handler for 'click' event */
     onclick: FederatedEventHandler | null;
     /** Handler for 'mousedown' event */
@@ -170,6 +140,36 @@ export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
     ontouchstart: FederatedEventHandler | null;
     /** Handler for 'wheel' event */
     onwheel: FederatedEventHandler<FederatedWheelEvent> | null;
+}
+
+/**
+ * Describes the shape for a {@link PIXI.FederatedEvent}'s' `eventTarget`.
+ * @memberof PIXI
+ */
+export interface FederatedEventTarget extends utils.EventEmitter, EventTarget, FederatedOptions
+{
+    /** The parent of this event target. */
+    readonly parent?: FederatedEventTarget;
+
+    /** The children of this event target. */
+    readonly children?: ReadonlyArray<FederatedEventTarget>;
+
+    /** Whether this event target should fire UI events. */
+    interactive: boolean
+    _internalInteractive: boolean;
+    _internalEventMode: EventMode;
+
+    /** Returns true if the DisplayObject has interactive 'static' or 'dynamic' */
+    isInteractive: () => boolean;
+
+    // In Angular projects, zone.js is monkey patching the `EventTarget`
+    // by adding its own `removeAllListeners(event?: string): void;` method,
+    // so we have to override this signature when extending both `EventTarget` and `utils.EventEmitter`
+    // to make it compatible with Angular projects
+    // @see https://github.com/pixijs/pixijs/issues/8794
+
+    /** Remove all listeners, or those of the specified event. */
+    removeAllListeners(event?: string | symbol): this;
 }
 
 type AddListenerOptions = boolean | AddEventListenerOptions;
@@ -783,4 +783,19 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
     }
 };
 
-DisplayObject.mixin(FederatedDisplayObject);
+export const federatedOptions: Partial<FederatedOptions> = {
+    /**
+     * See {@link PIXI.DisplayObject#hitArea}
+     * @memberof PIXI.DisplayObject.defaultDisplayObjectOptions
+     * @type {IHitArea}
+     * @default null
+     */
+    hitArea: null,
+    /**
+     * See {@link PIXI.Container#interactiveChildren}
+     * @memberof PIXI.Container.defaultContainerOptions
+     */
+    interactiveChildren: true,
+};
+
+DisplayObject.mixin(FederatedDisplayObject, federatedOptions);

--- a/packages/sprite/global.d.ts
+++ b/packages/sprite/global.d.ts
@@ -5,4 +5,10 @@ declare namespace GlobalMixins
     {
 
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface IDisplayObjectOptions extends Partial<import('@pixi/sprite').ISpriteOptions>
+    {
+
+    }
 }

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -163,7 +163,8 @@ export class Sprite extends Container
         {
             options = { texture: options };
         }
-        const { texture } = options;
+
+        const texture = options?.texture;
 
         this._anchor = new ObservablePoint(
             this._onAnchorUpdate,
@@ -196,7 +197,7 @@ export class Sprite extends Container
         this.isSprite = true;
         this._roundPixels = settings.ROUND_PIXELS;
 
-        Object.assign(this, { ...Sprite.defaultSpriteOptions, ...options });
+        Object.assign(this, Sprite.defaultSpriteOptions, options);
     }
 
     /** When the texture is updated, this event will fire to update the scale and frame. */

--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -18,6 +18,7 @@ export interface ISpriteOptions
     tint: ColorSource;
     indices: Uint16Array;
     roundPixels?: boolean;
+    anchor: IPointData;
 }
 
 /**
@@ -149,6 +150,7 @@ export class Sprite extends Container
         blendMode: BLEND_MODES.NORMAL,
         pluginName: 'batch',
         tint: 0xFFFFFF,
+        anchor: { x: 0, y: 0 },
         indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
     };
 
@@ -164,13 +166,17 @@ export class Sprite extends Container
             options = { texture: options };
         }
 
-        const texture = options?.texture;
+        const originalTexture = options?.texture;
+
+        options = Object.assign({}, Sprite.defaultSpriteOptions, options);
+
+        const anchor = originalTexture?.defaultAnchor ?? options.anchor;
 
         this._anchor = new ObservablePoint(
             this._onAnchorUpdate,
             this,
-            (texture ? texture.defaultAnchor.x : 0),
-            (texture ? texture.defaultAnchor.y : 0)
+            anchor.x,
+            anchor.y
         );
 
         this._width = 0;
@@ -197,7 +203,7 @@ export class Sprite extends Container
         this.isSprite = true;
         this._roundPixels = settings.ROUND_PIXELS;
 
-        Object.assign(this, Sprite.defaultSpriteOptions, options);
+        Object.assign(this, options);
     }
 
     /** When the texture is updated, this event will fire to update the scale and frame. */


### PR DESCRIPTION
### ⚠️ Work in progress

Trying out some more declarative constructor options for display objects. I feel like you should be able to set things like x/y from the constructor of display objects. Currently, only implemented Sprite, Container, DisplayObject.

```js
const container = new Container();
const sprite = new Sprite(Texture.WHITE);
sprite.tint = 'red';
sprite.x = 100;
sprite.y = 100;
sprite.height = 200;
sprite.width = 200;
sprite.anchor.x = 0.5;
sprite.anchor.y = 0.5;
sprite.alpha = 0.8;
container.addChild(sprite);
```

```js
const container = new Container({
  children: [
    new Sprite({
       texture: Texture.WHITE,
       tint: 'red',
       x: 100,
       y: 100,
       width: 200,
       height: 200,
       anchor: { x: 0.5, y: 0.5 },
       alpha: 0.8,
    })
  ]
});
```

Demo:
https://jsfiddle.net/bigtimebuddy/m2rz5k18/

## TODO

- [x] DisplayObject
- [x] Container
- [x] Sprite
- [ ] AnimatedSprite
- [ ] Text
- [ ] HTMLText
- [ ] Graphics
- [ ] Mesh
- [ ] ParticleContainer
- [ ] BitmapText
- [ ] TilingSprite