### PR TITLE
ensure destroy() implemented on all Systems

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -5,6 +5,7 @@ import { Container } from '../rendering/scene/Container';
 import type { Rectangle } from '../maths/shapes/Rectangle';
 import type { AutoDetectOptions } from '../rendering/renderers/autoDetectRenderer';
 import type { Renderer } from '../rendering/renderers/types';
+import type { DestroyOptions } from '../rendering/scene/destroyTypes';
 import type { ICanvas } from '../settings/adapter/ICanvas';
 import type { ResizePluginOptions } from './ResizePlugin';
 
@@ -118,37 +119,40 @@ export class Application<VIEW extends ICanvas = ICanvas>
         return this.renderer.screen;
     }
 
-    // TODO: implement destroy
-    // /**
-    //  * Destroy and don't use after this.
-    //  * @param {boolean} [removeView=false] - Automatically remove canvas from DOM.
-    //  * @param {object|boolean} [stageOptions] - Options parameter. A boolean will act as if all options
-    //  *  have been set to that value
-    //  * @param {boolean} [stageOptions.children=false] - if set to true, all the children will have their destroy
-    //  *  method called as well. 'stageOptions' will be passed on to those calls.
-    //  * @param {boolean} [stageOptions.texture=false] - Only used for child Sprites if stageOptions.children is set
-    //  *  to true. Should it destroy the texture of the child sprite
-    //  * @param {boolean} [stageOptions.baseTexture=false] - Only used for child Sprites if stageOptions.children is set
-    //  *  to true. Should it destroy the base texture of the child sprite
-    //  */
-    // public destroy(removeView?: boolean, stageOptions?: IDestroyOptions | boolean): void
-    // {
-    //     // Destroy plugins in the opposite order
-    //     // which they were constructed
-    //     const plugins = Application._plugins.slice(0);
+    /**
+     * Destroys the application and all of its resources.
+     * @param {object|boolean} [options=false] - The options for destroying the application.
+     * @param {boolean} [options.removeView=false] - Whether to remove the application's canvas element from the DOM.
+     * @param {boolean} [options.children=false] - If set to true, all the children will have their destroy method
+     * called as well. `options` will be passed on to those calls.
+     * @param {boolean} [options.texture=false] - Only used for children with textures e.g. Sprites.
+     * If options.children is set to true,
+     * it should destroy the texture of the child sprite.
+     * @param {boolean} [options.textureSource=false] - Only used for children with textures e.g. Sprites.
+     *  If options.children is set to true,
+     * it should destroy the texture source of the child sprite.
+     * @param {boolean} [options.context=false] - Only used for children with graphicsContexts e.g. Graphics.
+     * If options.children is set to true,
+     * it should destroy the context of the child graphics.
+     */
+    public destroy(options: DestroyOptions = false): void
+    {
+        // Destroy plugins in the opposite order
+        // which they were constructed
+        const plugins = Application._plugins.slice(0);
 
-    //     plugins.reverse();
-    //     plugins.forEach((plugin) =>
-    //     {
-    //         plugin.destroy.call(this);
-    //     });
+        plugins.reverse();
+        plugins.forEach((plugin) =>
+        {
+            plugin.destroy.call(this);
+        });
 
-    //     this.stage.destroy(stageOptions);
-    //     this.stage = null;
+        this.stage.destroy(options);
+        this.stage = null;
 
-    //     this.renderer.destroy(removeView);
-    //     this.renderer = null;
-    // }
+        this.renderer.destroy(options);
+        this.renderer = null;
+    }
 }
 
 extensions.handleByList(ExtensionType.Application, Application._plugins);

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -271,6 +271,7 @@ export class EventSystem implements System<EventSystemOptions>
     {
         this.setTargetElement(null);
         this.renderer = null;
+        this._currentCursor = null;
     }
 
     /**

--- a/src/rendering/filters/shared/FilterSystem.ts
+++ b/src/rendering/filters/shared/FilterSystem.ts
@@ -538,8 +538,5 @@ export class FilterSystem implements System
         return mappedMatrix;
     }
 
-    public destroy()
-    {
-        // No critical operations to be called in the destroy method.
-    }
+    public destroy?: () => void;
 }

--- a/src/rendering/filters/shared/FilterSystem.ts
+++ b/src/rendering/filters/shared/FilterSystem.ts
@@ -540,7 +540,6 @@ export class FilterSystem implements System
 
     public destroy()
     {
-        // BOOM!
+        // No critical operations to be called in the destroy method.
     }
 }
-

--- a/src/rendering/graphics/shared/GraphicsContextSystem.ts
+++ b/src/rendering/graphics/shared/GraphicsContextSystem.ts
@@ -239,6 +239,13 @@ export class GraphicsContextSystem implements System
 
     public destroy()
     {
-        // boom!
+        // Clean up all graphics contexts
+        for (const context of this._needsContextNeedsRebuild)
+        {
+            this._cleanGraphicsContextData(context);
+            this._gpuContextHash[context.uid] = null;
+        }
+
+        this._needsContextNeedsRebuild.length = 0;
     }
 }

--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -132,6 +132,10 @@ export class GlBackBufferSystem implements System
 
     public destroy()
     {
-        //
+        if (this._backBufferTexture)
+        {
+            this._backBufferTexture.destroy();
+            this._backBufferTexture = null;
+        }
     }
 }

--- a/src/rendering/renderers/gl/GlColorMaskSystem.ts
+++ b/src/rendering/renderers/gl/GlColorMaskSystem.ts
@@ -34,8 +34,5 @@ export class GlColorMaskSystem implements System
         );
     }
 
-    public destroy()
-    {
-        // No critical operations to be called in the destroy method.
-    }
+    public destroy?: () => void;
 }

--- a/src/rendering/renderers/gl/GlColorMaskSystem.ts
+++ b/src/rendering/renderers/gl/GlColorMaskSystem.ts
@@ -36,6 +36,6 @@ export class GlColorMaskSystem implements System
 
     public destroy()
     {
-        // boom
+        // No critical operations to be called in the destroy method.
     }
 }

--- a/src/rendering/renderers/gl/GlEncoderSystem.ts
+++ b/src/rendering/renderers/gl/GlEncoderSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
+import type { Writeable } from '../../../utils/types';
 import type { Topology } from '../shared/geometry/const';
 import type { Geometry } from '../shared/geometry/Geometry';
 import type { Shader } from '../shared/shader/Shader';
@@ -63,6 +64,8 @@ export class GlEncoderSystem implements System
 
     public destroy()
     {
-        // boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }

--- a/src/rendering/renderers/gl/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/GlRenderTargetSystem.ts
@@ -523,8 +523,5 @@ export class GlRenderTargetSystem implements System
         }
     }
 
-    public destroy()
-    {
-        // No critical operations to be called in the destroy method.
-    }
+    public destroy?: () => void;
 }

--- a/src/rendering/renderers/gl/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/GlRenderTargetSystem.ts
@@ -525,7 +525,6 @@ export class GlRenderTargetSystem implements System
 
     public destroy()
     {
-        //
+        // No critical operations to be called in the destroy method.
     }
 }
-

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -151,8 +151,5 @@ export class GlStencilSystem implements System
         }
     }
 
-    public destroy()
-    {
-        // No critical operations to be called in the destroy method.
-    }
+    public destroy?: () => void;
 }

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -153,6 +153,6 @@ export class GlStencilSystem implements System
 
     public destroy()
     {
-        // boom!
+        // No critical operations to be called in the destroy method.
     }
 }

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -3,6 +3,7 @@ import { BufferUsage } from '../../shared/buffer/const';
 import { BUFFER_TYPE } from './const';
 import { GlBuffer } from './GlBuffer';
 
+import type { Writeable } from '../../../../utils/types';
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GlRenderingContext } from '../context/GlRenderingContext';
@@ -56,7 +57,13 @@ export class GlBufferSystem implements System
      */
     public destroy(): void
     {
+        const writeable = this as Writeable<typeof this, '_boundBufferBases'>;
+
+        this.destroyAll(true);
         this._renderer = null;
+        this._gl = null;
+        this._gpuBuffers = null;
+        writeable._boundBufferBases = null;
     }
 
     /** Sets up the renderer context and necessary buffers. */

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -475,5 +475,8 @@ export class GlGeometrySystem implements System
     public destroy(): void
     {
         this._renderer = null;
+        this.gl = null;
+        this._activeVao = null;
+        this._activeGeometry = null;
     }
 }

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -203,4 +203,18 @@ export class GlShaderSystem
 
         return this._programDataHash[key];
     }
