### PR TITLE
v8: Texture GC / unload / destroy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.1",
+  "version": "8.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pixi.js",
-      "version": "8.0.0-alpha.1",
+      "version": "8.0.0-alpha.2",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.8",
         "@types/earcut": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.3",
+  "version": "8.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pixi.js",
-      "version": "8.0.0-alpha.3",
+      "version": "8.0.0-alpha.2",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.8",
         "@types/earcut": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.2",
+  "version": "8.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pixi.js",
-      "version": "8.0.0-alpha.2",
+      "version": "8.0.0-alpha.3",
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.8",
         "@types/earcut": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.1",
+  "version": "8.0.0-alpha.2",
   "author": "PixiJS Team",
   "sideEffects": [
     "./lib/events/init.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.2",
+  "version": "8.0.0-alpha.3",
   "author": "PixiJS Team",
   "sideEffects": [
     "./lib/events/init.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixi.js",
-  "version": "8.0.0-alpha.3",
+  "version": "8.0.0-alpha.2",
   "author": "PixiJS Team",
   "sideEffects": [
     "./lib/events/init.*",

--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -43,11 +43,9 @@ export class GlBatchAdaptor implements BatcherAdaptor
     {
         const renderer = batchPipe.renderer as WebGLRenderer;
 
-        batchPipe.state.blendMode = batch.blendMode;
-
-        renderer.state.set(batchPipe.state);
-
         renderer.shader.bind(this._shader, this._didUpload);
+
+        renderer.shader.bindUniformBlock(renderer.globalUniforms.uniformGroup, 'globalUniforms', 0);
 
         this._didUpload = true;
 
@@ -55,12 +53,12 @@ export class GlBatchAdaptor implements BatcherAdaptor
 
         renderer.geometry.bind(activeBatcher.geometry, this._shader.glProgram);
 
+        renderer.state.set(batch.state);
+
         for (let i = 0; i < batch.textures.textures.length; i++)
         {
             renderer.texture.bind(batch.textures.textures[i], i);
         }
-
-        renderer.shader.bindUniformBlock(renderer.globalUniforms.uniformGroup, 'globalUniforms', 0);
 
         renderer.geometry.draw('triangle-list', batch.size, batch.start);
     }

--- a/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
+++ b/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
@@ -32,8 +32,6 @@ export class GpuBatchAdaptor implements BatcherAdaptor
 
     public execute(batchPipe: BatcherPipe, batch: Batch): void
     {
-        batchPipe.state.blendMode = batch.blendMode;
-
         if (!batch.textures.bindGroup)
         {
             batch.textures.bindGroup = getTextureBatchBindGroup(batch.textures.textures);
@@ -54,7 +52,7 @@ export class GpuBatchAdaptor implements BatcherAdaptor
         encoder.setPipelineFromGeometryProgramAndState(
             activeBatcher.geometry,
             program,
-            batchPipe.state
+            batch.state
         );
 
         encoder.setGeometry(activeBatcher.geometry);

--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -118,7 +118,6 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
             const attributeBuffer = activeBatcher.geometry.buffers[0];
 
             attributeBuffer.update(activeBatcher.batcher.attributeSize * 4);
-            this.renderer.buffer.updateBuffer(attributeBuffer);
         }
     }
 

--- a/src/rendering/batcher/shared/TextureBatcher.ts
+++ b/src/rendering/batcher/shared/TextureBatcher.ts
@@ -7,7 +7,6 @@ import type { BindableTexture } from '../../renderers/shared/texture/Texture';
 import type { TextureBatch } from './Batcher';
 
 const batchPool: TextureBatchOutput[] = [];
-let batchPoolIndex = 0;
 
 export class TextureBatchOutput implements TextureBatch
 {
@@ -23,10 +22,10 @@ export class TextureBatcher
     private _tick = 1000;
     private _output: TextureBatch;
     private _bindingOffset: number;
-
+    private _batchPoolIndex = 0;
     public begin()
     {
-        batchPoolIndex = 0;
+        this._batchPoolIndex = 0;
 
         this._bindingOffset = 0;
         this.reset();
@@ -36,7 +35,7 @@ export class TextureBatcher
     {
         this._tick++;
 
-        this._output = batchPool[batchPoolIndex++] || new TextureBatchOutput();
+        this._output = batchPool[this._batchPoolIndex++] || new TextureBatchOutput();
 
         this._output.size = 0;
     }
@@ -76,7 +75,7 @@ export class TextureBatcher
 
         output.batchLocations[styleSourceKey] = output.size++;
 
-        batchPoolIndex = 0;
+        this._batchPoolIndex = 0;
 
         return true;
     }

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -192,9 +192,7 @@ export class GlShaderSystem
 
     public getProgramData(program: GlProgram): GlProgramData
     {
-        const key = program.key;
-
-        return this._programDataHash[key] || this._createProgramData(program);
+        return this._programDataHash[program.key] || this._createProgramData(program);
     }
 
     private _createProgramData(program: GlProgram): GlProgramData

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -118,9 +118,13 @@ export class GpuEncoderSystem implements System
         if (this._boundBindGroup[index] === bindGroup) return;
         this._boundBindGroup[index] = bindGroup;
 
-        // TODO or is dirty!
+        bindGroup.touch(this._renderer.textureGC.count);
+
+        // TODO getting the bind group works as it looks at th e assets and generates a key
+        // should this just be hidden behind a dirty flag?
         const gpuBindGroup = this._renderer.bindGroup.getBindGroup(bindGroup, program, index);
 
+        // mark each item as having been used..
         this.renderPassEncoder.setBindGroup(index, gpuBindGroup);
     }
 

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -66,6 +66,16 @@ export class BindGroup
         return this.resources[index];
     }
 
+    public touch(tick: number)
+    {
+        const resources = this.resources;
+
+        for (const i in resources)
+        {
+            resources[i].touched = tick;
+        }
+    }
+
     public destroy()
     {
         const resources = this.resources;

--- a/src/rendering/renderers/gpu/shader/BindResource.ts
+++ b/src/rendering/renderers/gpu/shader/BindResource.ts
@@ -9,6 +9,8 @@ export interface BindResource
     /** Unique id for this resource this can change and is used to link the gpu*/
     resourceId: number;
 
+    touched: number;
+
     /**
      * event dispatch whenever the underlying resource needs to change
      * this could be a texture or buffer that has been resized.

--- a/src/rendering/renderers/shared/BlendModePipe.ts
+++ b/src/rendering/renderers/shared/BlendModePipe.ts
@@ -92,10 +92,7 @@ export class BlendModePipe implements InstructionPipe<AdvancedBlendInstruction>
     {
         if (this._activeBlendMode === blendMode)
         {
-            if (this._isAdvanced)
-            {
-                this._renderableList.push(renderable);
-            }
+            if (this._isAdvanced) this._renderableList.push(renderable);
 
             return;
         }

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -35,6 +35,7 @@ export class Buffer extends EventEmitter<{
     public readonly resourceType = 'buffer';
     public resourceId = generateUID();
 
+    public touched = 0;
     public readonly uid = UID++;
 
     public descriptor: BufferDescriptor;

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -9,6 +9,7 @@ export class BufferResource extends EventEmitter<{
 }> implements BindResource
 {
     public readonly uid = generateUID();
+    public touched = 0;
 
     public resourceType = 'bufferResource';
 

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -24,6 +24,8 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
         isStatic: false,
     };
 
+    public touched = 0;
+
     public readonly uid = generateUID();
 
     public resourceType = 'uniformGroup';

--- a/src/rendering/renderers/shared/system/SharedSystems.ts
+++ b/src/rendering/renderers/shared/system/SharedSystems.ts
@@ -19,6 +19,7 @@ import { BlendModePipe } from '../BlendModePipe';
 import { GlobalUniformSystem } from '../renderTarget/GlobalUniformSystem';
 import { UniformBufferSystem } from '../shader/UniformBufferSystem';
 import { HelloSystem } from '../startup/HelloSystem';
+import { TextureGCSystem } from '../texture/TextureGCSystem';
 import { ViewSystem } from '../ViewSystem';
 
 export const SharedSystems = [
@@ -31,6 +32,7 @@ export const SharedSystems = [
     CanvasTextSystem,
     LayerSystem,
     UniformBufferSystem,
+    TextureGCSystem,
 ];
 
 export const SharedRenderPipes = [

--- a/src/rendering/renderers/shared/texture/TextureGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/TextureGCSystem.ts
@@ -1,0 +1,135 @@
+import { extensions, ExtensionType } from '../../../../extensions/Extensions';
+
+import type { Renderer } from '../../types';
+import type { System } from '../system/System';
+
+export interface TextureGCSystemOptions
+{
+    textureGCActive: boolean;
+    textureGCAMaxIdle: number;
+    textureGCCheckCountMax: number;
+}
+/**
+ * System plugin to the renderer to manage texture garbage collection on the GPU,
+ * ensuring that it does not get clogged up with textures that are no longer being used.
+ * @memberof PIXI
+ */
+export class TextureGCSystem implements System
+{
+    /** @ignore */
+    public static extension = {
+        type: [
+            ExtensionType.WebGLSystem,
+            ExtensionType.WebGPUSystem,
+        ],
+        name: 'textureGC',
+    } as const;
+
+    public static defaultOptions: TextureGCSystemOptions = {
+        textureGCActive: true,
+        textureGCAMaxIdle: 60 * 6,
+        textureGCCheckCountMax: 60,
+    };
+
+    /**
+     * Frame count since started.
+     * @readonly
+     */
+    public count: number;
+
+    /**
+     * Frame count since last garbage collection.
+     * @readonly
+     */
+    public checkCount: number;
+
+    /**
+     * Maximum idle frames before a texture is destroyed by garbage collection.
+     * @see PIXI.TextureGCSystem.defaultMaxIdle
+     */
+    public maxIdle: number;
+
+    /**
+     * Frames between two garbage collections.
+     * @see PIXI.TextureGCSystem.defaultCheckCountMax
+     */
+    public checkCountMax: number;
+
+    /**
+     * Current garbage collection mode.
+     * @see PIXI.TextureGCSystem.defaultMode
+     */
+    public active: boolean;
+    private _renderer: Renderer;
+
+    /** @param renderer - The renderer this System works for. */
+    constructor(renderer: Renderer)
+    {
+        this._renderer = renderer;
+
+        this.count = 0;
+        this.checkCount = 0;
+    }
+
+    public init(options: TextureGCSystemOptions): void
+    {
+        options = { ...TextureGCSystem.defaultOptions, ...options };
+
+        this.checkCountMax = options.textureGCCheckCountMax;
+        this.maxIdle = options.textureGCAMaxIdle;
+        this.active = options.textureGCActive;
+    }
+
+    /**
+     * Checks to see when the last time a texture was used.
+     * If the texture has not been used for a specified amount of time, it will be removed from the GPU.
+     */
+    protected postrender(): void
+    {
+        // if (!this.renderer.objectRenderer.renderingToScreen)
+        // {
+        //     return;
+        // }
+
+        this.count++;
+
+        if (!this.active) return;
+
+        this.checkCount++;
+
+        if (this.checkCount > this.checkCountMax)
+        {
+            this.checkCount = 0;
+
+            this.run();
+        }
+    }
+
+    /**
+     * Checks to see when the last time a texture was used.
+     * If the texture has not been used for a specified amount of time, it will be removed from the GPU.
+     */
+    public run(): void
+    {
+        const managedTextures = this._renderer.texture.managedTextures;
+
+        for (let i = 0; i < managedTextures.length; i++)
+        {
+            const texture = managedTextures[i];
+
+            // Only supports non generated textures at the moment!
+            if (texture.resource && texture.touched > -1 && this.count - texture.touched > this.maxIdle)
+            {
+                texture.touched = -1;
+                texture.unload();
+            }
+        }
+    }
+
+    public destroy(): void
+    {
+        this._renderer = null as any as Renderer;
+    }
+}
+
+extensions.add(TextureGCSystem);

--- a/src/rendering/renderers/shared/texture/TextureStyle.ts
+++ b/src/rendering/renderers/shared/texture/TextureStyle.ts
@@ -55,6 +55,7 @@ export class TextureStyle extends EventEmitter<{
 }> implements BindResource
 {
     public resourceType = 'textureSampler';
+    public touched = 0;
     private _resourceId: number;
 
     // override to set styles globally


### PR DESCRIPTION
- added default options to texture source
- added TextureGCSystem
- added unload to `TextureSource`

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b870f2e</samp>

### Summary
🚀🗑️🎨

<!--
1.  🚀 - This emoji represents the performance improvement and optimization of the state management and shader binding for the batcher and the adaptor, as well as the removal of redundant code.
2.  🗑️ - This emoji represents the garbage collection feature for the textures and the buffers, which frees up GPU memory and prevents memory leaks.
3.  🎨 - This emoji represents the customization and refactoring of the batch types and the texture types, which allows more flexibility and consistency for rendering different kinds of graphics.
-->
This pull request improves the performance and memory management of the rendering system, especially for WebGL and GPU rendering. It optimizes the state and shader handling for different batch types, adds a feature to automatically unload unused textures from the GPU memory, and refactors some code to enhance readability and consistency. It also updates the package version number and fixes some minor issues. The main files affected are `GlBatchAdaptor.ts`, `GpuBatchAdaptor.ts`, `Batcher.ts`, `TextureBatcher.ts`, `GlTextureSystem.ts`, `GpuTextureSystem.ts`, `SharedSystems.ts`, `TextureSource.ts`, and `TextureGCSystem.ts`.

> _Oh, we're the crew of the `GlBatchAdaptor`_
> _We render batches with skill and splendor_
> _We optimize our state and shader_
> _And garbage collect our textures later_

### Walkthrough
*  Update the package version number to 8.0.0-alpha.2 ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))
*  Refactor the batch state structure to use the State class and pass it to the batch pipe and the draw call, to avoid unnecessary state changes and allow more flexibility for different batch types ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-71719a370a41477b6b10f352b538614bc2982d420ca5c2c2bdd23365aeed69ccL46-R49), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-71719a370a41477b6b10f352b538614bc2982d420ca5c2c2bdd23365aeed69ccR56-R57), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-71719a370a41477b6b10f352b538614bc2982d420ca5c2c2bdd23365aeed69ccL63-L64), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-a0f3f9b4b6542d13dbae01459e1936d490c982d65be81867d1257e05996b0a19L35-L36), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-a0f3f9b4b6542d13dbae01459e1936d490c982d65be81867d1257e05996b0a19L57-R55), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341R3), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341R34), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341L140-R142), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341L244-R256), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341L274-R266))
*  Extract the data packing logic for the batcher into a separate private method, to improve readability and maintainability ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-5b0990b7f67a73bcf39db49902b4f21c89d78fdb3a0077293ddcf822eb047341R355-R392))
*  Remove the buffer update call from the batcher pipe, as it was redundant and caused performance issues ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-89625f6f630aefb661146d12dc5859848581a3df90cbcf736ec1094c4c97d3a8L121))
*  Move the batch pool index variable from the global scope to the texture batcher class as a private property, to align with the new texture batcher structure ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-98ae7086fcff6302228d24a15e44544a433dd8d66b6a8f8ebe07331b120fdd9bL10), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-98ae7086fcff6302228d24a15e44544a433dd8d66b6a8f8ebe07331b120fdd9bL26-R28), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-98ae7086fcff6302228d24a15e44544a433dd8d66b6a8f8ebe07331b120fdd9bL39-R38), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-98ae7086fcff6302228d24a15e44544a433dd8d66b6a8f8ebe07331b120fdd9bL79-R78))
*  Remove the unnecessary key variable from the getProgramData method in the `GlShaderSystem` class ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-12ce009d2a0d935bfeb03075623943c691443059175bdc053d4c0bcc8aaf6a77L195-R195))
*  Add the managedTextures property to the `GlTextureSystem` and `GpuTextureSystem` classes, to store an array of texture sources that are managed by the system and subject to garbage collection ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50R34-R35), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-58d642fc4a29e8e84a5bea4fe52419cb0f90dbbbbe1e5f2764c2b94999731386R24-R25))
*  Add the touched property to the texture source, bind resource, buffer, buffer resource, uniform group, and texture style classes, to store the last frame count when the resource was used, for garbage collection purposes ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50R96-R97), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-876af84217b4bc4cc9ff948aa388f037c97e1b9d21864def1efc81dad58a674dR69-R78), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-54bf53b9b28c2b1cf84934a99fa30442a64e38b0d41c6208e651b1ba819a6609R12-R13), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-bfbce9e754c1022cf2c1c1319cd2e81b8b3cb4f81baacb5686e64ac9e375d92fR38), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-8623421fc3dadc38b3cb9a79d0beaae7a19ee82240946d05947e8ea98a9ff826R12), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-984b1c73264c64684bfdb732d9172f4ea5e637483fdc6d6d45e313e7e08f52b7R27-R28), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-ad6f3f2068fc04074284162808870474022706b8ccbb63b3f7a8478e651e3027R58), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d1b5f71f5eb8f4a296006f6bc327f0dc179db23df5957eaff2b2e8cbcab9c6caL79-R105))
*  Add the unload event listener and the onSourceUnload method to the `GlTextureSystem` and `GpuTextureSystem` classes, to handle the logic of unbinding and deleting the texture from the GPU when the unload event is emitted by the texture source ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50L180-R187), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50R193-R204), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-58d642fc4a29e8e84a5bea4fe52419cb0f90dbbbbe1e5f2764c2b94999731386L71-R76), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-58d642fc4a29e8e84a5bea4fe52419cb0f90dbbbbe1e5f2764c2b94999731386L100-R126))
*  Modify the onSourceDestroy method in the `GlTextureSystem` class to remove the texture source from the managedTextures array, and to call the onSourceUnload method instead of duplicating the logic of deleting the texture from the GPU ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50L214-R239))
*  Change the texture parameter type from Texture to BindableTexture in the `GlTextureSystem` class, to allow for more generic texture types that can be bound by the system ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50L129-R133))
*  Call the onSourceUnload method instead of duplicating the logic of destroying the GPU texture when the texture source is resized and needs to be reinitialized in the `GpuTextureSystem` class ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-58d642fc4a29e8e84a5bea4fe52419cb0f90dbbbbe1e5f2764c2b94999731386L119-R135))
*  Add the touch method to the bind group and the bind group class, to mark each resource in the group as having been used in the current frame, for garbage collection purposes ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-a9bb4356e83dae8c3e504b589c7f4e577ce26084d096a36b735369da50942bd1L121-R127), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-876af84217b4bc4cc9ff948aa388f037c97e1b9d21864def1efc81dad58a674dR69-R78))
*  Add the unload event type and the unload method to the texture source class, to emit the event when the texture source is unloaded from the GPU by the garbage collector or manually ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d1b5f71f5eb8f4a296006f6bc327f0dc179db23df5957eaff2b2e8cbcab9c6caL36-R51), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d1b5f71f5eb8f4a296006f6bc327f0dc179db23df5957eaff2b2e8cbcab9c6caR174-R180))
*  Add the default options for the texture source class as a static property, to provide default values for the constructor parameters, and use them to initialize the instance properties, instead of using nullish coalescing operators for each property ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d1b5f71f5eb8f4a296006f6bc327f0dc179db23df5957eaff2b2e8cbcab9c6caL79-R105), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d1b5f71f5eb8f4a296006f6bc327f0dc179db23df5957eaff2b2e8cbcab9c6caL108-R133))
*  Simplify the if statement to a single line in the `BlendModePipe` class, to improve readability and style consistency ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-fdb0f92b9bce3720e8f81991df4c17c6b4d76a398a79e0b7aa6bac5883dc90eeL95-R95))
*  Import the texture GC system class from the texture module, and add it to the shared systems array, to register it as a system plugin for the renderer ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d2a0b8e44f574629757472dd9371335ab1ce460ba1e4b82eed83d19332420091R22), [link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-d2a0b8e44f574629757472dd9371335ab1ce460ba1e4b82eed83d19332420091R35))
*  Add the texture GC system class to the texture module, to implement the logic of managing texture garbage collection on the GPU, based on the frame count and the touched property of the texture sources ([link](https://github.com/pixijs/pixijs/pull/9614/files?diff=unified&w=0#diff-824a564a68765fb2f788c35df85176125138efca2c41d7dac3d3732588a191ddR1-R135))

