### PR TITLE
Fix: Round `Sprite` vertices in `calculateTrimmedVertices` if `roundPixels`

### DIFF
--- a/packages/sprite/src/Sprite.ts
+++ b/packages/sprite/src/Sprite.ts
@@ -349,6 +349,16 @@ export class Sprite extends Container
         // xy
         vertexData[6] = (a * w1) + (c * h0) + tx;
         vertexData[7] = (d * h0) + (b * w1) + ty;
+
+        if (this._roundPixels)
+        {
+            const resolution = settings.RESOLUTION;
+
+            for (let i = 0; i < vertexData.length; ++i)
+            {
+                vertexData[i] = Math.round(vertexData[i] * resolution) / resolution;
+            }
+        }
     }
 
     /**
@@ -510,6 +520,7 @@ export class Sprite extends Container
         if (this._roundPixels !== value)
         {
             this._transformID = -1;
+            this._transformTrimmedID = -1;
         }
         this._roundPixels = value;
     }


### PR DESCRIPTION
Rounding of vertices is missing in `Sprite.calculateTrimmedVertices`.