### PR TITLE
split color to bgr + alpha properties

### DIFF
--- a/src/rendering/renderers/shared/LayerRenderable.ts
+++ b/src/rendering/renderers/shared/LayerRenderable.ts
@@ -20,10 +20,12 @@ export class LayerRenderable<T extends View = View> extends EventEmitter impleme
     public view: T;
     private readonly _original: Container<View>;
     public layerTransform: Matrix;
-    public worldTransform: Matrix;
-    public layerColor: number;
     public layerVisibleRenderable: number;
     public didViewUpdate: boolean;
+    public worldTransform: Matrix;
+    public layerColorAlpha = 0xffffffff;
+    public layerColor = 0xffffff;
+    public layerAlpha = 1;
 
     constructor({ original, view }: { original: Container<View>; view: T })
     {
@@ -32,7 +34,6 @@ export class LayerRenderable<T extends View = View> extends EventEmitter impleme
         this.view = view;
         this._original = original;
         this.layerTransform = new Matrix();
-        this.layerColor = 0xffffffff;
         this.layerVisibleRenderable = 0b11;
 
         this.view.owner = this;

--- a/src/rendering/renderers/shared/ProxyRenderable.ts
+++ b/src/rendering/renderers/shared/ProxyRenderable.ts
@@ -38,9 +38,19 @@ export class ProxyRenderable<T extends View = View> extends EventEmitter impleme
         this.layerTransform = original.layerTransform;
     }
 
+    get layerColorAlpha()
+    {
+        return this._original.layerColorAlpha;
+    }
+
     get layerColor()
     {
         return this._original.layerColor;
+    }
+
+    get layerAlpha()
+    {
+        return this._original.layerAlpha;
     }
 
     get layerBlendMode()

--- a/src/rendering/renderers/shared/Renderable.ts
+++ b/src/rendering/renderers/shared/Renderable.ts
@@ -10,7 +10,9 @@ export interface Renderable<VIEW extends View = View> extends EventEmitter
     didViewUpdate: boolean;
     layerTransform: Matrix;
     worldTransform: Matrix;
+    layerAlpha: number;
     layerColor: number;
+    layerColorAlpha: number;
     layerBlendMode: BLEND_MODES;
     layerVisibleRenderable: number;
     isRenderable: boolean;

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -456,7 +456,7 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
      */
     public layerAlpha = 1; // A
     public layerColor = 0xFFFFFF; // BGR
-    public layerColorAlpha = 0xFFFFFFFF; // BGRA
+    public layerColorAlpha = 0xFFFFFFFF; // ABGR
 
     /// BLEND related props //////////////
 

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -939,7 +939,7 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
 
     set tint(value: ColorSource)
     {
-        const tempColor = Color.shared.setValue(value);
+        const tempColor = Color.shared.setValue(value ?? 0xFFFFFF);
         const bgr = tempColor.toBgrNumber();
 
         if (bgr === this.localColor) return;

--- a/src/scene/container/LayerGroup.ts
+++ b/src/scene/container/LayerGroup.ts
@@ -20,7 +20,9 @@ export class LayerGroup implements Instruction
     private readonly _children: Container[] = [];
 
     public worldTransform: Matrix = new Matrix();
-    public worldColor = 0xffffffff;
+    public worldColorAlpha = 0xffffffff;
+    public worldColor = 0xffffff;
+    public worldAlpha = 1;
 
     // these updates are transform changes..
     public readonly childrenToUpdate: Record<number, { list: Container[]; index: number; }> = Object.create(null);
@@ -238,7 +240,7 @@ export class LayerGroup implements Instruction
 
     get isRenderable(): boolean
     {
-        const worldAlpha = ((this.worldColor >> 24) & 0xFF);
+        const worldAlpha = ((this.worldColorAlpha >> 24) & 0xFF);
 
         return (this.root.localVisibleRenderable === 0b11 && worldAlpha > 0);
     }

--- a/src/scene/container/LayerPipe.ts
+++ b/src/scene/container/LayerPipe.ts
@@ -37,7 +37,7 @@ export class LayerPipe implements InstructionPipe<LayerGroup>
 
         this._renderer.globalUniforms.push({
             worldTransformMatrix: layerGroup.worldTransform,
-            worldColor: layerGroup.worldColor,
+            worldColor: layerGroup.worldColorAlpha,
         });
 
         executeInstructions(layerGroup, this._renderer.renderPipes);

--- a/src/scene/container/utils/mixColors.ts
+++ b/src/scene/container/utils/mixColors.ts
@@ -2,16 +2,8 @@ import { mixHexColors } from './mixHexColors';
 
 const WHITE_WHITE = 0xFFFFFF + (0xFFFFFF << 32);
 
-export function mixColors(localColor: number, parentColor: number)
+export function mixColors(localBGRColor: number, parentBGRColor: number)
 {
-    const localAlpha = ((localColor >> 24) & 0xFF) / 255;
-    const parentAlpha = ((parentColor >> 24) & 0xFF) / 255;
-
-    const globalAlpha = ((localAlpha * parentAlpha) * 255);
-
-    const localBGRColor = localColor & 0x00FFFFFF;
-    const parentBGRColor = parentColor & 0x00FFFFFF;
-
     let sharedBGRColor = 0xFFFFFF;
 
     if (localBGRColor + (parentBGRColor << 32) !== WHITE_WHITE)
@@ -32,7 +24,7 @@ export function mixColors(localColor: number, parentColor: number)
         }
     }
 
