### PR TITLE
Fix: Handle getShaderPrecisionFormat error

### DIFF
--- a/packages/core/src/shader/utils/getMaxFragmentPrecision.ts
+++ b/packages/core/src/shader/utils/getMaxFragmentPrecision.ts
@@ -16,7 +16,10 @@ export function getMaxFragmentPrecision(): PRECISION
             {
                 const shaderFragment = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);
 
-                maxFragmentPrecision = shaderFragment.precision ? PRECISION.HIGH : PRECISION.MEDIUM;
+                if (shaderFragment)
+                {
+                    maxFragmentPrecision = shaderFragment.precision ? PRECISION.HIGH : PRECISION.MEDIUM;
+                }
             }
         }
     }


### PR DESCRIPTION
##### Description of change
According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLShaderPrecisionFormat/precision), WebGLRenderingContext.getShaderPrecisionFormat() can return `null` if an error occurs. This scenario is not handled currently.

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
