### PR TITLE
Minor fixes 4

### DIFF
--- a/src/rendering/filters/color-matrix/colorMatrixFilter.frag
+++ b/src/rendering/filters/color-matrix/colorMatrixFilter.frag
@@ -22,19 +22,10 @@ void main()
     
     float[20] cm = uColorMatrix;
 
-    // Un-premultiply alpha before applying the color matrix. See issue #3539.
-    if (color.a > 0.0) {
-        color.rgb /= color.a;
-    }
 
     if (uAlpha == 0.0) {
         fragColor = color;
         return;
-    }
-
-    // Un-premultiply alpha before applying the color matrix. See issue #3539.
-    if (color.a > 0.0) {
-      color.rgb /= color.a;
     }
 
     vec4 result;

--- a/src/rendering/mesh/shared/Mesh.ts
+++ b/src/rendering/mesh/shared/Mesh.ts
@@ -1,3 +1,4 @@
+import { deprecation } from '../../../utils/logging/deprecation';
 import { Container } from '../../scene/Container';
 import { MeshView } from './MeshView';
 
@@ -37,6 +38,18 @@ export class Mesh extends Container<MeshView>
     set geometry(value: MeshGeometry)
     {
         this.view.geometry = value;
+    }
+
+    get material()
+    {
+        deprecation('8', 'mesh.material property has been removed, use mesh.shader instead');
+
+        return this.view.shader;
+    }
+
+    get shader()
+    {
+        return this.view.shader;
     }
 }
 

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -61,9 +61,6 @@ export class TexturePoolClass
         return new Texture({
             source: textureSource,
             label: `texturePool_${count++}`,
-            style: {
-                scaleMode: 'nearest',
-            }
         });
     }
 

--- a/src/rendering/scene/container-mixins/measureMixin.ts
+++ b/src/rendering/scene/container-mixins/measureMixin.ts
@@ -22,7 +22,7 @@ export const measureMixin: Partial<Container> = {
 
     get width(): number
     {
-        return this.scale.x * getLocalBounds(this, tempBounds, tempMatrix).width;
+        return Math.abs(this.scale.x * getLocalBounds(this, tempBounds, tempMatrix).width);
     },
 
     set width(value: number)
@@ -41,7 +41,7 @@ export const measureMixin: Partial<Container> = {
 
     get height(): number
     {
-        return this.scale.y * getLocalBounds(this, tempBounds, tempMatrix).height;
+        return Math.abs(this.scale.y * getLocalBounds(this, tempBounds, tempMatrix).height);
     },
 
     set height(value: number)

--- a/src/rendering/sprite/shared/Sprite.ts
+++ b/src/rendering/sprite/shared/Sprite.ts
@@ -4,6 +4,7 @@ import { Container } from '../../scene/Container';
 import { SpriteView } from './SpriteView';
 
 import type { PointData } from '../../../maths/PointData';
+import type { PointLike } from '../../../maths/PointLike';
 import type { ContainerOptions } from '../../scene/Container';
 
 export interface SpriteOptions extends ContainerOptions<SpriteView>
@@ -39,7 +40,7 @@ export class Sprite extends Container<SpriteView>
         });
     }
 
-    get anchor()
+    get anchor(): PointLike
     {
         return this.view.anchor;
     }

--- a/src/rendering/sprite/shared/SpriteView.ts
+++ b/src/rendering/sprite/shared/SpriteView.ts
@@ -1,8 +1,8 @@
 import { ObservablePoint } from '../../../maths/ObservablePoint';
+import { Texture } from '../../renderers/shared/texture/Texture';
 import { emptyViewObserver } from '../../renderers/shared/View';
 
 import type { PointData } from '../../../maths/PointData';
-import type { Texture } from '../../renderers/shared/texture/Texture';
 import type { View } from '../../renderers/shared/View';
 import type { Bounds } from '../../scene/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../../scene/destroyTypes';
