### PR TITLE
Fix: Resolve the asset format with query parameters

### DIFF
--- a/packages/assets/src/resolver/Resolver.ts
+++ b/packages/assets/src/resolver/Resolver.ts
@@ -831,7 +831,7 @@ export class Resolver
         formattedAsset.src = this._appendDefaultSearchParams(formattedAsset.src);
         formattedAsset.data = { ...assetData || {}, ...formattedAsset.data };
         formattedAsset.loadParser = loadParser ?? formattedAsset.loadParser;
-        formattedAsset.format = format ?? formattedAsset.src.split('.').pop();
+        formattedAsset.format = format ?? utils.path.extname(formattedAsset.src).slice(1);
         formattedAsset.srcs = formattedAsset.src;
         formattedAsset.name = formattedAsset.alias;
 

--- a/packages/assets/src/resolver/parsers/resolveTextureUrl.ts
+++ b/packages/assets/src/resolver/parsers/resolveTextureUrl.ts
@@ -1,4 +1,4 @@
-import { extensions, ExtensionType, settings } from '@pixi/core';
+import { extensions, ExtensionType, settings, utils } from '@pixi/core';
 import { loadTextures } from '../../loader';
 
 import type { UnresolvedAsset } from '../../types';
@@ -10,7 +10,7 @@ export const resolveTextureUrl = {
     parse: (value: string): UnresolvedAsset =>
         ({
             resolution: parseFloat(settings.RETINA_PREFIX.exec(value)?.[1] ?? '1'),
-            format: value.split('.').pop(),
+            format: utils.path.extname(value).slice(1),
             src: value,
         }),
 } as ResolveURLParser;

--- a/packages/assets/test/resolver.tests.ts
+++ b/packages/assets/test/resolver.tests.ts
@@ -599,4 +599,21 @@ describe('Resolver', () =>
 
         expect(resolver.resolveUrl('my-image.png')).toBe('my-image.png?hello=world&lucky=23');
     });
+
+    it('should be able to resolve format with query parameters', () =>
+    {
+        const resolver = new Resolver();
+
+        resolver.prefer({
+            params: {
+                format: ['webp', 'png'],
+            },
+        });
+
+        resolver.add('bunny', 'http://example.com/bunny.{png,webp}');
+        resolver.add('bunny2', 'http://example.com/bunny.{png,webp}?abc');
+
+        expect(resolver.resolveUrl('bunny')).toBe('http://example.com/bunny.webp');
+        expect(resolver.resolveUrl('bunny2')).toBe('http://example.com/bunny.webp?abc');
+    });
 });

--- a/packages/compressed-textures/src/loaders/resolveCompressedTextureUrl.ts
+++ b/packages/compressed-textures/src/loaders/resolveCompressedTextureUrl.ts
@@ -1,4 +1,4 @@
-import { extensions, ExtensionType, settings } from '@pixi/core';
+import { extensions, ExtensionType, settings, utils } from '@pixi/core';
 
 import type { ResolveURLParser, UnresolvedAsset } from '@pixi/assets';
 
@@ -6,15 +6,13 @@ export const resolveCompressedTextureUrl = {
     extension: ExtensionType.ResolveParser,
     test: (value: string) =>
     {
-        const temp = value.split('?')[0];
-        const extension = temp.split('.').pop();
+        const extension = utils.path.extname(value).slice(1);
 
         return ['basis', 'ktx', 'dds'].includes(extension);
     },
     parse: (value: string): UnresolvedAsset =>
     {
-        const temp = value.split('?')[0];
-        const extension = temp.split('.').pop();
+        const extension = utils.path.extname(value).slice(1);
 
         if (extension === 'ktx')
         {
@@ -41,7 +39,7 @@ export const resolveCompressedTextureUrl = {
 
         return {
             resolution: parseFloat(settings.RETINA_PREFIX.exec(value)?.[1] ?? '1'),
-            format: value.split('.').pop(),
+            format: extension,
             src: value,
         };
     },


### PR DESCRIPTION
Fixes #9758

Favor using `utils.path.extname(url).slice(1)` to extract the file format instead of `url.split('.').pop()`. It's a more consistent way to ignore the query string and hash parameters.