### PR TITLE
Fix: detectAvif/Webp not working in Worker

### DIFF
--- a/packages/assets/src/detections/parsers/detectAvif.ts
+++ b/packages/assets/src/detections/parsers/detectAvif.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '@pixi/core';
+import { testImageFormat } from '../utils/testImageFormat';
 
 import type { FormatDetectionParser } from '..';
 
@@ -7,26 +8,10 @@ export const detectAvif: FormatDetectionParser = {
         type: ExtensionType.DetectionParser,
         priority: 1,
     },
-    test: async (): Promise<boolean> =>
-    {
+    test: async (): Promise<boolean> => testImageFormat(
         // eslint-disable-next-line max-len
-        const avifData = 'data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAIAAAACAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQ0MAAAAABNjb2xybmNseAACAAIAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgANogQEAwgMg8f8D///8WfhwB8+ErK42A=';
-
-        return new Promise((resolve) =>
-        {
-            const avif = new Image();
-
-            avif.onload = () =>
-            {
-                resolve(true);
-            };
-            avif.onerror = () =>
-            {
-                resolve(false);
-            };
-            avif.src = avifData;
-        });
-    },
+        'data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAIAAAACAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQ0MAAAAABNjb2xybmNseAACAAIAAYAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgANogQEAwgMg8f8D///8WfhwB8+ErK42A='
+    ),
     add: async (formats) => [...formats, 'avif'],
     remove: async (formats) => formats.filter((f) => f !== 'avif'),
 };

--- a/packages/assets/src/detections/parsers/detectWebp.ts
+++ b/packages/assets/src/detections/parsers/detectWebp.ts
@@ -1,4 +1,5 @@
 import { extensions, ExtensionType } from '@pixi/core';
+import { testImageFormat } from '../utils/testImageFormat';
 
 import type { FormatDetectionParser } from '..';
 
@@ -7,25 +8,9 @@ export const detectWebp = {
         type: ExtensionType.DetectionParser,
         priority: 0,
     },
-    test: async (): Promise<boolean> =>
-    {
-        const webpData = 'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=';
-
-        return new Promise((resolve) =>
-        {
-            const webp = new Image();
-
-            webp.onload = () =>
-            {
-                resolve(true);
-            };
-            webp.onerror = () =>
-            {
-                resolve(false);
-            };
-            webp.src = webpData;
-        });
-    },
+    test: async (): Promise<boolean> => testImageFormat(
+        'data:image/webp;base64,UklGRh4AAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA='
+    ),
     add: async (formats) => [...formats, 'webp'],
     remove: async (formats) => formats.filter((f) => f !== 'webp'),
 } as FormatDetectionParser;

--- a/packages/assets/src/detections/utils/testImageFormat.ts
+++ b/packages/assets/src/detections/utils/testImageFormat.ts
@@ -1,0 +1,41 @@
+export async function testImageFormat(imageData: string): Promise<boolean>
+{
+    try
+    {
+        // Some browsers currently do not support createImageBitmap with Blob, so new Image() is preferred when exist.
+        // See https://caniuse.com/createimagebitmap for more information.
+
+        if ('Image' in globalThis)
+        {
+            return await new Promise<boolean>((resolve) =>
+            {
+                const image = new Image();
+
+                image.onload = () =>
+                {
+                    resolve(true);
+                };
+                image.onerror = () =>
+                {
+                    resolve(false);
+                };
+                image.src = imageData;
+            });
+        }
+
+        if ('createImageBitmap' in globalThis && 'fetch' in globalThis)
+        {
+            const blob = await (await fetch(imageData)).blob();
+
+            await createImageBitmap(blob);
+
+            return true;
+        }
+
+        return false;
+    }
+    catch (e)
+    {
+        return false;
+    }
+}

