### PR TITLE
Don't set `sortDirty` to true if the `zIndex` doesn't change

### DIFF
--- a/packages/display/src/DisplayObject.ts
+++ b/packages/display/src/DisplayObject.ts
@@ -916,6 +916,11 @@ export abstract class DisplayObject extends utils.EventEmitter<DisplayObjectEven
 
     set zIndex(value: number)
     {
+        if (this._zIndex === value)
+        {
+            return;
+        }
+
         this._zIndex = value;
         if (this.parent)
         {

--- a/packages/display/test/Container.tests.ts
+++ b/packages/display/test/Container.tests.ts
@@ -803,6 +803,23 @@ describe('Container', () =>
 
             expect(parent.sortDirty).toBe(true);
         });
+
+        it('should not set sortDirty flag to true when the assignment of a child zIndex does not change the zIndex', () =>
+        {
+            const parent = new Container();
+            // @ts-expect-error - instantiating DisplayObject
+            const child = new DisplayObject();
+
+            parent.addChild(child);
+
+            child.zIndex = 10;
+
+            parent.sortDirty = false;
+
+            child.zIndex = 10;
+
+            expect(parent.sortDirty).toBe(false);
+        });
     });
 
     describe('sortChildren', () =>


### PR DESCRIPTION
##### Description of change

We shouldn't set `sortDiry` of the parent container to true if the `zIndex` is not changed by the assignment.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