+
+    public destroy(): void
+    {
+        for (const key of Object.keys(this._programDataHash))
+        {
+            const programData = this._programDataHash[key];
+
+            programData.destroy();
+            this._programDataHash[key] = null;
+        }
+
+        this._programDataHash = null;
+        this._boundUniformsIdsToIndexHash = null;
+    }
 }

--- a/src/rendering/renderers/gl/shader/GlUniformGroupSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlUniformGroupSystem.ts
@@ -150,5 +150,6 @@ export class GlUniformGroupSystem implements System
         this._renderer = null;
         // TODO implement destroy method for ShaderSystem
         this.destroyed = true;
+        this._cache = null;
     }
 }

--- a/src/rendering/renderers/gl/state/GlStateSystem.ts
+++ b/src/rendering/renderers/gl/state/GlStateSystem.ts
@@ -343,5 +343,6 @@ export class GlStateSystem implements System
     public destroy(): void
     {
         this.gl = null;
+        this.checks.length = 0;
     }
 }

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -17,6 +17,7 @@ import {
 import { unpremultiplyAlpha } from './utils/unpremultiplyAlpha';
 
 import type { ICanvas } from '../../../../settings/adapter/ICanvas';
+import type { Writeable } from '../../../../utils/types';
 import type { System } from '../../shared/system/System';
 import type { CanvasGenerator, GetPixelsOutput } from '../../shared/texture/GenerateCanvas';
 import type { TextureSource } from '../../shared/texture/sources/TextureSource';
@@ -373,7 +374,9 @@ export class GlTextureSystem implements System, CanvasGenerator
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }
 

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
+import type { Writeable } from '../../../utils/types';
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { BufferResource } from '../shared/buffer/BufferResource';
 import type { UniformGroup } from '../shared/shader/UniformGroup';
