### PR TITLE
Remove a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Or via unpkg:
 
 - [Filters Demo](https://pixijs.io/filters/tools/demo/)
 - [Run Pixie Run](http://work.goodboydigital.com/runpixierun/)
-- [Flash vs HTML](http://flashvhtml.com)
 - [Bunny Demo](http://www.goodboydigital.com/pixijs/bunnymark)
 - [Storm Brewing](http://www.goodboydigital.com/pixijs/storm)
 - [Render Texture Demo](http://www.goodboydigital.com/pixijs/examples/11)


### PR DESCRIPTION
The "Flash vs HTML" link most certainly does not point to anything relevant any more.

<details>
  <summary>flashvhtml.com is now a parked domain</summary>

The page looks about like this as of now:
![image](https://github.com/pixijs/pixijs/assets/6942070/48f92fc1-ee68-40e7-a94d-b5d8c599b5af)

</details>