### PR TITLE
Add the `Texture.destroyed` property/event. Log a warning if a `Texture` managed by `Assets` is destroyed but its `BaseTexture` is not

### DIFF
--- a/packages/assets/src/loader/Loader.ts
+++ b/packages/assets/src/loader/Loader.ts
@@ -245,9 +245,9 @@ export class Loader
             {
                 const loadedAsset = await loadPromise.promise;
 
-                loadPromise.parser?.unload?.(loadedAsset, asset, this);
-
                 delete this.promiseCache[url];
+
+                loadPromise.parser?.unload?.(loadedAsset, asset, this);
             }
         });
 

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -21,13 +21,22 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
     };
 
     // remove the promise from the loader and the url from the cache when the texture is destroyed
-    texture.baseTexture.once('destroyed', unload);
+    texture.baseTexture.once('destroyed', () =>
+    {
+        if (url in loader.promiseCache)
+        {
+            console.warn('[Assets] A BaseTexture managed by Assets was destroyed instead of unloaded! '
+                + 'Use Assets.unload() instead of destroying the BaseTexture.');
+            unload();
+        }
+    });
     texture.once('destroyed', () =>
     {
         if (!base.destroyed)
         {
+            console.warn('[Assets] A Texture managed by Assets was destroyed instead of unloaded! '
+                + 'Use Assets.unload() instead of destroying the Texture.');
             unload();
-            console.warn('[Assets] A Texture managed by Assets was destroyed but its BaseTexture was not!');
         }
     });
 

--- a/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
+++ b/packages/assets/src/loader/parsers/textures/utils/createTexture.ts
@@ -10,15 +10,24 @@ export function createTexture(base: BaseTexture, loader: Loader, url: string)
     base.resource.internal = true;
 
     const texture = new Texture(base);
-
-    // remove the promise from the loader and the url from the cache when the texture is destroyed
-    texture.baseTexture.once('destroyed', () =>
+    const unload = () =>
     {
         delete loader.promiseCache[url];
 
         if (Cache.has(url))
         {
             Cache.remove(url);
+        }
+    };
+
+    // remove the promise from the loader and the url from the cache when the texture is destroyed
+    texture.baseTexture.once('destroyed', unload);
+    texture.once('destroyed', () =>
+    {
+        if (!base.destroyed)
+        {
+            unload();
+            console.warn('[Assets] A Texture managed by Assets was destroyed but its BaseTexture was not!');
         }
     });
 

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -498,7 +498,7 @@ describe('Assets', () =>
         expect(loadTextures.config.preferWorkers).toBe(true);
     });
 
-    it('should remove the asset from the cache when destroyed', async () =>
+    it('should remove the asset from the cache when the texture is destroyed', async () =>
     {
         await Assets.init({
             basePath,
@@ -509,7 +509,7 @@ describe('Assets', () =>
 
         expect(Assets.cache.has(url)).toBeTrue();
 
-        texture1.destroy(true);
+        texture1.destroy();
 
         expect(Assets.cache.has(url)).toBeFalse();
 
@@ -518,7 +518,32 @@ describe('Assets', () =>
         expect(Assets.cache.has(url)).toBeTrue();
         expect(texture2).not.toBe(texture1);
 
-        texture2.destroy(true);
+        texture2.destroy();
+
+        expect(Assets.cache.has(url)).toBeFalse();
+    });
+
+    it('should remove the asset from the cache when the base texture is destroyed', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const url = 'textures/bunny.png';
+        const texture1 = await Assets.load(url);
+
+        expect(Assets.cache.has(url)).toBeTrue();
+
+        texture1.baseTexture.destroy();
+
+        expect(Assets.cache.has(url)).toBeFalse();
+
+        const texture2 = await Assets.load(url);
+
+        expect(Assets.cache.has(url)).toBeTrue();
+        expect(texture2).not.toBe(texture1);
+
+        texture2.baseTexture.destroy();
 
         expect(Assets.cache.has(url)).toBeFalse();
     });

--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -615,6 +615,7 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
 
         this.destroyed = true;
         this.emit('destroyed', this);
+        this.removeAllListeners();
     }
 
     /**

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -100,6 +100,12 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
     public valid: boolean;
 
     /**
+     * Has the texture been destroyed?
+     * @readonly
+     */
+    public destroyed: boolean;
+
+    /**
      * Does this Texture have any frame data assigned to it?
      *
      * This mode is enabled automatically if no frame was passed inside constructor.
@@ -190,6 +196,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
         this._frame = frame;
         this.trim = trim;
         this.valid = false;
+        this.destroyed = false;
         this._uvs = DEFAULT_UVS;
         this.uvMatrix = null;
         this.orig = orig || frame;// new Rectangle(0, 0, 1, 1);
@@ -314,6 +321,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
         this.orig = null;
 
         this.valid = false;
+        this.destroyed = true;
 
         Texture.removeFromCache(this);
         this.textureCacheIds = null;

--- a/packages/core/src/textures/Texture.ts
+++ b/packages/core/src/textures/Texture.ts
@@ -290,6 +290,7 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
     /**
      * Destroys this texture
      * @param [destroyBase=false] - Whether to destroy the base texture as well
+     * @fires PIXI.Texture#destroyed
      */
     destroy(destroyBase?: boolean): void
     {
@@ -321,10 +322,13 @@ export class Texture<R extends Resource = Resource> extends EventEmitter
         this.orig = null;
 
         this.valid = false;
-        this.destroyed = true;
 
         Texture.removeFromCache(this);
         this.textureCacheIds = null;
+
+        this.destroyed = true;
+        this.emit('destroyed', this);
+        this.removeAllListeners();
     }
 
     /**


### PR DESCRIPTION
- Added `Texture.destroyed` property
- Added `destroyed` event to `Texture`
- Forced the destruction of the base texture if the texture of the asset is destroyed. Currently, if the texture is destroyed without the `destroyBase` flag, then the destroyed texture remains in the asset cache and the base texture/resource is not destroyed.