### PR TITLE
v8 use `Object.create(null)` instead of `{}`

### DIFF
--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -36,7 +36,7 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
     private _batches: Record<number, {
         geometry: Geometry;
         batcher: Batcher
-    }> = {};
+    }> = Object.create(null);
     private _adaptor: BatcherAdaptor;
 
     constructor(renderer: Renderer, adaptor: BatcherAdaptor)

--- a/src/rendering/batcher/shared/TextureBatcher.ts
+++ b/src/rendering/batcher/shared/TextureBatcher.ts
@@ -14,12 +14,12 @@ export class TextureBatchOutput implements TextureBatch
     public textures: TextureSource[] = [];
     public bindGroup: BindGroup;
     public size = 0;
-    public batchLocations: Record<number, number> = {};
+    public batchLocations: Record<number, number> = Object.create(null);
 }
 
 export class TextureBatcher
 {
-    private _textureTicks: Record<number, number> = {};
+    private _textureTicks: Record<number, number> = Object.create(null);
     private _tick = 1000;
     private _output: TextureBatch;
     private _bindingOffset: number;

--- a/src/rendering/batcher/shared/optimizeBindings.ts
+++ b/src/rendering/batcher/shared/optimizeBindings.ts
@@ -7,7 +7,7 @@ export let missingCount = 0;
 export const currentCopy: TextureSource[] = [];
 export let currentCount = 0;
 
-export const usedSlots: Record<number, number> = {};
+export const usedSlots: Record<number, number> = Object.create(null);
 
 /**
  * This function will take the previous texture batch and the current texture batch and

--- a/src/rendering/graphics/shared/GraphicsContextSystem.ts
+++ b/src/rendering/graphics/shared/GraphicsContextSystem.ts
@@ -46,7 +46,7 @@ export class GraphicsContextSystem implements System
     private readonly _activeBatchers: Batcher[] = [];
     private _gpuContextHash: Record<number, GpuGraphicsContext> = {};
     // used for non-batchable graphics
-    private _graphicsDataContextHash: Record<number, GraphicsContextRenderData> = {};
+    private _graphicsDataContextHash: Record<number, GraphicsContextRenderData> = Object.create(null);
     private readonly _needsContextNeedsRebuild: GraphicsContext[] = [];
 
     protected prerender()

--- a/src/rendering/graphics/shared/GraphicsPipe.ts
+++ b/src/rendering/graphics/shared/GraphicsPipe.ts
@@ -48,7 +48,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
     public state: State = State.for2d();
 
     // batchable graphics list, used to render batches
-    private _renderableBatchesHash: Record<number, BatchableGraphics[]> = {};
+    private _renderableBatchesHash: Record<number, BatchableGraphics[]> = Object.create(null);
     private _adaptor: GraphicsAdaptor;
 
     constructor(renderer: GraphicsSystem, adaptor: GraphicsAdaptor)

--- a/src/rendering/mesh/shared/MeshPipe.ts
+++ b/src/rendering/mesh/shared/MeshPipe.ts
@@ -70,8 +70,8 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
     public renderer: Renderer;
     public state: State = State.for2d();
 
-    private _renderableHash: Record<number, RenderableData> = {};
-    private _gpuBatchableMeshHash: Record<number, BatchableMesh> = {};
+    private _renderableHash: Record<number, RenderableData> = Object.create(null);
+    private _gpuBatchableMeshHash: Record<number, BatchableMesh> = Object.create(null);
     private _adaptor: MeshAdaptor;
 
     constructor(renderer: Renderer, adaptor: MeshAdaptor)

--- a/src/rendering/renderers/gl/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/GlRenderTargetSystem.ts
@@ -36,7 +36,7 @@ export class GlRenderTargetSystem implements System
     private _gl: GlRenderingContext;
 
     private readonly _renderSurfaceToRenderTargetHash: Map<RenderSurface, RenderTarget> = new Map();
-    private _gpuRenderTargetHash: Record<number, GlRenderTarget> = {};
+    private _gpuRenderTargetHash: Record<number, GlRenderTarget> = Object.create(null);
     private readonly _renderer: WebGLRenderer;
     private readonly _renderTargetStack: RenderTarget[] = [];
     private readonly _defaultClearColor: RGBAArray = [0, 0, 0, 0];

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -27,7 +27,7 @@ export class GlStencilSystem implements System
     private _renderTargetStencilState: Record<number, {
         stencilMode: STENCIL_MODES;
         stencilReference: number;
-    }> = {};
+    }> = Object.create(null);
 
     private _stencilOpsMapping: {
         keep: number;

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -36,10 +36,10 @@ export class GlBufferSystem implements System
     } as const;
 
     private _gl: GlRenderingContext;
-    private _gpuBuffers: {[key: number]: GlBuffer} = {};
+    private _gpuBuffers: {[key: number]: GlBuffer} = Object.create(null);
 
     /** Cache keeping track of the base bound buffer bases */
-    private readonly _boundBufferBases: {[key: number]: Buffer};
+    private readonly _boundBufferBases: {[key: number]: Buffer} = Object.create(null);
 
     private _renderer: WebGLRenderer;
 
@@ -49,7 +49,6 @@ export class GlBufferSystem implements System
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
-        this._boundBufferBases = {};
     }
 
     /**

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -121,7 +121,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
         this._renderer = renderer;
 
         this.webGLVersion = 1;
-        this.extensions = {};
+        this.extensions = Object.create(null);
 
         this.supports = {
             uint32Indices: false,

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -195,7 +195,7 @@ export class GlGeometrySystem implements System
 
         if (!this._geometryVaoHash[geometry.uid])
         {
-            this._geometryVaoHash[geometry.uid] = {};
+            this._geometryVaoHash[geometry.uid] = Object.create(null);
 
             geometry.on('destroy', this.onGeometryDestroy, this);
         }

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -100,7 +100,7 @@ export class GlProgram
         this.transformFeedbackVaryings = null;
     }
 
-    public static programCached: Record<string, GlProgram> = {};
+    public static programCached: Record<string, GlProgram> = Object.create(null);
     public static from(options: GlProgramOptions): GlProgram
     {
         const key = `${options.vertex}:${options.fragment}`;

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -29,13 +29,13 @@ export class GlShaderSystem
 
     public activeProgram: GlProgram = null;
 
-    private _programDataHash: Record<string, GlProgramData> = {};
+    private _programDataHash: Record<string, GlProgramData> = Object.create(null);
     private readonly _renderer: WebGLRenderer;
     private _gl: WebGL2RenderingContext;
     private _maxBindings: number;
     private _nextIndex = 0;
-    private _boundUniformsIdsToIndexHash: Record<number, number> = {};
-    private _boundIndexToUniformsHash: Record<number, UniformGroup | BufferResource> = {};
+    private _boundUniformsIdsToIndexHash: Record<number, number> = Object.create(null);
+    private _boundIndexToUniformsHash: Record<number, UniformGroup | BufferResource> = Object.create(null);
 
     constructor(renderer: WebGLRenderer)
     {

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -33,13 +33,13 @@ export class GlTextureSystem implements System
 
     private readonly _renderer: WebGLRenderer;
 
-    private _glTextures: Record<number, GlTexture> = {};
-    private _glSamplers: Record<string, WebGLSampler> = {};
+    private _glTextures: Record<number, GlTexture> = Object.create(null);
+    private _glSamplers: Record<string, WebGLSampler> = Object.create(null);
 
     private _boundTextures: TextureSource[] = [];
     private _activeTextureLocation = -1;
 
-    private _boundSamplers: Record<number, WebGLSampler> = {};
+    private _boundSamplers: Record<number, WebGLSampler> = Object.create(null);
 
     private readonly _uploads: Record<string, GLTextureUploader> = {
         image: glUploadImageResource,

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -24,7 +24,7 @@ export class BindGroupSystem implements System
 
     private readonly _renderer: WebGPURenderer;
 
-    private _hash: Record<string, GPUBindGroup> = {};
+    private _hash: Record<string, GPUBindGroup> = Object.create(null);
     private _gpu: GPU;
 
     constructor(renderer: WebGPURenderer)

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -30,8 +30,8 @@ export class GpuEncoderSystem implements System
     private _resolveCommandFinished: (value: void) => void;
 
     private _gpu: GPU;
-    private _boundBindGroup: Record<number, BindGroup> = {};
-    private _boundVertexBuffer: Record<number, Buffer> = {};
+    private _boundBindGroup: Record<number, BindGroup> = Object.create(null);
+    private _boundVertexBuffer: Record<number, Buffer> = Object.create(null);
     private _boundIndexBuffer: Buffer;
     private _boundPipeline: GPURenderPipeline;
 

--- a/src/rendering/renderers/gpu/GpuStencilSystem.ts
+++ b/src/rendering/renderers/gpu/GpuStencilSystem.ts
@@ -20,7 +20,7 @@ export class GpuStencilSystem implements System
     private _renderTargetStencilState: Record<number, {
         stencilMode: STENCIL_MODES;
         stencilReference: number;
-    }> = {};
+    }> = Object.create(null);
 
     private _activeRenderTarget: RenderTarget;
 

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -24,7 +24,7 @@ export class GpuUniformBatchPipe
 
     private _renderer: WebGPURenderer;
 
-    private _bindGroupHash: Record<number, BindGroup> = {};
+    private _bindGroupHash: Record<number, BindGroup> = Object.create(null);
     private readonly _batchBuffer: UniformBufferBatch;
 
     // number of buffers..

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -16,7 +16,7 @@ export class BufferSystem implements System
     } as const;
 
     protected CONTEXT_UID: number;
-    private _gpuBuffers: { [key: number]: GPUBuffer } = {};
+    private _gpuBuffers: { [key: number]: GPUBuffer } = Object.create(null);
 
     private _gpu: GPU;
 

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -65,10 +65,10 @@ export class PipelineSystem implements System
 
     protected CONTEXT_UID: number;
 
-    private _moduleCache: Record<string, GPUShaderModule> = {};
-    private _bufferLayoutsCache: Record<number, GPUVertexBufferLayout[]> = {};
+    private _moduleCache: Record<string, GPUShaderModule> = Object.create(null);
+    private _bufferLayoutsCache: Record<number, GPUVertexBufferLayout[]> = Object.create(null);
 
-    private _pipeCache: Record<number, GPURenderPipeline> = {};
+    private _pipeCache: Record<number, GPURenderPipeline> = Object.create(null);
 
     private _gpu: GPU;
     private _stencilState: GPUDepthStencilState;

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -38,7 +38,7 @@ export class GpuRenderTargetSystem implements System
 
     private readonly _renderSurfaceToRenderTargetHash: Map<RenderSurface, RenderTarget>
         = new Map();
-    private _gpuRenderTargetHash: Record<number, GpuRenderTarget> = {};
+    private _gpuRenderTargetHash: Record<number, GpuRenderTarget> = Object.create(null);
 
     private readonly _renderTargetStack: RenderTarget[] = [];
     private readonly _renderer: WebGPURenderer;

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -2,14 +2,12 @@ import type { BindResource } from './BindResource';
 
 export class BindGroup
 {
-    public resources: Record<string, BindResource>;
+    public resources: Record<string, BindResource> = Object.create(null);
     public key: string;
     private _dirty = true;
 
     constructor(resources?: Record<string, BindResource>)
     {
-        this.resources = {};
-
         let index = 0;
 
         for (const i in resources)

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -73,7 +73,7 @@ export class GpuProgram
         this.vertex = null;
     }
 
-    public static programCached: Record<string, GpuProgram> = {};
+    public static programCached: Record<string, GpuProgram> = Object.create(null);
     public static from(options: GpuProgramOptions): GpuProgram
     {
         // eslint-disable-next-line max-len

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -22,10 +22,10 @@ export class GpuTextureSystem implements System
     } as const;
 
     protected CONTEXT_UID: number;
-    private _gpuSources: Record<number, GPUTexture> = {};
-    private _gpuSamplers: Record<string, GPUSampler> = {};
-    private _bindGroupHash: Record<string, BindGroup> = {};
-    private _textureViewHash: Record<string, GPUTextureView> = {};
+    private _gpuSources: Record<number, GPUTexture> = Object.create(null);
+    private _gpuSamplers: Record<string, GPUSampler> = Object.create(null);
+    private _bindGroupHash: Record<string, BindGroup> = Object.create(null);
+    private _textureViewHash: Record<string, GPUTextureView> = Object.create(null);
 
     private readonly _uploads: Record<string, GpuTextureUploader> = {
         image: gpuUploadImageResource,

--- a/src/rendering/renderers/shared/BlendModePipe.ts
+++ b/src/rendering/renderers/shared/BlendModePipe.ts
@@ -81,7 +81,7 @@ export class BlendModePipe implements InstructionPipe<AdvancedBlendInstruction>
 
     private _isAdvanced = false;
 
-    private _filterHash: Partial<Record<BLEND_MODES, FilterEffect>> = {};
+    private _filterHash: Partial<Record<BLEND_MODES, FilterEffect>> = Object.create(null);
 
     constructor(renderer: Renderer)
     {

--- a/src/rendering/renderers/shared/createIdFromString.ts
+++ b/src/rendering/renderers/shared/createIdFromString.ts
@@ -1,5 +1,5 @@
-const idCounts: Record<string, number> = {};
-const idHash: Record<string, number> = {};
+const idCounts: Record<string, number> = Object.create(null);
+const idHash: Record<string, number> = Object.create(null);
 
 export function createIdFromString(value: string, groupId: string): number
 {

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -47,7 +47,7 @@ export class Shader extends EventEmitter<{
     public groups: Record<number, BindGroup>;
     public resources: Record<string, any>;
 
-    public uniformBindMap: Record<number, Record<number, string>> = {};
+    public uniformBindMap: Record<number, Record<number, string>> = Object.create(null);
 
     constructor({ gpuProgram, glProgram, resources, compatibleRenderers }: ShaderWithResourcesDescriptor);
     constructor({ gpuProgram, glProgram, groups, groupMap, compatibleRenderers }: ShaderWithGroupsDescriptor);

--- a/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
+++ b/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
@@ -25,7 +25,7 @@ export class UniformBufferSystem implements System
     private _syncFunctionHash: Record<string, {
         layout: UniformBufferLayout,
         syncFunction: (uniforms: Record<string, any>, data: Float32Array, offset: number) => void
-    }> = {};
+    }> = Object.create(null);
 
     public ensureUniformGroup(uniformGroup: UniformGroup): void
     {

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -56,11 +56,11 @@ export class AbstractRenderer<PIPES, OPTIONS>
     public readonly type: number;
     public readonly name: string;
 
-    public readonly runners: Runners = {} as Runners;
-    public readonly renderPipes = {} as PIPES;
+    public readonly runners: Runners = Object.create(null) as Runners;
+    public readonly renderPipes = Object.create(null) as PIPES;
     public view: ViewSystem;
 
-    private _systemsHash: Record<string, System> = {};
+    private _systemsHash: Record<string, System> = Object.create(null);
     private _lastObjectRendered: Container;
 
     /**

--- a/src/rendering/renderers/shared/texture/CanvasPool.ts
+++ b/src/rendering/renderers/shared/texture/CanvasPool.ts
@@ -34,7 +34,7 @@ export class CanvasPoolClass
 
     constructor(canvasOptions?: ICanvasRenderingContext2DSettings)
     {
-        this._canvasPool = {};
+        this._canvasPool = Object.create(null);
         this.canvasOptions = canvasOptions || {};
         this.enableFullScreen = false;
     }

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -28,7 +28,7 @@ export class TexturePoolClass
     public enableFullScreen: boolean;
 
     private _texturePool: {[x in string | number]: Texture[]};
-    private _poolKeyHash: Record<number, number> = {};
+    private _poolKeyHash: Record<number, number> = Object.create(null);
 
     /**
      * @param textureOptions - options that will be passed to BaseRenderTexture constructor

--- a/src/rendering/scene/Container.ts
+++ b/src/rendering/scene/Container.ts
@@ -139,6 +139,8 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
     // the global transform taking into account the layer and all parents
     private _worldTransform: Matrix;
 
+    public destroyed = false;
+
     // transform data..
     /**
      * The coordinate of the object relative to the local coordinates of the parent.
@@ -801,6 +803,9 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
      */
     public destroy(options: DestroyOptions = false): void
     {
+        if (this.destroyed) return;
+        this.destroyed = true;
+
         this.removeFromParent();
         this.parent = null;
         // this._onRender = null;

--- a/src/rendering/scene/LayerGroup.ts
+++ b/src/rendering/scene/LayerGroup.ts
@@ -23,7 +23,7 @@ export class LayerGroup implements Instruction
     public worldColor = 0xffffffff;
 
     // these updates are transform changes..
-    public readonly childrenToUpdate: Record<number, { list: Container[]; index: number; }> = {};
+    public readonly childrenToUpdate: Record<number, { list: Container[]; index: number; }> = Object.create(null);
     public updateTick = 0;
 
     // these update are renderable changes..

--- a/src/rendering/sprite/shared/SpritePipe.ts
+++ b/src/rendering/sprite/shared/SpritePipe.ts
@@ -24,7 +24,7 @@ export class SpritePipe implements RenderPipe<SpriteView>
     } as const;
 
     private _renderer: Renderer;
