### PR TITLE
Handle data URLs & blob URLs properly

### DIFF
--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -136,6 +136,7 @@ export interface Path
     toAbsolute: (url: string, baseUrl?: string, rootUrl?: string) => string;
     isUrl: (path: string) => boolean;
     isDataUrl: (path: string) => boolean;
+    isBlobUrl: (path: string) => boolean;
     hasProtocol: (path: string) => boolean;
     getProtocol: (path: string) => string;
     normalize: (path: string) => string;
@@ -157,7 +158,7 @@ export const path: Path = {
      */
     toPosix(path: string) { return replaceAll(path, '\\', '/'); },
     /**
-     * Checks if the path is a URL
+     * Checks if the path is a URL e.g. http://, https://
      * @param path - The path to check
      */
     isUrl(path: string) { return (/^https?:/).test(this.toPosix(path)); },
@@ -172,13 +173,22 @@ export const path: Path = {
             .test(path);
     },
     /**
-     * Checks if the path has a protocol e.g. http://
+     * Checks if the path is a blob URL
+     * @param path - The path to check
+     */
+    isBlobUrl(path: string)
+    {
+        // Not necessary to have an exact regex to match the blob URLs
+        return path.startsWith('blob:');
+    },
+    /**
+     * Checks if the path has a protocol e.g. http://, https://, file:///, data:, blob:, C:/
      * This will return true for windows file paths
      * @param path - The path to check
      */
-    hasProtocol(path: string) { return (/^[^/:]+:\//).test(this.toPosix(path)); },
+    hasProtocol(path: string) { return (/^[^/:]+:/).test(this.toPosix(path)); },
     /**
-     * Returns the protocol of the path e.g. http://, C:/, file:///
+     * Returns the protocol of the path e.g. http://, https://, file:///, data:, blob:, C:/
      * @param path - The path to get the protocol from
      */
     getProtocol(path: string)
@@ -186,21 +196,21 @@ export const path: Path = {
         assertPath(path);
         path = this.toPosix(path);
 
-        let protocol = '';
+        const matchFile = (/^file:\/\/\//).exec(path);
 
-        const isFile = (/^file:\/\/\//).exec(path);
-        const isHttp = (/^[^/:]+:\/\//).exec(path);
-        const isWindows = (/^[^/:]+:\//).exec(path);
-
-        if (isFile || isHttp || isWindows)
+        if (matchFile)
         {
-            const arr = (isFile?.[0] || isHttp?.[0] || isWindows?.[0]) as string;
-
-            protocol = arr;
-            path = path.slice(arr.length);
+            return matchFile[0];
         }
 
-        return protocol;
+        const matchProtocol = (/^[^/:]+:\/{0,2}/).exec(path);
+
+        if (matchProtocol)
+        {
+            return matchProtocol[0];
+        }
+
+        return '';
     },
 
     /**
@@ -214,12 +224,13 @@ export const path: Path = {
      */
     toAbsolute(url: string, customBaseUrl?: string, customRootUrl?: string)
     {
-        if (this.isDataUrl(url)) return url;
+        assertPath(url);
+
+        if (this.isDataUrl(url) || this.isBlobUrl(url)) return url;
 
         const baseUrl = removeUrlParams(this.toPosix(customBaseUrl ?? settings.ADAPTER.getBaseUrl()));
         const rootUrl = removeUrlParams(this.toPosix(customRootUrl ?? this.rootname(baseUrl)));
 
-        assertPath(url);
         url = this.toPosix(url);
 
         // root relative url
@@ -239,10 +250,12 @@ export const path: Path = {
      */
     normalize(path: string)
     {
-        path = this.toPosix(path);
         assertPath(path);
 
         if (path.length === 0) return '.';
+        if (this.isDataUrl(path) || this.isBlobUrl(path)) return path;
+
+        path = this.toPosix(path);
 
         let protocol = '';
         const isAbsolute = path.startsWith('/');

--- a/packages/utils/test/path.tests.ts
+++ b/packages/utils/test/path.tests.ts
@@ -7,6 +7,7 @@ describe('Paths', () =>
         expect(path.toPosix('C:\\foo\\bar')).toBe('C:/foo/bar');
         expect(path.toPosix('C:\\foo\\bar/')).toBe('C:/foo/bar/');
         expect(path.toPosix('C:\\foo/bar')).toBe('C:/foo/bar');
+
         expect(path.toPosix('foo\\bar')).toBe('foo/bar');
         expect(path.toPosix('foo\\bar/baz')).toBe('foo/bar/baz');
     });
@@ -18,13 +19,17 @@ describe('Paths', () =>
         expect(path.isUrl('http://foo.com/bar/baz')).toBe(true);
         expect(path.isUrl('https://foo.com/bar/baz')).toBe(true);
         expect(path.isUrl('https://foo.com/bar/baz/')).toBe(true);
+
         expect(path.isUrl('file:///foo/bar/baz')).toBe(false);
+        expect(path.isUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')).toBe(false);
+        expect(path.isUrl('blob:http://example.com/00000000-0000-0000-0000-000000000000')).toBe(false);
+        expect(path.isUrl('blob:https://example.com/00000000-0000-0000-0000-000000000000')).toBe(false);
+        expect(path.isUrl('C:/foo/bar')).toBe(false);
+        expect(path.isUrl('C:\\foo\\bar')).toBe(false);
         expect(path.isUrl('//foo.com')).toBe(false);
         expect(path.isUrl('foo.com')).toBe(false);
         expect(path.isUrl('/foo.com')).toBe(false);
         expect(path.isUrl('foo/bar')).toBe(false);
-        expect(path.isUrl('C:/foo/bar')).toBe(false);
-        expect(path.isUrl('C:\\foo\\bar')).toBe(false);
     });
 
     it('should check if a path contains a protocol', () =>
@@ -33,6 +38,9 @@ describe('Paths', () =>
         expect(path.hasProtocol('https://foo.com')).toBe(true);
         expect(path.hasProtocol('https://foo.com/')).toBe(true);
         expect(path.hasProtocol('file:///foo/bar/baz')).toBe(true);
+        expect(path.hasProtocol('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')).toBe(true);
+        expect(path.hasProtocol('blob:http://example.com/00000000-0000-0000-0000-000000000000')).toBe(true);
+        expect(path.hasProtocol('blob:https://example.com/00000000-0000-0000-0000-000000000000')).toBe(true);
         expect(path.hasProtocol('C:/foo/bar')).toBe(true);
         expect(path.hasProtocol('C:\\foo\\bar')).toBe(true);
 
@@ -48,6 +56,9 @@ describe('Paths', () =>
         expect(path.getProtocol('https://foo.com')).toBe('https://');
         expect(path.getProtocol('https://foo.com/')).toBe('https://');
         expect(path.getProtocol('file:///foo/bar/baz')).toBe('file:///');
+        expect(path.getProtocol('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')).toBe('data:');
+        expect(path.getProtocol('blob:http://example.com/00000000-0000-0000-0000-000000000000')).toBe('blob:');
+        expect(path.getProtocol('blob:https://example.com/00000000-0000-0000-0000-000000000000')).toBe('blob:');
         expect(path.getProtocol('C:/foo/bar')).toBe('C:/');
         expect(path.getProtocol('C:\\foo\\bar')).toBe('C:/');
         expect(path.getProtocol('/foo/bar/baz')).toBe('');
@@ -56,15 +67,19 @@ describe('Paths', () =>
 
     it('should state if a path is absolute or not', () =>
     {
-        expect(path.isAbsolute('/foo/bar')).toBe(true);
-        expect(path.isAbsolute('/foo/bar/')).toBe(true);
-        expect(path.isAbsolute('C:\\foo\\bar')).toBe(true);
-        expect(path.isAbsolute('C:/foo/bar')).toBe(true);
-        expect(path.isAbsolute('C:/foo/bar/')).toBe(true);
         expect(path.isAbsolute('http://foo.com/bar/baz')).toBe(true);
         expect(path.isAbsolute('https://foo.com/bar/baz')).toBe(true);
         expect(path.isAbsolute('https://foo.com/bar/baz/')).toBe(true);
         expect(path.isAbsolute('file:///foo/bar/baz')).toBe(true);
+        expect(path.isAbsolute('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==')).toBe(true);
+        expect(path.isAbsolute('blob:http://example.com/00000000-0000-0000-0000-000000000000')).toBe(true);
+        expect(path.isAbsolute('blob:https://example.com/00000000-0000-0000-0000-000000000000')).toBe(true);
+        expect(path.isAbsolute('C:\\foo\\bar')).toBe(true);
+        expect(path.isAbsolute('C:/foo/bar')).toBe(true);
+        expect(path.isAbsolute('C:/foo/bar/')).toBe(true);
+        expect(path.isAbsolute('/foo/bar')).toBe(true);
+        expect(path.isAbsolute('/foo/bar/')).toBe(true);
+
         expect(path.isAbsolute('foo/bar')).toBe(false);
         expect(path.isAbsolute('foo/bar/')).toBe(false);
         expect(path.isAbsolute('foo\\bar')).toBe(false);
@@ -80,11 +95,17 @@ describe('Paths', () =>
         expect(path.normalize('https://foo.com/../../bar/baz//file')).toBe('https://foo.com/bar/baz/file');
         expect(path.normalize('https://foo.com/../../../../../bar/baz//file')).toBe('https://foo.com/bar/baz/file');
         expect(path.normalize('file:///foo/../../../../../bar/baz//file')).toBe('file:///bar/baz/file');
-        expect(path.normalize('C:/foo/../../../../../bar/baz//file')).toBe('C:/bar/baz/file');
-        expect(path.normalize('/foo/../../../../../bar/baz//file')).toBe('/bar/baz/file');
         expect(path.normalize('file:///foo/bar/baz//file')).toBe('file:///foo/bar/baz/file');
+        expect(path.normalize('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=='))
+            .toBe('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
+        expect(path.normalize('blob:http://example.com/00000000-0000-0000-0000-000000000000'))
+            .toBe('blob:http://example.com/00000000-0000-0000-0000-000000000000');
+        expect(path.normalize('blob:https://example.com/00000000-0000-0000-0000-000000000000'))
+            .toBe('blob:https://example.com/00000000-0000-0000-0000-000000000000');
+        expect(path.normalize('C:/foo/../../../../../bar/baz//file')).toBe('C:/bar/baz/file');
         expect(path.normalize('C:\\foo\\bar\\baz\\file')).toBe('C:/foo/bar/baz/file');
         expect(path.normalize('C:/foo\\bar\\baz\\file')).toBe('C:/foo/bar/baz/file');
+        expect(path.normalize('/foo/../../../../../bar/baz//file')).toBe('/bar/baz/file');
         expect(path.normalize('/foo/bar/baz/file')).toBe('/foo/bar/baz/file');
         expect(path.normalize('foo')).toBe('foo');
     });
@@ -268,6 +289,12 @@ describe('Paths', () =>
 
         // url is already absolute
         expect(path.toAbsolute('http://example.com/browser.png')).toEqual(`http://example.com/browser.png`);
+        expect(path.toAbsolute('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=='))
+            .toBe('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==');
+        expect(path.toAbsolute('blob:http://example.com/00000000-0000-0000-0000-000000000000'))
+            .toBe('blob:http://example.com/00000000-0000-0000-0000-000000000000');
+        expect(path.toAbsolute('blob:https://example.com/00000000-0000-0000-0000-000000000000'))
+            .toBe('blob:https://example.com/00000000-0000-0000-0000-000000000000');
         expect(path.toAbsolute('C:/windows.png')).toEqual(`C:/windows.png`);
         expect(path.toAbsolute('C:\\windows.png')).toEqual(`C:/windows.png`);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Handle data URLs & blob URLs properly in `utils.path`.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f61a46</samp>

### Summary
🌐🚀📝

<!--
1.  🌐 - This emoji represents the addition of support for different types of URLs, such as blob: and data:, which are often used for web resources and data transfers. This emoji conveys the idea of global or web connectivity and compatibility.
2.  🚀 - This emoji represents the improvement of performance and speed of some existing methods, such as `toAbsolute` and `isAbsolute`. This emoji conveys the idea of fast and efficient execution and delivery.
3.  📝 - This emoji represents the improvement of documentation and clarity of some existing methods, such as `join` and `relative`. This emoji conveys the idea of writing, explaining, and documenting.
-->
This pull request enhances the `Path` utility interface to handle different types of URLs, and updates the corresponding tests. ~It also fixes a bug in the `toAbsolute` method that ignored the adapter settings.~

> _`Path` can handle blobs_
> _and data URLs now_
> _a winter upgrade_

### Walkthrough
*  Add and implement `isBlobUrl` method to `Path` interface to check for blob URLs ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099R139), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099L175-R191))
*  Update `isUrl` method documentation and tests to clarify that it only checks for http:// or https:// URLs ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099L160-R161), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfL21-R32))
*  Refactor `getProtocol` method to simplify logic and avoid unnecessary regex executions ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099L189-R213), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfR59-R61))
*  Add conditions to `toAbsolute` and `normalize` methods to handle data: and blob: URLs, which are already absolute and normalized ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099L217-R233), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-51fde76ee3225b7600dee53aa779358f6b52520f11327e68ddc2058ea5ab2099L242-R259), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfL83-R108), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfR292-R297))
*  Add conditions and tests to `hasProtocol` and `isAbsolute` methods to handle data: and blob: URLs, which have a protocol and are absolute ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfR41-R43), [link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfL59-R82))
*  ~Import `settings` object from `@pixi/settings` module in `path.tests.ts` to access adapter settings ([link](https://github.com/pixijs/pixijs/pull/9634/files?diff=unified&w=0#diff-ceadfc345d0e0c6d99deb9cff1265472641136dffb60030d3455936b239d27cfR10))~



##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
