### PR TITLE
Misc v8 fixes and updates

### DIFF
--- a/src/assets/loader/parsers/textures/utils/createTexture.ts
+++ b/src/assets/loader/parsers/textures/utils/createTexture.ts
@@ -3,18 +3,18 @@ import { Texture } from '../../../../../rendering/renderers/shared/texture/Textu
 import type { TextureSource } from '../../../../../rendering/renderers/shared/texture/sources/TextureSource';
 import type { Loader } from '../../../Loader';
 
-export function createTexture(source: TextureSource, _loader: Loader, _url: string)
+export function createTexture(source: TextureSource, loader: Loader, url: string)
 {
     const texture = new Texture({
         source,
-        label: _url,
+        label: url,
     });
 
     // TODO: make sure to nuke the promise if a texture is destroyed..
-    // texture.baseTexture.on('dispose', () =>
-    // {
-    //     delete loader.promiseCache[url];
-    // });
+    texture.source.on('destroy', () =>
+    {
+        delete loader.promiseCache[url];
+    });
 
     return texture;
 }

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -251,7 +251,7 @@ export class EventSystem implements System<EventSystemOptions>
 
         this.setTargetElement(canvas as HTMLCanvasElement);
         this.resolution = resolution;
-        EventSystem._defaultEventMode = options.eventMode ?? 'passive';
+        EventSystem._defaultEventMode = options.eventMode ?? 'auto';
         Object.assign(this.features, options.eventFeatures ?? {});
         this.rootBoundary.enableGlobalMoveEvents = this.features.globalMove;
     }

--- a/src/mesh-extras/NineSlicePlane.ts
+++ b/src/mesh-extras/NineSlicePlane.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-rest-params */
 import { MeshView } from '../rendering/mesh/shared/MeshView';
 import { Texture } from '../rendering/renderers/shared/texture/Texture';
 import { Container } from '../rendering/scene/Container';
