### PR TITLE
feat(core): VideoResource autoplay in chrome

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -9,6 +9,9 @@ export interface IVideoResourceOptions
     autoPlay?: boolean;
     updateFPS?: number;
     crossorigin?: boolean | string;
+    loop?: boolean;
+    muted?: boolean;
+    playsinline?: boolean;
 }
 
 export interface IVideoResourceOptionsElement
@@ -67,6 +70,9 @@ export class VideoResource extends BaseImageResource
      * @param {number} [options.updateFPS=0] - How many times a second to update the texture from the video.
      * Leave at 0 to update at every render.
      * @param {boolean} [options.crossorigin=true] - Load image using cross origin
+     * @param {boolean} [options.loop=false] - Loops the video
+     * @param {boolean} [options.muted=false] - Mutes the video audio, useful for autoplay
+     * @param {boolean} [options.playsinline=true] - Prevents opening the video on mobile devices
      */
     constructor(
         source?: HTMLVideoElement | Array<string | IVideoResourceOptionsElement> | string, options?: IVideoResourceOptions
@@ -79,9 +85,35 @@ export class VideoResource extends BaseImageResource
             const videoElement = document.createElement('video');
 
             // workaround for https://github.com/pixijs/pixijs/issues/5996
-            videoElement.setAttribute('preload', 'auto');
-            videoElement.setAttribute('webkit-playsinline', '');
-            videoElement.setAttribute('playsinline', '');
+            if (options.autoLoad !== false)
+            {
+                videoElement.setAttribute('preload', 'auto');
+            }
+
+            if (options.playsinline !== false)
+            {
+                videoElement.setAttribute('webkit-playsinline', '');
+                videoElement.setAttribute('playsinline', '');
+            }
+
+            if (options.muted === true)
+            {
+                // For some reason we need to set both muted flags for chrome to autoplay
+                // https://stackoverflow.com/a/51189390
+
+                videoElement.setAttribute('muted', '');
+                videoElement.muted = true;
+            }
+
+            if (options.loop === true)
+            {
+                videoElement.setAttribute('loop', '');
+            }
+
+            if (options.autoPlay !== false)
+            {
+                videoElement.setAttribute('autoplay', '');
+            }
 
             if (typeof source === 'string')
             {


### PR DESCRIPTION
By adding the mute option to videoresource, we can trick chrome into autoplaying without user interaction. 

The loop flag is just because it's nice to have (i.e. it is not needed for the autoplay trick)

Default implementation is unchanged. If you don't set the variables, everything works as it did before.

## Demo code:
assets needed (taken from a random site on the internet) [mp4](https://robertcooper.me/mclovin.mp4), [webm](https://robertcooper.me/mclovin.webm)
```ts
Assets.add("mp4", "mclovin.mp4", {resourceOptions:{muted:true, loop:true}});
Assets.add("webm", "mclovin.webm", {resourceOptions:{muted:true, loop:true}});

Assets.add("mp4-default", "mclovin copy.mp4"); // copies just to avoid the cache
Assets.add("webm-default", "mclovin copy.webm"); // copies just to avoid the cache

Assets.load(["mp4","webm","mp4-default","webm-default"]).then(() => {
	const mp4: Sprite = Sprite.from("mp4");
	mp4.x = 0;
	mp4.y = 0;
	app.stage.addChild(mp4);

	const webm: Sprite = Sprite.from("webm");
	webm.x = app.screen.width * 0.5;
	webm.y = 0;
	app.stage.addChild(webm);

	const mp4Default = Sprite.from("mp4-default");
	mp4Default.x = 0;
	mp4Default.y = app.screen.height / 2;
	app.stage.addChild(mp4Default);

	const webmDefault = Sprite.from("webm-default");
	webmDefault.x = app.screen.width * 0.5;
	webmDefault.y = app.screen.height * 0.5;
	app.stage.addChild(webmDefault);
});
```

You can see only 2 errors about autoplay, the two that don't have the `muted` flag

![image](https://github.com/pixijs/pixijs/assets/15253010/1fffaf67-d5f0-4a20-b786-adecc0f543f8)


Ref: https://stackoverflow.com/a/51189390