### PR TITLE
Add resource to texture function

### DIFF
--- a/src/assets/cache/Cache.ts
+++ b/src/assets/cache/Cache.ts
@@ -21,7 +21,7 @@ class CacheClass
 {
     private readonly _parsers: CacheParser[] = [];
 
-    private readonly _cache: Map<string, any> = new Map();
+    private readonly _cache: Map<any, any> = new Map();
     private readonly _cacheMap: Map<string, {
         keys: string[],
         cacheKeys: string[],
@@ -38,7 +38,7 @@ class CacheClass
      * Check if the key exists
      * @param key - The key to check
      */
-    public has(key: string): boolean
+    public has(key: any): boolean
     {
         return this._cache.has(key);
     }
@@ -47,7 +47,7 @@ class CacheClass
      * Fetch entry by key
      * @param key - The key of the entry to get
      */
-    public get<T = any>(key: string): T
+    public get<T = any>(key: any): T
     {
         const result = this._cache.get(key);
 
@@ -66,7 +66,7 @@ class CacheClass
      * @param key - The key or keys to set
      * @param value - The value to store in the cache or from which cacheable assets will be derived.
      */
-    public set(key: string | string[], value: unknown): void
+    public set(key: any | any[], value: unknown): void
     {
         const keys = convertToList<string>(key);
 
@@ -84,17 +84,20 @@ class CacheClass
             }
         }
 
+        // convert cacheable assets to a map of key-value pairs
+        const cacheableMap = new Map();
+
         if (!cacheableAssets)
         {
             cacheableAssets = {};
 
             keys.forEach((key) =>
             {
-                cacheableAssets[key] = value;
+                cacheableMap.set(key, value);
             });
         }
 
-        const cacheKeys = Object.keys(cacheableAssets);
+        const cacheKeys = [...cacheableMap.keys()];
 
         const cachedAssets = {
             cacheKeys,
@@ -104,7 +107,7 @@ class CacheClass
         // this is so we can remove them later..
         keys.forEach((key) =>
         {
-            this._cacheMap.set(key, cachedAssets);
+            this._cacheMap.set(key, cachedAssets as any);
         });
 
         cacheKeys.forEach((key) =>
@@ -116,7 +119,7 @@ class CacheClass
                 // #endif
             }
 
-            this._cache.set(key, cacheableAssets[key]);
+            this._cache.set(key, cacheableMap.get(key));
         });
     }
 
@@ -126,7 +129,7 @@ class CacheClass
      * This function will also remove any associated alias from the cache also.
      * @param key - The key of the entry to remove
      */