@@ -194,6 +195,19 @@ export class NineSlicePlane extends NineSliceSprite
 {
     constructor(options: NineSliceSpriteOptions | Texture)
     {
+        if (options instanceof Texture)
+        {
+            // eslint-disable-next-line max-len
+            deprecation('v8', 'NineSlicePlane now uses the options object {texture, leftWidth, rightWidth, topHeight, bottomHeight}');
+
+            options = {
+                texture: options,
+                leftWidth: arguments[1],
+                topHeight: arguments[2],
+                rightWidth: arguments[3],
+                bottomHeight: arguments[4],
+            };
+        }
         deprecation('v8', 'NineSlicePlane is deprecated. Use NineSliceSprite instead.');
         super(options);
     }

--- a/src/rendering/filters/Filter.ts
+++ b/src/rendering/filters/Filter.ts
@@ -92,6 +92,9 @@ export class Filter extends Shader
 
         this.resolution = options.resolution;
         this.blendRequired = options.blendRequired;
+
+        this.addResource('globalUniforms', 0, 0);
+        this.addResource('myTexture', 1, 1);
     }
 
     /**

--- a/src/rendering/filters/color-matrix/ColorMatrixFilter.ts
+++ b/src/rendering/filters/color-matrix/ColorMatrixFilter.ts
@@ -1,6 +1,9 @@
+import { GlProgram } from '../../renderers/gl/shader/GlProgram';
 import { GpuProgram } from '../../renderers/gpu/shader/GpuProgram';
 import { UniformGroup } from '../../renderers/shared/shader/UniformGroup';
 import { Filter } from '../Filter';
+import fragment from './colorMatrixFilter.frag';
+import vertex from './colorMatrixFilter.vert';
 import source from './colorMatrixFilter.wgsl';
 
 // ts fixed array of length 20
@@ -45,7 +48,7 @@ export class ColorMatrixFilter extends Filter
             }
         });
 
-        const gpuProgram = new GpuProgram({
+        const gpuProgram = GpuProgram.from({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',
@@ -56,8 +59,15 @@ export class ColorMatrixFilter extends Filter
             },
         });
 
+        const glProgram = GlProgram.from({
+            vertex,
+            fragment,
+            name: 'color-matrix-filter'
+        });
+
         super({
             gpuProgram,
+            glProgram,
             resources: {
                 colorMatrixUniforms
             }
@@ -205,6 +215,16 @@ export class ColorMatrixFilter extends Filter
         ];
 
         this._loadMatrix(matrix, multiply);
+    }
+
+    /**
+     * for our american friends!
+     * @param scale
+     * @param multiply
+     */
+    public grayscale(scale: number, multiply: boolean): void
+    {
+        this.greyscale(scale, multiply);
     }
 
     /**

--- a/src/rendering/filters/color-matrix/colorMatrixFilter.frag
+++ b/src/rendering/filters/color-matrix/colorMatrixFilter.frag
@@ -1,0 +1,72 @@
+
+in vec2 vTextureCoord;
+in vec4 vColor;
+
+out vec4 fragColor;
+
+uniform float uColorMatrix[20];
+uniform float uAlpha;
+
+uniform sampler2D myTexture;
+
+float rand(vec2 co)
+{
+    return fract(sin(dot(co.xy, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main()
+{
+    vec4 color = texture(myTexture, vTextureCoord);
+    float randomValue = rand(gl_FragCoord.xy * 0.2);
+    float diff = (randomValue - 0.5) *  0.5;
+    
+    float[20] cm = uColorMatrix;
+
+    // Un-premultiply alpha before applying the color matrix. See issue #3539.
+    if (color.a > 0.0) {
+        color.rgb /= color.a;
+    }
+
+    if (uAlpha == 0.0) {
+        fragColor = color;
+        return;
+    }
+
+    // Un-premultiply alpha before applying the color matrix. See issue #3539.
+    if (color.a > 0.0) {
+      color.rgb /= color.a;
+    }
+
+    vec4 result;
+
+    result.r = (cm[0] * color.r);
+        result.r += (cm[1] * color.g);
+        result.r += (cm[2] * color.b);
+        result.r += (cm[3] * color.a);
+        result.r += cm[4];
+
+    result.g = (cm[5] * color.r);
+        result.g += (cm[6] * color.g);
+        result.g += (cm[7] * color.b);
+        result.g += (cm[8] * color.a);
+        result.g += cm[9];
+
+    result.b = (cm[10] * color.r);
+       result.b += (cm[11] * color.g);
+       result.b += (cm[12] * color.b);
+       result.b += (cm[13] * color.a);
+       result.b += cm[14];
+
+    result.a = (cm[15] * color.r);
+       result.a += (cm[16] * color.g);
+       result.a += (cm[17] * color.b);
+       result.a += (cm[18] * color.a);
+       result.a += cm[19];
+
+    vec3 rgb = mix(color.rgb, result.rgb, uAlpha);
+
+    // Premultiply alpha again.
+    rgb *= result.a;
+
+    fragColor = vec4(rgb, result.a);
+}

--- a/src/rendering/filters/color-matrix/colorMatrixFilter.vert
+++ b/src/rendering/filters/color-matrix/colorMatrixFilter.vert
@@ -1,0 +1,28 @@
+in vec2 aPosition;
+out vec2 vTextureCoord;
+
+uniform globalUniforms {
+  mat3 projectionMatrix;
+  mat3 worldTransformMatrix;
+  float worldAlpha;
+};
+
+uniform vec4 inputSize;
+uniform vec4 outputFrame;
+
+vec4 filterVertexPosition( void )
+{
+    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    return vec4((projectionMatrix * vec3(position, 1.0)).xy, 0.0, 1.0);
+}
+
+vec2 filterTextureCoord( void )
+{
+    return aPosition * (outputFrame.zw * inputSize.zw);
+}
+
+void main(void)
+{
+    gl_Position = filterVertexPosition();
+    vTextureCoord = filterTextureCoord();
+}

--- a/src/rendering/graphics/shared/GraphicsContextSystem.ts
+++ b/src/rendering/graphics/shared/GraphicsContextSystem.ts
@@ -96,7 +96,7 @@ export class GraphicsContextSystem implements System
                 {
                     size += contextBatches[i].vertexSize;
 
-                    if (size > 100)
+                    if (size > 400)
                     {
                         isBatchable = false;
                         break;

--- a/src/rendering/renderers/shared/ViewSystem.ts
+++ b/src/rendering/renderers/shared/ViewSystem.ts
@@ -91,7 +91,7 @@ export class ViewSystem implements System
          * {@link PIXI.WebGLOptions.autoDensity}
          * @default false
          */
