### PR TITLE
Allow resolveCharacters to return empty set for empty strings

### DIFF
--- a/src/rendering/text/bitmap/utils/resolveCharacters.ts
+++ b/src/rendering/text/bitmap/utils/resolveCharacters.ts
@@ -9,6 +9,12 @@
 
 export function resolveCharacters(chars: string | (string | string[])[]): string[]
 {
+    // Skip unexpected 'empty set' check at end
+    if (chars === '')
+    {
+        return [];
+    }
+
     // Split the chars string into individual characters
     if (typeof chars === 'string')
     {
@@ -28,6 +34,10 @@ export function resolveCharacters(chars: string | (string | string[])[]): string
             if (item.length !== 2)
             {
                 throw new Error(`[BitmapFont]: Invalid character range length, expecting 2 got ${item.length}.`);
+            }
+            if (item[0].length === 0 || item[1].length === 0)
+            {
+                throw new Error('[BitmapFont]: Invalid character delimiter.');
             }
 
             const startCode = item[0].charCodeAt(0);


### PR DESCRIPTION
Fixes #9660 

##### Description of change

`resolveCharacters` has a safety check to ensure it never returns an empty set of characters. However, for empty strings, that is the expected result. I've added an escape at the top of the function for this special check.

This will allow empty `Text` display-objects to render without any measurement issues.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
