### PR TITLE
fix: both touch and point events were called when using Apple pencil

### DIFF
--- a/packages/events/src/EventSystem.ts
+++ b/packages/events/src/EventSystem.ts
@@ -346,7 +346,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
         this.rootBoundary.rootTarget = this.renderer.lastObjectRendered as DisplayObject;
 
         // if we support touch events, then only use those for touch events, not pointer events
-        if (this.supportsTouchEvents && (nativeEvent as PointerEvent).pointerType === 'touch') return;
+        if (this.supportsTouchEvents && ['touch', 'pen'].includes((nativeEvent as PointerEvent).pointerType)) return;
 
         const events = this.normalizeToPointerData(nativeEvent);
 
@@ -389,7 +389,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
         this.rootBoundary.rootTarget = this.renderer.lastObjectRendered as DisplayObject;
 
         // if we support touch events, then only use those for touch events, not pointer events
-        if (this.supportsTouchEvents && (nativeEvent as PointerEvent).pointerType === 'touch') return;
+        if (this.supportsTouchEvents && ['touch', 'pen'].includes((nativeEvent as PointerEvent).pointerType)) return;
 
         EventsTicker.pointerMoved();
 
@@ -415,7 +415,7 @@ export class EventSystem implements ISystem<EventSystemOptions>
         this.rootBoundary.rootTarget = this.renderer.lastObjectRendered as DisplayObject;
 
         // if we support touch events, then only use those for touch events, not pointer events
-        if (this.supportsTouchEvents && (nativeEvent as PointerEvent).pointerType === 'touch') return;
+        if (this.supportsTouchEvents && ['touch', 'pen'].includes((nativeEvent as PointerEvent).pointerType)) return;
 
         let target = nativeEvent.target;
 


### PR DESCRIPTION
When support touch events , Only when `pointerType` is touch is filtered. When using a Apple pencil on iPad, `onPointerDown`、`onPointerMove` and `onPointerUp` will be called twice.
So use `['touch', 'pen'].includes((nativeEvent as PointerEvent).pointerType` instead of  ` (nativeEvent as PointerEvent).pointerType === 'touch'` to fix it.