-    return sharedBGRColor + (globalAlpha << 24);
+    return sharedBGRColor;
 }
 
 export function mixStandardAnd32BitColors(localColorRGB: number, localAlpha: number, parentColor: number)

--- a/src/scene/container/utils/mixColors.ts
+++ b/src/scene/container/utils/mixColors.ts
@@ -4,27 +4,22 @@ const WHITE_WHITE = 0xFFFFFF + (0xFFFFFF << 32);
 
 export function mixColors(localBGRColor: number, parentBGRColor: number)
 {
-    let sharedBGRColor = 0xFFFFFF;
-
     if (localBGRColor + (parentBGRColor << 32) !== WHITE_WHITE)
     {
         // color has changed!
         if (localBGRColor === 0xFFFFFF)
         {
-            sharedBGRColor = parentBGRColor;
+            return parentBGRColor;
         }
         else if (parentBGRColor === 0xFFFFFF)
         {
-            sharedBGRColor = localBGRColor;
+            return localBGRColor;
         }
 
-        else
-        {
-            sharedBGRColor = mixHexColors(localBGRColor, parentBGRColor, 0.5);
-        }
+        return mixHexColors(localBGRColor, parentBGRColor, 0.5);
     }
 
-    return sharedBGRColor;
+    return 0xFFFFFF;
 }
 
 export function mixStandardAnd32BitColors(localColorRGB: number, localAlpha: number, parentColor: number)

