### PR TITLE
Bump colord required version

### DIFF
--- a/packages/color/package.json
+++ b/packages/color/package.json
@@ -32,6 +32,6 @@
       "*.d.ts"
     ],
     "dependencies": {
-      "@pixi/colord": "^2.9.4"
+      "@pixi/colord": "^2.9.6"
     }
   }


### PR DESCRIPTION
Fixes #9725 

Ultimately this is probably a cache issue but we should probably bump the minimum version here to be the version that works.