### PR TITLE
remove the texture listener on sprite view

### DIFF
--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -47,13 +47,6 @@ export class SpriteView implements View
 
         if (this._texture === value) return;
 
-        if (this._texture)
-        {
-            this._texture.off('update', this.onUpdate, this);
-        }
-
-        value.on('update', this.onUpdate, this);
-
         this._texture = value;
 
         this.onUpdate();


### PR DESCRIPTION
This PR removes the dynamic addition and removal of update events for textures for performance optimization. During benchmarks, it was observed that about 70% of the rendering time was spent on managing these listeners, particularly when running the BunnyMark test where textures change every frame.

Performance Improvements
By eliminating this overhead, we've managed to surpass the performance levels of v7.

Caveats
The downside is that any modifications to a texture (e.g., changing the frame) will not be immediately reflected in sprites using that texture. To see the changes, developers will need to either:

Reassign the texture to the sprite, or
Call onUpdate() manually.
Rationale
This trade-off is justified as developers are more likely to swap textures on sprites every frame than to modify existing textures—modifying textures frequently is a discouraged practice.

