### PR TITLE
Default Renderer fallback to settings.RESOLUTION

### DIFF
--- a/packages/core/src/view/ViewSystem.ts
+++ b/packages/core/src/view/ViewSystem.ts
@@ -48,7 +48,7 @@ export interface ViewSystemOptions
 export class ViewSystem implements ISystem<ViewSystemOptions, boolean>
 {
     /** @ignore */
-    static defaultOptions = {
+    static defaultOptions: ViewSystemOptions = {
         /**
          * {@link PIXI.IRendererOptions.width}
          * @default 800
@@ -67,7 +67,7 @@ export class ViewSystem implements ISystem<ViewSystemOptions, boolean>
          * @default PIXI.settings.RESOLUTION
          * @memberof PIXI.settings.RENDER_OPTIONS
          */
-        resolution: settings.RESOLUTION,
+        resolution: undefined,
         /**
          * {@link PIXI.IRendererOptions.autoDensity}
          * @default false


### PR DESCRIPTION
Fixes #9429

The default value of `RENDER_OPTIONS.resolution` should be undefined. This way it will fallback to `settings.RESOLUTION` in the ViewSystem constructor.

Broken: https://jsfiddle.net/bigtimebuddy/tmg2u8rL/
Fixed: https://jsfiddle.net/bigtimebuddy/vjLx02tp/