### PR TITLE
fix issue with font format not parsing if only id is provided

### DIFF
--- a/src/scene/text/bitmap/asset/textFormat.ts
+++ b/src/scene/text/bitmap/asset/textFormat.ts
@@ -146,7 +146,7 @@ export const TextFormat = {
             const charNode = char[i];
             const id = parseInt(charNode.id, 10);
 
-            let letter = charNode.letter ?? charNode.char;
+            let letter = charNode.letter ?? charNode.char ?? String.fromCharCode(id);
 
             if (letter === 'space')letter = ' ';
 

--- a/tests/assets/TextFormat.test.ts
+++ b/tests/assets/TextFormat.test.ts
@@ -1,0 +1,31 @@
+import { TextFormat } from '../../src/scene/text/bitmap/asset/textFormat';
+
+const rawFontString = `
+info face="sans-serif" size=36 bold=0 italic=0 charset="" unicode=1 stretchH=100 smooth=1 aa=1 padding=1,1,1,1 spacing=1,1
+common lineHeight=36 base=27 scaleW=256 scaleH=256 pages=1 packed=0
+page id=0 file="sans-serif.png"
+chars count=2
+char id=32 x=0 y=0 width=0 height=0 xoffset=0 yoffset=0 xadvance=12 page=0 chnl=15
+char id=33 x=244 y=107 width=8 height=30 xoffset=4 yoffset=0 xadvance=15 page=0 chnl=15
+`;
+
+describe('TextFormat', () =>
+{
+    it.only('should parse text chars, if no letter or char property is present ', async () =>
+    {
+        const parsedText = TextFormat.parse(rawFontString);
+
+        expect(parsedText.chars['!']).toEqual({
+            id: 33,
+            page: 0,
+            x: 244,
+            y: 107,
+            width: 8,
+            height: 30,
+            xOffset: 4,
+            yOffset: 0,
+            xAdvance: 15,
+            kerning: {}
+        });
+    });
+});

--- a/tests/assets/TextFormat.test.ts
+++ b/tests/assets/TextFormat.test.ts
@@ -11,7 +11,7 @@ char id=33 x=244 y=107 width=8 height=30 xoffset=4 yoffset=0 xadvance=15 page=0 
 
 describe('TextFormat', () =>
 {
-    it.only('should parse text chars, if no letter or char property is present ', async () =>
+    it('should parse text chars, if no letter or char property is present ', async () =>
     {
         const parsedText = TextFormat.parse(rawFontString);
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37b3cdc</samp>

### Summary
🐛📝✅

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the first change.
2.  📝 - This emoji represents a document or a text, which is the type of data that the TextFormat class handles and the unit test verifies.
3.  ✅ - This emoji represents a check mark or a test, which is the outcome of the second change and the way to ensure the bug fix works as expected.
-->
Fix bitmap font rendering bug and add unit test. The bug fix ensures that all characters in a bitmap font have a valid letter property in `TextFormat`. The unit test checks the `TextFormat` parsing logic with a mock XML file in `TextFormat.test.ts`.

> _`TextFormat` bug_
> _XML parsing improved_
> _Fall is for testing_

### Walkthrough
* Fix bug where bitmap font characters without letter or char attributes are not rendered ([link](https://github.com/pixijs/pixijs/pull/9808/files?diff=unified&w=0#diff-7ee71b4a515906c2053a4415a39f864213318eb7322cbe3a7f4a0b906744e5b3L149-R149))
* Add unit test for `TextFormat` class to verify bug fix and parsing logic ([link](https://github.com/pixijs/pixijs/pull/9808/files?diff=unified&w=0#diff-a92915bf7e41a9f4da021a772f0a4bb2cdecde1a59e3baaf179245c7e923ca32R1-R31))


