### PR TITLE
Bugfix/v8/text-contains-point

### DIFF
--- a/src/scene/text/TextView.ts
+++ b/src/scene/text/TextView.ts
@@ -134,8 +134,9 @@ export class TextView implements View
 
     public containsPoint(point: PointData)
     {
-        const width = this.bounds[0];
-        const height = this.bounds[2];
+        const width = this.bounds[1];
+        const height = this.bounds[3];
+
         const x1 = -width * this.anchor.x;
         let y1 = 0;
 

--- a/tests/renderering/text/Text.test.ts
+++ b/tests/renderering/text/Text.test.ts
@@ -87,4 +87,11 @@ describe('Text', () =>
 
         expect(renderer.renderPipes.bitmapText['_gpuBitmapText'][text.uid]).toBeNull();
     });
+
+    it('should contain point correctly', async () =>
+    {
+        const text = new Text({ text: 'foo', renderMode: 'canvas' });
+
+        expect(text.view.containsPoint({ x: 4, y: 4 })).toBe(true);
+    });
 });


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e9d9f66</samp>

### Summary
🐛🧪🎨

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the first change. It is a common symbol for software errors and issues.
2.  🧪 - This emoji represents a unit test, which is the main feature of the second change. It is a common symbol for scientific experiments and testing.
3.  🎨 - This emoji represents the canvas render mode, which is the specific setting of the text object in the test. It is a common symbol for artistic and creative work.
-->
This pull request fixes a bug in the `containsPoint` method of the `TextView` class and adds a unit test for it. The bug affected the text rendering module of the pixijs library and could cause incorrect detection of text bounds.

> _`containsPoint` fixed_
> _Text bounds were out of sync_
> _A test in springtime_

### Walkthrough
* Fix bug in `containsPoint` method of `TextView` class by using correct indices of `bounds` array ([link](https://github.com/pixijs/pixijs/pull/9875/files?diff=unified&w=0#diff-d04b9b7f677e3d613051d777480cc08d96baf7ad7b8ea2e0e470d1b1dae64f97L137-R139))
* Add unit test for `containsPoint` method of `Text` class in `tests/renderering/text/Text.test.ts` file ([link](https://github.com/pixijs/pixijs/pull/9875/files?diff=unified&w=0#diff-247eb8b638357b166df7b896339ac47a42a6456a7fa173216b4ed9e03be7e690R90-R96))

