### PR TITLE
add filter tests

### DIFF
--- a/tests/filter-alpha/AlphaFilter.tests.ts
+++ b/tests/filter-alpha/AlphaFilter.tests.ts
@@ -1,0 +1,25 @@
+import { AlphaFilter } from '../../src/filters/defaults/alpha/AlphaFilter';
+
+describe('AlphaFilter', () =>
+{
+    it('should construct filter', () =>
+    {
+        const filter = new AlphaFilter();
+
+        expect(filter).toBeInstanceOf(AlphaFilter);
+        expect(filter.alpha).toEqual(1);
+
+        filter.destroy();
+    });
+
+    it('should allow alpha to be set', () =>
+    {
+        const filter = new AlphaFilter();
+
+        filter.alpha = 0.5;
+
+        expect(filter.alpha).toEqual(0.5);
+
+        filter.destroy();
+    });
+});

--- a/tests/filter-blur/BlurFilter.tests.ts
+++ b/tests/filter-blur/BlurFilter.tests.ts
@@ -1,0 +1,32 @@
+import { BlurFilter } from '../../src/filters/defaults/blur/BlurFilter';
+
+describe('BlurFilter', () =>
+{
+    it('should construct filter', () =>
+    {
+        const filter = new BlurFilter();
+
+        expect(filter).toBeInstanceOf(BlurFilter);
+        expect(filter.blur).toEqual(8);
+        expect(filter.blurX).toEqual(8);
+        expect(filter.blurY).toEqual(8);
+        expect(filter.quality).toEqual(4);
+
+        filter.destroy();
+    });
+
+    it('should support repeatEdgePixels', () =>
+    {
+        const filter = new BlurFilter();
+
+        expect(filter.repeatEdgePixels).toBe(false);
+        expect(filter.padding).toBeGreaterThan(0);
+
+        filter.repeatEdgePixels = true;
+
+        expect(filter.repeatEdgePixels).toBe(true);
+        expect(filter.padding).toEqual(0);
+
+        filter.destroy();
+    });
+});

--- a/tests/filter-color-matrix/ColorMatrixFilter.tests.ts
+++ b/tests/filter-color-matrix/ColorMatrixFilter.tests.ts
@@ -1,0 +1,79 @@
+import { ColorMatrixFilter } from '../../src/filters/defaults/color-matrix/ColorMatrixFilter';
+
+describe('ColorMatrixFilter', () =>
+{
+    it('should construct filter', () =>
+    {
+        const filter = new ColorMatrixFilter();
+
+        expect(filter).toBeInstanceOf(ColorMatrixFilter);
+        expect(filter.alpha).toEqual(1);
+
+        filter.alpha = 0.5;
+
+        expect(filter.alpha).toEqual(0.5);
+        expect(filter.matrix.toString()).toEqual(new Float32Array(
+            [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0]
+        ).toString());
+
+        filter.destroy();
+    });
+
+    it('should run all operations without multiply', () =>
+    {
+        const filter = new ColorMatrixFilter();
+
+        filter.brightness(0.5, false);
+        filter.tint(0xff0000, false);
+        filter.greyscale(0.5, false);
+        filter.blackAndWhite(false);
+        filter.hue(120, false);
+        filter.contrast(0.5, false);
+        filter.saturate(1, false);
+        filter.desaturate();
+        filter.negative(false);
+        filter.sepia(false);
+        filter.technicolor(false);
+        filter.polaroid(false);
+        filter.toBGR(false);
+        filter.kodachrome(false);
+        filter.browni(false);
+        filter.vintage(false);
+        filter.colorTone(0.2, 0.14, 0xffffff, 0x0, false);
+        filter.night(1, false);
+        filter.predator(1, false);
+        filter.lsd(false);
+        filter.reset();
+
+        filter.destroy();
+    });
+
+    it('should run all operations with multiply', () =>
+    {
+        const filter = new ColorMatrixFilter();
+
+        filter.brightness(0.5, true);
+        filter.tint(0xff0000, true);
+        filter.greyscale(0.5, true);
+        filter.blackAndWhite(true);
+        filter.hue(120, true);
+        filter.contrast(0.5, true);
+        filter.saturate(1, true);
+        filter.desaturate();
+        filter.negative(true);
+        filter.sepia(true);
+        filter.technicolor(true);
+        filter.polaroid(true);
+        filter.toBGR(true);
+        filter.kodachrome(true);
+        filter.browni(true);
+        filter.vintage(true);
+        filter.colorTone(0.2, 0.14, 0xffffff, 0x0, true);
+        filter.night(1, true);
+        filter.predator(1, true);
+        filter.lsd(true);
+        filter.reset();
+
+        filter.destroy();
+    });
+});


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c92f8bd</samp>

This pull request adds new test files for three filter classes: `AlphaFilter`, `BlurFilter`, and `ColorMatrixFilter`. The tests cover the basic functionality and properties of each filter, as well as some specific color operations for the `ColorMatrixFilter`. The tests are located in the `tests/filter-*` directories.