### PR TITLE
Little v8 fix when rendering huge Graphics

### DIFF
--- a/src/rendering/high-shader/shader-bits/localUniformBit.ts
+++ b/src/rendering/high-shader/shader-bits/localUniformBit.ts
@@ -24,6 +24,16 @@ export const localUniformBit = {
     },
 };
 
+// TODO this works, but i think down the road it will be better to manage groups automatically if there are clashes
+export const localUniformBitGroup2 = {
+    ...localUniformBit,
+    vertex: {
+        ...localUniformBit.vertex,
+        // replace the group!
+        header: localUniformBit.vertex.header.replace('group(1)', 'group(2)'),
+    }
+};
+
 export const localUniformBitGl = {
     name: 'local-uniform-bit',
     vertex: {


### PR DESCRIPTION
- uniform name type
- tweak to the bit that graphics uses

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d6255cf</samp>

### Summary
🎨🚀🛠️

<!--
1.  🎨 - This emoji represents the artistic or creative aspect of adding a new shader bit and uniform group, which allows for more expressive and efficient graphics rendering.
2.  🚀 - This emoji represents the performance or speed improvement of using the new shader bit and uniform group, which reduces the number of binding conflicts and state changes in the GPU pipeline.
3.  🛠️ - This emoji represents the technical or engineering aspect of adding a new shader bit and uniform group, which is a workaround for a limitation of the current shader system and requires some code changes and comments.
-->
This pull request improves the graphics rendering with GPU programs by using a new shader bit and uniform group, `localUniformBitGroup2`, in the `GpuGraphicsAdaptor` class. This avoids binding conflicts between uniform groups, but requires a temporary duplication of the `localUniformBit` shader bit.

> _We face the doom of binding conflicts_
> _We need a workaround to survive_
> _We copy the `localUniformBit`_
> _We change the group and we defy_

### Walkthrough
*  Add a new shader bit `localUniformBitGroup2` to avoid binding conflicts between uniform groups ([link](https://github.com/pixijs/pixijs/pull/9728/files?diff=unified&w=0#diff-04d4339f0c35c484d60d636c4880553bdb246c7e4b61806ed6c058fdb1329f0dR27-R36))
*  Simplify and update the creation and usage of the `localUniforms` uniform group in the `GpuGraphicsAdaptor` class ([link](https://github.com/pixijs/pixijs/pull/9728/files?diff=unified&w=0#diff-6d61decaf9f7217bf04dfe80ada52a992df26f97bfd786019c1afdc29ceaa41cR8), [link](https://github.com/pixijs/pixijs/pull/9728/files?diff=unified&w=0#diff-6d61decaf9f7217bf04dfe80ada52a992df26f97bfd786019c1afdc29ceaa41cL34-R39), [link](https://github.com/pixijs/pixijs/pull/9728/files?diff=unified&w=0#diff-6d61decaf9f7217bf04dfe80ada52a992df26f97bfd786019c1afdc29ceaa41cL70-R46))
*  Use the new `localUniformBitGroup2` in the `compileHighShaderGpuProgram` function to create GPU programs for graphics rendering ([link](https://github.com/pixijs/pixijs/pull/9728/files?diff=unified&w=0#diff-6d61decaf9f7217bf04dfe80ada52a992df26f97bfd786019c1afdc29ceaa41cL70-R46))

