### PR TITLE
Expand spritesheet types

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -34,12 +34,44 @@ export interface ISpritesheetFrameData
  */
 export interface ISpritesheetData
 {
-    frames: utils.Dict<ISpritesheetFrameData>;
     animations?: utils.Dict<string[]>;
+    frames: utils.Dict<ISpritesheetFrameData>;
     meta: {
+        app?: string;
+        format?: string;
+        frameTags?: {
+            from: number;
+            name: string;
+            to: number;
+            direction: string;
+        }[];
+        image?: string;
+        layers?: {
+            blendMode: string;
+            name: string;
+            opacity: number;
+        }[];
         scale: string;
+        size?: {
+            h: number;
+            w: number;
+        };
+        slices?: {
+            color: string;
+            name: string;
+            keys: {
+                frame: number,
+                bounds: {
+                    x: number;
+                    y: number;
+                    w: number;
+                    h: number;
+                };
+            }[];
+        }[];
         // eslint-disable-next-line camelcase
         related_multi_packs?: string[];
+        version?: string;
     };
 }
 

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -9,18 +9,20 @@ import type { ImageResource, IPointData, ITextureBorders } from '@pixi/core';
 export interface ISpritesheetFrameData
 {
     frame: {
+        h: number;
+        w: number;
         x: number;
         y: number;
-        w: number;
-        h: number;
     };
     trimmed?: boolean;
     rotated?: boolean;
     sourceSize?: {
-        w: number;
         h: number;
+        w: number;
     };
     spriteSourceSize?: {
+        h?: number;
+        w?: number;
         x: number;
         y: number;
     };


### PR DESCRIPTION
##### Description of change
This PR expands the types on spritesheet data. Most people are likely importing their spritesheet atlases from external JSON files, and thus will never run into an issue. That said, this change is valuable for those who are generating spritesheet atlases programmatically at runtime and are running into Typescript errors.

FWIW, none of these types are used within Pixi, but they **are** used within other applications and libraries. If they're not added, we'll have to generate 2 separate structures to support Pixi and other tools.

The following optional keys have been added based on the spritesheet atlas JSON output generated by [Aseprite](https://www.aseprite.org/):

* `meta.app`: A string representing the app used to generate the spritesheet atlas.
* `meta.format`: The color space used in the spritesheet, e.g. RGBA8888.
* `meta.frameTags`: An array of tags (basically keyframes) used in the spritesheet. Typically used to point to collections of frames that represent a particular animation.
* `meta.layers`: Information about the layers used in the source file.
* `meta.slices`: Slices of the sprite, typically used for indicating things like hitboxes. Slices also include the `keys` property, which indicates where the slice is positioned on each sprite frame.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
