### PR TITLE
Fix passive interaction

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -617,12 +617,6 @@ export class EventBoundary
      */
     protected hitTestFn(container: Container, location: Point): boolean
     {
-        // If the container is passive then it cannot be hit directly.
-        if (container.eventMode === 'passive')
-        {
-            return false;
-        }
-
         // If the container failed pruning with a hitArea, then it must pass it.
         if (container.hitArea)
         {


### PR DESCRIPTION
removed the `passive` check in `testHitFn` as it is incorrect

we don't care if it is passive or not if the parent is interactive and we already do this check in the recursive functions

this is also an issue in v7, so will look to back port this