-    private _gpuSpriteHash: Record<number, BatchableSprite> = {};
+    private _gpuSpriteHash: Record<number, BatchableSprite> = Object.create(null);
 
     constructor(renderer: Renderer)
     {

--- a/src/rendering/text/bitmap/AbstractBitmapFont.ts
+++ b/src/rendering/text/bitmap/AbstractBitmapFont.ts
@@ -79,7 +79,7 @@ export abstract class AbstractBitmapFont<FontType>
     implements Omit<BitmapFontData, 'chars' | 'pages' | 'fontSize'>
 {
     /** The map of characters by character code. */
-    public readonly chars: Record<string, CharData> = {};
+    public readonly chars: Record<string, CharData> = Object.create(null);
 
     /** The line-height of the font face in pixels. */
     public readonly lineHeight: BitmapFontData['lineHeight'] = 0;

--- a/src/rendering/text/bitmap/DynamicBitmapFont.ts
+++ b/src/rendering/text/bitmap/DynamicBitmapFont.ts
@@ -36,7 +36,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
     public override readonly pages: {canvasAndContext?: CanvasAndContext, texture: Texture}[] = [];
 
     private readonly _padding: number = 4;
-    private readonly _measureCache: Record<string, number> = {};
+    private readonly _measureCache: Record<string, number> = Object.create(null);
     private _currentChars: string[] = [];
     private _currentX = 0;
     private _currentY = 0;

--- a/src/rendering/text/canvas/CanvasTextPipe.ts
+++ b/src/rendering/text/canvas/CanvasTextPipe.ts
@@ -29,7 +29,7 @@ export class CanvasTextPipe implements RenderPipe<TextView>
         currentKey: string,
         batchableSprite: BatchableSprite,
         needsTextureUpdate: boolean,
-    }> = {};
+    }> = Object.create(null);
 
     constructor(renderer: Renderer)
     {

--- a/src/tiling-sprite/TilingSpritePipe.ts
+++ b/src/tiling-sprite/TilingSpritePipe.ts
@@ -34,16 +34,16 @@ export class TilingSpritePipe implements RenderPipe<TilingSpriteView>
 
     private _renderer: Renderer;
 
-    private _renderableHash: Record<number, RenderableData> = {};
+    private _renderableHash: Record<number, RenderableData> = Object.create(null);
 
     // TODO can prolly merge these properties into a single mesh and
     // add them onto the renderableHash (rather than having them on separate hashes)
-    private _gpuBatchedTilingSprite: Record<string, Renderable<MeshView>> = {};
+    private _gpuBatchedTilingSprite: Record<string, Renderable<MeshView>> = Object.create(null);
 
     private _gpuTilingSprite: Record<string, {
         meshRenderable: Renderable<MeshView>
         textureMatrix: Matrix;
-    }> = {};
+    }> = Object.create(null);
 
     constructor(renderer: Renderer)
     {


### PR DESCRIPTION
`Object.create(null)` is a tiny bit more performant when doing look ups and using objects as Maps. (although more expensive to create, so not a replacement for all instances of `{}`

Updated the maps in Pixi v8 to make use of this (small) performance boost. Every little helps :)