### PR TITLE
v8 Extract tweaks 

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "build:dts": "ts-node --transpile-only ./scripts/types/fixTypes.ts && copyfiles -u 1 \"src/**/*.d.ts\" lib/",
     "dist": "run-s lint test:types build docs",
     "prewatch": "npm run build",
+    "postwatch:build": "rimraf \"src/**/index.ts\" --glob",
     "watch": "nodemon --watch \"./src/*\" --exec \"npm run watch:build\" -e ts,js,vert,frag,wgsl,d.ts --ignore \"index.ts\"",
     "watch:build": "run-s build:index build:rollup build:tsc build:dts",
     "test": "npx jest --silent",

--- a/src/filters/color-matrix/colorMatrixFilter.wgsl
+++ b/src/filters/color-matrix/colorMatrixFilter.wgsl
@@ -108,9 +108,9 @@ fn mainFragment(
 
     var rgb = mix(c.rgb, result.rgb, colorMatrixUniforms.uAlpha);
 
-    // rgb.r *= result.a;
-    // rgb.g *= result.a;
-    // rgb.b *= result.a;
+    rgb.r *= result.a;
+    rgb.g *= result.a;
+    rgb.b *= result.a;
 
     return vec4(rgb, result.a);
 }

--- a/src/rendering/graphics/gpu/GpuGraphicsAdaptor.ts
+++ b/src/rendering/graphics/gpu/GpuGraphicsAdaptor.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { Matrix } from '../../../maths/Matrix';
+import { getTextureBatchBindGroup } from '../../batcher/gpu/getTextureBatchBindGroup';
 import { MAX_TEXTURES } from '../../batcher/shared/const';
 import { BindGroup } from '../../renderers/gpu/shader/BindGroup';
 import { Shader } from '../../renderers/shared/shader/Shader';
@@ -98,6 +99,16 @@ export class GpuGraphicsAdaptor implements GraphicsAdaptor
             const batch = batches[i];
 
             shader.groups[1] = batch.bindGroup;
+
+            if (!batch.gpuBindGroup)
+            {
+                const textureBatch = batch.textures;
+
+                batch.bindGroup = getTextureBatchBindGroup(textureBatch.textures, textureBatch.count);
+                batch.gpuBindGroup = renderer.bindGroup.getBindGroup(
+                    batch.bindGroup, shader.gpuProgram, 1
+                );
+            }
 
             encoder.setBindGroup(1, batch.bindGroup, shader.gpuProgram);
 

--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -5,7 +5,7 @@ import { TextureSource } from '../shared/texture/sources/TextureSource';
 import { Texture } from '../shared/texture/Texture';
 import { GlProgram } from './shader/GlProgram';
 
-import type { RenderSurface } from '../gpu/renderTarget/GpuRenderTargetSystem';
+import type { RenderSurface, RGBAArray } from '../gpu/renderTarget/GpuRenderTargetSystem';
 import type { System } from '../shared/system/System';
 import type { WebGLRenderer } from './WebGLRenderer';
 
@@ -66,7 +66,7 @@ export class GlBackBufferSystem implements System
         this._useBackBuffer = useBackBuffer;
     }
 
-    protected renderStart({ target, clear }: { target: RenderSurface, clear: boolean })
+    protected renderStart({ target, clear, clearColor }: { target: RenderSurface, clear: boolean, clearColor: RGBAArray })
     {
         this._useBackBufferThisRender = this._useBackBuffer && !!target;
 
@@ -79,7 +79,7 @@ export class GlBackBufferSystem implements System
             target = this._getBackBufferTexture(renderTarget.colorTexture);
         }
 
-        this._renderer.renderTarget.start(target, clear, this._renderer.background.colorRgba);
+        this._renderer.renderTarget.start(target, clear, clearColor || this._renderer.background.colorRgba);
     }
 
     protected renderEnd()

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -216,7 +216,7 @@ export class GpuTextureSystem implements System, CanvasGenerator
             // eslint-disable-next-line max-len
             usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
             format: 'bgra8unorm',
