### PR TITLE
v8 ixed issue with resolving preferred formats

### DIFF
--- a/src/assets/resolver/Resolver.ts
+++ b/src/assets/resolver/Resolver.ts
@@ -694,7 +694,6 @@ export class Resolver
                 if (this._assetMap[key])
                 {
                     let assets = this._assetMap[key];
-                    const bestAsset = assets[0];
                     const preferredOrder = this._getPreferredOrder(assets);
 
                     preferredOrder?.priority.forEach((priorityKey) =>
@@ -718,7 +717,7 @@ export class Resolver
                         });
                     });
 
-                    this._resolverHash[key] = (assets[0] ?? bestAsset);
+                    this._resolverHash[key] = assets[0];
                 }
                 else
                 {
@@ -807,7 +806,7 @@ export class Resolver
         formattedAsset.src = this._appendDefaultSearchParams(formattedAsset.src);
         formattedAsset.data = { ...assetData || {}, ...formattedAsset.data };
         formattedAsset.loadParser = loadParser ?? formattedAsset.loadParser;
-        formattedAsset.format = format ?? formattedAsset.src.split('.').pop();
+        formattedAsset.format = format ?? formattedAsset.format ?? formattedAsset.src.split('.').pop();
         formattedAsset.srcs = formattedAsset.src;
         formattedAsset.name = formattedAsset.alias;
 

--- a/tests/assets/Resolver.tests.ts
+++ b/tests/assets/Resolver.tests.ts
@@ -1,0 +1,45 @@
+import { Assets } from '../../src/assets/Assets';
+import { extensions, ExtensionType } from '../../src/extensions/Extensions';
+
+import type { FormatDetectionParser } from '../../src/assets/detections/types';
+
+export const testDetector = {
+    extension: {
+        type: ExtensionType.DetectionParser,
+        priority: 2,
+    },
+    test: async (): Promise<boolean> =>
+        true,
+    add: async (formats: string[]): Promise<string[]> =>
+        ['best', 'ok', 'worst', ...formats],
+
+} as FormatDetectionParser;
+
+describe('Resolver', () =>
+{
+    beforeEach(() =>
+    {
+        // reset the loader
+        Assets.reset();
+    });
+
+    it('should load correct preferred asset', async () =>
+    {
+        extensions.add(testDetector);
+
+        await Assets.init();
+
+        Assets.resolver.add({
+            alias: 'test',
+            src: [
+                'src.worst',
+                'src.ok',
+                'src.best',
+            ]
+        });
+
+        const resolvedAsset = Assets.resolver.resolve('test');
+
+        expect(resolvedAsset.src).toBe('src.best');
+    });
+});


### PR DESCRIPTION
fixed a little issue i found whilst working on textures.. may need to port this to v7?

Resolved was not using the format assigned by the detection pass if available.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 76437e9</samp>

### Summary
:white_check_mark::wastebasket::bug:

<!--
1.  :white_check_mark: - This emoji represents the addition of a new unit test that checks the functionality and correctness of the code. It also implies a positive outcome and a passing result.
2.  :wastebasket: - This emoji represents the removal of unused or redundant code that is not needed or does not contribute to the logic or performance of the code. It also implies a cleanup or refactoring of the code.
3.  :bug: - This emoji represents the fixing of a potential bug or error that could occur if the `format` property of a formatted asset is missing or undefined. It also implies an improvement or enhancement of the code.
-->
Improved asset resolution logic and added unit test. The `Resolver` class now handles missing or unknown asset formats better and has a new unit test in `tests/assets/Resolver.tests.ts` to check its functionality.

> _We'll test the `Resolver` class with a mock parser_
> _We'll add some formats and sources to make it harder_
> _We'll call the `resolve` method and check the answer_
> _Heave ho, me hearties, heave ho on the count of three_

### Walkthrough
*  Simplify and improve asset format detection and parsing logic in `Resolver` class ([link](https://github.com/pixijs/pixijs/pull/9760/files?diff=unified&w=0#diff-557e5c5d1f9a7403fc9ef963116200f118efe70b803206a88e3c256f0eec29e4L697), [link](https://github.com/pixijs/pixijs/pull/9760/files?diff=unified&w=0#diff-557e5c5d1f9a7403fc9ef963116200f118efe70b803206a88e3c256f0eec29e4L721-R720), [link](https://github.com/pixijs/pixijs/pull/9760/files?diff=unified&w=0#diff-557e5c5d1f9a7403fc9ef963116200f118efe70b803206a88e3c256f0eec29e4L810-R809))
* Add unit test for `Resolver` class in `tests/assets/Resolver.tests.ts` file ([link](https://github.com/pixijs/pixijs/pull/9760/files?diff=unified&w=0#diff-1a73b6e50d65039ef52ee8c2ff61f6ea35902c0e712b1ccfcfc16f64e14bd4b7R1-R45))

