### PR TITLE
Text premultiply alpha issue

### DIFF
--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -167,7 +167,7 @@ export class GraphicsContext extends EventEmitter<{
 
                 transform: this._transform.clone(),
                 alpha: this._fillStyle.alpha,
-                style: tint ? Color.shared.setValue(tint).toNumber() : 0xffffff,
+                style: tint ? Color.shared.setValue(tint).toNumber() : 0,
             }
         });
 

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -3,7 +3,7 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import { nextPow2 } from '../../../maths/misc/pow2';
 import { CanvasPool } from '../../../rendering/renderers/shared/texture/CanvasPool';
 import { TexturePool } from '../../../rendering/renderers/shared/texture/TexturePool';
-import { Bounds } from '../../container/bounds/Bounds';
+import { getPo2TextureFromSource } from '../html/utils/getPo2TextureFromSource';
 import { CanvasTextMetrics } from './CanvasTextMetrics';
 import { fontStringFromTextStyle } from './utils/fontStringFromTextStyle';
 import { getCanvasFillStyle } from './utils/getCanvasFillStyle';
@@ -13,8 +13,6 @@ import type { Texture } from '../../../rendering/renderers/shared/texture/Textur
 import type { ICanvas } from '../../../settings/adapter/ICanvas';
 import type { ICanvasRenderingContext2D } from '../../../settings/adapter/ICanvasRenderingContext2D';
 import type { TextStyle } from '../TextStyle';
-
-const tempBounds = new Bounds();
 
 interface CanvasAndContext
 {
@@ -79,32 +77,7 @@ export class CanvasTextSystem implements System
 
         this.renderTextToCanvas(text, style, resolution, canvasAndContext);
 
-        const bounds = tempBounds;
-
-        bounds.minX = 0;
-        bounds.minY = 0;
-
-        bounds.maxX = (canvas.width / resolution) | 0;
-        bounds.maxY = (canvas.height / resolution) | 0;
-
-        const texture = TexturePool.getOptimalTexture(
-            bounds.width,
-            bounds.height,
-            resolution,
-            false
-        );
-
-        const source = texture.source;
-
-        source.uploadMethodId = 'image';
-        source.alphaMode = 'premultiply-alpha-on-upload';
-        source.resource = canvas;
-
-        texture.frameWidth = width / resolution;
-        texture.frameHeight = height / resolution;
-
-        source.update();
-        texture.layout.updateUvs();
+        const texture = getPo2TextureFromSource(canvas, resolution);
 
         this._activeTextures[textKey] = {
             canvasAndContext,

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -94,13 +94,16 @@ export class CanvasTextSystem implements System
             false
         );
 
-        texture.source.uploadMethodId = 'image';
-        texture.source.resource = canvas;
+        const source = texture.source;
+
+        source.uploadMethodId = 'image';
+        source.alphaMode = 'premultiply-alpha-on-upload';
+        source.resource = canvas;
 
         texture.frameWidth = width / resolution;
         texture.frameHeight = height / resolution;
 
-        texture.source.update();
+        source.update();
         texture.layout.updateUvs();
 
         this._activeTextures[textKey] = {
@@ -127,8 +130,12 @@ export class CanvasTextSystem implements System
         {
             CanvasPool.returnCanvasAndContext(activeTexture.canvasAndContext);
             TexturePool.returnTexture(activeTexture.texture);
-            activeTexture.texture.source.resource = null;
-            activeTexture.texture.source.uploadMethodId = 'unknown';
+
+            const source = activeTexture.texture.source;
+
+            source.resource = null;
+            source.uploadMethodId = 'unknown';
+            source.alphaMode = 'no-premultiply-alpha';
 
             this._activeTextures[textKey] = null;
         }

--- a/src/scene/text/html/utils/getPo2TextureFromSource.ts
+++ b/src/scene/text/html/utils/getPo2TextureFromSource.ts
@@ -2,6 +2,7 @@ import { TexturePool } from '../../../../rendering/renderers/shared/texture/Text
 import { Bounds } from '../../../container/bounds/Bounds';
 
 import type { Texture } from '../../../../rendering/renderers/shared/texture/Texture';
+import type { ICanvas } from '../../../../settings/adapter/ICanvas';
 
 const tempBounds = new Bounds();
 
@@ -12,7 +13,7 @@ const tempBounds = new Bounds();
  * @param resolution - The resolution of the texture
  * @returns - The texture
  */
-export function getPo2TextureFromSource(image: HTMLImageElement | HTMLCanvasElement, resolution: number): Texture
+export function getPo2TextureFromSource(image: HTMLImageElement | HTMLCanvasElement | ICanvas, resolution: number): Texture
 {
     const bounds = tempBounds;
 
@@ -31,6 +32,7 @@ export function getPo2TextureFromSource(image: HTMLImageElement | HTMLCanvasElem
 
     texture.source.uploadMethodId = 'image';
     texture.source.resource = image;
+    texture.source.alphaMode = 'premultiply-alpha-on-upload';
 
     texture.frameWidth = image.width / resolution;
     texture.frameHeight = image.height / resolution;


### PR DESCRIPTION
fixes #9701.

Premultiply Alpha was not set on the texture we were writing to. 

[example](https://codesandbox.io/s/pixi-js-sandbox-forked-zkfc8h?file=/index.js)