--- a/packages/assets/src/detections/utils/testImageFormat.ts
+++ b/packages/assets/src/detections/utils/testImageFormat.ts
@@ -1,41 +1,41 @@
 export async function testImageFormat(imageData: string): Promise<boolean>
 {
-    try
+    // Some browsers currently do not support createImageBitmap with Blob, so new Image() is preferred when exist.
+    // See https://caniuse.com/createimagebitmap for more information.
+
+    if ('Image' in globalThis)
     {
-        // Some browsers currently do not support createImageBitmap with Blob, so new Image() is preferred when exist.
-        // See https://caniuse.com/createimagebitmap for more information.
-
-        if ('Image' in globalThis)
+        return new Promise<boolean>((resolve) =>
         {
-            return await new Promise<boolean>((resolve) =>
+            const image = new Image();
+
+            image.onload = () =>
             {
-                const image = new Image();
+                resolve(true);
+            };
+            image.onerror = () =>
+            {
+                resolve(false);
+            };
+            image.src = imageData;
+        });
+    }
 
-                image.onload = () =>
-                {
-                    resolve(true);
-                };
-                image.onerror = () =>
-                {
-                    resolve(false);
-                };
-                image.src = imageData;
-            });
-        }
-
-        if ('createImageBitmap' in globalThis && 'fetch' in globalThis)
+    if ('createImageBitmap' in globalThis && 'fetch' in globalThis)
+    {
+        try
         {
             const blob = await (await fetch(imageData)).blob();
 
             await createImageBitmap(blob);
-
-            return true;
+        }
+        catch (e)
+        {
+            return false;
         }
 
-        return false;
+        return true;
     }
-    catch (e)
-    {
-        return false;
-    }
+
+    return false;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Previously `detectAvif` & `detectWebp` use `new Image()` to detect image format, which won't work in Web Workers. This PR use `createImageBitmap` to detect image format when `Image` is not available.

Fixes #9697.

