### PR TITLE
Fix: adapt KTXWorker messageHandlers

### DIFF
--- a/src/compressed-textures/ktx/worker/KTXWorker.ts
+++ b/src/compressed-textures/ktx/worker/KTXWorker.ts
@@ -182,7 +182,7 @@ const messageHandlers = {
 self.onmessage = (async (messageEvent) =>
 {
     const message = messageEvent.data;
-    const response = await messageHandlers[message.type as 'load' | 'init'](message as any);
+    const response = await messageHandlers[message.type as 'load' | 'init']?.(message as any);
 
     if (response)
     {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

KTXWorker `onmessage` listen is global, some tools like vite also send message `type: 'messsage'`.
We should be compatible for it.

![image](https://github.com/pixijs/pixijs/assets/25154432/2f43f60f-d0e1-4539-96a4-31aba214e53f)

![image](https://github.com/pixijs/pixijs/assets/25154432/f6a143a1-3298-4dcf-9c9b-bad696ef6516)
![image](https://github.com/pixijs/pixijs/assets/25154432/6c855873-aa30-4fd3-b4b6-acd71c80c4b8)

messageHandlers[message] will be undefined.

![image](https://github.com/pixijs/pixijs/assets/25154432/e9a07de6-36c2-4278-88dc-56103d9ced58)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
