### PR TITLE
Change element to canvas

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -223,7 +223,7 @@ export class AccessibilitySystem implements System
         globalThis.removeEventListener('keydown', this._onKeyDown, false);
 
         this._renderer.runners.postrender.add(this);
-        this._renderer.view.element.parentNode?.appendChild(this._div);
+        this._renderer.view.canvas.parentNode?.appendChild(this._div);
     }
 
     /**
@@ -310,7 +310,7 @@ export class AccessibilitySystem implements System
 
         this._androidUpdateCount = now + this._androidUpdateFrequency;
 
-        if (!this._renderer.renderingToScreen || !this._renderer.view.element)
+        if (!this._renderer.renderingToScreen || !this._renderer.view.canvas)
         {
             return;
         }
@@ -321,7 +321,7 @@ export class AccessibilitySystem implements System
             this._updateAccessibleObjects(this._renderer.lastObjectRendered as Container);
         }
 
-        const { x, y, width, height } = this._renderer.view.element.getBoundingClientRect();
+        const { x, y, width, height } = this._renderer.view.canvas.getBoundingClientRect();
         const { width: viewWidth, height: viewHeight, resolution } = this._renderer;
 
         const sx = (width / viewWidth) * resolution;

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -99,7 +99,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      */
     get canvas(): VIEW
     {
-        return this.renderer.element as VIEW;
+        return this.renderer.canvas as VIEW;
     }
 
     /**

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -242,7 +242,7 @@ export class EventSystem implements System<EventSystemOptions>
      */
     public init(options: EventSystemOptions): void
     {
-        const { element: canvas, resolution } = this.renderer;
+        const { canvas, resolution } = this.renderer;
 
         this.setTargetElement(canvas as HTMLCanvasElement);
         this.resolution = resolution;

--- a/src/rendering/renderers/gl/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/GlRenderTargetSystem.ts
@@ -116,7 +116,7 @@ export class GlRenderTargetSystem implements System
         if (renderTarget.isRoot)
         {
             // /TODO this is the same logic?
-            viewPortY = this._renderer.view.element.height - viewport.height;
+            viewPortY = this._renderer.view.canvas.height - viewport.height;
         }
 
         const viewPortCache = this._viewPortCache;

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -185,7 +185,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
 
         this._renderer.runners.contextChange.emit(gl);
 
-        const element = this._renderer.view.element;
+        const element = this._renderer.view.canvas;
 
         (element as any).addEventListener('webglcontextlost', this.handleContextLost, false);
         element.addEventListener('webglcontextrestored', this.handleContextRestored, false);
@@ -199,7 +199,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
      */
     protected initFromOptions(options: WebGLContextAttributes): void
     {
-        const gl = this.createContext(this._renderer.view.element, options);
+        const gl = this.createContext(this._renderer.view.canvas, options);
 
         this.initFromContext(gl);
     }
@@ -267,7 +267,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
 
     public destroy(): void
     {
-        const element = this._renderer.view.element;
+        const element = this._renderer.view.canvas;
 
         this._renderer = null;
 

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -204,9 +204,9 @@ export class AbstractRenderer<PIPES, OPTIONS>
 
     // NOTE: this was `view` in v7
     /** The canvas element that everything is drawn to.*/
-    get element(): ICanvas
+    get canvas(): ICanvas
     {
-        return this.view.element;
+        return this.view.canvas;
     }
 
     /**


### PR DESCRIPTION
update the app api to be consistent. Now `canvas` is used everywhere instead of the mix between canvas, view, and element