### PR TITLE
Fix: Publishing latest v6 dist-tag for deprecated v7 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "release": "lerna version --exact --force-publish",
     "version": "ts-node scripts/fixPeerVersions.ts && npx --yes npm@7.20.2 i --package-lock-only && git add package-lock.json",
     "publish-ci": "lerna publish from-package --yes --no-verify-access",
+    "postpublish-ci": "ts-node scripts/fixPublish.ts",
     "webdoc": "webdoc"
   },
   "pre-commit": [

--- a/scripts/fixPublish.ts
+++ b/scripts/fixPublish.ts
@@ -1,0 +1,18 @@
+import { version } from '../lerna.json';
+import { execSync } from 'child_process';
+
+/**
+ * The following packages were removed in v7, so dist-tag needs to get fixed after publish
+ * in order for npm to consider it the default version when installing, for instance
+ * `npm install @pixi/loaders@6`.
+ * @see https://github.com/pixijs/pixijs/issues/9108
+ */
+['@pixi/loaders', '@pixi/polyfill', '@pixi/interaction'].forEach((pkg) =>
+{
+    const command = `npm dist-tag add ${pkg}@${version} latest`;
+
+    // eslint-disable-next-line no-console
+    console.log(command);
+
+    execSync(command, { stdio: 'inherit' });
+});


### PR DESCRIPTION
Fixes #9544 and #9108

This is a more permanent solution so we won't get bit by publishing v6 in the future.