### PR TITLE
Set `valid` to false if the `BaseTexture` is destroyed

### DIFF
--- a/packages/core/src/textures/BaseTexture.ts
+++ b/packages/core/src/textures/BaseTexture.ts
@@ -607,6 +607,8 @@ export class BaseTexture<R extends Resource = Resource, RO = IAutoDetectOptions>
             this.cacheId = null;
         }
 
+        this.valid = false;
+
         // finally let the WebGL renderer know..
         this.dispose();
 

--- a/packages/core/test/TextureSystem.tests.ts
+++ b/packages/core/test/TextureSystem.tests.ts
@@ -132,5 +132,21 @@ describe('TextureSystem', () =>
         textureSystem.bind(Texture.EMPTY.baseTexture, 0);
 
         expect(textureSystem.boundTextures[0]).toEqual(null);
+
+        const baseTexture = createTempTexture();
+
+        expect(baseTexture.valid).toBe(true);
+
+        textureSystem.bind(baseTexture, 0);
+
+        expect(textureSystem.boundTextures[0]).toEqual(baseTexture);
+
+        baseTexture.destroy();
+
+        expect(baseTexture.valid).toBe(false);
+
+        textureSystem.bind(baseTexture, 0);
+
+        expect(textureSystem.boundTextures[0]).toEqual(null);
     });
 });


### PR DESCRIPTION
Fixed: `BaseTexture`s remained `valid` after destruction.