### PR TITLE
Fix an exception when installing a BitmapFont from an XML as a string

### DIFF
--- a/packages/text-bitmap/src/formats/TextFormat.ts
+++ b/packages/text-bitmap/src/formats/TextFormat.ts
@@ -54,7 +54,7 @@ export class TextFormat
      * @param data
      * @returns - True if resource could be treated as font data, false otherwise.
      */
-    static test(data: unknown): boolean
+    static test(data: string | XMLDocument | BitmapFontData): boolean
     {
         return typeof data === 'string' && data.startsWith('info face=');
     }

--- a/packages/text-bitmap/src/formats/XMLFormat.ts
+++ b/packages/text-bitmap/src/formats/XMLFormat.ts
@@ -11,11 +11,11 @@ export class XMLFormat
      * @param data
      * @returns - True if resource could be treated as font data, false otherwise.
      */
-    static test(data: unknown): boolean
+    static test(data: string | XMLDocument | BitmapFontData): boolean
     {
         const xml = data as Document;
 
-        return 'getElementsByTagName' in xml
+        return 'getElementsByTagName' in data
             && xml.getElementsByTagName('page').length
             && xml.getElementsByTagName('info')[0].getAttribute('face') !== null;
     }

--- a/packages/text-bitmap/src/formats/XMLFormat.ts
+++ b/packages/text-bitmap/src/formats/XMLFormat.ts
@@ -15,7 +15,8 @@ export class XMLFormat
     {
         const xml = data as Document;
 
-        return 'getElementsByTagName' in data
+        return typeof data !== 'string'
+            && 'getElementsByTagName' in data
             && xml.getElementsByTagName('page').length
             && xml.getElementsByTagName('info')[0].getAttribute('face') !== null;
     }

--- a/packages/text-bitmap/src/formats/XMLStringFormat.ts
+++ b/packages/text-bitmap/src/formats/XMLStringFormat.ts
@@ -14,7 +14,7 @@ export class XMLStringFormat
      * @param data
      * @returns - True if resource could be treated as font data, false otherwise.
      */
-    static test(data: unknown): boolean
+    static test(data: string | XMLDocument | BitmapFontData): boolean
     {
         if (typeof data === 'string' && data.includes('<font>'))
         {

--- a/packages/text-bitmap/src/formats/index.ts
+++ b/packages/text-bitmap/src/formats/index.ts
@@ -2,6 +2,8 @@ import { TextFormat } from './TextFormat';
 import { XMLFormat } from './XMLFormat';
 import { XMLStringFormat } from './XMLStringFormat';
 
+import type { BitmapFontData } from '../BitmapFontData';
+
 // Registered formats, maybe make this extensible in the future?
 const formats = [
     TextFormat,
@@ -15,7 +17,7 @@ const formats = [
  * @param {any} data - Data to detect format
  * @returns {any} Format or null
  */
-export function autoDetectFormat(data: unknown): typeof formats[number] | null
+export function autoDetectFormat(data: string | XMLDocument | BitmapFontData): typeof formats[number] | null
 {
     for (let i = 0; i < formats.length; i++)
     {


### PR DESCRIPTION
When using `PIXI.BitmapFont.install` with XML as a string. It gives this error:
```
cannot use 'in' operator to search for "getElementsByTag..." in "<?xml version=\"1..."
```

This code allows to reproduce the issue:
https://codesandbox.io/s/bitmapfont-from-string-64l8r5

Fixes: https://github.com/pixijs/pixijs/issues/9640

##### Description of change
- Improve type declaration and fix the type error.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
  - I guess a better type declaration is a better fit to cover this issue than a unit test.
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
  - Tests don't seem to work on my computer (but `npm run types` is passing)
  ![image](https://github.com/pixijs/pixijs/assets/2611977/b8b12b69-d2b5-48e6-8dd3-ced3e5a3041a)

