### PR TITLE
Add precision options to GLProgram

### DIFF
--- a/src/rendering/batcher/gl/batcher-template.vert
+++ b/src/rendering/batcher/gl/batcher-template.vert
@@ -1,4 +1,3 @@
-precision highp float;
 in vec2 aPosition;
 in vec2 aUV;
 in vec4 aColor;

--- a/src/rendering/renderers/gl/shader/program/ensurePrecision.ts
+++ b/src/rendering/renderers/gl/shader/program/ensurePrecision.ts
@@ -1,25 +1,39 @@
 import type { PRECISION } from '../const';
 
+interface EnsurePrecisionOptions
+{
+    requestedVertexPrecision: PRECISION;
+    requestedFragmentPrecision: PRECISION;
+    maxSupportedVertexPrecision: PRECISION;
+    maxSupportedFragmentPrecision: PRECISION;
+}
+
 /**
  * Sets the float precision on the shader, ensuring the device supports the request precision.
  * If the precision is already present, it just ensures that the device is able to handle it.
  * @param src
- * @param root0
- * @param root0.requestedPrecision
- * @param root0.maxSupportedPrecision
+ * @param options
+ * @param options.requestedVertexPrecision
+ * @param options.requestedFragmentPrecision
+ * @param options.maxSupportedVertexPrecision
+ * @param options.maxSupportedFragmentPrecision
+ * @param isFragment
  */
 export function ensurePrecision(
     src: string,
-    { requestedPrecision, maxSupportedPrecision }: {requestedPrecision: PRECISION, maxSupportedPrecision: PRECISION}
+    options: EnsurePrecisionOptions,
+    isFragment: boolean,
 ): string
 {
+    const maxSupportedPrecision = isFragment ? options.maxSupportedFragmentPrecision : options.maxSupportedVertexPrecision;
+
     if (src.substring(0, 9) !== 'precision')
     {
         // no precision supplied, so PixiJS will add the requested level.
-        let precision = requestedPrecision;
+        let precision = isFragment ? options.requestedFragmentPrecision : options.requestedVertexPrecision;
 
         // If highp is requested but not supported, downgrade precision to a level all devices support.
-        if (requestedPrecision === 'highp' && maxSupportedPrecision !== 'highp')
+        if (precision === 'highp' && maxSupportedPrecision !== 'highp')
         {
             precision = 'mediump';
         }

--- a/src/rendering/renderers/gl/shader/program/getMaxFragmentPrecision.ts
+++ b/src/rendering/renderers/gl/shader/program/getMaxFragmentPrecision.ts
@@ -1,0 +1,26 @@
+import { getTestContext } from './getTestContext';
+
+import type { PRECISION } from '../const';
+
+let maxFragmentPrecision: PRECISION;
+
+export function getMaxFragmentPrecision(): PRECISION
+{
+    if (!maxFragmentPrecision)
+    {
+        maxFragmentPrecision = 'mediump';
+        const gl = getTestContext();
+
+        if (gl)
+        {
+            if (gl.getShaderPrecisionFormat)
+            {
+                const shaderFragment = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
+
+                maxFragmentPrecision = shaderFragment.precision ? 'highp' : 'mediump';
+            }
+        }
+    }
+
+    return maxFragmentPrecision;
+}

--- a/src/rendering/renderers/gl/shader/program/getTestContext.ts
+++ b/src/rendering/renderers/gl/shader/program/getTestContext.ts
@@ -1,0 +1,22 @@
+import { settings } from '../../../../../settings/settings';
+
+const unknownContext = {};
+let context: WebGLRenderingContext | WebGL2RenderingContext = unknownContext as any;
+
+/**
+ * returns a little WebGL context to use for program inspection.
+ * @static
+ * @private
+ * @returns {WebGLRenderingContext} a gl context to test with
+ */
+export function getTestContext(): WebGLRenderingContext | WebGL2RenderingContext
+{
+    if (context === unknownContext || context?.isContextLost())
+    {
+        const canvas = settings.ADAPTER.createCanvas();
+
+        context = canvas.getContext('webgl2', {});
+    }
+
+    return context;
+}

--- a/src/rendering/text/sdfShader/sdf-batcher-template.vert
+++ b/src/rendering/text/sdfShader/sdf-batcher-template.vert
@@ -1,4 +1,3 @@
-precision highp float;
 in vec2 aPosition;
 in vec2 aUV;
 in vec4 aColor;


### PR DESCRIPTION
- Add precision options to GLProgram

- ensure fragment and vertex have the appropriate precision applied

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4a4524b</samp>

### Summary
🔧🎨🚀

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate a change that involves refactoring, fixing, or improving some code or functionality.
2.  🎨 - This emoji represents a paintbrush or a palette, and can be used to indicate a change that involves graphics, rendering, or visual effects.
3.  🚀 - This emoji represents a rocket or a launch, and can be used to indicate a change that involves performance, optimization, or speed.
-->
This pull request enhances the `GlProgram` class to allow specifying the precision of the vertex and fragment shaders, and to use the highest supported precision on the device. It also removes the hardcoded precision declarations from the batcher and sdf shaders, and adds some utility functions to query and create test WebGL contexts.

> _`GlProgram` adjusts_
> _shader precision for device_
> _autumn leaves falling_

### Walkthrough
*  Remove precision declaration from vertex shaders `batcher-template.vert` and `sdf-batcher-template.vert` to allow dynamic precision based on device capabilities and user options ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-3416c7109b51b1434aa5cca9a53201ad407f200a2d52ade6c27ad9ea7f99bcf5L1), [link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-823b20a049376df1c4ed7fca3c8da46a5454d07fe13f6279eafb863e2b4f114bL1))
* Add new module `getMaxFragmentPrecision.ts` that exports a function to query and cache the highest supported precision for the fragment shader on the current device ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-8abf9a661b1513bbc75f035e5f05ed67e12391f9af3dd89e8bfa611baed6e523R1-R26))
* Add new module `getTestContext.ts` that exports a function to create and return a small WebGL or WebGL2 context for program inspection and handle context loss or unavailability ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-a6ce9aa476461f7bfe7850493e4973054f757393e9928bea2aafb3ae74eacf4bR1-R22))
* Refactor `ensurePrecision` function to take an object with four precision properties and use a flag to determine whether to apply fragment or vertex precision to the shader source ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-5169060d334aab5af8f0fd2344e0e92e434603b149b8f47c29d81c243f4a3b93L3-R36))
* Add two new optional properties to `GlProgramOptions` interface to specify the preferred precision for the vertex and fragment shaders ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-b772f53b85be24e5a235f9c85c1450af5bb61962a9cfcc3b889517a4d7f81a5cR42-R43))
* Define default options for `GlProgram` class that set the preferred vertex precision to highp and the preferred fragment precision to mediump ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-b772f53b85be24e5a235f9c85c1450af5bb61962a9cfcc3b889517a4d7f81a5cR54-R58))
* Modify constructor of `GlProgram` class to merge given options with default options and create a `preprocessorOptions` object that contains the requested and max supported precision for both shaders ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-b772f53b85be24e5a235f9c85c1450af5bb61962a9cfcc3b889517a4d7f81a5cL62-R82))
* Update loop that applies preprocessor functions to shader source to use `preprocessorOptions` object and pass fragment and vertex source separately with a flag ([link](https://github.com/pixijs/pixijs/pull/9621/files?diff=unified&w=0#diff-b772f53b85be24e5a235f9c85c1450af5bb61962a9cfcc3b889517a4d7f81a5cL77-R94))

