### PR TITLE
Fixes formats not being added correctly

### DIFF
--- a/packages/assets/src/Assets.ts
+++ b/packages/assets/src/Assets.ts
@@ -54,6 +54,12 @@ export interface AssetInitOptions
         format?: ArrayOr<string>;
     };
 
+    /**
+     * If true, don't attempt to detect whether browser has preferred formats available.
+     * May result in increased performance as it skips detection step.
+     */
+    skipDetections?: boolean;
+
     /** advanced - override how bundlesIds are generated */
     bundleIdentifier?: BundleIdentifierOptions;
 
@@ -296,34 +302,11 @@ export class AssetsClass
         const resolutionPref = options.texturePreference?.resolution ?? 1;
         const resolution = (typeof resolutionPref === 'number') ? [resolutionPref] : resolutionPref;
 
-        let formats: string[] = [];
-
-        if (options.texturePreference?.format)
-        {
-            const formatPref = options.texturePreference?.format;
-
-            formats = (typeof formatPref === 'string') ? [formatPref] : formatPref;
-
-            // we should remove any formats that are not supported by the browser
-            for (const detection of this._detections)
-            {
-                if (!await detection.test())
-                {
-                    formats = await detection.remove(formats);
-                }
-            }
-        }
-        else
-        {
-            // we should add any formats that are supported by the browser
-            for (const detection of this._detections)
-            {
-                if (await detection.test())
-                {
-                    formats = await detection.add(formats);
-                }
-            }
-        }
+        const formats = await this._detectFormats({
+            preferredFormats: options.texturePreference?.format,
+            skipDetections: options.skipDetections,
+            detections: this._detections
+        });
 
         this.resolver.prefer({
             params: {
@@ -836,6 +819,49 @@ export class AssetsClass
         });
 
         await this.loader.unload(resolveArray);
+    }
+
+    /**
+     * Detects the supported formats for the browser, and returns an array of supported formats, respecting
+     * the users preferred formats order.
+     * @param options - the options to use when detecting formats
+     * @param options.preferredFormats - the preferred formats to use
+     * @param options.skipDetections - if we should skip the detections altogether
+     * @param options.detections - the detections to use
+     * @returns - the detected formats
+     */
+    private async _detectFormats(options: {
+        preferredFormats: string | string[],
+        skipDetections: boolean,
+        detections: FormatDetectionParser[]
+    }): Promise<string[]>
+    {
+        let formats: string[] = [];
+
+        // set preferred formats
+        if (options.preferredFormats)
+        {
+            formats = Array.isArray(options.preferredFormats)
+                ? options.preferredFormats : [options.preferredFormats];
+        }
+
+        // we should add any formats that are supported by the browser
+        for (const detection of options.detections)
+        {
+            if (options.skipDetections || await detection.test())
+            {
+                formats = await detection.add(formats);
+            }
+            else if (!options.skipDetections)
+            {
+                formats = await detection.remove(formats);
+            }
+        }
+
+        // remove any duplicates
+        formats = formats.filter((format, index) => formats.indexOf(format) === index);
+
+        return formats;
     }
 
     /** All the detection parsers currently added to the Assets class. */

--- a/packages/assets/test/detections.tests.ts
+++ b/packages/assets/test/detections.tests.ts
@@ -1,0 +1,103 @@
+import { Assets, detectAvif, detectDefaults, detectMp4, detectOgv, detectWebm, detectWebp } from '@pixi/assets';
+import { ExtensionType } from '@pixi/core';
+import '@pixi/spritesheet';
+
+describe('Assets', () =>
+{
+    const defaultDetections = [
+        detectAvif,
+        detectWebp,
+        detectDefaults,
+        detectMp4,
+        detectWebm,
+        detectOgv
+    ];
+
+    const passDetection = {
+        format: 'foo',
+        extension: {
+            type: ExtensionType.DetectionParser,
+            priority: 0
+        },
+        test: async () => true,
+        async add(formats: string[]): Promise<string[]>
+        {
+            return [...formats, this.format];
+        },
+        async remove(formats: string[]): Promise<string[]>
+        {
+            return formats.filter((f) => f !== this.format);
+        }
+    };
+
+    const failDetection = {
+        extension: {
+            type: ExtensionType.DetectionParser,
+        },
+        test: async () => false,
+        add: async (formats: string[]) => [...formats, 'bar'],
+        remove: async (formats: string[]) => formats.filter((f) => f !== 'bar'),
+    };
+
+    beforeEach(() =>
+    {
+        // reset the loader
+        Assets.reset();
+    });
+
+    it('should add format', async () =>
+    {
+        const pass = { ...passDetection };
+        const fail = { ...failDetection };
+
+        const res = await Assets['_detectFormats']({
+            preferredFormats: null,
+            skipDetections: false,
+            detections: [...defaultDetections, pass, fail],
+        });
+
+        expect(res).toEqual([
+            'avif',
+            'webp',
+            'png',
+            'jpg',
+            'jpeg',
+            'mp4',
+            'm4v',
+            'webm',
+            'ogv',
+            // added foo
+            'foo',
+        ]);
+    });
+
+    it('should prioritise a user defined format', async () =>
+    {
+        const pass = { ...passDetection };
+        const pass2 = { ...passDetection };
+        const fail = { ...failDetection };
+
+        pass2.format = 'baz';
+
+        const res = await Assets['_detectFormats']({
+            preferredFormats: ['foo', 'bar', 'baz', 'ogv'],
+            skipDetections: false,
+            detections: [...defaultDetections, pass, fail, pass2],
+        });
+
+        expect(res).toEqual([
+            // added foo and baz to the start
+            'foo',
+            'baz',
+            'ogv',
+            'avif',
+            'webp',
+            'png',
+            'jpg',
+            'jpeg',
+            'mp4',
+            'm4v',
+            'webm',
+        ]);
+    });
+});


### PR DESCRIPTION
While i was looking at #9530 I noticed we are doing something wrong with the detection logic.

When a user sets `texturePreferrences.format` it completely overrides all default formats. What we should be doing instead is adding these user defined formats to the start of the array, and the others can be used as fallbacks

This issue also meant if you defined a preferred format like this: `['png', 'avif']`, something like pixi sound detections would never be added

This does also mean that using `texturePreferrence.format = ['mp3', 'ogg', 'pmg', 'jpg']` is something you can do, so maybe we should deprecate this option and just use `preferredFormat = [...]` instead, since it has nothing to do with textures explicitly

Also while i was here is did add the `skipDetections` option from #9530  