@@ -44,6 +44,8 @@ export class SpriteView implements View
 
     set texture(value: Texture)
     {
+        value ||= Texture.EMPTY;
+
         if (this._texture === value) return;
 
         value.on('update', this.onUpdate, this);

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -508,7 +508,7 @@ function convertV7Tov8Style(style: TextStyleOptions)
     {
         deprecation('8', 'gradient fill is now a fill pattern: `new FillGradient(...)`');
 
-        const gradientFill = new FillGradient(0, 0, 0, style.fontSize as number);
+        const gradientFill = new FillGradient(0, 0, 0, (style.fontSize as number) * 1.7);
 
         const fills: number[] = oldStyle.fill.map(convertColorToNumber);
 

--- a/src/rendering/text/canvas/CanvasTextSystem.ts
+++ b/src/rendering/text/canvas/CanvasTextSystem.ts
@@ -174,6 +174,19 @@ export class CanvasTextSystem implements System
         // context.fillStyle = 'red';
         context.clearRect(0, 0, measured.width, measured.height);
 
+        // set stroke styles..
+
+        if (style._stroke?.width)
+        {
+            const strokeStyle = style._stroke;
+
+            context.lineWidth = strokeStyle.width;
+
+            context.miterLimit = strokeStyle.miterLimit;
+            context.lineJoin = strokeStyle.join;
+            context.lineCap = strokeStyle.cap;
+        }
+
         // return;
         context.font = font;
 
@@ -230,20 +243,10 @@ export class CanvasTextSystem implements System
 
                 if (style._stroke?.width)
                 {
-                    const strokeStyle = style._stroke;
-
                     context.strokeStyle = getCanvasFillStyle(style._stroke, context);
-                    context.lineWidth = strokeStyle.width;
-
-                    context.miterLimit = strokeStyle.miterLimit;
-                    context.lineJoin = strokeStyle.join;
-                    context.lineCap = strokeStyle.cap;
                 }
 
                 context.shadowColor = 'black';
-                context.shadowBlur = 0;
-                context.shadowOffsetX = 0;
-                context.shadowOffsetY = 0;
             }
 
             let linePositionYShift = (lineHeight - fontProperties.fontSize) / 2;


### PR DESCRIPTION
- fix text quality
- fix color matrix alpha issue
- fix width and height to always be positive
- fix anchor type issue
- alway have at least an empty texture
- fix text style stroke + drop shadow
- tweak gradient fill for v7
- add getters for `shader` in `mesh`

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fc2b76c</samp>

### Summary
🎨🐛🚀

<!--
1.  🎨 - This emoji is often used for changes related to code style, formatting, or refactoring. It could apply to the first, third, and sixth changes, as they all involve improving or simplifying the code structure or appearance.
2. 🐛 - This emoji is often used for changes related to bug fixes or error handling. It could apply to the fourth and seventh changes, as they both involve fixing issues or adding warnings for deprecated or invalid usage.
3. 🚀 - This emoji is often used for changes related to performance, optimization, or new features. It could apply to the second and fifth changes, as they both involve enhancing the functionality or efficiency of the code.
-->
This pull request improves the performance, correctness, and code quality of various rendering modules in pixijs. It simplifies the color matrix filter shader, updates the mesh and sprite APIs to use the new shader system, fixes bugs in the measure mixin and the canvas text system, and removes unused or outdated code from the texture pool and the text style conversion function.

> _We're refactoring the code, me hearties, yo ho ho_
> _We're simplifying shaders and textures as we go_
> _We're fixing bugs and adding types, we're making it run fast_
> _We're heaving on the `SpriteView` on the count of three, at last_

### Walkthrough
* Remove un-premultiply alpha steps from color matrix filter shader to fix issue #3539 ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-882109fa93725f766cfd80cf9c1dafd9ab858f43449332ee157dd0c8c04d8235L25-L28), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-882109fa93725f766cfd80cf9c1dafd9ab858f43449332ee157dd0c8c04d8235L35-L39))
* Add deprecation utility and getters for material and shader properties to Mesh to maintain backward compatibility and inform users about API change ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-2b8470e97115b501fe2c2bfc9cdf461846d58009ec226f5072e664a327b9e7efR1), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-2b8470e97115b501fe2c2bfc9cdf461846d58009ec226f5072e664a327b9e7efR42-R53))
* Remove unused style property from texture pool ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-6cefea59bbceede896fadbdc072d403ae7528934559b85bd659f435419b210a6L64-L66))
* Add Math.abs calls to width and height getters of measure mixin to handle negative scales correctly ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-898c9c8be31211792915cb6c279ae72aa3f1e415c0daa2f34a3a202ecfd00768L25-R25), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-898c9c8be31211792915cb6c279ae72aa3f1e415c0daa2f34a3a202ecfd00768L44-R44))
* Add type import and annotation for anchor getter return type in `Sprite.ts` ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-97eab4515efaa3035cec114661720e6ad1153a3c539a1634b3a6e09d6e979443R7), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-97eab4515efaa3035cec114661720e6ad1153a3c539a1634b3a6e09d6e979443L42-R43))
* Reorder imports and add nullish coalescing operator in `SpriteView.ts` for consistency and safety ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-3c30fbe8827478bc9e1d1c068a2eb85bcc5907c1a52eb09ed1c6d9fa1c61451bL2-R5), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-3c30fbe8827478bc9e1d1c068a2eb85bcc5907c1a52eb09ed1c6d9fa1c61451bR47-R48))
* Add stroke style settings and remove redundant and unused settings from context in `CanvasTextSystem.ts` to apply stroke properties correctly ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-8393c735ac09d32cf2441068d3711a155f4ef1c6aa0c82017316af90c00c486cR177-R189), [link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-8393c735ac09d32cf2441068d3711a155f4ef1c6aa0c82017316af90c00c486cL233-R249))
* Modify gradient fill height calculation in `TextStyle.ts` to match new text metrics and avoid clipping or stretching issues ([link](https://github.com/pixijs/pixijs/pull/9558/files?diff=unified&w=0#diff-85113c34fc7a760bb28a60f57fa23b14b107b4797230e736700f07f6dd4eab1bL511-R511))

