### PR TITLE
Fixed colord type imports

### DIFF
--- a/packages/color/src/Color.ts
+++ b/packages/color/src/Color.ts
@@ -9,7 +9,7 @@ import type {
     HsvColor,
     RgbaColor,
     RgbColor
-} from 'colord/types';
+} from 'colord';
 
 extend([namesPlugin]);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Changes colord type imports to use types file set in its package.json.

Fixes `ColorSource` being `any` in TypeScript 5.1.6 when using `module:"ESNext"` and `moduleResolution:"Bundler"` tsconfig settings.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
