### PR TITLE
Chore: Cache node_modules in GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,9 +28,21 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm
       run: npm install -g npm@8
+    - name: Get npm cache directory
+      id: npm-cache-dir
+      shell: bash
+      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+    - name: Cache npm
+      id: npm-cache
+      uses: actions/cache@v3
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-cache-
     - name: Install Dependencies
+      if: steps.npm-cache.outputs.cache-hit != 'true'
       run: npm ci
-
     - name: Run Unit Tests
       run: xvfb-run --auto-servernum npm run coverage
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,63 +39,63 @@ jobs:
     - name: Install Dependencies
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: npm ci
-    # - name: Run Unit Tests
-    #   run: xvfb-run --auto-servernum npm run coverage
-    #   env:
-    #     NODE_ENV: production
+    - name: Run Unit Tests
+      run: xvfb-run --auto-servernum npm run coverage
+      env:
+        NODE_ENV: production
 
     - name: Extract Branch Name
       id: branch_name
       if: github.event_name == 'push'
       run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
-    # - name: Build for Distribution
-    #   run: npm run dist
+    - name: Build for Distribution
+      run: npm run dist
 
     # Append assets to releases
-    # - name: Upload Assets to Release
-    #   if: github.event_name == 'release'
-    #   uses: softprops/action-gh-release@v1
-    #   with:
-    #     files: |
-    #       ./dist/*
+    - name: Upload Assets to Release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ./dist/*
 
     # Examples:
     # 1) PR feature/acme merged into dev
     # 2) branch A merged into branch B
     # 3) branch A pushed directly to git
-    # - name: Deploy Non-Tag Branches
-    #   uses: jakejarvis/s3-sync-action@master
-    #   if: github.event_name == 'push' && env.AWS_ACCESS_KEY_ID != ''
-    #   with:
-    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
-    #   env:
-    #     DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+    - name: Deploy Non-Tag Branches
+      uses: jakejarvis/s3-sync-action@master
+      if: github.event_name == 'push' && env.AWS_ACCESS_KEY_ID != ''
+      with:
+        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
+      env:
+        DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
 
     # Release is published and deployed into s3://bucket-name/v5.22/
-    # - name: Deploy Released Branches
-    #   uses: jakejarvis/s3-sync-action@master
-    #   if: github.event_name == 'release' && env.AWS_ACCESS_KEY_ID != ''
-    #   with:
-    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
-    #   env:
-    #     DEST_DIR: ${{ github.event.release.tag_name }}
+    - name: Deploy Released Branches
+      uses: jakejarvis/s3-sync-action@master
+      if: github.event_name == 'release' && env.AWS_ACCESS_KEY_ID != ''
+      with:
+        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
+      env:
+        DEST_DIR: ${{ github.event.release.tag_name }}
 
     # Same release from previous deployed into s3://bucket-name/release/
-    # - name: Deploy Latest Release
-    #   uses: jakejarvis/s3-sync-action@master
-    #   if: github.event_name == 'release' && github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
-    #   with:
-    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
-    #   env:
-    #     DEST_DIR: 'release'
+    - name: Deploy Latest Release
+      uses: jakejarvis/s3-sync-action@master
+      if: github.event_name == 'release' && github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
+      with:
+        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
+      env:
+        DEST_DIR: 'release'
 
     # Publish to NPM
-    # - name: Publish Latest Release
-    #   if: github.event_name == 'release' && github.event.release.prerelease == false && env.NODE_AUTH_TOKEN != ''
-    #   run: npm run publish-ci
+    - name: Publish Latest Release
+      if: github.event_name == 'release' && github.event.release.prerelease == false && env.NODE_AUTH_TOKEN != ''
+      run: npm run publish-ci
 
     # Publish to NPM with prerelease dist-tag
-    # - name: Publish Latest Prerelease
-    #   if: github.event_name == 'release' && github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
-    #   run: npm run publish-ci -- --tag prerelease
+    - name: Publish Latest Prerelease
+      if: github.event_name == 'release' && github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
+      run: npm run publish-ci -- --tag prerelease

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -44,10 +44,10 @@ jobs:
     #   env:
     #     NODE_ENV: production
 
-    # - name: Extract Branch Name
-    #   id: branch_name
-    #   if: github.event_name == 'push'
-    #   run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
+    - name: Extract Branch Name
+      id: branch_name
+      if: github.event_name == 'push'
+      run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
     # - name: Build for Distribution
     #   run: npm run dist

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,7 +41,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-npm-cache-
     - name: Install Dependencies
-      if: steps.npm-cache.outputs.cache-hit != 'true'
+      # if: steps.npm-cache.outputs.cache-hit != 'true'
       run: npm ci
     # - name: Run Unit Tests
     #   run: xvfb-run --auto-servernum npm run coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,20 +28,16 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm
       run: npm install -g npm@8
-    - name: Get Dependencies Directory
-      id: npm-cache-dir
-      shell: bash
-      run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
     - name: Cache Dependencies
-      id: npm-cache
+      id: node-modules-cache
       uses: actions/cache@v3
       with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-npm-cache-
+          ${{ runner.os }}-node-modules-
     - name: Install Dependencies
-      # if: steps.npm-cache.outputs.cache-hit != 'true'
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: npm ci
     # - name: Run Unit Tests
     #   run: xvfb-run --auto-servernum npm run coverage

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,11 +28,11 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install npm
       run: npm install -g npm@8
-    - name: Get npm cache directory
+    - name: Get Dependencies Directory
       id: npm-cache-dir
       shell: bash
       run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-    - name: Cache npm
+    - name: Cache Dependencies
       id: npm-cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,11 +35,11 @@ jobs:
     - name: Cache npm
       id: npm-cache
       uses: actions/cache@v3
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-cache-
+      with:
+        path: ${{ steps.npm-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-cache-
     - name: Install Dependencies
       if: steps.npm-cache.outputs.cache-hit != 'true'
       run: npm ci

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install Dependencies
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: npm ci
+
     - name: Run Unit Tests
       run: xvfb-run --auto-servernum npm run coverage
       env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,63 +43,63 @@ jobs:
     - name: Install Dependencies
       if: steps.npm-cache.outputs.cache-hit != 'true'
       run: npm ci
-    - name: Run Unit Tests
-      run: xvfb-run --auto-servernum npm run coverage
-      env:
-        NODE_ENV: production
+    # - name: Run Unit Tests
+    #   run: xvfb-run --auto-servernum npm run coverage
+    #   env:
+    #     NODE_ENV: production
 
-    - name: Extract Branch Name
-      id: branch_name
-      if: github.event_name == 'push'
-      run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
+    # - name: Extract Branch Name
+    #   id: branch_name
+    #   if: github.event_name == 'push'
+    #   run: echo BRANCH_NAME=${GITHUB_REF/refs\/heads\//} >> $GITHUB_OUTPUT
 
-    - name: Build for Distribution
-      run: npm run dist
+    # - name: Build for Distribution
+    #   run: npm run dist
 
     # Append assets to releases
-    - name: Upload Assets to Release
-      if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          ./dist/*
+    # - name: Upload Assets to Release
+    #   if: github.event_name == 'release'
+    #   uses: softprops/action-gh-release@v1
+    #   with:
+    #     files: |
+    #       ./dist/*
 
     # Examples:
     # 1) PR feature/acme merged into dev
     # 2) branch A merged into branch B
     # 3) branch A pushed directly to git
-    - name: Deploy Non-Tag Branches
-      uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'push' && env.AWS_ACCESS_KEY_ID != ''
-      with:
-        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
-      env:
-        DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
+    # - name: Deploy Non-Tag Branches
+    #   uses: jakejarvis/s3-sync-action@master
+    #   if: github.event_name == 'push' && env.AWS_ACCESS_KEY_ID != ''
+    #   with:
+    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=60"
+    #   env:
+    #     DEST_DIR: ${{ steps.branch_name.outputs.BRANCH_NAME }}
 
     # Release is published and deployed into s3://bucket-name/v5.22/
-    - name: Deploy Released Branches
-      uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'release' && env.AWS_ACCESS_KEY_ID != ''
-      with:
-        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
-      env:
-        DEST_DIR: ${{ github.event.release.tag_name }}
+    # - name: Deploy Released Branches
+    #   uses: jakejarvis/s3-sync-action@master
+    #   if: github.event_name == 'release' && env.AWS_ACCESS_KEY_ID != ''
+    #   with:
+    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=2592000"
+    #   env:
+    #     DEST_DIR: ${{ github.event.release.tag_name }}
 
     # Same release from previous deployed into s3://bucket-name/release/
-    - name: Deploy Latest Release
-      uses: jakejarvis/s3-sync-action@master
-      if: github.event_name == 'release' && github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
-      with:
-        args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
-      env:
-        DEST_DIR: 'release'
+    # - name: Deploy Latest Release
+    #   uses: jakejarvis/s3-sync-action@master
+    #   if: github.event_name == 'release' && github.event.release.prerelease == false && env.AWS_ACCESS_KEY_ID != ''
+    #   with:
+    #     args: --acl public-read --follow-symlinks --delete --cache-control "max-age=1209600"
+    #   env:
+    #     DEST_DIR: 'release'
 
     # Publish to NPM
-    - name: Publish Latest Release
-      if: github.event_name == 'release' && github.event.release.prerelease == false && env.NODE_AUTH_TOKEN != ''
-      run: npm run publish-ci
+    # - name: Publish Latest Release
+    #   if: github.event_name == 'release' && github.event.release.prerelease == false && env.NODE_AUTH_TOKEN != ''
+    #   run: npm run publish-ci
 
     # Publish to NPM with prerelease dist-tag
-    - name: Publish Latest Prerelease
-      if: github.event_name == 'release' && github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
-      run: npm run publish-ci -- --tag prerelease
+    # - name: Publish Latest Prerelease
+    #   if: github.event_name == 'release' && github.event.release.prerelease && env.NODE_AUTH_TOKEN != ''
+    #   run: npm run publish-ci -- --tag prerelease


### PR DESCRIPTION
This reduces the time on GitHub Actions by about 25-30s.

In this example you can see that `npm ci` is skipped, but everything else runs as expected:
* https://github.com/pixijs/pixijs/actions/runs/5834931462/job/15825689762
* https://github.com/pixijs/pixijs/actions/runs/5835018814/job/15825776476

It's important to note that cache are only maintained per-branch or per-PR. So a cold run happens with new branches or new PRs.