@@ -125,6 +126,15 @@ export class BindGroupSystem implements System
 
     public destroy(): void
     {
-        // boom!
+        for (const key of Object.keys(this._hash))
+        {
+            this._hash[key] = null;
+        }
+
+        this._hash = null;
+
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }

--- a/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
+++ b/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
+import type { Writeable } from '../../../utils/types';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
 
@@ -32,6 +33,9 @@ export class GpuColorMaskSystem implements System
 
     public destroy()
     {
-        // boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
+        this._colorMaskCache = null;
     }
 }

--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -81,6 +81,7 @@ export class GpuDeviceSystem implements System
 
     public destroy(): void
     {
+        this.gpu = null;
         this._renderer = null;
     }
 }

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -1,6 +1,7 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
 import type { Rectangle } from '../../../maths/shapes/Rectangle';
+import type { Writeable } from '../../../utils/types';
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { Topology } from '../shared/geometry/const';
 import type { Geometry } from '../shared/geometry/Geometry';
@@ -272,7 +273,14 @@ export class GpuEncoderSystem implements System
 
     public destroy()
     {
-        // boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
+        this._gpu = null;
+        this._boundBindGroup = null;
+        this._boundVertexBuffer = null;
+        this._boundIndexBuffer = null;
+        this._boundPipeline = null;
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/gpu/GpuStencilSystem.ts
+++ b/src/rendering/renderers/gpu/GpuStencilSystem.ts
@@ -1,6 +1,7 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { STENCIL_MODES } from '../shared/state/const';
 
+import type { Writeable } from '../../../utils/types';
 import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
@@ -63,6 +64,13 @@ export class GpuStencilSystem implements System
 
     public destroy()
     {
-        // boom
+        this._renderer.renderTarget.onRenderTargetChange.remove(this);
+
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
+
+        this._activeRenderTarget = null;
+        this._renderTargetStencilState = null;
     }
 }

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -1,6 +1,7 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { fastCopy } from '../../shared/buffer/utils/fastCopy';
 
