### PR TITLE
Fixed issue with tiling texture

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -219,6 +219,8 @@ export class GlTextureSystem implements System, CanvasGenerator
 
         gl.bindTexture(gl.TEXTURE_2D, glTexture.texture);
 
+        this._boundTextures[this._activeTextureLocation] = source;
+
         applyStyleParams(
             source.style,
             gl,

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -165,8 +165,14 @@ export class TilingSpritePipe implements RenderPipe<TilingSpriteView>
             const batchedMesh = this._getBatchedTilingSprite(renderable);
 
             batchedMesh.view.texture = view.texture;
-            view.texture.source.style.addressMode = 'repeat';
-            view.texture.source.style.update();
+
+            const style = view.texture.source.style;
+
+            if (style.addressMode !== 'repeat')
+            {
+                style.addressMode = 'repeat';
+                style.update();
+            }
 
             this._updateBatchPositions(renderable);
             this._updateBatchUvs(renderable);


### PR DESCRIPTION
fixes #9706

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at efba9dd</samp>

### Summary
📊🖼️🔁

<!--
1.  📊 - This emoji represents performance improvement, which is the main goal of these changes.
2.  🖼️ - This emoji represents texture or image manipulation, which is the core functionality of the classes that are modified by these changes.
3.  🔁 - This emoji represents repetition or looping, which is the characteristic feature of tiling sprites and the texture address mode that is optimized by these changes.
-->
This pull request improves the performance of texture binding and tiling sprite rendering in the `pixijs` library. It does this by avoiding unnecessary texture binding calls in `GlTextureSystem.ts` and redundant texture style updates in `TilingSpritePipe.ts`.

> _`_boundTextures` tracks_
> _texture sources for each slot_
> _less binding, more speed_

### Walkthrough
* Optimize texture binding and style updates for tiling sprites ([link](https://github.com/pixijs/pixijs/pull/9708/files?diff=unified&w=0#diff-e583155ec5dd946ff2bf3d340cb45c20d56745ddc2d5df413faed8cdf0c88d50R222-R223), [link](https://github.com/pixijs/pixijs/pull/9708/files?diff=unified&w=0#diff-b077f8aef0acc072709e620bceae4ea2b89e0366999f34a8dd1fb0c16bb18846L168-R176))

