### PR TITLE
add system runner tests

### DIFF
--- a/tests/system-runner/SystemRunner.tests.ts
+++ b/tests/system-runner/SystemRunner.tests.ts
@@ -1,0 +1,113 @@
+import { SystemRunner } from '../../src/rendering/renderers/shared/system/SystemRunner';
+
+describe('Runner', () =>
+{
+    it('should should exist', () =>
+    {
+        expect(SystemRunner).toBeDefined();
+        expect(typeof SystemRunner).toEqual('function');
+    });
+
+    it('should implement emit', () =>
+    {
+        const complete = new SystemRunner('complete');
+
+        expect(complete.name).toEqual('complete');
+        const callback = jest.fn();
+
+        complete.add({ complete: callback });
+        complete.emit();
+        expect(callback).toBeCalled();
+        expect(callback).toBeCalledTimes(1);
+        complete.emit();
+        expect(callback).toBeCalledTimes(2);
+        complete.emit();
+        expect(callback).toBeCalledTimes(3);
+        complete.destroy();
+        expect(!complete.items).toBe(true);
+        expect(!complete.name).toBe(true);
+    });
+
+    it('should implement emit with arguments', () =>
+    {
+        const update = new SystemRunner('update');
+        // eslint-disable-next-line func-names
+        const callback = jest.fn(function (time, delta)
+        {
+            let len = 0;
+            // Count the number of non-undefined arguments
+
+            for (let i = 0; i < arguments.length; i++)
+            {
+                // eslint-disable-next-line prefer-rest-params
+                if (arguments[i] !== undefined)
+                {
+                    len++;
+                }
+            }
+            expect(len).toEqual(2);
+            expect(time).toEqual(1);
+            expect(delta).toEqual(2);
+        });
+
+        update.add({ update: callback });
+        update.emit(1, 2);
+        expect(callback).toBeCalled();
+        expect(callback).toBeCalledTimes(1);
+    });
+
+    it('should implement multiple targets', () =>
+    {
+        const complete = new SystemRunner('complete');
+        const obj = { complete: jest.fn() };
+        const obj2 = { complete: jest.fn() };
+
+        expect(complete.empty).toBe(true);
+        complete.add(obj);
+        expect(complete.contains(obj)).toBe(true);
+        complete.add(obj2);
+        expect(complete.contains(obj2)).toBe(true);
+        complete.emit();
+        expect(!complete.empty).toBe(true);
+        expect(complete.items.length).toEqual(2);
+        expect(obj.complete).toBeCalled();
+        expect(obj.complete).toBeCalledTimes(1);
+        expect(obj2.complete).toBeCalled();
+        expect(obj2.complete).toBeCalledTimes(1);
+        complete.remove(obj);
+        expect(complete.items.length).toEqual(1);
+        complete.remove(obj2);
+        expect(complete.items.length).toEqual(0);
+        expect(complete.empty).toBe(true);
+    });
+
+    it('should implement removeAll', () =>
+    {
+        const complete = new SystemRunner('complete');
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        const obj = { complete() { } };
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        const obj2 = { complete() { } };
+        const obj3 = {};
+
+        complete
+            .add(obj)
+            .add(obj2)
+            .add(obj3);
+
+        expect(complete.items.length).toEqual(2);
+
+        complete.removeAll();
+        expect(complete.empty).toBe(true);
+    });
+
+    it('should not add items more than once', () =>
+    {
+        const complete = new SystemRunner('complete');
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        const obj = { complete() { } };
+
+        complete.add(obj).add(obj);
+        expect(complete.items.length).toEqual(1);
+    });
+});


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 20aa768</samp>

### Summary
🐛🧪🚀

<!--
1.  🐛 - This emoji represents a bug fix, and is appropriate for the first change, which fixes a bug in the `SystemRunner` class.
2.  🧪 - This emoji represents a test, and is appropriate for the second change, which adds unit tests for the `SystemRunner` class using Jest.
3.  🚀 - This emoji represents a performance improvement, and is appropriate for the overall effect of the changes, which make the `SystemRunner` class more robust and reliable.
-->
This pull request fixes a bug in the `SystemRunner` class that could cause incorrect or unexpected method calls when the `items` array was modified during an `emit` operation. It also adds unit tests for the `SystemRunner` class to ensure its correctness and reliability. The changes affect the file `src/rendering/renderers/shared/system/SystemRunner.ts` and the file `tests/system-runner/SystemRunner.tests.ts`.

> _`SystemRunner` fixed_
> _Copying `items` array_
> _Winter bug no more_

### Walkthrough
* Fix bug where `SystemRunner` would not handle `items` array mutation during `emit` ([link](https://github.com/pixijs/pixijs/pull/9827/files?diff=unified&w=0#diff-6d84d7f606ab4286a3bddf23481b1b795e9a9b12159bc57527ccf3bc831c6f30L66-R80))
* Add unit tests for `SystemRunner` class using Jest ([link](https://github.com/pixijs/pixijs/pull/9827/files?diff=unified&w=0#diff-2ade9d53e548730c30b4281b8549c5ee51b9ac6313c8cd335333a3f87fce4ff9R1-R165))