- Before: [Playground](https://pixijs.com/playground?source=eyJjb2RlIjoiZnVuY3Rpb24gd29ya2VyU291cmNlKHNlbGYpIHtcbiAgICBzZWxmLm9ubWVzc2FnZSA9IGFzeW5jICh7XG4gICAgICAgIGRhdGE6IHsgYmFzZVVybCwgcGl4aVdlYldvcmtlclVybCwgb3B0aW9ucyB9LFxuICAgIH0pID0%2BIHtcbiAgICAgICAgc2VsZi5pbXBvcnRTY3JpcHRzKG5ldyBVUkwocGl4aVdlYldvcmtlclVybCwgYmFzZVVybCkpO1xuXG4gICAgICAgIGNvbnN0IGFwcCA9IG5ldyBQSVhJLkFwcGxpY2F0aW9uKG9wdGlvbnMpO1xuXG4gICAgICAgIGNvbnN0IGNvbnRhaW5lciA9IG5ldyBQSVhJLkNvbnRhaW5lcigpO1xuXG4gICAgICAgIGFwcC5zdGFnZS5hZGRDaGlsZChjb250YWluZXIpO1xuXG4gICAgICAgIC8vIENyZWF0ZSBhIG5ldyB0ZXh0dXJlXG4gICAgICAgIGNvbnN0IHRleHR1cmVVcmwgPSAnaHR0cHM6Ly9waXhpanMuY29tL2Fzc2V0cy9idW5ueS5wbmcnO1xuICAgICAgICBjb25zdCB0ZXh0dXJlID0gYXdhaXQgUElYSS5Bc3NldHMubG9hZCh0ZXh0dXJlVXJsKTtcblxuICAgICAgICAvLyBDcmVhdGUgYSA1eDUgZ3JpZCBvZiBidW5uaWVzXG4gICAgICAgIGZvciAobGV0IGkgPSAwOyBpIDwgMjU7IGkrKykge1xuICAgICAgICAgICAgY29uc3QgYnVubnkgPSBuZXcgUElYSS5TcHJpdGUodGV4dHVyZSk7XG4gICAgICAgICAgICBidW5ueS5hbmNob3Iuc2V0KDAuNSk7XG4gICAgICAgICAgICBidW5ueS54ID0gKGkgJSA1KSAqIDQwO1xuICAgICAgICAgICAgYnVubnkueSA9IE1hdGguZmxvb3IoaSAvIDUpICogNDA7XG4gICAgICAgICAgICBjb250YWluZXIuYWRkQ2hpbGQoYnVubnkpO1xuICAgICAgICB9XG5cbiAgICAgICAgLy8gTW92ZSBjb250YWluZXIgdG8gdGhlIGNlbnRlclxuICAgICAgICBjb250YWluZXIueCA9IGFwcC5zY3JlZW4ud2lkdGggLyAyO1xuICAgICAgICBjb250YWluZXIueSA9IGFwcC5zY3JlZW4uaGVpZ2h0IC8gMjtcblxuICAgICAgICAvLyBDZW50ZXIgYnVubnkgc3ByaXRlIGluIGxvY2FsIGNvbnRhaW5lciBjb29yZGluYXRlc1xuICAgICAgICBjb250YWluZXIucGl2b3QueCA9IGNvbnRhaW5lci53aWR0aCAvIDI7XG4gICAgICAgIGNvbnRhaW5lci5waXZvdC55ID0gY29udGFpbmVyLmhlaWdodCAvIDI7XG5cbiAgICAgICAgLy8gTGlzdGVuIGZvciBhbmltYXRlIHVwZGF0ZVxuICAgICAgICBhcHAudGlja2VyLmFkZCgoZGVsdGEpID0%2BIHtcbiAgICAgICAgICAgIC8vIHJvdGF0ZSB0aGUgY29udGFpbmVyIVxuICAgICAgICAgICAgLy8gdXNlIGRlbHRhIHRvIGNyZWF0ZSBmcmFtZS1pbmRlcGVuZGVudCB0cmFuc2Zvcm1cbiAgICAgICAgICAgIGNvbnRhaW5lci5yb3RhdGlvbiAtPSAwLjAxICogZGVsdGE7XG4gICAgICAgIH0pO1xuICAgIH07XG59XG5jb25zdCBibG9iID0gbmV3IEJsb2IoWycoJywgd29ya2VyU291cmNlLCAnKShzZWxmKTsnXSwgeyB0eXBlOiAnYXBwbGljYXRpb24vamF2YXNjcmlwdCcgfSk7XG5jb25zdCB1cmwgPSBVUkwuY3JlYXRlT2JqZWN0VVJMKGJsb2IpO1xuY29uc3Qgd29ya2VyID0gbmV3IFdvcmtlcih1cmwpO1xuVVJMLnJldm9rZU9iamVjdFVSTCh1cmwpO1xuXG5jb25zdCB3aWR0aCA9IDgwMDtcbmNvbnN0IGhlaWdodCA9IDYwMDtcbmNvbnN0IHJlc29sdXRpb24gPSB3aW5kb3cuZGV2aWNlUGl4ZWxSYXRpbztcbmNvbnN0IGNhbnZhcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2NhbnZhcycpO1xuY2FudmFzLnN0eWxlLndpZHRoID0gYCR7d2lkdGh9cHhgO1xuY2FudmFzLnN0eWxlLmhlaWdodCA9IGAke2hlaWdodH1weGA7XG5kb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKGNhbnZhcyk7XG5jb25zdCB2aWV3ID0gY2FudmFzLnRyYW5zZmVyQ29udHJvbFRvT2Zmc2NyZWVuKCk7XG5cbmNvbnN0IGJhc2VVcmwgPSB3aW5kb3cubG9jYXRpb24uaHJlZjtcbmNvbnN0IHBpeGlXZWJXb3JrZXJVcmwgPSAnaHR0cHM6Ly9kMTU3bDdqZG44ZTVzZi5jbG91ZGZyb250Lm5ldC92Ny4zLjEvd2Vid29ya2VyLmpzJztcbndvcmtlci5wb3N0TWVzc2FnZSh7XG4gICAgYmFzZVVybCxcbiAgICBwaXhpV2ViV29ya2VyVXJsLFxuICAgIG9wdGlvbnM6IHtcbiAgICAgICAgd2lkdGgsIGhlaWdodCwgcmVzb2x1dGlvbiwgdmlldywgYmFja2dyb3VuZDogMHgxMDk5YmIsXG4gICAgfSxcbn0sIFt2aWV3XSk7In0%3D&pixiVersion=7.3.1) (*ReferenceError: Image is not defined*)
- After: [Playground](https://pixijs.com/playground?source=eyJjb2RlIjoiZnVuY3Rpb24gd29ya2VyU291cmNlKHNlbGYpIHtcbiAgICBzZWxmLm9ubWVzc2FnZSA9IGFzeW5jICh7XG4gICAgICAgIGRhdGE6IHsgYmFzZVVybCwgcGl4aVdlYldvcmtlclVybCwgb3B0aW9ucyB9LFxuICAgIH0pID0%2BIHtcbiAgICAgICAgc2VsZi5pbXBvcnRTY3JpcHRzKG5ldyBVUkwocGl4aVdlYldvcmtlclVybCwgYmFzZVVybCkpO1xuXG4gICAgICAgIGNvbnN0IGFwcCA9IG5ldyBQSVhJLkFwcGxpY2F0aW9uKG9wdGlvbnMpO1xuXG4gICAgICAgIGNvbnN0IGNvbnRhaW5lciA9IG5ldyBQSVhJLkNvbnRhaW5lcigpO1xuXG4gICAgICAgIGFwcC5zdGFnZS5hZGRDaGlsZChjb250YWluZXIpO1xuXG4gICAgICAgIC8vIENyZWF0ZSBhIG5ldyB0ZXh0dXJlXG4gICAgICAgIGNvbnN0IHRleHR1cmVVcmwgPSAnaHR0cHM6Ly9waXhpanMuY29tL2Fzc2V0cy9idW5ueS5wbmcnO1xuICAgICAgICBjb25zdCB0ZXh0dXJlID0gYXdhaXQgUElYSS5Bc3NldHMubG9hZCh0ZXh0dXJlVXJsKTtcblxuICAgICAgICAvLyBDcmVhdGUgYSA1eDUgZ3JpZCBvZiBidW5uaWVzXG4gICAgICAgIGZvciAobGV0IGkgPSAwOyBpIDwgMjU7IGkrKykge1xuICAgICAgICAgICAgY29uc3QgYnVubnkgPSBuZXcgUElYSS5TcHJpdGUodGV4dHVyZSk7XG4gICAgICAgICAgICBidW5ueS5hbmNob3Iuc2V0KDAuNSk7XG4gICAgICAgICAgICBidW5ueS54ID0gKGkgJSA1KSAqIDQwO1xuICAgICAgICAgICAgYnVubnkueSA9IE1hdGguZmxvb3IoaSAvIDUpICogNDA7XG4gICAgICAgICAgICBjb250YWluZXIuYWRkQ2hpbGQoYnVubnkpO1xuICAgICAgICB9XG5cbiAgICAgICAgLy8gTW92ZSBjb250YWluZXIgdG8gdGhlIGNlbnRlclxuICAgICAgICBjb250YWluZXIueCA9IGFwcC5zY3JlZW4ud2lkdGggLyAyO1xuICAgICAgICBjb250YWluZXIueSA9IGFwcC5zY3JlZW4uaGVpZ2h0IC8gMjtcblxuICAgICAgICAvLyBDZW50ZXIgYnVubnkgc3ByaXRlIGluIGxvY2FsIGNvbnRhaW5lciBjb29yZGluYXRlc1xuICAgICAgICBjb250YWluZXIucGl2b3QueCA9IGNvbnRhaW5lci53aWR0aCAvIDI7XG4gICAgICAgIGNvbnRhaW5lci5waXZvdC55ID0gY29udGFpbmVyLmhlaWdodCAvIDI7XG5cbiAgICAgICAgLy8gTGlzdGVuIGZvciBhbmltYXRlIHVwZGF0ZVxuICAgICAgICBhcHAudGlja2VyLmFkZCgoZGVsdGEpID0%2BIHtcbiAgICAgICAgICAgIC8vIHJvdGF0ZSB0aGUgY29udGFpbmVyIVxuICAgICAgICAgICAgLy8gdXNlIGRlbHRhIHRvIGNyZWF0ZSBmcmFtZS1pbmRlcGVuZGVudCB0cmFuc2Zvcm1cbiAgICAgICAgICAgIGNvbnRhaW5lci5yb3RhdGlvbiAtPSAwLjAxICogZGVsdGE7XG4gICAgICAgIH0pO1xuICAgIH07XG59XG5jb25zdCBibG9iID0gbmV3IEJsb2IoWycoJywgd29ya2VyU291cmNlLCAnKShzZWxmKTsnXSwgeyB0eXBlOiAnYXBwbGljYXRpb24vamF2YXNjcmlwdCcgfSk7XG5jb25zdCB1cmwgPSBVUkwuY3JlYXRlT2JqZWN0VVJMKGJsb2IpO1xuY29uc3Qgd29ya2VyID0gbmV3IFdvcmtlcih1cmwpO1xuVVJMLnJldm9rZU9iamVjdFVSTCh1cmwpO1xuXG5jb25zdCB3aWR0aCA9IDgwMDtcbmNvbnN0IGhlaWdodCA9IDYwMDtcbmNvbnN0IHJlc29sdXRpb24gPSB3aW5kb3cuZGV2aWNlUGl4ZWxSYXRpbztcbmNvbnN0IGNhbnZhcyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2NhbnZhcycpO1xuY2FudmFzLnN0eWxlLndpZHRoID0gYCR7d2lkdGh9cHhgO1xuY2FudmFzLnN0eWxlLmhlaWdodCA9IGAke2hlaWdodH1weGA7XG5kb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKGNhbnZhcyk7XG5jb25zdCB2aWV3ID0gY2FudmFzLnRyYW5zZmVyQ29udHJvbFRvT2Zmc2NyZWVuKCk7XG5cbmNvbnN0IGJhc2VVcmwgPSB3aW5kb3cubG9jYXRpb24uaHJlZjtcbmNvbnN0IHBpeGlXZWJXb3JrZXJVcmwgPSAnaHR0cHM6Ly9kMTU3bDdqZG44ZTVzZi5jbG91ZGZyb250Lm5ldC9maXgvdGVzdC1pbWFnZS1mb3JtYXQvd2Vid29ya2VyLmpzJztcbndvcmtlci5wb3N0TWVzc2FnZSh7XG4gICAgYmFzZVVybCxcbiAgICBwaXhpV2ViV29ya2VyVXJsLFxuICAgIG9wdGlvbnM6IHtcbiAgICAgICAgd2lkdGgsIGhlaWdodCwgcmVzb2x1dGlvbiwgdmlldywgYmFja2dyb3VuZDogMHgxMDk5YmIsXG4gICAgfSxcbn0sIFt2aWV3XSk7In0%3D&pixiVersion=7.3.1) (*Fixed*)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1acba00</samp>

### Summary
🆕♻️♻️

<!--
1.  🆕 for adding a new utility function
2.  ♻️ for refactoring the `detectAvif` parser
3.  ♻️ for refactoring the `detectWebp` parser
-->
Refactor the image format detection parsers to use a shared utility function. This change adds the `testImageFormat` function to the `../utils/testImageFormat` module, which tests whether a browser can load an image data URI. The `detectAvif` and `detectWebp` parsers use this function to improve code reuse and readability.

> _Sing, O Muse, of the skillful coder who devised_
> _A clever function, `testImageFormat`, to discern_
> _The various forms of images that browsers can display_
> _And gracefully handle errors that may arise or spurn._

### Walkthrough
*  Refactor `test` methods of `detectAvif` and `detectWebp` parsers to use a common utility function `testImageFormat` ([link](https://github.com/pixijs/pixijs/pull/9703/files?diff=unified&w=0#diff-2893bd1ff410ca9a9e2a839301d813b9d44ec7d1ff4e9b7f0676d615b2bdfa44L10-R14), [link](https://github.com/pixijs/pixijs/pull/9703/files?diff=unified&w=0#diff-a81edc7e9b7669c9a7cc3bc3558f0a37bcd4033bf2ef4653a68cab87b320534cL10-R13))
*  Import `testImageFormat` function from `../utils/testImageFormat` module in `detectAvif.ts` and `detectWebp.ts` files ([link](https://github.com/pixijs/pixijs/pull/9703/files?diff=unified&w=0#diff-2893bd1ff410ca9a9e2a839301d813b9d44ec7d1ff4e9b7f0676d615b2bdfa44R2), [link](https://github.com/pixijs/pixijs/pull/9703/files?diff=unified&w=0#diff-a81edc7e9b7669c9a7cc3bc3558f0a37bcd4033bf2ef4653a68cab87b320534cR2))
*  Add `testImageFormat` function to `../utils/testImageFormat` module that tests whether a given image data URI can be loaded in the browser using different APIs ([link](https://github.com/pixijs/pixijs/pull/9703/files?diff=unified&w=0#diff-96b8c3034ad2a97b59da023d537032ee57b28433b6eaf72df4c26ff071c5a4bcR1-R41))



##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