+import type { Writeable } from '../../../../utils/types';
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
@@ -102,7 +103,20 @@ export class BufferSystem implements System
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        for (const k of Object.keys(this._gpuBuffers))
+        {
+            const key = Number(k);
+            const gpuBuffer = this._gpuBuffers[key];
+
+            gpuBuffer.destroy();
+            this._gpuBuffers[key] = null;
+        }
+
+        this._gpuBuffers = null;
+
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }
 

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -3,6 +3,7 @@ import { createIdFromString } from '../../shared/createIdFromString';
 import { STENCIL_MODES } from '../../shared/state/const';
 import { GpuStencilModesToPixi } from '../state/GpuStencilModesToPixi';
 
+import type { Writeable } from '../../../../utils/types';
 import type { Topology } from '../../shared/geometry/const';
 import type { Geometry } from '../../shared/geometry/Geometry';
 import type { State } from '../../shared/state/State';
@@ -299,6 +300,9 @@ export class PipelineSystem implements System
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
+        this._bufferLayoutsCache = null;
     }
 }

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -10,6 +10,7 @@ import { getCanvasTexture } from '../../shared/texture/utils/getCanvasTexture';
 import { GpuRenderTarget } from './GpuRenderTarget';
 
 import type { ICanvas } from '../../../../settings/adapter/ICanvas';
+import type { Writeable } from '../../../../utils/types';
 import type { CLEAR_OR_BOOL } from '../../gl/const';
 import type { System } from '../../shared/system/System';
 import type { BindableTexture } from '../../shared/texture/Texture';
@@ -282,7 +283,10 @@ export class GpuRenderTargetSystem implements System
 
     public destroy()
     {
-        // boom
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
+        this._renderSurfaceToRenderTargetHash.clear();
     }
 
     private _startRenderPass(

--- a/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
+++ b/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
@@ -51,6 +51,6 @@ export class GpuShaderSystem implements System
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        this._gpu = null;
     }
 }

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -260,6 +260,29 @@ export class GpuTextureSystem implements System, CanvasGenerator
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        for (const k of Object.keys(this._gpuSources))
+        {
+            const key = Number(k);
+            const gpuTexture = this._gpuSources[key];
+
+            gpuTexture.destroy();
+            this._gpuSources[key] = null;
+        }
+
+        for (const k of Object.keys(this._bindGroupHash))
+        {
+            const key = Number(k);
+            const bindGroup = this._bindGroupHash[key];
+
+            bindGroup.destroy();
+            this._bindGroupHash[key] = null;
+        }
+
+        this._gpu = null;
+        this._mipmapGenerator = null;
+        this._gpuSources = null;
+        this._bindGroupHash = null;
+        this._textureViewHash = null;
+        this._gpuSamplers = null;
     }
 }

--- a/src/rendering/renderers/shared/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/GenerateTextureSystem.ts
@@ -6,6 +6,7 @@ import { getLocalBounds } from '../../scene/bounds/getLocalBounds';
 import { Container } from '../../scene/Container';
 import { RenderTexture } from './texture/RenderTexture';
 
+import type { Writeable } from '../../../utils/types';
 import type { Renderer } from '../types';
 import type { System } from './system/System';
 import type { TextureSourceOptions } from './texture/sources/TextureSource';
