### PR TITLE
v8 Reset childrenRenderablesToUpdate index between renders

### DIFF
--- a/src/scene/container/LayerSystem.ts
+++ b/src/scene/container/LayerSystem.ts
@@ -78,6 +78,9 @@ export class LayerSystem implements System
                 updateRenderables(layerGroup);
             }
 
+            // reset the renderables to update
+            layerGroup.childrenRenderablesToUpdate.index = 0;
+
             // upload all the things!
             renderer.renderPipes.batch.upload(layerGroup.instructionSet);
         }
@@ -121,7 +124,5 @@ function updateRenderables(layerGroup: LayerGroup)
             layerGroup.updateRenderable(container);
         }
     }
-
-    layerGroup.childrenRenderablesToUpdate.index = 0;
 }
 

--- a/src/scene/container/utils/validateRenderables.ts
+++ b/src/scene/container/utils/validateRenderables.ts
@@ -25,10 +25,5 @@ export function validateRenderables(layerGroup: LayerGroup, renderPipes: RenderP
 
     layerGroup.structureDidChange = rebuildRequired;
 
-    if (rebuildRequired)
-    {
-        layerGroup.childrenRenderablesToUpdate.index = 0;
-    }
-
     return rebuildRequired;
 }

--- a/src/scene/text/bitmap/BitmapTextPipe.ts
+++ b/src/scene/text/bitmap/BitmapTextPipe.ts
@@ -181,8 +181,6 @@ export class BitmapTextPipe implements RenderPipe<TextView>
 
     private _initGpuText(renderable: Renderable<TextView>)
     {
-        renderable.view._style.update();
-
         // TODO we could keep a bunch of contexts around and reuse one that hav the same style!
         const proxyRenderable = BigPool.get(GraphicsProxyRenderable, renderable);
 

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -162,10 +162,6 @@ export class CanvasTextPipe implements RenderPipe<TextView>
 
     private _initGpuText(renderable: Renderable<TextView>)
     {
-        const view = renderable.view;
-
-        view._style.update();
-
         const gpuTextData: CanvasTextPipe['_gpuText'][number] = {
             texture: null,
             currentKey: '--',

--- a/src/scene/text/html/HTMLTextPipe.ts
+++ b/src/scene/text/html/HTMLTextPipe.ts
@@ -173,10 +173,6 @@ export class HTMLTextPipe implements RenderPipe<TextView>
 
     private _initGpuText(renderable: Renderable<TextView>)
     {
-        const view = renderable.view;
-
-        view._style.update();
-
         const gpuTextData: HTMLTextPipe['_gpuText'][number] = {
             texture: Texture.EMPTY,
             currentKey: '--',

--- a/tests/renderering/scene/LayerSystem.test.ts
+++ b/tests/renderering/scene/LayerSystem.test.ts
@@ -1,0 +1,27 @@
+import { Container } from '../../../src/scene/container/Container';
+import { Text } from '../../../src/scene/text/Text';
+import { getRenderer } from '../../utils/getRenderer';
+import '../../../src/rendering/renderers/shared/texture/Texture';
+
+describe('LayerSystem', () =>
+{
+    it('should reset childrenRenderablesToUpdate index between renders', async () =>
+    {
+        const renderer = await getRenderer();
+
+        const container = new Container({ layer: true });
+        const text = new Text({ text: 'hello world' });
+
+        container.addChild(text);
+
+        expect(container.layerGroup.childrenRenderablesToUpdate.index).toEqual(0);
+
+        text.text = 'hello world 2';
+
+        expect(container.layerGroup.childrenRenderablesToUpdate.index).toEqual(1);
+
+        renderer.render(container);
+
+        expect(container.layerGroup.childrenRenderablesToUpdate.index).toEqual(0);
+    });
+});


### PR DESCRIPTION
fixes #9836

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ca8b32f</samp>

### Summary
🐛🚀✅

<!--
1.  🐛 - This emoji represents a bug fix, since the change in F0L79R79 fixes a bug that caused the `childrenRenderablesToUpdate` index to not be reset properly between renders, which could lead to incorrect rendering or unnecessary updates.
2.  🚀 - This emoji represents a performance improvement, since the change in F0L79R79 also reduces the number of times the `childrenRenderablesToUpdate` array is cleared, which could improve the rendering speed or reduce memory usage.
3.  ✅ - This emoji represents a test, since the change in F0L79R79 adds a new test case to the `LayerSystem.test.ts` file, which verifies the correctness of the bug fix and the performance improvement.
-->
This pull request optimizes the `LayerSystem` class by reducing unnecessary array operations and adds a test case to verify the functionality. The changes affect the files `src/scene/container/LayerSystem.ts` and `tests/renderering/scene/LayerSystem.test.ts`.

> _We're the crew of the `LayerSystem` ship_
> _We sail the seas of code with skill and wit_
> _We clear the `childrenRenderablesToUpdate` once_
> _And then we render fast and smooth, we're done_

### Walkthrough
*  Reset `childrenRenderablesToUpdate` index of layer groups before sorting them to avoid unnecessary updates ([link](https://github.com/pixijs/pixijs/pull/9874/files?diff=unified&w=0#diff-0d16cb5973b93e4603e2f89fbf8467e78da6962d56823d8115eba80d72e8e95dR81-R83))
*  Remove redundant line that also resets `childrenRenderablesToUpdate` index in `render` method ([link](https://github.com/pixijs/pixijs/pull/9874/files?diff=unified&w=0#diff-0d16cb5973b93e4603e2f89fbf8467e78da6962d56823d8115eba80d72e8e95dL124-L125))
*  Add test case in `LayerSystem.test.ts` to check if index is correctly reset between renders ([link](https://github.com/pixijs/pixijs/pull/9874/files?diff=unified&w=0#diff-d4c1d889d98aab63cafc5d3528765690bd4d37e7e7cc48d6ac182b5cecd74674R1-R27))


