### PR TITLE
fix bitmap text install bug

### DIFF
--- a/src/scene/text/TextView.ts
+++ b/src/scene/text/TextView.ts
@@ -1,20 +1,17 @@
-import { Cache } from '../../assets/cache/Cache';
 import { ObservablePoint } from '../../maths/point/ObservablePoint';
 import { emptyViewObserver } from '../../rendering/renderers/shared/view/View';
 import { uid } from '../../utils/data/uid';
-import { BitmapFont } from './bitmap/BitmapFont';
 import { BitmapFontManager } from './bitmap/BitmapFontManager';
-import { DynamicBitmapFont } from './bitmap/DynamicBitmapFont';
 import { CanvasTextMetrics } from './canvas/CanvasTextMetrics';
-import { HTMLTextStyle } from './html/HtmlTextStyle';
 import { measureHtmlText } from './html/utils/measureHtmlText';
+import { detectRenderType } from './utils/detectRenderType';
 import { ensureTextStyle } from './utils/ensureTextStyle';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { View, ViewObserver } from '../../rendering/renderers/shared/view/View';
 import type { Bounds } from '../container/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
-import type { HTMLTextStyleOptions } from './html/HtmlTextStyle';
+import type { HTMLTextStyle, HTMLTextStyleOptions } from './html/HtmlTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
 
 export type TextString = string | number | { toString: () => string };
@@ -66,7 +63,7 @@ export class TextView implements View
     {
         this.text = options.text ?? '';
 
-        const renderMode = options.renderMode ?? this._detectRenderType(options.style);
+        const renderMode = options.renderMode ?? detectRenderType(options.style);
 
         this._renderMode = renderMode;
 
@@ -209,23 +206,6 @@ export class TextView implements View
             bounds[2] = (-anchor._y * height) - padding;
             bounds[3] = bounds[2] + height;
         }
-    }
-
-    private _detectRenderType(style: TextStyleOptions | AnyTextStyle): 'canvas' | 'html' | 'bitmap'
-    {
-        if (style instanceof HTMLTextStyle)
-        {
-            return 'html';
-        }
-
-        const fontData = Cache.get(`${style?.fontFamily as string}-bitmap`);
-
-        if (fontData instanceof DynamicBitmapFont || fontData instanceof BitmapFont)
-        {
-            return 'bitmap';
-        }
-
-        return 'canvas';
     }
 
     /**

--- a/src/scene/text/bitmap/BitmapFontManager.ts
+++ b/src/scene/text/bitmap/BitmapFontManager.ts
@@ -130,7 +130,7 @@ class BitmapFontManagerClass
 
         font.ensureCharacters(flatChars.join(''));
 
-        Cache.set(name, font);
+        Cache.set(`${name}-bitmap`, font);
 
         return font;
     }

--- a/src/scene/text/utils/detectRenderType.ts
+++ b/src/scene/text/utils/detectRenderType.ts
@@ -1,0 +1,31 @@
+import { Cache } from '../../../assets/cache/Cache';
+import { BitmapFont } from '../bitmap/BitmapFont';
+import { DynamicBitmapFont } from '../bitmap/DynamicBitmapFont';
+import { HTMLTextStyle } from '../html/HtmlTextStyle';
+
+import type { TextStyleOptions } from '../TextStyle';
+import type { AnyTextStyle } from '../TextView';
+
+/**
+ * Takes a text style and returns the recommended renderMode for that style.
+ * This is used internally by the Text class to work out whether the text should
+ * be rendered using a Canvas / Bitmap or HTML Text pipeline.
+ * @param style - the style to check
+ * @returns the renderMode to use
+ */
+export function detectRenderType(style: TextStyleOptions | AnyTextStyle): 'canvas' | 'html' | 'bitmap'
+{
+    if (style instanceof HTMLTextStyle)
+    {
+        return 'html';
+    }
+
+    const fontData = Cache.get(`${style?.fontFamily as string}-bitmap`);
+
+    if (fontData instanceof DynamicBitmapFont || fontData instanceof BitmapFont)
+    {
+        return 'bitmap';
+    }
+
+    return 'canvas';
+}

--- a/tests/renderering/text/BitmapFont.test.ts
+++ b/tests/renderering/text/BitmapFont.test.ts
@@ -1,0 +1,18 @@
+import { BitmapFontManager } from '../../../src/scene/text/bitmap/BitmapFontManager';
+import { detectRenderType } from '../../../src/scene/text/utils/detectRenderType';
+
+describe('BitmapFont', () =>
+{
+    it('should install a font and be accessible', async () =>
+    {
+        BitmapFontManager.install('cool-font', {
+            fontFamily: 'Arial',
+        }, { resolution: 2, chars: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' });
+
+        const type = detectRenderType({
+            fontFamily: 'cool-font',
+        });
+
+        expect(type).toEqual('bitmap');
+    });
+});


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e93da13</samp>

### Summary
🔤🔎🧪

<!--
1.  🔤 - This emoji represents the change in the cache key for the bitmap font, as it is related to the alphabet and text rendering.
2.  🔎 - This emoji represents the addition of the `detectRenderType` function, as it is related to searching and finding the best render mode for a text style.
3.  🧪 - This emoji represents the addition of the test case for the `detectRenderType` function, as it is related to testing and verifying the code functionality.
-->
Refactored and tested text rendering detection logic. Extracted `detectRenderType` function to a separate module in `utils/detectRenderType.ts` and changed the cache key format for bitmap fonts. Added a test case for `detectRenderType` in `tests/renderering/text/BitmapFont.test.ts`.

> _Sing, O Muse, of the cunning coder who changed the cache key_
> _Of the bitmap font, adding a suffix to avoid a clash_
> _With other fonts of different kinds that share the same name_
> _And thus ensure consistency with `detectRenderType`, the wise._

### Walkthrough
*  Change cache key for bitmap fonts to include `-bitmap` suffix, to avoid conflicts with other font types ([link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-5c274706f2455dbc088e781792388450a349bd0df5fe2c9736d369828998ab74L133-R133))
* Simplify imports in `TextView.ts` by removing unused or redundant modules ([link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-d04b9b7f677e3d613051d777480cc08d96baf7ad7b8ea2e0e470d1b1dae64f97L1-R7))
* Move `detectRenderType` function from `TextView` class to a separate module in `utils/detectRenderType.ts`, to improve modularity and testability ([link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-d04b9b7f677e3d613051d777480cc08d96baf7ad7b8ea2e0e470d1b1dae64f97L69-R66), [link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-d04b9b7f677e3d613051d777480cc08d96baf7ad7b8ea2e0e470d1b1dae64f97L214-L230), [link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-8751c926ca4500cd55b4e7d7bf093fd246256c8c1f276c2fe25a9618716b1e88R1-R31))
* Add type import of `HTMLTextStyle` to `TextView.ts` to enable type checking for `detectRenderType` function ([link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-d04b9b7f677e3d613051d777480cc08d96baf7ad7b8ea2e0e470d1b1dae64f97L17-R14))
* Add test case to `tests/renderering/text/BitmapFont.test.ts` to verify `detectRenderType` function returns `bitmap` for bitmap font styles ([link](https://github.com/pixijs/pixijs/pull/9861/files?diff=unified&w=0#diff-9f92c63b1cfc805800818fc366b194e5697d79c60daee1ca9ff90c452d66bb1dR1-R18))

