### PR TITLE
rename type to renderPipeId

### DIFF
--- a/src/rendering/graphics/shared/GraphicsView.ts
+++ b/src/rendering/graphics/shared/GraphicsView.ts
@@ -13,7 +13,7 @@ export class GraphicsView implements View
     public readonly uid = UID++;
     public readonly canBundle = true;
     public readonly owner = emptyViewObserver;
-    public readonly type = 'graphics';
+    public readonly renderPipeId = 'graphics';
     public batched: boolean;
 
     /** @internal */

--- a/src/rendering/mesh/shared/MeshView.ts
+++ b/src/rendering/mesh/shared/MeshView.ts
@@ -35,7 +35,7 @@ export class MeshView<
 >implements View
 {
     public readonly uid: number = UID++;
-    public readonly type = 'mesh';
+    public readonly renderPipeId = 'mesh';
     public readonly canBundle = true;
     public readonly owner = emptyViewObserver;
     public state = State.for2d();

--- a/src/rendering/renderers/shared/View.ts
+++ b/src/rendering/renderers/shared/View.ts
@@ -21,7 +21,7 @@ export interface View
      * an identifier that is used to identify the type of system that will be used to render this renderable
      * eg, 'sprite' will use the sprite system (based on the systems name
      */
-    type: string;
+    renderPipeId: string;
 
     owner: ViewObserver;
 

--- a/src/rendering/scene/LayerGroup.ts
+++ b/src/rendering/scene/LayerGroup.ts
@@ -210,7 +210,7 @@ export class LayerGroup implements Instruction
 
         container.didViewUpdate = false;
         // actually updates the renderable..
-        this.instructionSet.renderPipes[container.view.type].updateRenderable(container);
+        this.instructionSet.renderPipes[container.view.renderPipeId].updateRenderable(container);
     }
 
     public onChildViewUpdate(child: Renderable)

--- a/src/rendering/scene/utils/buildInstructions.ts
+++ b/src/rendering/scene/utils/buildInstructions.ts
@@ -76,7 +76,7 @@ function collectAllRenderablesSimple(
 
         const rp = renderPipes as unknown as Record<string, RenderPipe>;
 
-        rp[view.type].addRenderable(container, instructionSet);
+        rp[view.renderPipeId].addRenderable(container, instructionSet);
     }
 
     if (!container.isLayerRoot)
@@ -112,7 +112,7 @@ function collectAllRenderablesAdvanced(
                 renderPipes.blendMode.setBlendMode(proxyRenderable, proxyRenderable.layerBlendMode, instructionSet);
 
                 // eslint-disable-next-line max-len
-                (renderPipes[proxyRenderable.view.type as keyof RenderPipes] as any).addRenderable(proxyRenderable, instructionSet);
+                (renderPipes[proxyRenderable.view.renderPipeId as keyof RenderPipes] as any).addRenderable(proxyRenderable, instructionSet);
             }
         }
     }
@@ -141,7 +141,7 @@ function collectAllRenderablesAdvanced(
             renderPipes.blendMode.setBlendMode(container as Renderable, container.layerBlendMode, instructionSet);
             container.didViewUpdate = false;
 
-            const pipe = renderPipes[view.type as keyof RenderPipes]as RenderPipe<any>;
+            const pipe = renderPipes[view.renderPipeId as keyof RenderPipes]as RenderPipe<any>;
 
             pipe.addRenderable(container, instructionSet);
         }

--- a/src/rendering/scene/utils/validateRenderables.ts
+++ b/src/rendering/scene/utils/validateRenderables.ts
@@ -13,7 +13,7 @@ export function validateRenderables(layerGroup: LayerGroup, renderPipes: RenderP
         const container = list[i];
 
         const renderable = container.view;
-        const pipe = renderPipes[renderable.type as keyof RenderPipes] as RenderPipe<any>;
+        const pipe = renderPipes[renderable.renderPipeId as keyof RenderPipes] as RenderPipe<any>;
 
         rebuildRequired = pipe.validateRenderable(container);
 

--- a/src/rendering/sprite/shared/SpriteView.ts
+++ b/src/rendering/sprite/shared/SpriteView.ts
@@ -12,7 +12,7 @@ let uid = 0;
 
 export class SpriteView implements View
 {
-    public readonly type = 'sprite';
+    public readonly renderPipeId = 'sprite';
     public readonly owner: ViewObserver = emptyViewObserver;
     public readonly uid: number = uid++;
     public batched = true;

--- a/src/rendering/text/TextView.ts
+++ b/src/rendering/text/TextView.ts
@@ -45,7 +45,7 @@ export class TextView implements View
     public static defaultAutoResolution = true;
 
     public readonly uid: number = uid++;
-    public readonly type: string = 'text';
+    public readonly renderPipeId: string = 'text';
     public readonly owner: ViewObserver = emptyViewObserver;
     public batched = true;
     public anchor: ObservablePoint;
@@ -74,7 +74,7 @@ export class TextView implements View
 
         this._style = ensureTextStyle(renderMode, options.style);
 
-        this.type = map[renderMode];
+        this.renderPipeId = map[renderMode];
 
         this.anchor = new ObservablePoint(this, 0, 0);
 
@@ -186,7 +186,7 @@ export class TextView implements View
         const bounds = this._bounds;
         const padding = this._style.padding;
 
-        if (this.type === 'bitmapText')
+        if (this.renderPipeId === 'bitmapText')
         {
             const bitmapMeasurement = BitmapFontManager.measureText(this.text, this._style);
             const scale = bitmapMeasurement.scale;
@@ -197,7 +197,7 @@ export class TextView implements View
             bounds[2] = (bitmapMeasurement.width * scale) - padding;
             bounds[3] = ((bitmapMeasurement.height * scale) + offset) - padding;
         }
-        else if (this.type === 'htmlText')
+        else if (this.renderPipeId === 'htmlText')
         {
             const htmlMeasurement = measureHtmlText(this.text, this._style as HTMLTextStyle);
 

--- a/src/tiling-sprite/TilingSpriteView.ts
+++ b/src/tiling-sprite/TilingSpriteView.ts
@@ -30,7 +30,7 @@ export class TilingSpriteView implements View
 
     public readonly owner = emptyViewObserver;
     public readonly uid = uid++;
-    public readonly type = 'tilingSprite';
+    public readonly renderPipeId = 'tilingSprite';
     public batched = true;
     public anchor: ObservablePoint;
 

--- a/tests/scene/DummyView.ts
+++ b/tests/scene/DummyView.ts
@@ -10,7 +10,7 @@ export class DummyView extends EventEmitter implements View
     public owner: ViewObserver;
     public uid: number;
     public batched: boolean;
-    public type = 'dummy';
+    public renderPipeId = 'dummy';
     public renderableUpdateRequested: boolean;
     public onUpdate: () => void;
     public addBounds = (bounds: Bounds) =>


### PR DESCRIPTION
using `type` always confused me as it didn't really mean anything. So i think changing it to `renderPipeId` makes it a bit clearer 