### PR TITLE
Some misc v8 fixes and tweaks

### DIFF
--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -54,9 +54,11 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
         if (!this._batches[instructionSet.uid])
         {
             // TODO keeping around to bench mark at a later date..
-            //   this._batches[instructionSet.uid] = new BatcherStyleSource();
-            this._batches[instructionSet.uid] = new Batcher();
-            this._geometries[instructionSet.uid] = getBatchedGeometry();
+            // const batcher = new BatcherStyleSource();
+            const batcher = new Batcher();
+
+            this._batches[instructionSet.uid] = batcher;
+            this._geometries[batcher.uid] = getBatchedGeometry();
         }
 
         this._activeBatch = this._batches[instructionSet.uid];

--- a/src/rendering/high-shader/shader-bits/colorBit.ts
+++ b/src/rendering/high-shader/shader-bits/colorBit.ts
@@ -5,7 +5,7 @@ export const colorBit = {
             @in aColor: vec4<f32>;
         `,
         main: /* wgsl */`
-            vColor *= aColor;
+            vColor *= vec4<f32>(aColor.rgb * aColor.a, aColor.a);
         `
     }
 };
@@ -17,7 +17,7 @@ export const colorBitGl = {
             in vec4 aColor;
         `,
         main: /* glsl */`
-            vColor *= aColor;
+            vColor *= vec4(aColor.rgb * aColor.a, aColor.a);
         `
     }
 };

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -8,6 +8,7 @@ import { TextureLayout } from './TextureLayout';
 import { TextureMatrix } from './TextureMatrix';
 import { TextureStyle } from './TextureStyle';
 
+import type { Rectangle } from '../../../../maths/shapes/Rectangle';
 import type { BufferSourceOptions } from './sources/BufferImageSource';
 import type { TextureSourceOptions } from './sources/TextureSource';
 import type { TextureLayoutOptions } from './TextureLayout';
@@ -21,6 +22,7 @@ export interface TextureOptions
     style?: TextureStyle | TextureStyleOptions
     layout?: TextureLayout | TextureLayoutOptions
     label?: string;
+    frame?: Rectangle;
 }
 
 export interface BindableTexture
