### PR TITLE
set default alpha mode to `premultiply-alpha-on-upload`

### DIFF
--- a/src/compressed-textures/basis/worker/BasisWorker.ts
+++ b/src/compressed-textures/basis/worker/BasisWorker.ts
@@ -105,6 +105,7 @@ async function load(url: string): Promise<TextureSourceOptions>
         height: basisTexture.getImageHeight(0, 0),
         format: basisTranscodedTextureFormat,
         resource: levelBuffers,
+        alphaMode: 'no-premultiply-alpha'
     } as TextureSourceOptions;
 }
 

--- a/src/compressed-textures/dds/parseDDS.ts
+++ b/src/compressed-textures/dds/parseDDS.ts
@@ -145,6 +145,7 @@ export function parseDDS(buffer: ArrayBuffer, supportedFormats: TEXTURE_FORMATS[
             width,
             height,
             resource: [new Uint8Array(buffer, dataOffset, width * height * bytesPerPixel)],
+            alphaMode: 'no-premultiply-alpha'
         };
     }
 
@@ -180,6 +181,7 @@ export function parseDDS(buffer: ArrayBuffer, supportedFormats: TEXTURE_FORMATS[
         width,
         height,
         resource: levelBuffers,
+        alphaMode: 'no-premultiply-alpha'
     };
 
     return textureOptions;

--- a/src/compressed-textures/ktx/worker/KTXWorker.ts
+++ b/src/compressed-textures/ktx/worker/KTXWorker.ts
@@ -126,7 +126,8 @@ async function load(url: string): Promise<TextureSourceOptions>
         format: format as TEXTURE_FORMATS,
         mipLevelCount: ktxTexture.numLevels,
         resource: levelBuffers,
-    };
+        alphaMode: 'no-premultiply-alpha'
+    } as TextureSourceOptions;
 
     convertFormatIfRequired(textureOptions);
 

--- a/src/rendering/renderers/shared/texture/sources/TextureSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/TextureSource.ts
@@ -43,7 +43,7 @@ export class TextureSource<T extends Record<string, any> = any> extends EventEmi
     public static defaultOptions: TextureSourceOptions = {
         resolution: 1,
         format: 'bgra8unorm',
-        alphaMode: 'no-premultiply-alpha',
+        alphaMode: 'premultiply-alpha-on-upload',
         dimensions: '2d',
         mipLevelCount: 1,
         autoGenerateMipmaps: false,


### PR DESCRIPTION
`premultiply-alpha-on-upload` is a better default mode, as it is used by most textures users might create on the. 