### PR TITLE
v8 Graphics - only destroy context by default if context is owned

### DIFF
--- a/src/scene/graphics/shared/GraphicsView.ts
+++ b/src/scene/graphics/shared/GraphicsView.ts
@@ -21,12 +21,19 @@ export class GraphicsView implements View
     public _didUpdate: boolean;
 
     private _context: GraphicsContext;
-    private readonly _ownedContext: boolean;
+    private readonly _ownedContext: GraphicsContext;
 
     constructor(graphicsContext?: GraphicsContext)
     {
-        this._ownedContext = !graphicsContext;
-        this._context = graphicsContext || new GraphicsContext();
+        if (!graphicsContext)
+        {
+            this._context = this._ownedContext = new GraphicsContext();
+        }
+        else
+        {
+            this._context = graphicsContext;
+        }
+
         this._context.on('update', this.onGraphicsContextUpdate, this);
     }
 
@@ -68,28 +75,32 @@ export class GraphicsView implements View
     /**
      * Destroys this graphics renderable and optionally its context.
      * @param options - Options parameter. A boolean will act as if all options
-     *  have been set to that value
+     *
+     * If the context was created by this graphics view and `destroy(false)` or `destroy()` is called
+     * then the context will still be destroyed.
+     *
+     * If you want to explicitly not destroy this context that this graphics created,
+     * then you should pass destroy({ context: false })
+     *
+     * If the context was passed in as an argument to the constructor then it will not be destroyed
      * @param {boolean} [options.texture=false] - Should destroy the texture of the graphics context
      * @param {boolean} [options.textureSource=false] - Should destroy the texture source of the graphics context
      * @param {boolean} [options.context=false] - Should destroy the context
      */
-    public destroy(options: TypeOrBool<TextureDestroyOptions & ContextDestroyOptions> = false): void
+    public destroy(options: TypeOrBool<TextureDestroyOptions & ContextDestroyOptions>): void
     {
         (this as any).owner = null;
 
-        if (this._ownedContext && !options)
+        if (this._ownedContext && options === false)
+        {
+            this._ownedContext.destroy(options);
+        }
+        else if (options === true || (options as ContextDestroyOptions)?.context === true)
         {
             this._context.destroy(options);
         }
 
-        const destroyContext = typeof options === 'boolean' ? options : options?.context;
-
-        /** if the context was created by this graphics, we should destroy it*/
-        if (destroyContext || (destroyContext === undefined && this._ownedContext))
-        {
-            this._context.destroy(options);
-        }
-
+        (this._ownedContext as null) = null;
         this._context = null;
     }
 }

--- a/src/scene/graphics/shared/GraphicsView.ts
+++ b/src/scene/graphics/shared/GraphicsView.ts
@@ -21,9 +21,11 @@ export class GraphicsView implements View
     public _didUpdate: boolean;
 
     private _context: GraphicsContext;
+    private readonly _ownedContext: boolean;
 
     constructor(graphicsContext?: GraphicsContext)
     {
+        this._ownedContext = !graphicsContext;
         this._context = graphicsContext || new GraphicsContext();
         this._context.on('update', this.onGraphicsContextUpdate, this);
     }
@@ -75,9 +77,15 @@ export class GraphicsView implements View
     {
         (this as any).owner = null;
 
+        if (this._ownedContext && !options)
+        {
+            this._context.destroy(options);
+        }
+
         const destroyContext = typeof options === 'boolean' ? options : options?.context;
 
-        if (destroyContext)
+        /** if the context was created by this graphics, we should destroy it*/
+        if (destroyContext || (destroyContext === undefined && this._ownedContext))
         {
             this._context.destroy(options);
         }

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -3,6 +3,7 @@ import { Bounds } from '../../../src/scene/container/bounds/Bounds';
 import { getLocalBounds } from '../../../src/scene/container/bounds/getLocalBounds';
 import { Container } from '../../../src/scene/container/Container';
 import { Graphics } from '../../../src/scene/graphics/shared/Graphics';
+import { GraphicsContext } from '../../../src/scene/graphics/shared/GraphicsContext';
 import { getRenderer } from '../../utils/getRenderer';
 
 describe('Graphics', () =>
@@ -38,7 +39,7 @@ describe('Graphics', () =>
         // we will lose this ref once its destroyed:
         const context = graphics.context;
 
-        graphics.destroy();
+        graphics.destroy({ context: false });
 
         expect(graphics.context).toBeNull();
 
@@ -66,5 +67,37 @@ describe('Graphics', () =>
         const bounds = getLocalBounds(g, new Bounds(), new Matrix());
 
         expect(bounds.rectangle.width).toBe(200);
+    });
+
+    it('should destroy its own context', async () =>
+    {
+        const g = new Graphics();
+
+        const context = g.context;
+
+        // listen to function..
+        const spy = jest.fn();
+
+        context.on('destroy', spy);
+
+        g.destroy();
+
+        expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not destroy its context if its managed externally', async () =>
+    {
+        const context = new GraphicsContext();
+
+        const g = new Graphics(context);
+
+        // listen to function..
+        const spy = jest.fn();
+
+        context.on('destroy', spy);
+
+        g.destroy();
+
+        expect(spy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fdc9e8b</samp>

### Summary
🚩🛠️✅

<!--
1.  🚩 for adding a flag to `GraphicsView`
2.  🛠️ for updating the `destroy` method
3.  ✅ for adding and updating test cases
-->
This pull request improves the management of graphics contexts in `Graphics` and `GraphicsView` classes, and adds tests to verify the correct behavior. It allows `GraphicsView` to own or share its context, and `Graphics` to destroy its context or not depending on the ownership.

> _We control the `GraphicsContext`_
> _We decide when it will die_
> _We unleash the power of `GraphicsView`_
> _We defy the rules of the GUI_

### Walkthrough
*  Add `_ownedContext` property to `GraphicsView` class to track context ownership ([link](https://github.com/pixijs/pixijs/pull/9870/files?diff=unified&w=0#diff-64854e497fd53ac240b8f7665a4715e80893e4aa03cd7a492c9cb7318fa1a5a5L24-R28))
*  Update `destroy` method of `GraphicsView` class to respect `_ownedContext` property and `destroyContext` option ([link](https://github.com/pixijs/pixijs/pull/9870/files?diff=unified&w=0#diff-64854e497fd53ac240b8f7665a4715e80893e4aa03cd7a492c9cb7318fa1a5a5L78-R88))
*  Import `GraphicsContext` class to `Graphics.test.ts` module for testing context destruction ([link](https://github.com/pixijs/pixijs/pull/9870/files?diff=unified&w=0#diff-ff477ae949065c590fb000be22f28af100deb8be086047610477e7cdb279b53bR6))
*  Modify existing test case for `Graphics` class to avoid destroying shared context ([link](https://github.com/pixijs/pixijs/pull/9870/files?diff=unified&w=0#diff-ff477ae949065c590fb000be22f28af100deb8be086047610477e7cdb279b53bL41-R42))
*  Add new test cases for `Graphics` class to check context destruction behavior for owned and external contexts ([link](https://github.com/pixijs/pixijs/pull/9870/files?diff=unified&w=0#diff-ff477ae949065c590fb000be22f28af100deb8be086047610477e7cdb279b53bR71-R102))

