### PR TITLE
Warn if load parser doesn't have a name

### DIFF
--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -11,7 +11,7 @@ import type { ResolveURLParser } from './resolver/types';
 interface AssetExtension<ASSET = any, META_DATA = any>
 {
     extension: ExtensionType.Asset,
-    loader?: Partial<LoaderParser<ASSET, META_DATA>>,
+    loader?: LoaderParser<ASSET, META_DATA>,
     resolver?: Partial<ResolveURLParser>,
     cache?: Partial<CacheParser<ASSET>>,
     detection?: Partial<FormatDetectionParser>,

--- a/src/assets/loader/Loader.ts
+++ b/src/assets/loader/Loader.ts
@@ -261,7 +261,13 @@ export class Loader
             .filter((parser) => parser.name)
             .reduce((hash, parser) =>
             {
-                if (hash[parser.name])
+                if (!parser.name)
+                {
+                    // #if _DEBUG
+                    warn(`[Assets] loadParser should have a name`);
+                    // #endif
+                }
+                else if (hash[parser.name])
                 {
                     // #if _DEBUG
                     warn(`[Assets] loadParser name conflict "${parser.name}"`);

--- a/src/assets/loader/parsers/LoaderParser.ts
+++ b/src/assets/loader/parsers/LoaderParser.ts
@@ -41,7 +41,7 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
     config?: CONFIG;
 
     /** The name of the parser (this can be used when specifying loadParser in a ResolvedAsset) */
-    name?: string;
+    name: string;
 
     /**
      * each URL to load will be tested here,


### PR DESCRIPTION
load parsers should give themselves a name, otherwise a user can't forcibly select them when loading