--- a/src/scene/container/utils/updateLayerGroupTransforms.ts
+++ b/src/scene/container/utils/updateLayerGroupTransforms.ts
@@ -42,22 +42,35 @@ export function updateLayerGroupTransforms(layerGroup: LayerGroup, updateChildRe
 
 export function updateLayerTransform(layerGroup: LayerGroup)
 {
+    const root = layerGroup.root;
+
     if (layerGroup.layerGroupParent)
     {
+        const layerGroupParent = layerGroup.layerGroupParent;
+
         layerGroup.worldTransform.appendFrom(
-            layerGroup.root.layerTransform,
-            layerGroup.layerGroupParent.worldTransform,
+            root.layerTransform,
+            layerGroupParent.worldTransform,
         );
 
         layerGroup.worldColor = mixColors(
-            layerGroup.root.layerColor,
-            layerGroup.layerGroupParent.worldColor,
+            root.layerColor,
+            layerGroupParent.worldColor,
         );
+
+        layerGroup.worldAlpha = root.layerAlpha * layerGroupParent.worldAlpha;
+
+        layerGroup.worldColorAlpha = layerGroup.worldColor
+            + (((layerGroup.worldAlpha * 255) | 0) << 24);
     }
     else
     {
-        layerGroup.worldTransform.copyFrom(layerGroup.root.layerTransform);
-        layerGroup.worldColor = layerGroup.root.localColor;
+        layerGroup.worldTransform.copyFrom(root.layerTransform);
+        layerGroup.worldColor = root.localColor;
+        layerGroup.worldAlpha = root.localAlpha;
+
+        layerGroup.worldColorAlpha = layerGroup.worldColor
+            + (((layerGroup.worldAlpha * 255) | 0) << 24);
     }
 }
 
@@ -128,7 +141,14 @@ function updateColorBlendVisibility(
 {
     if (updateFlags & UPDATE_COLOR)
     {
-        container.layerColor = mixColors(container.localColor, parent.layerColor);
+        container.layerColor = mixColors(
+            container.localColor,
+            parent.layerColor
+        );
+
+        container.layerAlpha = container.localAlpha * parent.layerAlpha;
+
+        container.layerColorAlpha = container.layerColor + (((container.layerAlpha * 255) | 0) << 24);
     }
 
     if (updateFlags & UPDATE_BLEND)

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -66,7 +66,8 @@ export class BatchableGraphics implements BatchableObject
 
         if (this.applyTransform)
         {
-            const argb = mixColors(bgr + ((this.alpha * 255) << 24), graphics.layerColor);
+            const argb = mixColors(bgr, graphics.layerColor)
+            + ((this.alpha * graphics.layerAlpha * 255) << 24);
 
             const wt = graphics.layerTransform;
             const textureIdAndRound = (textureId << 16) | (this.roundPixels & 0xFFFF);

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -152,7 +152,7 @@ export class GraphicsPipe implements RenderPipe<GraphicsView>
         localUniforms.uRound = renderer._roundPixels | renderable.view.roundPixels;
 
         color32BitToUniform(
-            renderable.layerColor,
+            renderable.layerColorAlpha,
             localUniforms.uColor,
             0
         );

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -61,7 +61,7 @@ export class BatchableMesh implements BatchableObject
         const positions = geometry.positions;
         const uvs = geometry.uvs;
 
-        const abgr = renderable.layerColor;
+        const abgr = renderable.layerColorAlpha;
 
         for (let i = 0; i < positions.length; i += 2)
         {

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -185,7 +185,7 @@ export class MeshPipe implements RenderPipe<MeshView>, InstructionPipe<MeshInstr
         localUniforms.update();
 
         color32BitToUniform(
-            renderable.layerColor,
+            renderable.layerColorAlpha,
             localUniforms.uniforms.uColor,
             0
         );

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -52,7 +52,7 @@ export class BatchableSprite implements BatchableObject
 
         // _ _ _ _
         // a b g r
-        const argb = sprite.layerColor;
+        const argb = sprite.layerColorAlpha;
 
         const textureIdAndRound = (textureId << 16) | (this.roundPixels & 0xFFFF);
 

--- a/tests/scene/transform-tint.tests.ts
+++ b/tests/scene/transform-tint.tests.ts
@@ -37,9 +37,7 @@ describe('Transform Tints', () =>
 
         root.alpha = 0.5;
 
-        const roundedAlpha = ((0.5 * 255) | 0) / 255;
-
-        expect((root.alpha)).toEqual(roundedAlpha);
+        expect((root.alpha)).toEqual(0.5);
 
         root.alpha = 0.5;
 
@@ -71,11 +69,8 @@ describe('Transform Tints', () =>
 
         expect((root.tint)).toEqual(0xFF00FF);
 
-        const roundedAlpha = ((0.5 * 255) | 0) / 255;
-
-        expect((root.alpha)).toEqual(roundedAlpha);
-
-        check32BitColorMatches(root.localColor, [127, 255, 0, 255]);
+        expect((root.alpha)).toEqual(0.5);
+        expect((root.localColor)).toEqual(0xFF00FF);
 
         expect(root.onUpdate).toHaveBeenCalledTimes(2);
     });
@@ -97,7 +92,7 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        check32BitColorMatches(child.layerColor, [63, 255, 255, 255]);
+        check32BitColorMatches(child.layerColorAlpha, [63, 255, 255, 255]);
     });
 
     it('should update global color (parent set only) correctly', async () =>
@@ -115,7 +110,7 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        check32BitColorMatches(child.layerColor, [255, 0, 0, 255]);
+        check32BitColorMatches(child.layerColorAlpha, [255, 0, 0, 255]);
     });
 
     it('should update global color (child set only) correctly', async () =>
@@ -133,7 +128,7 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        check32BitColorMatches(child.layerColor, [255, 0, 0, 255]);
+        check32BitColorMatches(child.layerColorAlpha, [255, 0, 0, 255]);
     });
 
     it('should update global color (parent and child set) correctly', async () =>
@@ -156,7 +151,7 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
         // ABGR
-        check32BitColorMatches(child.layerColor, [255, 0, 127, 128]);
+        check32BitColorMatches(child.layerColorAlpha, [255, 0, 127, 128]);
     });
 
     it('should update  alpha and color with nested layer group correctly', async () =>
@@ -189,7 +184,7 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        check32BitColorMatches(child.layerColor, [255, 0, 255, 0]);
+        check32BitColorMatches(child.layerColorAlpha, [255, 0, 255, 0]);
     });
 
     it('should update cap alpha to 1', async () =>
@@ -226,8 +221,8 @@ describe('Transform Tints', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        check32BitColorMatches(container2.layerGroup.worldColor, [127, 255, 255, 255]);
+        check32BitColorMatches(container2.layerGroup.worldColorAlpha, [127, 255, 255, 255]);
 
-        check32BitColorMatches(child.layerColor, [255, 255, 255, 255]);
+        check32BitColorMatches(child.layerColorAlpha, [255, 255, 255, 255]);
     });
 });


### PR DESCRIPTION
Container color + alpha handled a little better now

previously the alpha and colors were stored in one single ABGR value. This made the code a little more complex, and also lost precision of the alpha during conversion.

eg: 
```
container.alpha = 0.5

// 

console.log(container.alpha) // 0.4943234234
```

this PR addresse that by storing the values seperatly.