-    public remove(key: string): void
+    public remove(key: any): void
     {
         if (!this._cacheMap.has(key))
         {

--- a/src/assets/cache/Cache.ts
+++ b/src/assets/cache/Cache.ts
@@ -85,12 +85,10 @@ class CacheClass
         }
 
         // convert cacheable assets to a map of key-value pairs
-        const cacheableMap = new Map();
+        const cacheableMap = new Map(Object.entries(cacheableAssets || {}));
 
         if (!cacheableAssets)
         {
-            cacheableAssets = {};
-
             keys.forEach((key) =>
             {
                 cacheableMap.set(key, value);

--- a/src/extensions/Extensions.ts
+++ b/src/extensions/Extensions.ts
@@ -37,6 +37,8 @@ enum ExtensionType
     DetectionParser = 'detection-parser',
 
     MaskEffect = 'mask-effect',
+
+    TextureSource = 'texture-source',
 }
 
 interface ExtensionMetadataDetails

--- a/src/rendering/init.ts
+++ b/src/rendering/init.ts
@@ -2,5 +2,9 @@ import { extensions } from '../extensions/Extensions';
 import { AlphaMask } from './mask/alpha/AlphaMask';
 import { ColorMask } from './mask/color/ColorMask';
 import { StencilMask } from './mask/stencil/StencilMask';
+import { BufferImageSource } from './renderers/shared/texture/sources/BufferImageSource';
+import { CanvasSource } from './renderers/shared/texture/sources/CanvasSource';
+import { ImageSource } from './renderers/shared/texture/sources/ImageSource';
+import { VideoSource } from './renderers/shared/texture/sources/VideoSource';
 
-extensions.add(AlphaMask, ColorMask, StencilMask);
+extensions.add(AlphaMask, ColorMask, StencilMask, VideoSource, ImageSource, CanvasSource, BufferImageSource);

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -3,7 +3,7 @@ import { Cache } from '../../../../assets/cache/Cache';
 import { uid } from '../../../../utils/data/uid';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
 import { NOOP } from '../../../../utils/NOOP';
-import { BufferImageSource } from './sources/BufferImageSource';
+import { resourceToTexture } from './sources/resourceToTexture';
 import { TextureSource } from './sources/TextureSource';
 import { TextureLayout } from './TextureLayout';
 import { TextureMatrix } from './TextureMatrix';
@@ -31,7 +31,7 @@ export class Texture extends EventEmitter<{
     destroy: Texture
 }> implements BindableTexture
 {
-    public static from(id: string | TextureSource | TextureSourceOptions): Texture
+    public static from(id: string | TextureSource | TextureSourceOptions | BufferSourceOptions, skipCache = false): Texture
     {
         if (typeof id === 'string')
         {
@@ -42,22 +42,8 @@ export class Texture extends EventEmitter<{
             return new Texture({ source: id });
         }
 
-        // TODO check to see if there is a resource and use the correct source type
-        return new Texture({
-            source: new TextureSource(id)
-        });
-    }
-
-    public static fromBuffer(options: BufferSourceOptions): Texture
-    {
-        return new Texture({
-            source: BufferImageSource.from({
-                ...options,
-                style: {
-                    scaleMode: 'nearest',
-                }
-            }),
-        });
+        // return a auto generated texture from resource
+        return resourceToTexture(id, skipCache);
     }
 
     public label?: string;

--- a/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
@@ -1,5 +1,7 @@
+import { ExtensionType } from '../../../../../extensions/Extensions';
 import { TextureSource } from './TextureSource';
 
+import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { TypedArray } from '../../buffer/Buffer';
 import type { TextureSourceOptions } from './TextureSource';
 
@@ -11,12 +13,13 @@ export interface BufferSourceOptions extends TextureSourceOptions<TypedArray | A
 
 export class BufferImageSource extends TextureSource<TypedArray | ArrayBuffer>
 {
+    public static extension: ExtensionMetadata = ExtensionType.TextureSource;
+
     public uploadMethodId = 'buffer';
 
-    public static from(options: BufferSourceOptions): BufferImageSource
+    constructor(options: BufferSourceOptions)
     {
         const buffer = options.resource || new Float32Array(options.width * options.height * 4);
-
         let format = options.format;
 
         if (!format)
@@ -51,10 +54,21 @@ export class BufferImageSource extends TextureSource<TypedArray | ArrayBuffer>
             }
         }
 
-        return new BufferImageSource({
-
+        super({
             ...options,
             format,
         });
+    }
+
+    public static test(resource: any): resource is TypedArray | ArrayBuffer
+    {
+        return resource instanceof Int8Array
+        || resource instanceof Uint8Array
+        || resource instanceof Uint8ClampedArray
+        || resource instanceof Int16Array
+        || resource instanceof Uint16Array
+        || resource instanceof Int32Array
+        || resource instanceof Uint32Array
+        || resource instanceof Float32Array;
     }
 }

--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -1,6 +1,8 @@
+import { ExtensionType } from '../../../../../extensions/Extensions';
 import { DOMAdapter } from '../../../../../settings/adapter/adapter';
 import { TextureSource } from './TextureSource';
 
+import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { ICanvas } from '../../../../../settings/adapter/ICanvas';
 import type { TextureSourceOptions } from './TextureSource';
 
@@ -11,6 +13,8 @@ export interface CanvasSourceOptions extends TextureSourceOptions<ICanvas>
 
 export class CanvasSource extends TextureSource<ICanvas>
 {
+    public static extension: ExtensionMetadata = ExtensionType.TextureSource;
+
     public uploadMethodId = 'image';
     public autoDensity: boolean;
 
@@ -72,5 +76,11 @@ export class CanvasSource extends TextureSource<ICanvas>
         super.resize(width, height, resolution);
 
         this.resizeCanvas();
+    }
+
+    public static test(resource: any): resource is ICanvas
+    {
+        return (globalThis.HTMLCanvasElement && resource instanceof HTMLCanvasElement)
+        || (globalThis.OffscreenCanvas && resource instanceof OffscreenCanvas);
     }
 }

--- a/src/rendering/renderers/shared/texture/sources/ImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/ImageSource.ts
@@ -1,15 +1,31 @@
+import { ExtensionType } from '../../../../../extensions/Extensions';
 import { DOMAdapter } from '../../../../../settings/adapter/adapter';
 import { NOOP } from '../../../../../utils/NOOP';
 import { Texture } from '../Texture';
 import { TextureSource } from './TextureSource';
 
+import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { ICanvas } from '../../../../../settings/adapter/ICanvas';
 
-type ImageResource = ImageBitmap | HTMLCanvasElement | OffscreenCanvas | ICanvas | VideoFrame;
+export type ImageResource =
+ImageBitmap
+| HTMLCanvasElement
+| OffscreenCanvas
+| ICanvas
+| VideoFrame
+| HTMLImageElement
+| HTMLVideoElement;
 
 export class ImageSource extends TextureSource<ImageResource>
 {
+    public static extension: ExtensionMetadata = ExtensionType.TextureSource;
     public uploadMethodId = 'image';
+
+    public static test(resource: any): resource is ImageResource
+    {
+        return (typeof HTMLImageElement !== 'undefined' && resource instanceof HTMLImageElement)
+        || (typeof ImageBitmap !== 'undefined' && resource instanceof ImageBitmap);
+    }
 }
 
 // create a white canvas

--- a/src/rendering/renderers/shared/texture/sources/TextureSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/TextureSource.ts
@@ -303,4 +303,10 @@ export class TextureSource<T extends Record<string, any> = any> extends EventEmi
 
         return this._style.scaleMode;
     }
+
+    public static test(_resource: any): any
+    {
+        // this should be overridden by other sources..
+        throw new Error('Unimplemented');
+    }
 }

--- a/src/rendering/renderers/shared/texture/sources/VideoSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/VideoSource.ts
@@ -1,9 +1,11 @@
 // VideoSource.ts
 
+import { ExtensionType } from '../../../../../extensions/Extensions';
 import { Ticker } from '../../../../../ticker/Ticker';
 import { detectVideoAlphaMode } from '../../../../../utils/browser/detectVideoAlphaMode';
 import { TextureSource } from './TextureSource';
 
+import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { Dict } from '../../../../../utils/types';
 import type { ALPHA_MODES } from '../const';
 import type { TextureSourceOptions } from './TextureSource';
@@ -31,6 +33,8 @@ export interface VideoResourceOptionsElement
 
 export class VideoSource extends TextureSource<VideoResource>
 {
+    public static extension: ExtensionMetadata = ExtensionType.TextureSource;
+
     // Public static
     public static defaultOptions: VideoSourceOptions = {
         ...TextureSource.defaultOptions,
@@ -495,4 +499,10 @@ export class VideoSource extends TextureSource<VideoResource>
             mov: 'video/quicktime',
             m4v: 'video/mp4',
         };
+
+    public static test(resource: any): resource is VideoResource
+    {
+        return (globalThis.HTMLVideoElement && resource instanceof HTMLVideoElement)
+        || (globalThis.VideoFrame && resource instanceof VideoFrame);
+    }
 }

--- a/src/rendering/renderers/shared/texture/sources/resourceToTexture.ts
+++ b/src/rendering/renderers/shared/texture/sources/resourceToTexture.ts
@@ -1,0 +1,63 @@
+import { Cache } from '../../../../../assets/cache/Cache';
+import { extensions, ExtensionType } from '../../../../../extensions/Extensions';
+import { Texture } from '../Texture';
+
+import type { TypedArray } from '../../buffer/Buffer';
+import type { BufferSourceOptions } from './BufferImageSource';
+import type { ImageResource } from './ImageSource';
+import type { TextureSource, TextureSourceOptions } from './TextureSource';
+
+interface TextureSourceConstructor<T extends TextureSource = TextureSource>
+{
+    new (options: TextureSourceOptions): T;
+    test(options: ImageResource | TypedArray | ArrayBuffer): boolean;
+}
+
+const sources: TextureSourceConstructor[] = [];
+
+extensions.handleByList(ExtensionType.TextureSource, sources);
+
+export function autoDetectSource(options: TextureSourceOptions<ImageResource> | BufferSourceOptions = {}): TextureSource
+{
+    for (let i = 0; i < sources.length; i++)
+    {
+        const Source = sources[i];
+
+        if (Source.test(options.resource))
+        {
+            return new Source(options);
+        }
+    }
+
+    throw new Error(`Could not find a source type for resource: ${options.resource}`);
+}
+
+export function resourceToTexture(
+    options: TextureSourceOptions<ImageResource> | BufferSourceOptions = {},
+    skipCache = false
+): Texture
+{
+    const { resource } = options;
+
+    if (!skipCache && Cache.has(resource))
+    {
+        return Cache.get(resource);
+    }
+
+    const texture = new Texture({ source: autoDetectSource(options) });
+
+    texture.on('destroy', () =>
+    {
+        if (Cache.has(resource))
+        {
+            Cache.remove(resource);
+        }
+    });
+
+    if (!skipCache)
+    {
+        Cache.set(resource, texture);
+    }
+
+    return texture;
+}

--- a/tests/renderering/extract/Extract.test.ts
+++ b/tests/renderering/extract/Extract.test.ts
@@ -5,6 +5,7 @@ import { Graphics } from '../../../src/scene/graphics/shared/Graphics';
 import { Sprite } from '../../../src/scene/sprite/Sprite';
 import { getRenderer } from '../../utils/getRenderer';
 import { getTexture } from '../../utils/getTexture';
+import '../../../src/rendering/init';
 
 import type { WebGLRenderer } from '../../../src/rendering/renderers/gl/WebGLRenderer';
 
@@ -145,7 +146,7 @@ describe('GenerateTexture', () =>
             0, 0, 255, 102, 255, 255, 0, 51
         ]);
 
-        const texture = Texture.fromBuffer({
+        const texture = Texture.from({
             resource: texturePixels,
             width: 2,
             height: 2,
@@ -170,7 +171,7 @@ describe('GenerateTexture', () =>
             0, 0, 255, 102, 255, 255, 0, 51
         ]);
 
-        const texture = Texture.fromBuffer({
+        const texture = Texture.from({
             resource: texturePixels,
             width: 2,
             height: 2,
@@ -201,7 +202,7 @@ describe('GenerateTexture', () =>
             0, 0, 255, 102, 255, 255, 0, 51
         ]);
 
-        const texture = Texture.fromBuffer({
+        const texture = Texture.from({
             resource: texturePixels,
             width: 2,
             height: 2,

--- a/tests/renderering/textures/Textures.test.ts
+++ b/tests/renderering/textures/Textures.test.ts
@@ -1,4 +1,6 @@
+import { Cache } from '../../../src/assets/cache/Cache';
 import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+import '../../../src/rendering/init';
 
 describe('Texture', () =>
 {
@@ -8,5 +10,43 @@ describe('Texture', () =>
 
         texture.destroy(true);
         texture.destroy(true);
+    });
+
+    it('should return the same texture if the resource is the same', () =>
+    {
+        const videoElement = document.createElement('video');
+
+        let texture = Texture.from({ resource: videoElement });
+
+        expect(Texture.from({ resource: videoElement })).toBe(texture);
+        expect(Cache.has(videoElement)).toBe(true);
+
+        const imageElement = document.createElement('img');
+
+        texture = Texture.from({ resource: imageElement });
+
+        expect(Texture.from({ resource: imageElement })).toBe(texture);
+        expect(Cache.has(imageElement)).toBe(true);
+
+        const canvasElement = document.createElement('canvas');
+
+        texture = Texture.from({ resource: canvasElement });
+
+        expect(Texture.from({ resource: canvasElement })).toBe(texture);
+        expect(Cache.has(canvasElement)).toBe(true);
+
+        const buffer = new Uint8Array([
+            255, 0, 0, 255, 0, 255, 0, 153,
+            0, 0, 255, 102, 255, 255, 0, 51
+        ]);
+
+        texture = Texture.from({
+            resource: buffer,
+            width: 2,
+            height: 2,
+        });
+
+        expect(Texture.from({ resource: buffer })).toBe(texture);
+        expect(Cache.has(buffer)).toBe(true);
     });
 });


### PR DESCRIPTION
This PR changes how `Texture.from` works now

- added `autoDetectResource` which returns a `TextureSource`
- added `resourceToTexture` that automatically detect the resource, generates a texture, and caches it
- `Texture.from` now accepts any source, including a buffer and calls `resourceToTexture`
- all `TextureSource`'s are now extensions so they can do some auto detecting
- `BufferImageSource.from` removed as converting the format is now part of the constructor
- `Cache` now allows you to add anything as a key, not just a string