### PR TITLE
standardise powerPreference and forceFallbackAdapter for GL/GPU rende…

### DIFF
--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -3,6 +3,7 @@ import { warn } from '../../../../utils/logging/warn';
 
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
 import type { System } from '../../shared/system/System';
+import type { GpuPowerPreference } from '../../types';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { GlRenderingContext } from './GlRenderingContext';
 import type { WebGLExtensions } from './WebGLExtensions';
@@ -21,12 +22,14 @@ export interface ContextSystemOptions
     /** **WebGL Only.** User-provided WebGL rendering context object. */
     context: WebGL2RenderingContext | null;
     /**
-     * **WebGL Only.** A hint indicating what configuration of GPU is suitable for the WebGL context,
-     * can be `'default'`, `'high-performance'` or `'low-power'`.
+     * An optional hint indicating what configuration of GPU is suitable for the WebGL context,
+     * can be `'high-performance'` or `'low-power'`.
      * Setting to `'high-performance'` will prioritize rendering performance over power consumption,
      * while setting to `'low-power'` will prioritize power saving over rendering performance.
      */
-    powerPreference: WebGLPowerPreference;
+    powerPreference?: GpuPowerPreference;
+    /** Whether to force the use of the fallback WebGL1 rendering context instead of WebGL2. */
+    forceFallbackAdapter: boolean;
     /** **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha. */
     premultipliedAlpha: boolean;
     /**
@@ -70,7 +73,12 @@ export class GlContextSystem implements System<ContextSystemOptions>
          * {@link WebGLOptions.powerPreference}
          * @default default
          */
-        powerPreference: 'default',
+        powerPreference: undefined,
+        /**
+         * {@link WebGLOptions.forceFallbackAdapter}
+         * @default false
+         */
+        forceFallbackAdapter: false,
     };
 
     /**
@@ -168,7 +176,9 @@ export class GlContextSystem implements System<ContextSystemOptions>
                 antialias,
                 stencil: true,
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
-                powerPreference: options.powerPreference,
+                powerPreference: options.powerPreference ?? 'default',
+                // todo: fallback to WebGL1 if WebGL2 is not supported? Option doesn't seem available?
+                // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
             });
         }
     }

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -28,8 +28,7 @@ export interface ContextSystemOptions
      * while setting to `'low-power'` will prioritize power saving over rendering performance.
      */
     powerPreference?: GpuPowerPreference;
-    /** Whether to force the use of the fallback WebGL1 rendering context instead of WebGL2. */
-    forceFallbackAdapter: boolean;
+
     /** **WebGL Only.** Whether the compositor will assume the drawing buffer contains colors with premultiplied alpha. */
     premultipliedAlpha: boolean;
     /**
@@ -74,11 +73,6 @@ export class GlContextSystem implements System<ContextSystemOptions>
          * @default default
          */
         powerPreference: undefined,
-        /**
-         * {@link WebGLOptions.forceFallbackAdapter}
-         * @default false
-         */
-        forceFallbackAdapter: false,
     };
 
     /**
@@ -177,8 +171,6 @@ export class GlContextSystem implements System<ContextSystemOptions>
                 stencil: true,
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
                 powerPreference: options.powerPreference ?? 'default',
-                // todo: fallback to WebGL1 if WebGL2 is not supported? Option doesn't seem available?
-                // https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
             });
         }
     }

--- a/src/rendering/renderers/types.ts
+++ b/src/rendering/renderers/types.ts
@@ -21,3 +21,5 @@ export enum RendererType
     WEBGL = 0b1,
     WEBGPU = 0b10
 }
+
+export type GpuPowerPreference = 'low-power' | 'high-performance';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7d4e2e2</samp>

### Summary
🎨🔌🛠️

<!--
1.  🎨 - This emoji represents the change of defining the `GpuPowerPreference` type as a union of two possible values, which is a way of expressing the preference for the GPU configuration in a more concise and clear way.
2.  🔌 - This emoji represents the change of adding the `forceFallbackAdapter` option to the WebGL and WebGPU contexts, which is a way of allowing the user to explicitly request a fallback GPU adapter if the preferred one is not available. This option can be useful for testing or debugging purposes, or for ensuring compatibility with older devices.
3.  🛠️ - This emoji represents the change of using the `GpuContextOptions` interface to the `GpuDeviceSystem` class, which is a way of simplifying and unifying the options for the WebGL and WebGPU contexts. This change also makes the code more consistent and maintainable.
-->
This pull request introduces a common type `GpuPowerPreference` and a new option `forceFallbackAdapter` for both the WebGL and WebGPU context creation options. These changes allow users to specify their preferred GPU configuration and to fallback to a different GPU if the preferred one is not available. The changes affect the `GlContextSystem`, `GpuDeviceSystem`, and `types` modules.

> _To render with WebGL or WebGPU_
> _We need to select a GPU_
> _So we use `GpuPowerPreference`_
> _And `forceFallbackAdapter` for reference_
> _To unify the options and get the best view_

### Walkthrough
*  Define `GpuPowerPreference` type to unify the options for WebGL and WebGPU contexts ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-29caa69d88d233fd807ab95112a8f2f45abef1bb4947e5ec0d8cbbc01f190374R24-R25))
*  Import `GpuPowerPreference` type and use it in `ContextSystemOptions` and `GlContextSystem` for WebGL context ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901R6), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901L24-R32), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901L73-R81))
*  Pass `powerPreference` option to `getContext` method when creating WebGL context ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901L171-R181))
*  Implement `System` interface with `GpuContextOptions` type and use `GpuPowerPreference` type in `GpuDeviceSystem` for WebGPU context ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaR4), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaL12-R30), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaR40-R52))
*  Accept `GpuContextOptions` as a parameter in `init` method and pass it to `_createDeviceAndAdaptor` method for WebGPU context ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaL39-R70), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaL70-R103))
*  Add `forceFallbackAdapter` option to `ContextSystemOptions` and `GpuContextOptions` to allow forcing the use of the fallback WebGL1 or WebGPU context ([link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901L24-R32), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-352085852c3b28ec900cda6495d71e0dc60a6893ab09c9fa16771eba719e3901L73-R81), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaL12-R30), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaR40-R52), [link](https://github.com/pixijs/pixijs/pull/9783/files?diff=unified&w=0#diff-7cf77bc3844ad46682dd5ca4e54152517daea3a33bdee6b48cc4bebe64476feaL70-R103))

