### PR TITLE
Fix resuming video playback not working

### DIFF
--- a/packages/core/src/textures/resources/VideoResource.ts
+++ b/packages/core/src/textures/resources/VideoResource.ts
@@ -306,7 +306,7 @@ export class VideoResource extends BaseImageResource
     {
         const source = this.source as HTMLVideoElement;
 
-        return (!source.paused && !source.ended && this._isSourceReady());
+        return (!source.paused && !source.ended);
     }
 
     /**


### PR DESCRIPTION
Regression of #9374.

In Chrome (I wasn't able to reproduce it in Firefox) I'm unable to resume a paused video if the `play()` call is preceded by an assignment to `currentTime`. Even this fails to resume the video playback:
```js
source.currentTime = source.currentTime;
source.play();
```

In the `play` event (`_onPlayStart()`) the `readyState` isn't necessarily greater than 2 (the example above gives me 1) and so `_isSourceReady()` is false and consequently `_isSourcePlaying()` too. If that is the case, the `_configureAutoUpdate()` call does not register the ticker / frame callback.

I don't think we need to consider the `readyState` of the video in `_isSourcePlaying()`. We are not uploading frames while `readyState <= 1`.