### PR TITLE
v8 use the pixi cdn to get transcoders

### DIFF
--- a/src/compressed-textures/basis/utils/setBasisTranscoderPath.ts
+++ b/src/compressed-textures/basis/utils/setBasisTranscoderPath.ts
@@ -1,6 +1,6 @@
 export const basisTranscoderUrls = {
-    jsUrl: './basis/basis_transcoder.js',
-    wasmUrl: './basis/basis_transcoder.wasm'
+    jsUrl: 'https://files.pixijs.download/transcoders/basis/basis_transcoder.js',
+    wasmUrl: 'https://files.pixijs.download/transcoders/basis/basis_transcoder.wasm',
 };
 
 export function setBasisTranscoderPath(config: Partial<typeof basisTranscoderUrls>)

--- a/src/compressed-textures/basis/worker/BasisWorker.ts
+++ b/src/compressed-textures/basis/worker/BasisWorker.ts
@@ -35,7 +35,24 @@ async function getBasis(): Promise<BasisTextureConstructor>
         const absoluteJsUrl = new URL(settings.jsUrl, location.origin).href;
         const absoluteWasmUrl = new URL(settings.wasmUrl, location.origin).href;
 
-        importScripts(absoluteJsUrl);
+        try
+        {
+            importScripts(absoluteJsUrl);
+        }
+        catch (e)
+        {
+            // #if _DEBUG
+            console.warn('[Pixi.js] Failed to load Basis in worker via importScripts. Falling back to eval.');
+            // #endif
+
+            const response = await fetch(absoluteJsUrl);
+            let text = await response.text();
+
+            text += '\nself.BASIS = BASIS;';
+
+            // eslint-disable-next-line no-eval
+            eval(text);
+        }
 
         basisPromise = new Promise((resolve) =>
         {

--- a/src/compressed-textures/ktx/utils/setKTXTranscoderPath.ts
+++ b/src/compressed-textures/ktx/utils/setKTXTranscoderPath.ts
@@ -1,6 +1,6 @@
 export const ktxTranscoderUrls = {
-    jsUrl: './ktx/libktx.js',
-    wasmUrl: './ktx/libktx.wasm'
+    jsUrl: 'https://files.pixijs.download/transcoders/ktx/libktx.js',
+    wasmUrl: 'https://files.pixijs.download/transcoders/ktx/libktx.wasm'
 };
 
 export function setKTXTranscoderPath(config: Partial<typeof ktxTranscoderUrls>)

--- a/src/compressed-textures/ktx/worker/KTXWorker.ts
+++ b/src/compressed-textures/ktx/worker/KTXWorker.ts
@@ -37,7 +37,24 @@ async function getKTX(): Promise<LIBKTXModule>
         const absoluteJsUrl = new URL(settings.jsUrl, location.origin).href;
         const absoluteWasmUrl = new URL(settings.wasmUrl, location.origin).href;
 
-        importScripts(absoluteJsUrl);
+        try
+        {
+            importScripts(absoluteJsUrl);
+        }
+        catch (e)
+        {
+            // #if _DEBUG
+            console.warn('Failed to load KTX(2) in worker via importScripts. Falling back to eval.');
+            // #endif
+
+            const response = await fetch(absoluteJsUrl);
+            let text = await response.text();
+
+            text += '\nself.LIBKTX = LIBKTX;';
+
+            // eslint-disable-next-line no-eval
+            eval(text);
+        }
 
         ktxPromise = new Promise((resolve) =>
         {


### PR DESCRIPTION
by loading via our CDN it means compressed textures can be used out of the box

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 95c3b29</samp>

### Summary
🌐🛡️⚠️

<!--
1.  🌐 - This emoji represents the use of CDN URLs instead of local ones, which implies a global or web-based distribution of the transcoder files.
2.  🛡️ - This emoji represents the handling of CSP policies or network errors, which implies a defensive or protective approach to loading the transcoder files.
3.  ⚠️ - This emoji represents the warning messages in debug mode, which implies a cautious or alert attitude to potential issues with loading the transcoder files.
-->
Updated the Basis and KTX transcoder URLs to use CDN sources instead of local ones to avoid CORS issues. Added fallback logic to the Basis and KTX workers to try to load the transcoder scripts using `fetch` and `eval` when `importScripts` fails.

> _`importScripts` fails_
> _CORS and CSP block scripts_
> _Use `fetch` and `eval` - ouch!_

### Walkthrough
*  Use CDN URLs for Basis and KTX transcoder files to avoid CORS issues ([link](https://github.com/pixijs/pixijs/pull/9776/files?diff=unified&w=0#diff-aa3ff9b95f7c72e60e3fb7e84947b248d665e6def7a840c76c21b0c75a129f88L2-R3), [link](https://github.com/pixijs/pixijs/pull/9776/files?diff=unified&w=0#diff-8a9089c9caf75d86215ba69b8223110b8e9d242e4afcf69ae3f702ab6f6c71f8L2-R3))
*  Add fallback solution using `fetch` and `eval` when `importScripts` fails to load transcoder scripts in workers ([link](https://github.com/pixijs/pixijs/pull/9776/files?diff=unified&w=0#diff-ca7c504e14f26b576a294d77942399d507cd46af85aacc4f721233fe61bc630bL38-R56), [link](https://github.com/pixijs/pixijs/pull/9776/files?diff=unified&w=0#diff-57afa126463bd3d4a869f4a047fea66dfa8ef46ec59993f29708fe30f1719adeL40-R58))

