### PR TITLE
Fix: loadWebFont: Don't encodeURI if already valid

### DIFF
--- a/packages/assets/src/loader/parsers/loadWebFont.ts
+++ b/packages/assets/src/loader/parsers/loadWebFont.ts
@@ -78,6 +78,23 @@ export function getFontFamilyName(url: string): string
     return fontFamilyName;
 }
 
+// See RFC 3986 Chapter 2. Characters
+const validURICharactersRegex = /^[0-9A-Za-z%:/?#\[\]@!\$&'()\*\+,;=\-._~]*$/;
+
+/**
+ * Encode URI only when it contains invalid characters.
+ * @param uri - URI to encode.
+ */
+function encodeURIWhenNeeded(uri: string)
+{
+    if (validURICharactersRegex.test(uri))
+    {
+        return uri;
+    }
+
+    return encodeURI(uri);
+}
+
 /** Web font loader plugin */
 export const loadWebFont = {
     extension: {
@@ -107,7 +124,7 @@ export const loadWebFont = {
             {
                 const weight = weights[i];
 
-                const font = new FontFace(name, `url(${encodeURI(url)})`, {
+                const font = new FontFace(name, `url(${encodeURIWhenNeeded(url)})`, {
                     ...data,
                     weight,
                 });

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -504,6 +504,17 @@ describe('Assets', () =>
         expect(font).toBeInstanceOf(FontFace);
     });
 
+    it('should load font assets with encoded URL', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const font = await Assets.load('fonts/url%20with%20space.ttf');
+
+        expect(font).toBeInstanceOf(FontFace);
+    });
+
     it('should append default url params when specified in the constructor', async () =>
     {
         await Assets.init({


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

In `loadWebFont`, if the URI is already valid, do not call `encodeURI` to avoid it being accidentally encoded twice.

Fixes #9705.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
