### PR TITLE
Use fetch to load video textures

### DIFF
--- a/packages/assets/src/loader/parsers/textures/loadVideo.ts
+++ b/packages/assets/src/loader/parsers/textures/loadVideo.ts
@@ -79,7 +79,11 @@ export const loadVideo = {
             });
 
             base.resource.src = url;
-            texture = createTexture(base, loader, url, blobURL);
+            texture = createTexture(base, loader, url);
+            texture.baseTexture.once('destroyed', () =>
+            {
+                URL.revokeObjectURL(blobURL);
+            });
         }
         catch (e)
         {

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -4,7 +4,7 @@ import { Cache } from '../../../../cache/Cache';
 import type { BaseTexture } from '@pixi/core';
 import type { Loader } from '../../../Loader';
 
-export function createTexture(base: BaseTexture, loader: Loader, url: string, objectURL?: string)
+export function createTexture(base: BaseTexture, loader: Loader, url: string)
 {
     // make sure the resource is destroyed when the base texture is destroyed
     base.resource.internal = true;
@@ -19,11 +19,6 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string, ob
         if (Cache.has(url))
         {
             Cache.remove(url);
-        }
-
-        if (objectURL)
-        {
-            URL.revokeObjectURL(objectURL);
         }
     });
 

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -4,7 +4,7 @@ import { Cache } from '../../../../cache/Cache';
 import type { BaseTexture } from '@pixi/core';
 import type { Loader } from '../../../Loader';
 
-export function createTexture(base: BaseTexture, loader: Loader, url: string)
+export function createTexture(base: BaseTexture, loader: Loader, url: string, objectURL?: string)
 {
     // make sure the resource is destroyed when the base texture is destroyed
     base.resource.internal = true;
@@ -19,6 +19,11 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
         if (Cache.has(url))
         {
             Cache.remove(url);
+        }
+
+        if (objectURL)
+        {
+            URL.revokeObjectURL(objectURL);
         }
     });
 

--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -105,7 +105,7 @@ export class VideoResource extends BaseImageResource
                 {
                     mime = src.slice(5, src.indexOf(';'));
                 }
-                else
+                else if (!src.startsWith('blob:'))
                 {
                     const baseSrc = src.split('?').shift().toLowerCase();
                     const ext = baseSrc.slice(baseSrc.lastIndexOf('.') + 1);
@@ -114,7 +114,11 @@ export class VideoResource extends BaseImageResource
                 }
 
                 sourceElement.src = src;
-                sourceElement.type = mime;
+
+                if (mime)
+                {
+                    sourceElement.type = mime;
+                }
 
                 videoElement.appendChild(sourceElement);
             }


### PR DESCRIPTION
Video loading may never resolve, because the video load can be suspended by the browser (`suspend` event). It seems that the browser is free to just suspend the video loading and seems to do that frequently if other assets are loaded at the same time. Spamming `videoElement.load()` in `onsuspend` seems to eventually make the video load, but only after a significant delay. Using `fetch` and a blob URL fixes this issue. We should probably have something in `VideoResource` to handle `suspend` events, but I'm not entirely sure what the correct approach would be.