-            alphaMode: 'opaque',
+            alphaMode: 'premultiplied',
         });
 
         commandEncoder.copyTextureToTexture({

--- a/src/rendering/renderers/shared/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/ExtractSystem.ts
@@ -145,17 +145,14 @@ export class ExtractSystem implements System
 
     public canvas(options: ExtractOptions | Container | Texture): ICanvas
     {
-        const { target, frame, clearColor, resolution } = this._normalizeOptions(options);
+        options = this._normalizeOptions(options);
+
+        const target = options.target;
 
         const renderer = this._renderer;
         const texture = target instanceof Texture
             ? target
-            : renderer.textureGenerator.generateTexture({
-                container: target,
-                region: frame,
-                clearColor,
-                resolution,
-            } as GenerateTextureOptions);
+            : renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
 
         const canvas = renderer.texture.generateCanvas(texture);
 
@@ -170,15 +167,14 @@ export class ExtractSystem implements System
 
     public pixels(options: ExtractOptions | Container | Texture): GetPixelsOutput
     {
-        const { target, frame, resolution } = this._normalizeOptions(options);
+        options = this._normalizeOptions(options);
+
+        const target = options.target;
+
         const renderer = this._renderer;
         const texture = target instanceof Texture
             ? target
-            : renderer.textureGenerator.generateTexture({
-                container: target,
-                region: frame,
-                resolution,
-            } as GenerateTextureOptions);
+            : renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
 
         const pixelInfo = renderer.texture.getPixels(texture);
 
@@ -193,25 +189,20 @@ export class ExtractSystem implements System
 
     public texture(options: ExtractOptions | Container | Texture): Texture
     {
-        const { target, frame, resolution } = this._normalizeOptions(options);
+        options = this._normalizeOptions(options);
 
-        return this._renderer.textureGenerator.generateTexture({
-            container: target,
-            region: frame,
-            resolution,
-        } as GenerateTextureOptions);
+        return this._renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
     }
 
     public download(options: ExtractDownloadOptions | Container | Texture)
     {
-        const {
-            filename,
-        } = this._normalizeOptions<ExtractDownloadOptions>(options);
+        options = this._normalizeOptions<ExtractDownloadOptions>(options);
+
         const canvas = this.canvas(options);
 
         const link = document.createElement('a');
 
-        link.download = filename ?? 'image.png';
+        link.download = options.filename ?? 'image.png';
         link.href = canvas.toDataURL('image/png');
         document.body.appendChild(link);
         link.click();

--- a/src/rendering/renderers/shared/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/GenerateTextureSystem.ts
@@ -6,6 +6,7 @@ import { getLocalBounds } from '../../scene/bounds/getLocalBounds';
 import { Container } from '../../scene/Container';
 import { RenderTexture } from './texture/RenderTexture';
 
+import type { RGBAArray } from '../gpu/renderTarget/GpuRenderTargetSystem';
 import type { Renderer } from '../types';
 import type { System } from './system/System';
 import type { TextureSourceOptions } from './texture/sources/TextureSource';
@@ -25,12 +26,15 @@ export type GenerateTextureOptions =
 
     resolution?: number;
 
+    clearColor?: RGBAArray;
+
     /** The options passed to the texture source. */
-    textureSourceOptions?: GenerateTextureSourceOptions
+    textureSourceOptions?: GenerateTextureSourceOptions,
 };
 
 const tempRect = new Rectangle();
 const tempBounds = new Bounds();
+const noColor: RGBAArray = [0, 0, 0, 0];
 
 /**
  * System that manages the generation of textures from the renderer.
@@ -77,8 +81,9 @@ export class GenerateTextureSystem implements System
         }
 
         const resolution = options.resolution || this._renderer.resolution;
-        const container = options.container;
 
+        const container = options.container;
+        const clearColor = options.clearColor || noColor;
         const region = options.region?.copyTo(tempRect)
             || getLocalBounds(container, tempBounds).rectangle;
 
@@ -98,6 +103,7 @@ export class GenerateTextureSystem implements System
             container,
             transform,
             target,
+            clearColor,
         });
 
         return target;

--- a/src/rendering/renderers/shared/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/GenerateTextureSystem.ts
@@ -17,12 +17,12 @@ export type GenerateTextureSourceOptions = Omit<TextureSourceOptions, 'resource'
 export type GenerateTextureOptions =
 {
     /** The container to generate the texture from */
-    container: Container;
+    target: Container;
     /**
      * The region of the displayObject, that shall be rendered,
      * if no region is specified, defaults to the local bounds of the displayObject.
      */
-    region?: Rectangle;
+    frame?: Rectangle;
 
     resolution?: number;
 
@@ -73,8 +73,8 @@ export class GenerateTextureSystem implements System
         if (options instanceof Container)
         {
             options = {
-                container: options,
-                region: undefined,
+                target: options,
+                frame: undefined,
                 textureSourceOptions: {},
                 resolution: undefined,
             };
@@ -82,9 +82,9 @@ export class GenerateTextureSystem implements System
 
         const resolution = options.resolution || this._renderer.resolution;
 
-        const container = options.container;
+        const container = options.target;
         const clearColor = options.clearColor || noColor;
-        const region = options.region?.copyTo(tempRect)
+        const region = options.frame?.copyTo(tempRect)
             || getLocalBounds(container, tempBounds).rectangle;
 
         region.width = Math.max(region.width, 1 / resolution) | 0;

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -21,7 +21,7 @@ export class BufferResource extends EventEmitter<{
     public readonly size: number;
     public readonly bufferResource = true;
 
-    constructor({ buffer, offset, size }: { buffer: Buffer; offset: number; size: number; })
+    constructor({ buffer, offset, size }: { buffer: Buffer; offset: number; size?: number; })
     {
         super();
 

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -6,7 +6,7 @@ import type { Matrix } from '../../../../maths/Matrix';
 import type { Rectangle } from '../../../../maths/shapes/Rectangle';
 import type { ICanvas } from '../../../../settings/adapter/ICanvas';
 import type { Writeable } from '../../../../utils/types';
-import type { RenderSurface } from '../../gpu/renderTarget/GpuRenderTargetSystem';
+import type { RenderSurface, RGBAArray } from '../../gpu/renderTarget/GpuRenderTargetSystem';
 import type { Renderer } from '../../types';
 import type { GenerateTextureOptions, GenerateTextureSystem } from '../GenerateTextureSystem';
 import type { PipeConstructor } from '../instructions/RenderPipe';
@@ -29,6 +29,7 @@ export interface RenderOptions
     container: Container;
     transform?: Matrix;
     target?: RenderSurface;
+    clearColor?: RGBAArray;
 }
 
 const defaultRunners = [

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -2,11 +2,13 @@ import EventEmitter from 'eventemitter3';
 import { Cache } from '../../../../assets/cache/Cache';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
 import { NOOP } from '../../../../utils/NOOP';
+import { BufferImageSource } from './sources/BufferImageSource';
 import { TextureSource } from './sources/TextureSource';
 import { TextureLayout } from './TextureLayout';
 import { TextureMatrix } from './TextureMatrix';
 import { TextureStyle } from './TextureStyle';
 
+import type { BufferSourceOptions } from './sources/BufferImageSource';
 import type { TextureSourceOptions } from './sources/TextureSource';
 import type { TextureLayoutOptions } from './TextureLayout';
 import type { TextureStyleOptions } from './TextureStyle';
@@ -47,6 +49,16 @@ export class Texture extends EventEmitter<{
         // TODO check to see if there is a resource and use the correct source type
         return new Texture({
             source: new TextureSource(id)
+        });
+    }
+
+    public static fromBuffer(options: BufferSourceOptions): Texture
+    {
+        return new Texture({
+            source: BufferImageSource.from(options),
+            style: {
+                scaleMode: 'nearest',
+            }
         });
     }
 

--- a/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
@@ -3,7 +3,7 @@ import { TextureSource } from './TextureSource';
 import type { TypedArray } from '../../buffer/Buffer';
 import type { TextureSourceOptions } from './TextureSource';
 
-export interface BufferSourceOptions extends TextureSourceOptions<Buffer>
+export interface BufferSourceOptions extends TextureSourceOptions<TypedArray | ArrayBuffer>
 {
     width: number;
     height: number;
@@ -12,4 +12,49 @@ export interface BufferSourceOptions extends TextureSourceOptions<Buffer>
 export class BufferImageSource extends TextureSource<TypedArray | ArrayBuffer>
 {
     public type = 'buffer';
+
+    public static from(options: BufferSourceOptions): BufferImageSource
+    {
+        const buffer = options.resource || new Float32Array(options.width * options.height * 4);
+
+        let format = options.format;
+
+        if (!format)
+        {
+            if (buffer instanceof Float32Array)
+            {
+                format = 'rgba32float';
+            }
+            else if (buffer instanceof Int32Array)
+            {
+                format = 'rgba32uint';
+            }
+            else if (buffer instanceof Uint32Array)
+            {
+                format = 'rgba32uint';
+            }
+            else if (buffer instanceof Int16Array)
+            {
+                format = 'rgba16uint';
+            }
+            else if (buffer instanceof Uint16Array)
+            {
+                format = 'rgba16uint';
+            }
+            else if (buffer instanceof Int8Array)
+            {
+                format = 'bgra8unorm';
+            }
+            else
+            {
+                format = 'bgra8unorm';
+            }
+        }
+
+        return new BufferImageSource({
+
+            ...options,
+            format,
+        });
+    }
 }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -82,7 +82,7 @@ const settings: Settings & Partial<PixiMixins.Settings> = {
      * @type {number}
      * @default 1
      */
-    RESOLUTION: 2,
+    RESOLUTION: 1,
 };
 
 export { settings };

--- a/tests/renderering/extract/Extract.test.ts
+++ b/tests/renderering/extract/Extract.test.ts
@@ -1,6 +1,8 @@
+import { Graphics } from '../../../src/rendering/graphics/shared/Graphics';
 import { ExtractSystem } from '../../../src/rendering/renderers/shared/ExtractSystem';
 import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
 import { Container } from '../../../src/rendering/scene/Container';
+import { Sprite } from '../../../src/rendering/sprite/shared/Sprite';
 import { getRenderer } from '../../utils/getRenderer';
 import { getTexture } from '../../utils/getTexture';
 
@@ -108,136 +110,111 @@ describe('GenerateTexture', () =>
         renderer.destroy();
     });
 
-    // it('should extract the same pixels', async () =>
-    // {
-    //     const renderer = (await getRenderer('webgl', { width: 2, height: 2 })) as WebGLRenderer;
-    //     const graphics = new Graphics()
-    //         .context.
-    //         // .beginFill(0xFF0000)
-    //         .drawRect(0, 0, 1, 1)
-    //         .endFill()
-    //         .beginFill(0x00FF00)
-    //         .drawRect(1, 0, 1, 1)
-    //         .endFill()
-    //         .beginFill(0x0000FF)
-    //         .drawRect(0, 1, 1, 1)
-    //         .endFill()
-    //         .beginFill(0xFFFF00)
-    //         .drawRect(1, 1, 1, 1)
-    //         .endFill();
-    //     const expectedPixels = new Uint8Array([
-    //         255, 0, 0, 255,
-    //         0, 255, 0, 255,
-    //         0, 0, 255, 255,
-    //         255, 255, 0, 255
-    //     ]);
-    //     const renderTexture = renderer.generateTexture(graphics);
-    //     const extract = renderer.extract;
+    it('should extract the same pixels', async () =>
+    {
+        const renderer = (await getRenderer({ width: 2, height: 2 })) as WebGLRenderer;
 
-    //     renderer.render(graphics);
+        const graphics = new Graphics()
+            // .beginFill(0xFF0000)
+            .rect(0, 0, 1, 1)
+            .fill(0xFF0000)
+            .rect(1, 0, 1, 1)
+            .fill(0x00FF00)
+            .rect(0, 1, 1, 1)
+            .fill(0x0000FF)
+            .rect(1, 1, 1, 1)
+            .fill(0xFFFF00);
 
-    //     const pixelsRenderer = extract.pixels();
-    //     const pixelsRenderTexture = extract.pixels(renderTexture);
-    //     const pixelsGraphics = extract.pixels(graphics);
+        const expectedPixels = new Uint8ClampedArray([
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            255, 255, 0, 255
+        ]);
 
-    //     expect(pixelsRenderer).toEqual(expectedPixels);
-    //     expect(pixelsRenderTexture).toEqual(expectedPixels);
-    //     expect(pixelsGraphics).toEqual(expectedPixels);
+        const pixelsGraphics = renderer.extract.pixels(graphics);
 
-    //     renderTexture.destroy(true);
-    //     graphics.destroy();
-    //     renderer.destroy();
-    // });
+        expect(pixelsGraphics.pixels).toEqual(expectedPixels);
+    });
 
-    // it('should extract pixels from renderer correctly', async () =>
-    // {
-    //     const renderer = new Renderer({ width: 2, height: 2 });
-    //     const texturePixels = new Uint8Array([
-    //         255, 0, 0, 255, 0, 255, 0, 153,
-    //         0, 0, 255, 102, 255, 255, 0, 51
-    //     ]);
-    //     const texture = Texture.fromBuffer(texturePixels, 2, 2, {
-    //         width: 2,
-    //         height: 2,
-    //         format: FORMATS.RGBA,
-    //         type: TYPES.UNSIGNED_BYTE,
-    //         alphaMode: ALPHA_MODES.UNPACK
-    //     });
-    //     const sprite = new Sprite(texture);
-    //     const extract = renderer.extract;
+    it('should extract pixels from renderer correctly', async () =>
+    {
+        const renderer = (await getRenderer({ width: 2, height: 2 })) as WebGLRenderer;
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
 
-    //     renderer.render(sprite);
+        const texture = Texture.fromBuffer({
+            resource: texturePixels,
+            width: 2,
+            height: 2,
+        });
 
-    //     const extractedPixels = extract.pixels();
+        const sprite = new Sprite(texture);
 
-    //     expect(extractedPixels).toEqual(new Uint8Array([
-    //         255, 0, 0, 255, 0, 153, 0, 255,
-    //         0, 0, 102, 255, 51, 51, 0, 255
-    //     ]));
+        const extractedPixels = renderer.extract.pixels(sprite).pixels;
 
-    //     texture.destroy(true);
-    //     sprite.destroy();
-    //     renderer.destroy();
-    // });
+        expect(extractedPixels).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]));
+    });
 
-    // it('should extract canvas from renderer correctly', async () =>
-    // {
-    //     const renderer = new Renderer({ width: 2, height: 2 });
-    //     const texturePixels = new Uint8Array([
-    //         255, 0, 0, 255, 0, 255, 0, 153,
-    //         0, 0, 255, 102, 255, 255, 0, 51
-    //     ]);
-    //     const texture = Texture.fromBuffer(texturePixels, 2, 2, {
-    //         width: 2,
-    //         height: 2,
-    //         format: FORMATS.RGBA,
-    //         type: TYPES.UNSIGNED_BYTE,
-    //         alphaMode: ALPHA_MODES.UNPACK
-    //     });
-    //     const sprite = new Sprite(texture);
-    //     const extract = renderer.extract;
+    it('should extract canvas from renderer correctly', async () =>
+    {
+        const renderer = (await getRenderer({ width: 2, height: 2 })) as WebGLRenderer;
 
-    //     renderer.render(sprite);
+        const texturePixels = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
 
-    //     const canvas = extract.canvas();
-    //     const context = canvas.getContext('2d');
-    //     const imageData = context?.getImageData(0, 0, 2, 2);
+        const texture = Texture.fromBuffer({
+            resource: texturePixels,
+            width: 2,
+            height: 2,
+        });
 
-    //     expect(imageData?.data).toEqual(new Uint8ClampedArray([
-    //         255, 0, 0, 255, 0, 153, 0, 255,
-    //         0, 0, 102, 255, 51, 51, 0, 255
-    //     ]));
+        const sprite = new Sprite(texture);
 
-    //     texture.destroy(true);
-    //     sprite.destroy();
-    //     renderer.destroy();
-    // });
+        renderer.render(sprite);
 
-    // it('should extract pixels from render texture correctly', async () =>
-    // {
-    //     const renderer = new Renderer({ width: 2, height: 2 });
-    //     const texturePixels = new Uint8Array([
-    //         255, 0, 0, 255, 0, 255, 0, 153,
-    //         0, 0, 255, 102, 255, 255, 0, 51
-    //     ]);
-    //     const texture = Texture.fromBuffer(texturePixels, 2, 2, {
-    //         width: 2,
-    //         height: 2,
-    //         format: FORMATS.RGBA,
-    //         type: TYPES.UNSIGNED_BYTE,
-    //         alphaMode: ALPHA_MODES.UNPACK
-    //     });
-    //     const sprite = new Sprite(texture);
-    //     const extract = renderer.extract;
+        const canvas = renderer.extract.canvas(sprite);
+        const context = canvas.getContext('2d');
+        const imageData = context?.getImageData(0, 0, 2, 2);
 
-    //     const extractedPixels = extract.pixels(sprite);
+        expect(imageData?.data).toEqual(new Uint8ClampedArray([
+            255, 0, 0, 255,
+            0, 255, 0, 153,
+            0, 0, 255, 102,
+            255, 255, 0, 51
+        ]));
+    });
 
-    //     expect(extractedPixels).toEqual(texturePixels);
+    it('should extract pixels from render texture correctly', async () =>
+    {
+        const renderer = (await getRenderer({ width: 2, height: 2 })) as WebGLRenderer;
 
-    //     texture.destroy(true);
-    //     sprite.destroy();
-    //     renderer.destroy();
-    // });
+        const texturePixels = new Uint8ClampedArray([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+
+        const texture = Texture.fromBuffer({
+            resource: texturePixels,
+            width: 2,
+            height: 2,
+        });
+
+        const sprite = new Sprite(texture);
+
+        const { pixels, width, height } = renderer.extract.pixels(sprite);
+
+        expect(pixels).toEqual(texturePixels);
+        expect(width).toEqual(2);
+        expect(height).toEqual(2);
+    });
 
     // it('should extract canvas from render texture correctly', async () =>
     // {

--- a/tests/renderering/textures/GenerateTexture.test.ts
+++ b/tests/renderering/textures/GenerateTexture.test.ts
@@ -20,7 +20,7 @@ describe('GenerateTexture', () =>
         const renderer = (await getRenderer()) as WebGLRenderer;
         const container = new Container();
         const texture = renderer.textureGenerator.generateTexture({
-            container,
+            target: container,
         });
 
         expect(texture).toBeInstanceOf(Texture);


### PR DESCRIPTION
- resolution now part of `BaseExtractOptions`
- resolution now working
- generateTexture now has same options names as extract (frame + target instead of region + container)
- this simplifies extract code
- added fromBuffer to Texture
- set default resolution to 1
- fixed a bunch of tests (will do the rest during the test pass ticket!)
- we now delete index on build watch
- fixed transpancy issue on extract
- added clearColor option for extract and render

copilot:all