### PR TITLE
fix: worldAlpha becomes abnormal

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -550,6 +550,8 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
         const parentRef = this.parent;
 
         this.parent = null;
+        // inherit the worldAlpha of the parent node
+        this._tempDisplayObjectParent.worldAlpha = parentRef?.worldAlpha || 1;
         this.transform = this._tempDisplayObjectParent.transform;
 
         const worldBounds = this._bounds;

--- a/packages/display/test/DisplayObject.tests.ts
+++ b/packages/display/test/DisplayObject.tests.ts
@@ -341,4 +341,28 @@ describe('DisplayObject', () =>
             expect(listenerCallCount).toEqual(1);
         });
     });
+
+    describe('worldAlpha', () =>
+    {
+        it('should calculate the parent worldAlpha', () =>
+        {
+            const parent = new Container();
+
+            parent.alpha = 0.4;
+            const child = new Container();
+
+            child.alpha = 0.6;
+            parent.addChild(child);
+
+            parent.enableTempParent();
+            parent.updateTransform();
+            parent.disableTempParent(null);
+
+            expect(child.worldAlpha).toBe(0.24);
+
+            child.getLocalBounds();
+
+            expect(child.worldAlpha).toBe(0.24);
+        });
+    });
 });


### PR DESCRIPTION
fix #9600
when calling the `getLocalBounds` method, assign the parent node's `worldAlpha` value to `_tempDisplayObjectParent` so that the `updateTransform` method can correctly calculate the `worldAlpha`.