-        autoDensity: true,
+        autoDensity: false,
         /**
          * {@link PIXI.WebGLOptions.antialias}
          * @default false

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -160,6 +160,13 @@ export class Shader extends EventEmitter<{
         this.resources = this._buildResourceAccessor(groups, nameHash);
     }
 
+    public addResource(name: string, groupIndex: number, bindIndex: number): void
+    {
+        this.uniformBindMap[groupIndex] ||= {};
+
+        this.uniformBindMap[groupIndex][bindIndex] ||= name;
+    }
+
     private _buildResourceAccessor(groups: ShaderGroups, nameHash: Record<string, GroupsData>)
     {
         const uniformsOut = {};

--- a/src/rendering/renderers/shared/texture/RenderTexture.ts
+++ b/src/rendering/renderers/shared/texture/RenderTexture.ts
@@ -1,0 +1,21 @@
+import { TextureSource } from './sources/TextureSource';
+import { Texture } from './Texture';
+
+import type { TextureSourceOptions } from './sources/TextureSource';
+
+export class RenderTexture extends Texture
+{
+    static create(options: TextureSourceOptions): Texture
+    {
+        return new Texture({
+            source: new TextureSource(options)
+        });
+    }
+
+    resize(width: number, height: number, resolution?: number): this
+    {
+        this.source.resize(width, height, resolution);
+
+        return this;
+    }
+}

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -61,6 +61,9 @@ export class TexturePoolClass
         return new Texture({
             source: textureSource,
             label: `texturePool_${count++}`,
+            style: {
+                scaleMode: 'nearest',
+            }
         });
     }
 

--- a/src/rendering/renderers/shared/texture/TextureStyle.ts
+++ b/src/rendering/renderers/shared/texture/TextureStyle.ts
@@ -62,9 +62,9 @@ export class TextureStyle extends EventEmitter<{
     _resourceId: number;
 
     // override to set styles globally
-    static readonly DEFAULT: TextureStyleOptions = {
+    static readonly defaultOptions: TextureStyleOptions = {
         addressMode: 'clamp-to-edge',
-        scaleMode: 'nearest'
+        scaleMode: 'linear'
     };
 
     uid = UID++;
@@ -104,7 +104,7 @@ export class TextureStyle extends EventEmitter<{
     {
         super();
 
-        options = { ...TextureStyle.DEFAULT, ...options };
+        options = { ...TextureStyle.defaultOptions, ...options };
 
         this.addressMode = options.addressMode;
 

--- a/src/rendering/scene/container-mixins/sortMixin.ts
+++ b/src/rendering/scene/container-mixins/sortMixin.ts
@@ -1,9 +1,12 @@
+import { deprecation } from '../../../utils/logging/deprecation';
+
 import type { Container } from '../Container';
 
 export interface SortMixin
 {
     _depth: 0;
     depth: number;
+    zIndex: number;
     sortDirty: boolean;
     sortChildren: boolean;
 
@@ -15,6 +18,18 @@ export const sortMixin: Partial<Container> = {
     _depth: 0,
     sortDirty: false,
     sortChildren: false,
+
+    get zIndex()
+    {
+        return this._depth;
+    },
+
+    /** The depth of the object. Setting this value, will automatically set the parent to be sortable */
+    set zIndex(value)
+    {
+        deprecation('v8', 'zIndex has been renamed to depth');
+        this.depth = value;
+    },
 
     get depth()
     {

--- a/src/rendering/sprite/shared/Sprite.ts
+++ b/src/rendering/sprite/shared/Sprite.ts
@@ -3,6 +3,7 @@ import { Texture } from '../../renderers/shared/texture/Texture';
 import { Container } from '../../scene/Container';
 import { SpriteView } from './SpriteView';
 
+import type { PointData } from '../../../maths/PointData';
 import type { ContainerOptions } from '../../scene/Container';
 
 export interface SpriteOptions extends ContainerOptions<SpriteView>
@@ -41,6 +42,12 @@ export class Sprite extends Container<SpriteView>
     get anchor()
     {
         return this.view.anchor;
+    }
+
+    set anchor(value: PointData)
+    {
+        this.view.anchor.x = value.x;
+        this.view.anchor.y = value.y;
     }
 
     get texture()

--- a/src/rendering/sprite/shared/SpriteView.ts
+++ b/src/rendering/sprite/shared/SpriteView.ts
@@ -29,7 +29,7 @@ export class SpriteView implements View
 
     boundsDirty = true;
     sourceBoundsDirty = true;
-    didUpdate: boolean;
+    didUpdate = false;
 
     constructor(texture: Texture)
     {

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -1,3 +1,4 @@
+import { deprecation } from '../../utils/logging/deprecation';
 import { Container } from '../scene/Container';
 import { TextView } from './TextView';
 
@@ -9,8 +10,19 @@ export type TextOptions = ContainerOptions<TextView> & TextViewOptions;
 
 export class Text extends Container<TextView>
 {
-    constructor(options: TextOptions)
+    constructor(options: TextOptions = {})
     {
+        // @deprecated
+        if (typeof options === 'string')
+        {
+            deprecation('v8', 'use new Text({ text: "hi!", style }) instead');
+            options = {
+                text: options,
+                // eslint-disable-next-line prefer-rest-params
+                style: arguments[1],
+            } as TextOptions;
+        }
+
         super({
             view: new TextView(options),
             label: 'Text',

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -1,4 +1,5 @@
 import EventEmitter from 'eventemitter3';
+import { deprecation } from '../../utils/logging/deprecation';
 import { GraphicsContext } from '../graphics/shared/GraphicsContext';
 import { convertFillInputToFillStyle } from '../graphics/shared/utils/convertFillInputToFillStyle';
 
@@ -235,7 +236,32 @@ export class TextStyle extends EventEmitter<{
     {
         super();
 
-        // TODO getter setters...
+        const oldStyle = style as any;
+
+        if (typeof oldStyle.dropShadow === 'boolean')
+        {
+            deprecation('v8', 'dropShadow is now an object, not a boolean');
+
+            style.dropShadow = {
+                alpha: oldStyle.dropShadowAlpha ?? 1,
+                angle: oldStyle.dropShadowAngle,
+                blur: oldStyle.dropShadowBlur ?? 0,
+                color: oldStyle.dropShadowColor,
+                distance:   oldStyle.dropShadowDistance,
+            };
+        }
+
+        if (oldStyle.strokeThickness)
+        {
+            deprecation('v8', 'strokeThickness is now a part of stroke');
+
+            const color = oldStyle.stroke;
+
+            style.stroke = {
+                color,
+                width: oldStyle.strokeThickness
+            };
+        }
 
         const fullStyle = { ...TextStyle.defaultTextStyle, ...style };
 
@@ -358,6 +384,8 @@ export class TextStyle extends EventEmitter<{
 
         index = addFillStyleKey(this._fill, key as string[], index);
         index = addStokeStyleKey(this._stroke, key as string[], index);
+
+        // TODO - we need to add some shadow stuff here!
 
         this._styleKey = key.join('-');
 

--- a/src/rendering/text/bitmap/BitmapTextPipe.ts
+++ b/src/rendering/text/bitmap/BitmapTextPipe.ts
@@ -66,9 +66,6 @@ export class BitmapTextPipe implements RenderPipe<TextView>
     {
         const graphicsRenderable = this.getGpuBitmapText(renderable);
 
-        // TODO break the batch if we are not batching..
-        this.renderer.renderPipes.batch.break(instructionSet);
-
         this.renderer.renderPipes.graphics.addRenderable(graphicsRenderable, instructionSet);
 
         if (graphicsRenderable.view.context.customShader)

--- a/src/rendering/text/canvas/CanvasTextMetrics.ts
+++ b/src/rendering/text/canvas/CanvasTextMetrics.ts
@@ -263,7 +263,7 @@ export class CanvasTextMetrics
             maxLineWidth = Math.max(maxLineWidth, lineWidth);
         }
 
-        const strokeWidth = (style.stroke as StrokeStyle)?.width || 0;
+        const strokeWidth = (style._stroke as StrokeStyle)?.width || 0;
 
         let width = maxLineWidth + strokeWidth;
 

--- a/src/rendering/text/canvas/CanvasTextSystem.ts
+++ b/src/rendering/text/canvas/CanvasTextSystem.ts
@@ -253,7 +253,7 @@ export class CanvasTextSystem implements System
                 linePositionYShift = 0;
             }
 
-            const strokeWidth = (style.stroke as StrokeStyle)?.width ?? 0;
+            const strokeWidth = (style._stroke as StrokeStyle)?.width ?? 0;
 
             // draw lines line by line
             for (let i = 0; i < lines.length; i++)


### PR DESCRIPTION
- re-enable texture destroy even on loader
- ensure events is `auto` by default like v7
- added deprecation for `NineSlicePlane`
- fixed filter uniform issue
- added back `RenderTexture`
- make texture pool `nearest` by default
- added `zIndex` deprecation
- added `anchor setter onto `Sprite`
- added `Text` options and `TextStyle` deprecation
- fixed up `ColorMatrixFilter` for WebGL
- increased batchable `Graphics` size
- set `autoDensity` to be false by default like v7
- fixed needless break in Bitmap font rendering
- Fixed issues with measuring text with stroke style

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd9010a</samp>

### Summary
🎨🚀🗑️

<!--
1.  🎨 - This emoji is often used to indicate changes related to the appearance, style, or design of the code or the output. It could be used for the changes related to the `ColorMatrixFilter`, the `TextureStyle`, the `scaleMode`, the `stroke`, and the `anchor` properties, as well as the new shader files and the `RenderTexture` class.
2.  🚀 - This emoji is often used to indicate changes related to the performance, speed, or optimization of the code or the output. It could be used for the changes related to the `eventMode`, the `autoDensity`, the `batchSize`, the `didUpdate`, and the `glProgram` properties, as well as the removal of the batch breaking line in the `BitmapTextPipe` class.
3.  🗑️ - This emoji is often used to indicate changes related to the removal, deprecation, or cleanup of the code or the output. It could be used for the changes related to the `NineSlicePlane`, the `Text`, and the `TextStyle` constructors, as well as the `zIndex` and the `grayscale` aliases.
-->
This pull request adds support for GL programs to some filters and graphics classes, improves the performance and consistency of rendering, and handles some deprecated syntax and options. It also adds new files for the `ColorMatrixFilter` shaders and the `RenderTexture` class, and updates the constructors and properties of several classes such as `NineSlicePlane`, `Text`, `TextStyle`, and `Sprite`. It renames some unused parameters and adds some comments and warnings.

> _`ColorMatrixFilter`_
> _Adds GL programs and noise_
> _Winter of shaders_

### Walkthrough
*  Add `ColorMatrixFilter` class and shaders to apply color matrix transformations and noise to textures (F4,F5,F6)
*  Add `grayscale` method to `ColorMatrixFilter` class as an alias for `greyscale` method ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-822aa07db8602fa87e2ca4fe333d5d5d9442d95c08e4ece811b9d5394630d193R221-R230))
*  Add `zIndex` property to `SortMixin` interface and `sortMixin` value as an alias for `depth` property ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-e8040c80b7ac122072ac6bbbdcc16520b561f6d578562a7da876e08201caa280R9),[link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-e8040c80b7ac122072ac6bbbdcc16520b561f6d578562a7da876e08201caa280R22-R33))
*  Add setter for `anchor` property to `Sprite` class to allow setting anchor with a single value ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-97eab4515efaa3035cec114661720e6ad1153a3c539a1634b3a6e09d6e979443R47-R52))
*  Add optional `options` parameter to `Text` class constructor and support deprecated usage of passing a string and a style object ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-e5a4c40083481be2e803f5c9b1b86a390046d44307f01e213e846b0494e7bc6eL12-R25))
*  Add `dropShadow` and `stroke` objects to `TextStyle` class and support deprecated usage of individual shadow and stroke properties ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL238-R265))
*  Change default value of `eventMode` option in `ViewSystem` constructor from `'passive'` to `'auto'` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-8de4284383bc6a5cb52d3ef6592b1129816a8712991683451bb10849f27eb66fL254-R254))
*  Change default value of `autoDensity` option in `ViewSystem` constructor from `true` to `false` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-f555bb999343ac3196fb70c367ae046f90836195faa15e236a556fe6144b018eL94-R94))
*  Change default value of `scaleMode` property in `TextureStyle` class from `'nearest'` to `'linear'` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-ad6f3f2068fc04074284162808870474022706b8ccbb63b3f7a8478e651e3027L65-R67))
*  Change `gpuProgram` variable in `ColorMatrixFilter` class to use `from` method of `GpuProgram` class ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-822aa07db8602fa87e2ca4fe333d5d5d9442d95c08e4ece811b9d5394630d193L48-R51))
*  Change `glProgram` variable in `ColorMatrixFilter` class to use `from` method of `GlProgram` class and pass shader sources and name ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-822aa07db8602fa87e2ca4fe333d5d5d9442d95c08e4ece811b9d5394630d193L59-R70))
*  Change `style` property in `TexturePoolClass` class to add `scaleMode` property with value `'nearest'` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-6cefea59bbceede896fadbdc072d403ae7528934559b85bd659f435419b210a6R64-R66))
*  Change `didUpdate` property in `SpriteView` class to have initial value `false` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-3c30fbe8827478bc9e1d1c068a2eb85bcc5907c1a52eb09ed1c6d9fa1c61451bL32-R32))
*  Change `stroke` property in `CanvasTextMetrics` class to use `_stroke` property instead of `stroke` property ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-f08da8ca888483e0e0b3c4f755b1b4504871981e301a18b6113be71e63d88d97L266-R266))
*  Change `DEFAULT` property in `TextureStyle` class to `defaultOptions` and use it in constructor ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-ad6f3f2068fc04074284162808870474022706b8ccbb63b3f7a8478e651e3027L65-R67),[link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-ad6f3f2068fc04074284162808870474022706b8ccbb63b3f7a8478e651e3027L107-R107))
*  Change condition for breaking batch in `GraphicsContextSystem` class from `size > 100` to `size > 400` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-faee89d0d8c9e904b7ee9c935e8909e023f99ca35c19ac29f565790f6fffa2baL99-R99))
*  Change unused parameters `_loader` and `_url` in `createTexture` function to `loader` and `url` ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-4efe34f0b6f256df8e32bf16f4fae97a904d0e168475c353ab9a92b69b8b3d5dL6-R17))
*  Remove line of code that breaks batch in `BitmapTextPipe` class ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-b7f0f5264b475be1a4e05f886e89245d28bac6891cb9cc6c7179e3b8035e26d7L69-L71))
*  Add comment to disable eslint rule `prefer-rest-params` for `NineSlicePlane.ts` file ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cR1))
*  Add conditional block to `NineSlicePlane` constructor to support deprecated usage of passing a texture and four numbers as arguments ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-ec1a9fb11260855ad2b87ad50b98db0f89501f64cb038adf406446f84bf2802cR198-R210))
*  Add lines of code to `Filter` constructor to call `addResource` method with `globalUniforms` and `myTexture` resources ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-06a9b48495e4a5cdca6e4cd29722dfb54eef1941a1e94ce391746e1e261be37cR95-R97))
*  Add imports for `deprecation` function to `Text.ts`, `TextStyle.ts`, and `sortMixin.ts` files ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-e8040c80b7ac122072ac6bbbdcc16520b561f6d578562a7da876e08201caa280R1-R2),[link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-e5a4c40083481be2e803f5c9b1b86a390046d44307f01e213e846b0494e7bc6eR1),[link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bR2))
*  Add imports for `GlProgram` class and `fragment` and `vertex` shader sources to `ColorMatrixFilter.ts` file ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-822aa07db8602fa87e2ca4fe333d5d5d9442d95c08e4ece811b9d5394630d193L1-R6))
*  Add import for `PointData` type to `Sprite.ts` file ([link](https://github.com/pixijs/pixijs/pull/9540/files?diff=unified&w=0#diff-97eab4515efaa3035cec114661720e6ad1153a3c539a1634b3a6e09d6e979443R6))

