### PR TITLE
remove `Writeable` type from the code base

### DIFF
--- a/src/rendering/renderers/gl/GlEncoderSystem.ts
+++ b/src/rendering/renderers/gl/GlEncoderSystem.ts
@@ -1,6 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
-import type { Writeable } from '../../../utils/types';
 import type { Topology } from '../shared/geometry/const';
 import type { Geometry } from '../shared/geometry/Geometry';
 import type { Shader } from '../shared/shader/Shader';
@@ -64,8 +63,6 @@ export class GlEncoderSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
     }
 }

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -3,7 +3,6 @@ import { BufferUsage } from '../../shared/buffer/const';
 import { BUFFER_TYPE } from './const';
 import { GlBuffer } from './GlBuffer';
 
-import type { Writeable } from '../../../../utils/types';
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 // @ts-expect-error - used for jsdoc typedefs
@@ -58,13 +57,11 @@ export class GlBufferSystem implements System
      */
     public destroy(): void
     {
-        const writeable = this as Writeable<typeof this, '_boundBufferBases'>;
-
         this.destroyAll(true);
         this._renderer = null;
         this._gl = null;
         this._gpuBuffers = null;
-        writeable._boundBufferBases = null;
+        (this._boundBufferBases as null) = null;
     }
 
     /** Sets up the renderer context and necessary buffers. */

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -169,8 +169,8 @@ export class GlProgram
     /** destroys the program */
     public destroy(): void
     {
-        (this.fragment as any) = null;
-        (this.vertex as any) = null;
+        (this.fragment as null) = null;
+        (this.vertex as null) = null;
 
         this._attributeData = null;
         this._uniformData = null;

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -387,9 +387,9 @@ export class GlTextureSystem implements System, CanvasGenerator
             .slice()
             .forEach((source) => this.onSourceDestroy(source));
 
-        (this.managedTextures as any) = null;
+        (this.managedTextures as null) = null;
 
-        (this._renderer as any) = null;
+        (this._renderer as null) = null;
     }
 }
 

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -1,6 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
-import type { Writeable } from '../../../utils/types';
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { BufferResource } from '../shared/buffer/BufferResource';
 import type { UniformGroup } from '../shared/shader/UniformGroup';
@@ -133,8 +132,6 @@ export class BindGroupSystem implements System
 
         this._hash = null;
 
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
     }
 }

--- a/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
+++ b/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
@@ -1,6 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
-import type { Writeable } from '../../../utils/types';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
 
@@ -33,9 +32,7 @@ export class GpuColorMaskSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
         this._colorMaskCache = null;
     }
 }

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -1,7 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 
 import type { Rectangle } from '../../../maths/shapes/Rectangle';
-import type { Writeable } from '../../../utils/types';
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { Topology } from '../shared/geometry/const';
 import type { Geometry } from '../shared/geometry/Geometry';
@@ -273,9 +272,7 @@ export class GpuEncoderSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
         this._gpu = null;
         this._boundBindGroup = null;
         this._boundVertexBuffer = null;

--- a/src/rendering/renderers/gpu/GpuStencilSystem.ts
+++ b/src/rendering/renderers/gpu/GpuStencilSystem.ts
@@ -1,7 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { STENCIL_MODES } from '../shared/state/const';
 
-import type { Writeable } from '../../../utils/types';
 import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
@@ -66,9 +65,7 @@ export class GpuStencilSystem implements System
     {
         this._renderer.renderTarget.onRenderTargetChange.remove(this);
 
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
 
         this._activeRenderTarget = null;
         this._renderTargetStencilState = null;

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -1,7 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { fastCopy } from '../../shared/buffer/utils/fastCopy';
 
-import type { Writeable } from '../../../../utils/types';
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
@@ -113,10 +112,6 @@ export class BufferSystem implements System
         }
 
         this._gpuBuffers = null;
-
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
     }
 }
 

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -3,7 +3,6 @@ import { STENCIL_MODES } from '../../shared/state/const';
 import { createIdFromString } from '../../shared/utils/createIdFromString';
 import { GpuStencilModesToPixi } from '../state/GpuStencilModesToPixi';
 
-import type { Writeable } from '../../../../utils/types';
 import type { Topology } from '../../shared/geometry/const';
 import type { Geometry } from '../../shared/geometry/Geometry';
 import type { State } from '../../shared/state/State';
@@ -300,9 +299,7 @@ export class PipelineSystem implements System
 
     public destroy(): void
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
         this._bufferLayoutsCache = null;
     }
 }

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -11,7 +11,6 @@ import { GpuRenderTarget } from './GpuRenderTarget';
 
 import type { RgbaArray } from '../../../../color/Color';
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
-import type { Writeable } from '../../../../utils/types';
 import type { CLEAR_OR_BOOL } from '../../gl/const';
 import type { System } from '../../shared/system/System';
 import type { BindableTexture } from '../../shared/texture/Texture';
