### PR TITLE
v8 add `setDataWithSize` to `Buffer`

### DIFF
--- a/src/rendering/batcher/gpu/BatchGeometry.ts
+++ b/src/rendering/batcher/gpu/BatchGeometry.ts
@@ -15,12 +15,14 @@ export class BatchGeometry extends Geometry
             data: placeHolderBufferData,
             label: 'attribute-batch-buffer',
             usage: BufferUsage.VERTEX | BufferUsage.COPY_DST,
+            shrinkToFit: false,
         });
 
         const indexBuffer = new Buffer({
             data: placeHolderIndexData,
             label: 'index-batch-buffer',
             usage: BufferUsage.INDEX | BufferUsage.COPY_DST, // | BufferUsage.STATIC,
+            shrinkToFit: false,
         });
 
         const stride = vertexSize * 4;

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -194,7 +194,7 @@ export class Buffer extends EventEmitter<{
 
     set data(value: TypedArray)
     {
-        this.setData(value, value.length);
+        this.setDataWithSize(value, value.length);
     }
 
     /**
@@ -203,15 +203,12 @@ export class Buffer extends EventEmitter<{
      * @param value - the data to set
      * @param size - the size of the data in bytes
      */
-    public setData(value: TypedArray, size?: number)
+    public setDataWithSize(value: TypedArray, size: number)
     {
         // Increment update ID
         this._updateID++;
 
-        // Calculate size in bytes
-        const sizeInBytes = size ? (size * value.BYTES_PER_ELEMENT) : value.byteLength;
-
-        this._updateSize = sizeInBytes;
+        this._updateSize = (size * value.BYTES_PER_ELEMENT);
 
         // If the data hasn't changed, early return after emitting 'update'
         if (this._data === value)

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -22,6 +22,15 @@ export interface BufferOptions
     usage: number;
     /** a label for the buffer, this is useful for debugging */
     label?: string;
+    /**
+     * should the GPU buffer bew shrunk when the data becomes smaller?
+     * changing this will cause the buffer to be destroyed and a new one created on the GPU
+     * this can be expensive, especially if the buffer is already big enough!
+     * setting ts to false will prevent the buffer from being shrunk. This will yield better performance
+     * if you are constantly setting data that is changing size often.
+     * @default true
+     */
+    shrinkToFit?: boolean;
 }
 
 export interface BufferDescriptor
@@ -136,13 +145,23 @@ export class Buffer extends EventEmitter<{
     private _data: TypedArray;
 
     /**
+     * should the GPU buffer bew shrunk when the data becomes smaller?
+     * changing this will cause the buffer to be destroyed and a new one created on the GPU
+     * this can be expensive, especially if the buffer is already big enough!
+     * setting ts to false will prevent the buffer from being shrunk. This will yield better performance
+     * if you are constantly setting data that is changing size often.
+     * @default true
+     */
+    public shrinkToFit = true;
+
+    /**
      * Creates a new Buffer with the given options
      * @param options - the options for the buffer
      */
     constructor(options: BufferOptions)
     {
         let { data, size } = options;
-        const { usage, label } = options;
+        const { usage, label, shrinkToFit } = options;
 
         super();
 
@@ -163,6 +182,8 @@ export class Buffer extends EventEmitter<{
             mappedAtCreation,
             label,
         };
+
+        this.shrinkToFit = shrinkToFit ?? true;
     }
 
     /** @todo */
@@ -173,24 +194,56 @@ export class Buffer extends EventEmitter<{
 
     set data(value: TypedArray)
     {
-        if (this._data !== value)
+        this.setData(value, value.length);
+    }
+
+    /**
+     * Sets the data in the buffer to the given value. This will immediately update the buffer on the GPU.
+     * If you only want to update a subset of the buffer, you can pass in the size of the data.
+     * @param value - the data to set
+     * @param size - the size of the data in bytes
+     */
+    public setData(value: TypedArray, size?: number)
+    {
+        // Increment update ID
+        this._updateID++;
+
+        // Calculate size in bytes
+        const sizeInBytes = size ? (size * value.BYTES_PER_ELEMENT) : value.byteLength;
+
+        this._updateSize = sizeInBytes;
+
+        // If the data hasn't changed, early return after emitting 'update'
+        if (this._data === value)
         {
-            const oldData = this._data;
+            this.emit('update', this);
 
-            this._data = value;
+            return;
+        }
 
-            if (oldData.length !== value.length)
-            {
-                this.descriptor.size = value.byteLength;
-                this._resourceId = uid('bufferResource');
+        // Cache old data and update to new value
+        const oldData = this._data;
 
-                this.emit('change', this);
-            }
-            else
+        this._data = value;
+
+        // Event handling
+        if (oldData.length !== value.length)
+        {
+            if (!this.shrinkToFit && value.byteLength < oldData.byteLength)
             {
                 this.emit('update', this);
             }
+            else
+            {
+                this.descriptor.size = value.byteLength;
+                this._resourceId = uid('bufferResource');
+                this.emit('change', this);
+            }
+
+            return;
         }
+
+        this.emit('update', this);
     }
 
     /**

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -23,10 +23,10 @@ export interface BufferOptions
     /** a label for the buffer, this is useful for debugging */
     label?: string;
     /**
-     * should the GPU buffer bew shrunk when the data becomes smaller?
+     * should the GPU buffer be shrunk when the data becomes smaller?
      * changing this will cause the buffer to be destroyed and a new one created on the GPU
      * this can be expensive, especially if the buffer is already big enough!
-     * setting ts to false will prevent the buffer from being shrunk. This will yield better performance
+     * setting this to false will prevent the buffer from being shrunk. This will yield better performance
      * if you are constantly setting data that is changing size often.
      * @default true
      */
@@ -145,10 +145,10 @@ export class Buffer extends EventEmitter<{
     private _data: TypedArray;
 
     /**
-     * should the GPU buffer bew shrunk when the data becomes smaller?
+     * should the GPU buffer be shrunk when the data becomes smaller?
      * changing this will cause the buffer to be destroyed and a new one created on the GPU
      * this can be expensive, especially if the buffer is already big enough!
-     * setting ts to false will prevent the buffer from being shrunk. This will yield better performance
+     * setting this to false will prevent the buffer from being shrunk. This will yield better performance
      * if you are constantly setting data that is changing size often.
      * @default true
      */

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -165,15 +165,11 @@ export class GraphicsContextSystem implements System
 
         const geometry = graphicsData.geometry;
 
-        geometry.indexBuffer.data = batcher.indexBuffer;
-
         // not to self - this works as we are assigning the batchers array buffer
         // once its up loaded - this buffer is then put back in the pool to be reused.
         // this mean we don't have to creating new Batchers for each graphics items
-        geometry.buffers[0].data = batcher.attributeBuffer.float32View;
-
-        geometry.indexBuffer.update(batcher.indexSize * 4);
-        geometry.buffers[0].update(batcher.attributeSize * 4);
+        geometry.indexBuffer.setData(batcher.indexBuffer, batcher.indexSize);
+        geometry.buffers[0].setData(batcher.attributeBuffer.float32View, batcher.attributeSize);
 
         const drawBatches = batcher.batches;
 

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -168,8 +168,8 @@ export class GraphicsContextSystem implements System
         // not to self - this works as we are assigning the batchers array buffer
         // once its up loaded - this buffer is then put back in the pool to be reused.
         // this mean we don't have to creating new Batchers for each graphics items
-        geometry.indexBuffer.setData(batcher.indexBuffer, batcher.indexSize);
-        geometry.buffers[0].setData(batcher.attributeBuffer.float32View, batcher.attributeSize);
+        geometry.indexBuffer.setDataWithSize(batcher.indexBuffer, batcher.indexSize);
+        geometry.buffers[0].setDataWithSize(batcher.attributeBuffer.float32View, batcher.attributeSize);
 
         const drawBatches = batcher.batches;
 

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -58,4 +58,111 @@ describe('Buffer', () =>
 
         expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeUndefined();
     });
+
+    it('should set data correctly with setData', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const changeObserver = jest.fn();
+        const updateObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+        buffer.on('update', updateObserver);
+
+        buffer.setData(new Float32Array([1, 2, 3, 4]));
+
+        expect(changeObserver).toHaveBeenCalled();
+        expect(updateObserver).not.toHaveBeenCalled();
+
+        expect(buffer.descriptor.size).toBe(4 * 4);
+
+        ///
+
+        changeObserver.mockClear();
+        updateObserver.mockClear();
+
+        buffer.setData(new Float32Array([1, 2, 3]));
+
+        expect(changeObserver).toHaveBeenCalled();
+        expect(updateObserver).not.toHaveBeenCalled();
+
+        ///
+
+        changeObserver.mockClear();
+        updateObserver.mockClear();
+
+        buffer.setData(new Float32Array([4, 5, 6]));
+
+        expect(changeObserver).not.toHaveBeenCalled();
+        expect(updateObserver).toHaveBeenCalled();
+
+        ///
+
+        changeObserver.mockClear();
+        updateObserver.mockClear();
+
+        buffer.setData(new Float32Array([4, 5, 6]), 2);
+
+        expect(changeObserver).not.toHaveBeenCalled();
+        expect(updateObserver).toHaveBeenCalled();
+
+        expect(buffer.descriptor.size).toBe(3 * 4);
+        expect(buffer._updateSize).toBe(2 * 4);
+    });
+
+    it('should set data correctly with setData and shrinkToFit set to false', async () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+            shrinkToFit: false,
+        });
+
+        const changeObserver = jest.fn();
+        const updateObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+        buffer.on('update', updateObserver);
+
+        // grow the buffer...
+
+        buffer.setData(new Float32Array([1, 2, 3, 4]));
+
+        expect(changeObserver).toHaveBeenCalled();
+        expect(updateObserver).not.toHaveBeenCalled();
+
+        expect(buffer.descriptor.size).toBe(4 * 4);
+
+        /// shrink the buffer
+
+        changeObserver.mockClear();
+        updateObserver.mockClear();
+
+        buffer.setData(new Float32Array([1, 2, 3]));
+
+        expect(changeObserver).not.toHaveBeenCalled();
+        expect(updateObserver).toHaveBeenCalled();
+
+        expect(buffer.descriptor.size).toBe(4 * 4);
+        expect(buffer._updateSize).toBe(3 * 4);
+    });
+
+    it('should set data correctly with setData if only the size if modified', async () =>
+    {
+        const data = new Float32Array([1, 2, 3]);
+
+        const buffer = new Buffer({
+            data,
+            usage: 1,
+            shrinkToFit: false,
+        });
+
+        buffer.setData(data, 2);
+
+        expect(buffer.descriptor.size).toBe(3 * 4);
+        expect(buffer._updateSize).toBe(2 * 4);
+    });
 });

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -72,7 +72,7 @@ describe('Buffer', () =>
         buffer.on('change', changeObserver);
         buffer.on('update', updateObserver);
 
-        buffer.setData(new Float32Array([1, 2, 3, 4]));
+        buffer.setDataWithSize(new Float32Array([1, 2, 3, 4]), 4);
 
         expect(changeObserver).toHaveBeenCalled();
         expect(updateObserver).not.toHaveBeenCalled();
@@ -84,7 +84,7 @@ describe('Buffer', () =>
         changeObserver.mockClear();
         updateObserver.mockClear();
 
-        buffer.setData(new Float32Array([1, 2, 3]));
+        buffer.setDataWithSize(new Float32Array([1, 2, 3]), 3);
 
         expect(changeObserver).toHaveBeenCalled();
         expect(updateObserver).not.toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe('Buffer', () =>
         changeObserver.mockClear();
         updateObserver.mockClear();
 
-        buffer.setData(new Float32Array([4, 5, 6]));
+        buffer.setDataWithSize(new Float32Array([4, 5, 6]), 3);
 
         expect(changeObserver).not.toHaveBeenCalled();
         expect(updateObserver).toHaveBeenCalled();
@@ -104,7 +104,7 @@ describe('Buffer', () =>
         changeObserver.mockClear();
         updateObserver.mockClear();
 
-        buffer.setData(new Float32Array([4, 5, 6]), 2);
+        buffer.setDataWithSize(new Float32Array([4, 5, 6]), 2);
 
         expect(changeObserver).not.toHaveBeenCalled();
         expect(updateObserver).toHaveBeenCalled();
@@ -129,7 +129,7 @@ describe('Buffer', () =>
 
         // grow the buffer...
 
-        buffer.setData(new Float32Array([1, 2, 3, 4]));
+        buffer.setDataWithSize(new Float32Array([1, 2, 3, 4]), 4);
 
         expect(changeObserver).toHaveBeenCalled();
         expect(updateObserver).not.toHaveBeenCalled();
@@ -141,7 +141,7 @@ describe('Buffer', () =>
         changeObserver.mockClear();
         updateObserver.mockClear();
 
-        buffer.setData(new Float32Array([1, 2, 3]));
+        buffer.setDataWithSize(new Float32Array([1, 2, 3]), 3);
 
         expect(changeObserver).not.toHaveBeenCalled();
         expect(updateObserver).toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('Buffer', () =>
             shrinkToFit: false,
         });
 
-        buffer.setData(data, 2);
+        buffer.setDataWithSize(data, 2);
 
         expect(buffer.descriptor.size).toBe(3 * 4);
         expect(buffer._updateSize).toBe(2 * 4);


### PR DESCRIPTION
add a function that lets devs update the data whilst allso setting the size. 

Also added new property, `shrinkToFit` which if false will not shrink the GPU buffer if the data becomes smaller.

added tests to ensure it works like a boss