### PR TITLE
type change: update Application to accept Renderer as a type

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -6,7 +6,6 @@ import type { Rectangle } from '../maths/shapes/Rectangle';
 import type { AutoDetectOptions } from '../rendering/renderers/autoDetectRenderer';
 import type { Renderer } from '../rendering/renderers/types';
 import type { DestroyOptions } from '../scene/container/destroyTypes';
-import type { ICanvas } from '../settings/adapter/ICanvas';
 import type { ResizePluginOptions } from './ResizePlugin';
 
 /** Any plugin that's usable for Application should contain these methods. */
@@ -47,7 +46,7 @@ export interface Application extends PixiMixins.Application {}
  * app.stage.addChild(Sprite.from('something.png'));
  * @class
  */
-export class Application<VIEW extends ICanvas = ICanvas>
+export class Application<R extends Renderer = Renderer>
 {
     /** Collection of installed plugins. */
     public static _plugins: ApplicationPlugin[] = [];
@@ -62,7 +61,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
      * WebGL renderer if available, otherwise CanvasRenderer.
      * @member {Renderer}
      */
-    public renderer: Renderer;
+    public renderer: R;
 
     /**
      * @param options - The optional application and renderer parameters.
@@ -77,7 +76,7 @@ export class Application<VIEW extends ICanvas = ICanvas>
             ...options,
         };
 
-        this.renderer = await autoDetectRenderer(options as ApplicationOptions);
+        this.renderer = await autoDetectRenderer(options as ApplicationOptions) as R;
 
         // install plugins here
         Application._plugins.forEach((plugin) =>
@@ -94,12 +93,11 @@ export class Application<VIEW extends ICanvas = ICanvas>
 
     /**
      * Reference to the renderer's canvas element.
-     * @member {ICanvas}
      * @readonly
      */
-    get canvas(): VIEW
+    get canvas(): R['canvas']
     {
-        return this.renderer.canvas as VIEW;
+        return this.renderer.canvas as R['canvas'];
     }
 
     /**

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -18,6 +18,7 @@ import { GlUniformGroupSystem } from './shader/GlUniformGroupSystem';
 import { GlStateSystem } from './state/GlStateSystem';
 import { GlTextureSystem } from './texture/GlTextureSystem';
 
+import type { ICanvas } from '../../../settings/adapter/ICanvas';
 import type { PipeConstructor } from '../shared/instructions/RenderPipe';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
@@ -54,24 +55,24 @@ extensions.handleByNamedList(ExtensionType.WebGLPipesAdaptor, renderPipeAdaptors
 extensions.add(...DefaultWebGLSystems, ...DefaultWebGLPipes, ...DefaultWebGLAdapters);
 
 /** The default WebGL renderer, uses WebGL2 contexts. */
-type WebGLSystems = ExtractSystemTypes<typeof DefaultWebGLSystems> &
-PixiMixins.RendererSystems &
-PixiMixins.WebGLSystems;
+type WebGLSystems = ExtractSystemTypes<typeof DefaultWebGLSystems> & PixiMixins.RendererSystems & PixiMixins.WebGLSystems;
 
 /** The default WebGL renderer, uses WebGL2 contexts. */
-export type WebGLPipes = ExtractSystemTypes<typeof DefaultWebGLPipes> &
-PixiMixins.RendererPipes &
-PixiMixins.WebGLPipes;
+export type WebGLPipes = ExtractSystemTypes<typeof DefaultWebGLPipes> & PixiMixins.RendererPipes & PixiMixins.WebGLPipes;
 
 /** Options for WebGLRenderer. */
-export interface WebGLOptions extends ExtractRendererOptions<typeof DefaultWebGLSystems>,
+export interface WebGLOptions
+    extends ExtractRendererOptions<typeof DefaultWebGLSystems>,
     PixiMixins.RendererOptions,
     PixiMixins.WebGLOptions {}
 
 /** The default WebGL renderer, uses WebGL2 contexts. */
-export interface WebGLRenderer extends AbstractRenderer<WebGLPipes, WebGLOptions>, WebGLSystems {}
-/** The default WebGL renderer, uses WebGL2 contexts. */
-export class WebGLRenderer extends AbstractRenderer<WebGLPipes, WebGLOptions> implements WebGLSystems
+export interface WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
+    extends AbstractRenderer<WebGLPipes, WebGLOptions, T>,
+    WebGLSystems {}
+export class WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
+    extends AbstractRenderer<WebGLPipes, WebGLOptions, T>
+    implements WebGLSystems
 {
     public gl: GlRenderingContext;
 

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -19,6 +19,7 @@ import { GpuShaderSystem } from './shader/GpuShaderSystem';
 import { GpuStateSystem } from './state/GpuStateSystem';
 import { GpuTextureSystem } from './texture/GpuTextureSystem';
 
+import type { ICanvas } from '../../../settings/adapter/ICanvas';
 import type { PipeConstructor } from '../shared/instructions/RenderPipe';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
@@ -65,9 +66,13 @@ export type WebGPUOptions = ExtractRendererOptions<typeof DefaultWebGPUSystems> 
 PixiMixins.RendererOptions &
 PixiMixins.WebGPUOptions;
 
-export interface WebGPURenderer extends AbstractRenderer<WebGPUPipes, WebGPUOptions>, WebGPUSystems {}
+export interface WebGPURenderer<T extends ICanvas = HTMLCanvasElement>
+    extends AbstractRenderer<WebGPUPipes, WebGPUOptions, T>,
+    WebGPUSystems {}
 
-export class WebGPURenderer extends AbstractRenderer<WebGPUPipes, WebGPUOptions> implements WebGPUSystems
+export class WebGPURenderer<T extends ICanvas = HTMLCanvasElement>
+    extends AbstractRenderer<WebGPUPipes, WebGPUOptions, T>
+    implements WebGPUSystems
 {
     public gpu: GPU;
 

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -59,7 +59,7 @@ type Runners = {[key in DefaultRunners]: SystemRunner} & {
  * The SystemManager is a class that provides functions for managing a set of systems
  * This is a base class, that is generic (no render code or knowledge at all)
  */
-export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions>
+export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions, CANVAS extends ICanvas = HTMLCanvasElement>
 {
     public readonly type: number;
     public readonly name: string;
@@ -211,9 +211,9 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions>
 
     // NOTE: this was `view` in v7
     /** The canvas element that everything is drawn to.*/
-    get canvas(): ICanvas
+    get canvas(): CANVAS
     {
-        return this.view.canvas;
+        return this.view.canvas as CANVAS;
     }
 
     /**

--- a/src/rendering/renderers/types.ts
+++ b/src/rendering/renderers/types.ts
@@ -1,8 +1,9 @@
+import type { ICanvas } from '../../settings/adapter/ICanvas';
 import type { WebGLOptions, WebGLPipes, WebGLRenderer } from './gl/WebGLRenderer';
 import type { WebGPUOptions, WebGPUPipes, WebGPURenderer } from './gpu/WebGPURenderer';
 
 /** A generic renderer. */
-export type Renderer = WebGLRenderer | WebGPURenderer;
+export type Renderer<T extends ICanvas = HTMLCanvasElement> = WebGLRenderer<T> | WebGPURenderer<T>;
 export type RenderPipes = WebGLPipes | WebGPUPipes;
 export interface RendererOptions extends WebGLOptions, WebGPUOptions {}
 

--- a/src/settings/adapter/ICanvas.ts
+++ b/src/settings/adapter/ICanvas.ts
@@ -93,7 +93,7 @@ export interface ICanvas extends PixiMixins.ICanvas, Partial<EventTarget>
     ): WebGL2RenderingContext | null;
     getContext(
         contextId: 'webgpu',
-    ): WebGL2RenderingContext | null;
+    ): GPUCanvasContext | null;
     getContext(
         contextId: ContextIds,
         options?: ContextSettings,


### PR DESCRIPTION
this PR allows you to better set the type of renderer and canvas you are using in your app

```
const app = new Application<Renderer<HTMLCanvasElement>()

app.canvas // HTMLCanvasElement
```
this also works with just initialising a renderer

```
const webgl = new WebGLRenderer<HTMLCanvasElement>()
const webgpu = new WebGPURenderer<HTMLCanvasElement>()
```