@@ -281,9 +280,7 @@ export class GpuRenderTargetSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
         this._renderSurfaceToRenderTargetHash.clear();
     }
 

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -156,11 +156,11 @@ export class GpuProgram
     public destroy(): void
     {
         this._gpuLayout = null;
-        (this.gpuLayout as any) = null;
-        (this.layout as any) = null;
-        (this.structsAndGroups as any) = null;
-        (this.fragment as any) = null;
-        (this.vertex as any) = null;
+        (this.gpuLayout as null) = null;
+        (this.layout as null) = null;
+        (this.structsAndGroups as null) = null;
+        (this.fragment as null) = null;
+        (this.vertex as null) = null;
     }
 
     /**

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -286,7 +286,7 @@ export class GpuTextureSystem implements System, CanvasGenerator
             .slice()
             .forEach((source) => this.onSourceDestroy(source));
 
-        (this.managedTextures as any) = null;
+        (this.managedTextures as null) = null;
 
         for (const k of Object.keys(this._bindGroupHash))
         {

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -212,7 +212,7 @@ export class Buffer extends EventEmitter<{
         this.emit('destroy', this);
 
         this._data = null;
-        (this.descriptor as any) = null;
+        (this.descriptor as null) = null;
 
         this.removeAllListeners();
     }

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -7,7 +7,6 @@ import { getLocalBounds } from '../../../../scene/container/bounds/getLocalBound
 import { Container } from '../../../../scene/container/Container';
 import { RenderTexture } from '../texture/RenderTexture';
 
-import type { Writeable } from '../../../../utils/types';
 import type { Renderer } from '../../types';
 import type { System } from '../system/System';
 import type { TextureSourceOptions } from '../texture/sources/TextureSource';
@@ -122,8 +121,6 @@ export class GenerateTextureSystem implements System
 
     public destroy(): void
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
     }
 }

--- a/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
@@ -5,7 +5,6 @@ import { BindGroup } from '../../gpu/shader/BindGroup';
 import { UniformGroup } from '../shader/UniformGroup';
 
 import type { PointData } from '../../../../maths/point/PointData';
-import type { Writeable } from '../../../../utils/types';
 import type { GlRenderTargetSystem } from '../../gl/GlRenderTargetSystem';
 import type { GpuRenderTargetSystem } from '../../gpu/renderTarget/GpuRenderTargetSystem';
 import type { WebGPURenderer } from '../../gpu/WebGPURenderer';
@@ -205,8 +204,6 @@ export class GlobalUniformSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
     }
 }

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -7,7 +7,6 @@ import type { ICanvas } from '../../../../environment/canvas/ICanvas';
 import type { Matrix } from '../../../../maths/matrix/Matrix';
 import type { Rectangle } from '../../../../maths/shapes/Rectangle';
 import type { DestroyOptions } from '../../../../scene/container/destroyTypes';
-import type { Writeable } from '../../../../utils/types';
 import type { RenderSurface } from '../../gpu/renderTarget/GpuRenderTargetSystem';
 import type { Renderer } from '../../types';
 import type { GenerateTextureOptions, GenerateTextureSystem } from '../extract/GenerateTextureSystem';
@@ -365,8 +364,6 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions,
 
     public destroy(options: DestroyOptions = false): void
     {
-        const writeable = this as Writeable<typeof this, 'renderPipes' | 'runners'>;
-
         this.runners.destroy.items.reverse();
         this.runners.destroy.emit(options);
 
@@ -376,11 +373,10 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions,
             runner.destroy();
         });
 
-        writeable.runners = null;
         this._systemsHash = null;
 
         // destroy all pipes
-        writeable.renderPipes = null;
+        (this.renderPipes as null) = null;
     }
 
     /**

--- a/src/scene/container/LayerSystem.ts
+++ b/src/scene/container/LayerSystem.ts
@@ -9,7 +9,6 @@ import type { Matrix } from '../../maths/matrix/Matrix';
 import type { WebGPURenderer } from '../../rendering/renderers/gpu/WebGPURenderer';
 import type { System } from '../../rendering/renderers/shared/system/System';
 import type { Renderer } from '../../rendering/renderers/types';
-import type { Writeable } from '../../utils/types';
 import type { Container } from './Container';
 import type { LayerGroup } from './LayerGroup';
 
@@ -107,9 +106,7 @@ export class LayerSystem implements System
 
     public destroy()
     {
-        const writeable = this as Writeable<typeof this, '_renderer'>;
-
-        writeable._renderer = null;
+        (this._renderer as null) = null;
     }
 }
 

--- a/src/scene/text/bitmap/AbstractBitmapFont.ts
+++ b/src/scene/text/bitmap/AbstractBitmapFont.ts
@@ -2,7 +2,6 @@ import EventEmitter from 'eventemitter3';
 import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
-import type { Writeable } from '../../../utils/types';
 import type { FontMetrics } from '../canvas/CanvasTextMetrics';
 
 export interface CharData
@@ -71,8 +70,6 @@ interface BitmapFontEvents<Type>
 {
     destroy: [Type];
 }
-
-type WriteableAbstractBitmapFont = Writeable<AbstractBitmapFont<any>, keyof AbstractBitmapFont<any>>;
 
 export abstract class AbstractBitmapFont<FontType>
     extends EventEmitter<BitmapFontEvents<FontType>>
@@ -161,6 +158,6 @@ export abstract class AbstractBitmapFont<FontType>
             this.chars[i].texture.destroy();
         }
 
-        (this as WriteableAbstractBitmapFont).chars = null;
+        (this.chars as null) = null;
     }
 }

--- a/src/scene/text/bitmap/BitmapFont.ts
+++ b/src/scene/text/bitmap/BitmapFont.ts
@@ -2,7 +2,7 @@ import { Rectangle } from '../../../maths/shapes/Rectangle';
 import { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import { AbstractBitmapFont } from './AbstractBitmapFont';
 
-import type { Writeable } from '../../../utils/types';
+import type { FontMetrics } from '../canvas/CanvasTextMetrics';
 import type { BitmapFontData } from './AbstractBitmapFont';
 
 export interface BitmapFontOptions
@@ -10,8 +10,6 @@ export interface BitmapFontOptions
     data: BitmapFontData
     textures: Texture[]
 }
-
-type WriteableBitmapFont = Writeable<BitmapFont, keyof BitmapFont>;
 
 export class BitmapFont extends AbstractBitmapFont<BitmapFont>
 {
@@ -61,18 +59,16 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
 
         this.baseRenderedFontSize = data.fontSize;
 
-        const writable = this as WriteableBitmapFont;
-
-        writable.baseMeasurementFontSize = data.fontSize;
-        writable.fontMetrics = {
+        (this.baseMeasurementFontSize as number) = data.fontSize;
+        (this.fontMetrics as FontMetrics) = {
             ascent: 0,
             descent: 0,
             fontSize: data.fontSize,
         };
-        writable.baseLineOffset = data.baseLineOffset;
-        writable.lineHeight = data.lineHeight;
-        writable.fontFamily = data.fontFamily;
-        writable.distanceField = data.distanceField ?? {
+        (this.baseLineOffset as number) = data.baseLineOffset;
+        (this.lineHeight as number) = data.lineHeight;
+        (this.fontFamily as string) = data.fontFamily;
+        (this.distanceField as {type: string, range: number}) = data.distanceField ?? {
             type: 'none',
             range: 0,
         };
@@ -89,6 +85,6 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
             texture.destroy(true);
         }
 
-        (this as WriteableBitmapFont).pages = null;
+        (this.pages as null) = null;
     }
 }

--- a/src/scene/text/bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text/bitmap/DynamicBitmapFont.ts
@@ -12,7 +12,7 @@ import { resolveCharacters } from './utils/resolveCharacters';
 
 import type { ICanvasRenderingContext2D } from '../../../environment/canvas/ICanvasRenderingContext2D';
 import type { CanvasAndContext } from '../../../rendering/renderers/shared/texture/CanvasPool';
-import type { Writeable } from '../../../utils/types';
+import type { FontMetrics } from '../canvas/CanvasTextMetrics';
 import type { TextStyle } from '../TextStyle';
 
 export interface DynamicBitmapFontOptions
@@ -23,8 +23,6 @@ export interface DynamicBitmapFontOptions
     resolution?: number
     padding?: number
 }
-
-type WriteableDynamicBitmapFont = Writeable<DynamicBitmapFont, keyof DynamicBitmapFont>;
 
 export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
 {
@@ -66,10 +64,9 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
         this._padding = dynamicOptions.padding ?? 4;
 
         const font = fontStringFromTextStyle(style);
-        const writable = this as WriteableDynamicBitmapFont;
 
-        writable.fontMetrics = CanvasTextMetrics.measureFont(font);
-        writable.lineHeight = style.lineHeight || this.fontMetrics.fontSize || style.fontSize;
+        (this.fontMetrics as FontMetrics) = CanvasTextMetrics.measureFont(font);
+        (this.lineHeight as number) = style.lineHeight || this.fontMetrics.fontSize || style.fontSize;
     }
 
     public ensureCharacters(chars: string): void
@@ -382,6 +379,6 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
             texture.destroy(true);
         }
 
-        (this as WriteableDynamicBitmapFont).pages = null;
+        (this.pages as null) = null;
     }
 }

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -757,11 +757,7 @@ export class CanvasTextMetrics
      * @param font - String representing the style of the font
      * @returns Font properties object
      */
-    public static measureFont(font: string): {
-        ascent: number;
-        descent: number;
-        fontSize: number;
-    }
+    public static measureFont(font: string): FontMetrics
     {
         // as this method is used for preparing assets, don't recalculate things if we don't need to
         if (CanvasTextMetrics._fonts[font])

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,10 +3,6 @@ export type ArrayFixed<T, L extends number> = [ T, ...Array<T> ] & { length: L }
 
 export type Dict<T> = {[key: string]: T};
 
-export type Writeable<T extends { [x: string]: any }, K extends string> = {
-    [P in K]: T[P];
-};
-
 /**
  * @namespace utils
  */


### PR DESCRIPTION
When destroying read only types this syntax is a little simpler to use:

`(this.readOnlyProperry as null) = null;`