@@ -105,6 +106,8 @@ export class GenerateTextureSystem implements System
 
     public destroy(): void
     {
-        // ka boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }

--- a/src/rendering/renderers/shared/ViewSystem.ts
+++ b/src/rendering/renderers/shared/ViewSystem.ts
@@ -186,7 +186,6 @@ export class ViewSystem implements System
             this.element.parentNode.removeChild(this.element);
         }
 
-        // this._renderer = null;
-        this.element = null;
+        // note: don't clear the element as other systems may need to unbind from it (eg. GLContextSystem)
     }
 }

--- a/src/rendering/renderers/shared/ViewSystem.ts
+++ b/src/rendering/renderers/shared/ViewSystem.ts
@@ -4,6 +4,7 @@ import { settings } from '../../../settings/settings';
 import { getCanvasTexture } from './texture/utils/getCanvasTexture';
 
 import type { ICanvas } from '../../../settings/adapter/ICanvas';
+import type { DestroyOptions } from '../../scene/destroyTypes';
 import type { System } from './system/System';
 import type { CanvasSourceOptions } from './texture/sources/CanvasSource';
 import type { Texture } from './texture/Texture';
@@ -176,16 +177,19 @@ export class ViewSystem implements System
 
     /**
      * Destroys this System and optionally removes the canvas from the dom.
-     * @param {boolean} [removeView=false] - Whether to remove the canvas from the DOM.
+     * @param {options | false} options - The options for destroying the view, or "false".
+     * @param options.removeView - Whether to remove the view element from the DOM. Defaults to `false`.
      */
-    public destroy(removeView: boolean): void
+    public destroy(options: DestroyOptions = false): void
     {
-        // ka boom!
+        const removeView = typeof options === 'boolean' ? options : !!options?.removeView;
+
         if (removeView && this.element.parentNode)
         {
             this.element.parentNode.removeChild(this.element);
         }
 
-        // note: don't clear the element as other systems may need to unbind from it (eg. GLContextSystem)
+        // note: don't nullify the element
+        //       other systems may need to unbind from it during the destroy iteration (eg. GLContextSystem)
     }
 }

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -169,6 +169,6 @@ export class BackgroundSystem implements System
 
     public destroy(): void
     {
-        // ka boom!
+        // No cleanup required
     }
 }

--- a/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
@@ -5,6 +5,7 @@ import { BindGroup } from '../../gpu/shader/BindGroup';
 import { UniformGroup } from '../shader/UniformGroup';
 
 import type { PointData } from '../../../../maths/PointData';
+import type { Writeable } from '../../../../utils/types';
 import type { GlRenderTargetSystem } from '../../gl/GlRenderTargetSystem';
 import type { GpuRenderTargetSystem } from '../../gpu/renderTarget/GpuRenderTargetSystem';
 import type { WebGPURenderer } from '../../gpu/WebGPURenderer';
@@ -195,6 +196,8 @@ export class GlobalUniformSystem implements System
 
     public destroy()
     {
-        // boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }

--- a/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
+++ b/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
@@ -91,6 +91,6 @@ export class UniformBufferSystem implements System
 
     public destroy(): void
     {
-        throw new Error('Method not implemented.');
+        this._syncFunctionHash = null;
     }
 }

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -281,20 +281,6 @@ export class AbstractRenderer<PIPES, OPTIONS>
         return this;
     }
 