@@ -80,13 +82,27 @@ export class Texture extends EventEmitter<{
     /** @internal */
     public _source: TextureSource;
 
-    constructor({ source, style, layout, label }: TextureOptions = {})
+    constructor({ source, style, layout, label, frame }: TextureOptions = {})
     {
         super();
 
         this.label = label;
         this.source = source?.source ?? new TextureSource();
-        this.layout = layout instanceof TextureLayout ? layout : new TextureLayout(layout);
+
+        layout = layout instanceof TextureLayout ? layout : new TextureLayout(layout);
+
+        if (frame)
+        {
+            const { width, height } = this._source;
+
+            layout.frame.x = frame.x / width;
+            layout.frame.y = frame.y / height;
+
+            layout.frame.width = frame.width / width;
+            layout.frame.height = frame.height / height;
+        }
+
+        this.layout = layout as TextureLayout;
 
         if (style)
         {

--- a/src/rendering/sprite/shared/BatchableSprite.ts
+++ b/src/rendering/sprite/shared/BatchableSprite.ts
@@ -43,10 +43,10 @@ export class BatchableSprite implements BatchableObject
 
         const bounds = this.bounds;
 
-        const w0 = bounds[0];
-        const w1 = bounds[1];
-        const h0 = bounds[2];
-        const h1 = bounds[3];
+        const w0 = bounds[1];
+        const w1 = bounds[0];
+        const h0 = bounds[3];
+        const h1 = bounds[2];
 
         const uvs = texture._layout.uvs;
 

--- a/src/rendering/text/canvas/CanvasTextSystem.ts
+++ b/src/rendering/text/canvas/CanvasTextSystem.ts
@@ -99,8 +99,8 @@ export class CanvasTextSystem implements System
         texture.source.type = 'image';
         texture.source.resource = canvas;
 
-        texture.frameWidth = width;
-        texture.frameHeight = height;
+        texture.frameWidth = width / resolution;
+        texture.frameHeight = height / resolution;
 
         texture.source.update();
         texture.layout.updateUvs();

--- a/src/rendering/text/html/utils/getPo2TextureFromSource.ts
+++ b/src/rendering/text/html/utils/getPo2TextureFromSource.ts
@@ -32,8 +32,8 @@ export function getPo2TextureFromSource(image: HTMLImageElement | HTMLCanvasElem
     texture.source.type = 'image';
     texture.source.resource = image;
 
-    texture.frameWidth = image.width;
-    texture.frameHeight = image.height;
+    texture.frameWidth = image.width / resolution;
+    texture.frameHeight = image.height / resolution;
 
     texture.source.update();
     texture.layout.updateUvs();

--- a/src/utils/updateQuadBounds.ts
+++ b/src/utils/updateQuadBounds.ts
@@ -26,20 +26,20 @@ export function updateQuadBounds(
         const sourceWidth = textureSourceWidth * trim.width;
         const sourceHeight = textureSourceHeight * trim.height;
 
-        bounds[1] = (trim.x * textureSourceWidth) - (anchor._x * width) - padding;
-        bounds[0] = bounds[1] + sourceWidth;
+        bounds[0] = (trim.x * textureSourceWidth) - (anchor._x * width) - padding;
+        bounds[1] = bounds[0] + sourceWidth;
 
-        bounds[3] = (trim.y * textureSourceHeight) - (anchor._y * height) - padding;
-        bounds[2] = bounds[3] + sourceHeight;
+        bounds[2] = (trim.y * textureSourceHeight) - (anchor._y * height) - padding;
+        bounds[3] = bounds[2] + sourceHeight;
     }
 
     else
     {
-        bounds[1] = (-anchor._x * width) - padding;
-        bounds[0] = bounds[1] + width;
+        bounds[0] = (-anchor._x * width) - padding;
+        bounds[1] = bounds[0] + width;
 
-        bounds[3] = (-anchor._y * height) - padding;
-        bounds[2] = bounds[3] + height;
+        bounds[2] = (-anchor._y * height) - padding;
+        bounds[3] = bounds[2] + height;
     }
 
     return;


### PR DESCRIPTION
- fix text anchor points
- fix text bounds
- fixed text style detection
- adjust bounds to be correct index in the bounds
- fix alpha issue on tints
- fixed batcher bug
- added frame option to texture constructor

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fff0319</samp>

### Summary
🆔🔄🔎

<!--
1.  🆔 - This emoji represents the change of using the batcher uid instead of the instruction set uid for the geometries map. It conveys the idea of identity, uniqueness, and avoiding conflicts.
2.  🔄 - This emoji represents the change of swapping the order of the bounds array elements in the BatchableSprite and the updateQuadBounds function. It conveys the idea of reversing, rotating, or changing direction.
3.  🔎 - This emoji represents the change of dividing the texture frame dimensions by the resolution factor in the CanvasTextSystem and the getPo2TextureFromSource function. It conveys the idea of scaling, zooming, or adjusting the size of something.
-->
This pull request fixes a color bug in the WebGPU renderer, adds a frame option for creating sub-textures, improves the text rendering and bounds calculation logic, and harmonizes the order and size of the quad bounds and texture frames in the batcher and its related classes and functions. It affects the files `colorBit.ts`, `Texture.ts`, `TextView.ts`, `BatcherPipe.ts`, `BatchableSprite.ts`, `CanvasTextSystem.ts`, `getPo2TextureFromSource.ts`, and `updateQuadBounds.ts`.

> _We are the batchers of doom, we control the geometries_
> _We swap the bounds and vertices, we match the resolutions_
> _We render the colors of despair, we multiply the alphas_
> _We frame the textures of the night, we handle the fonts and modes_

### Walkthrough
*  Fix a bug where transparent colors would appear darker than expected in the WebGPU and WebGL renderers by multiplying the alpha component of the vertex color by the rgb components in the color bit shader (`[link](https://github.com/pixijs/pixijs/pull/9668/files?diff=unified&w=0#diff-8637e39dc14c519effcbd439e8a0f468323bad8c2baa9d1c0b64065e9c774f13L8-R8),[link](https://github.com/pixijs/pixijs/pull/9668/files?diff=unified&w=0#diff-8637e39dc14c519effcbd439e8a0f468323bad8c2baa9d1c0b64065e9c774f13L20-R20)`)



