### PR TITLE
fix premultiply alpha issue with the white texture

### DIFF
--- a/src/rendering/renderers/shared/texture/sources/ImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/ImageSource.ts
@@ -53,6 +53,7 @@ ctx.fill();
 Texture.WHITE = new Texture({
     source: new ImageSource({
         resource: canvas,
+        alphaMode: 'premultiply-alpha-on-upload'
     }),
 });
 

--- a/tests/renderering/textures/Textures.test.ts
+++ b/tests/renderering/textures/Textures.test.ts
@@ -49,4 +49,9 @@ describe('Texture', () =>
         expect(Texture.from({ resource: buffer })).toBe(texture);
         expect(Cache.has(buffer)).toBe(true);
     });
+
+    it('texture.WHITE should have correct alpha mode set', () =>
+    {
+        expect(Texture.WHITE.source.alphaMode).toBe('premultiply-alpha-on-upload');
+    });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a2150f0</samp>

### Summary
🎨🧪🐛

<!--
1.  🎨 - This emoji represents the change in the alpha mode of the image source, which is a visual or artistic aspect of the texture rendering.
2.  🧪 - This emoji represents the addition of a test case, which is a scientific or experimental aspect of the code quality and functionality.
3.  🐛 - This emoji represents the prevention of artifacts and blending issues, which are potential bugs or errors in the texture rendering.
-->
The pull request fixes the alpha mode of `texture.WHITE` and `ImageSource` to be consistent with other textures and avoid rendering artifacts. It also adds a test case to check the alpha mode of `texture.WHITE`.

> _`alpha` mode set_
> _to avoid artifacts, blend_
> _texture test added_

### Walkthrough
*  Set the alpha mode of image sources to 'premultiply-alpha-on-upload' to avoid rendering artifacts ([link](https://github.com/pixijs/pixijs/pull/9806/files?diff=unified&w=0#diff-da7fd86fc62fef22b5e279123615533ef426053d455dc2060f19894628c7cacdR56))
*  Add a test case to check that texture.WHITE has the same alpha mode as other image sources ([link](https://github.com/pixijs/pixijs/pull/9806/files?diff=unified&w=0#diff-95e9c04f5f20d4e3eea19b98afe14c523f6113fde2d3536a1afa3c69c9b2392cR52-R56))