-    private _destroySystem(name: string, options: DestroyOptions = false): void
-    {
-        const system = this._systemsHash[name];
-
-        for (const i in this.runners)
-        {
-            this.runners[i].remove(system);
-        }
-
-        system.destroy?.(options);
-
-        delete this._systemsHash[name];
-    }
-
     private _addPipes(pipes: RendererConfig['renderPipes'], pipeAdaptors: RendererConfig['renderPipeAdaptors']): void
     {
         const adaptors = pipeAdaptors.reduce((acc, adaptor) =>
@@ -323,6 +309,9 @@ export class AbstractRenderer<PIPES, OPTIONS>
     {
         const writeable = this as Writeable<typeof this, 'renderPipes' | 'runners'>;
 
+        this.runners.destroy.items.reverse();
+        this.runners.destroy.emit(options);
+
         // destroy all runners
         Object.values(this.runners).forEach((runner) =>
         {
@@ -330,13 +319,6 @@ export class AbstractRenderer<PIPES, OPTIONS>
         });
 
         writeable.runners = null;
-
-        // destroy all systems
-        Object.keys(this._systemsHash).forEach((name) =>
-        {
-            this._destroySystem(name, options);
-        });
-
         this._systemsHash = null;
 
         // destroy all pipes

--- a/src/rendering/renderers/shared/system/System.ts
+++ b/src/rendering/renderers/shared/system/System.ts
@@ -1,6 +1,7 @@
+import type { DestroyOptions } from '../../../scene/destroyTypes';
 import type { Renderer } from '../../types';
 
-export interface System<INIT_OPTIONS = null, DESTROY_OPTIONS = null>
+export interface System<INIT_OPTIONS = null, DESTROY_OPTIONS = DestroyOptions>
 {
     init?: (options?: INIT_OPTIONS) => void;
     /** Generic destroy methods to be overridden by the subclass */

--- a/src/rendering/scene/LayerSystem.ts
+++ b/src/rendering/scene/LayerSystem.ts
@@ -6,6 +6,7 @@ import { updateLayerGroupTransforms } from './utils/updateLayerGroupTransforms';
 import { validateRenderables } from './utils/validateRenderables';
 
 import type { Matrix } from '../../maths/Matrix';
+import type { Writeable } from '../../utils/types';
 import type { WebGPURenderer } from '../renderers/gpu/WebGPURenderer';
 import type { System } from '../renderers/shared/system/System';
 import type { Renderer } from '../renderers/types';
@@ -107,7 +108,9 @@ export class LayerSystem implements System
 
     public destroy()
     {
-        // boom!
+        const writeable = this as Writeable<typeof this, '_renderer'>;
+
+        writeable._renderer = null;
     }
 }
 

--- a/src/rendering/scene/destroyTypes.ts
+++ b/src/rendering/scene/destroyTypes.ts
@@ -14,10 +14,16 @@ export interface ContextDestroyOptions
     context?: boolean;
 }
 
+export interface ViewSystemDestroyOptions
+{
+    removeView?: boolean;
+}
+
 export type TypeOrBool<T> = T | boolean;
 
 export type DestroyOptions = TypeOrBool<
 BaseDestroyOptions &
 ContextDestroyOptions &
-TextureDestroyOptions
+TextureDestroyOptions &
+ViewSystemDestroyOptions
 >;

--- a/src/rendering/text/canvas/CanvasTextSystem.ts
+++ b/src/rendering/text/canvas/CanvasTextSystem.ts
@@ -385,6 +385,6 @@ export class CanvasTextSystem implements System
 
     public destroy(): void
     {
-        // TODO: Destroy all the canvas elements
+        this._activeTextures = null;
     }
 }

--- a/src/rendering/text/html/HTMLTextSystem.ts
+++ b/src/rendering/text/html/HTMLTextSystem.ts
@@ -213,6 +213,6 @@ export class HTMLTextSystem implements System
 
     public destroy(): void
     {
-        // TODO: Destroy all the canvas elements
+        this._activeTextures = null;
     }
 }


### PR DESCRIPTION
Ensure `destroy()` is implemented for all systems.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa4041f</samp>

This pull request adds or implements the `destroy` method for various classes that are part of the rendering systems of pixijs. The `destroy` method is used to free up resources and references that are no longer needed by the application. The pull request also imports some type definitions and helpers to enable the destruction operations and fixes a minor issue with the `_currentCursor` property of the `EventSystem` class.