### PR TITLE
Fix up the depth sorting

### DIFF
--- a/src/rendering/scene/Container.ts
+++ b/src/rendering/scene/Container.ts
@@ -350,7 +350,7 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
 
         if (child._zIndex !== 0)
         {
-            this.depthOfChildModified();
+            child.depthOfChildModified();
         }
 
         return child;

--- a/tests/scene/depthSorting.tests.ts
+++ b/tests/scene/depthSorting.tests.ts
@@ -1,0 +1,52 @@
+import { Container } from '../../src/rendering/scene/Container';
+
+describe('Depth sorting', () =>
+{
+    it('should depth sort children correctly', async () =>
+    {
+        const container = new Container();
+
+        const child1 = new Container();
+        const child2 = new Container();
+        const child3 = new Container();
+
+        container.addChild(child1);
+        container.addChild(child2);
+        container.addChild(child3);
+
+        expect(container.sortableChildren).toBe(false);
+        expect(container.sortDirty).toBe(false);
+
+        child3.zIndex = -1;
+
+        expect(container.sortableChildren).toBe(true);
+        expect(container.sortDirty).toBe(true);
+
+        container.sortChildren();
+
+        expect(container.sortDirty).toBe(false);
+        expect(container.sortableChildren).toBe(true);
+
+        expect(container.children[0]).toBe(child3);
+        expect(container.children[1]).toBe(child1);
+        expect(container.children[2]).toBe(child2);
+    });
+
+    it('should activate depth sort if a child is added with a zIndex set', async () =>
+    {
+        const container = new Container();
+
+        const child1 = new Container();
+        const child2 = new Container();
+        const child3 = new Container();
+
+        child1.zIndex = 4;
+
+        container.addChild(child1);
+        container.addChild(child2);
+        container.addChild(child3);
+
+        expect(container.sortableChildren).toBe(true);
+        expect(container.sortDirty).toBe(true);
+    });
+});


### PR DESCRIPTION
- tidy up depth sorting, added tests
- refactor `buildInstructions` to remove code duplication

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c375e2</samp>

### Summary
🐛🧪♻️

<!--
1.  🐛 for fixing a bug
2.  🧪 for adding tests
3.  ♻️ for refactoring code
-->
This pull request improves the rendering performance and correctness of layer groups, fixes a bug in the depth sorting of container children, and adds unit tests for the depth sorting feature. It refactors the `buildInstructions` function, fixes the `depthOfChildModified` method, and creates the `tests/scene/depthSorting.tests.ts` file.

> _Oh we'll sort the children by their `zIndex`_
> _And we'll test the depth of each container_
> _We'll refactor the code for the renderables_
> _And we'll heave away on the count of three_

### Walkthrough
*  Fix bug in `depthOfChildModified` method call ([link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-5690685fbd2d136cd8eef47227b4ead980216ab373b3de796a50bc3686dff2f7L353-R353))
*  Simplify and optimize the `buildInstructions` function in `src/rendering/scene/utils/buildInstructions.ts` ([link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL22-L36), [link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL42-R29), [link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL77-R56), [link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL171-R173))
*  Refactor the `collectAllRenderablesAdvanced` function in `src/rendering/scene/utils/buildInstructions.ts` ([link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL116-R96), [link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-da117e44a95821c8230c73f22379b3758de48f6f166d0ddc56547b6289455d3aL127-R127))
*  Add unit tests for the depth sorting functionality of the `Container` class in `tests/scene/depthSorting.tests.ts` ([link](https://github.com/pixijs/pixijs/pull/9576/files?diff=unified&w=0#diff-777507cbacdac36ff8f8722afce441747908cf3aac8ebe9f1c69481a71030facR1-R52))

