### PR TITLE
fix up containsPoint for trimmed sprite

### DIFF
--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -135,7 +135,7 @@ export class SpriteView implements View
         const height = textureSource.height * orig.height;
 
         sourceBounds[0] = -anchor._x * width;
-        sourceBounds[1] = sourceBounds[1] + width;
+        sourceBounds[1] = sourceBounds[0] + width;
 
         sourceBounds[2] = -anchor._y * height;
         sourceBounds[3] = sourceBounds[2] + height;

--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -82,16 +82,11 @@ export class SpriteView implements View
     // passed local space..
     public containsPoint(point: PointData)
     {
-        const width = this._texture.frameWidth;
-        const height = this._texture.frameHeight;
-        const x1 = -width * this.anchor.x;
-        let y1 = 0;
+        const bounds = this.sourceBounds;
 
-        if (point.x >= x1 && point.x <= x1 + width)
+        if (point.x >= bounds[0] && point.x <= bounds[1])
         {
-            y1 = -height * this.anchor.y;
-
-            if (point.y >= y1 && point.y <= y1 + height)
+            if (point.y >= bounds[2] && point.y <= bounds[3])
             {
                 return true;
             }
@@ -102,20 +97,9 @@ export class SpriteView implements View
 
     public addBounds(bounds: Bounds)
     {
-        const trim = this._texture._layout.trim;
+        const _bounds = this._texture._layout.trim ? this.sourceBounds : this.bounds;
 
-        if (trim)
-        {
-            const sourceBounds = this.sourceBounds;
-
-            bounds.addFrame(sourceBounds[0], sourceBounds[2], sourceBounds[1], sourceBounds[3]);
-        }
-        else
-        {
-            const _bounds = this.bounds;
-
-            bounds.addFrame(_bounds[0], _bounds[2], _bounds[1], _bounds[3]);
-        }
+        bounds.addFrame(_bounds[0], _bounds[2], _bounds[1], _bounds[3]);
     }
 
     /**
@@ -150,11 +134,11 @@ export class SpriteView implements View
         const width = textureSource.width * orig.width;
         const height = textureSource.height * orig.height;
 
-        sourceBounds[1] = -anchor._x * width;
-        sourceBounds[0] = sourceBounds[1] + width;
+        sourceBounds[0] = -anchor._x * width;
+        sourceBounds[1] = sourceBounds[1] + width;
 
-        sourceBounds[3] = -anchor._y * height;
-        sourceBounds[2] = sourceBounds[3] + height;
+        sourceBounds[2] = -anchor._y * height;
+        sourceBounds[3] = sourceBounds[3] + height;
     }
 
     /**

--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -138,7 +138,7 @@ export class SpriteView implements View
         sourceBounds[1] = sourceBounds[1] + width;
 
         sourceBounds[2] = -anchor._y * height;
-        sourceBounds[3] = sourceBounds[3] + height;
+        sourceBounds[3] = sourceBounds[2] + height;
     }
 
     /**

--- a/tests/renderering/sprite/Sprite.test.ts
+++ b/tests/renderering/sprite/Sprite.test.ts
@@ -211,7 +211,7 @@ describe('Sprite', () =>
             expect(sprite.view.containsPoint(point)).toBe(false);
         });
 
-        it.only('should return true when point inside a trimmed sprite', () =>
+        it('should return true when point inside a trimmed sprite', () =>
         {
             const textureSource = new TextureSource({
                 width: 100,

--- a/tests/renderering/sprite/Sprite.test.ts
+++ b/tests/renderering/sprite/Sprite.test.ts
@@ -1,5 +1,7 @@
 import { Point } from '../../../src/maths/point/Point';
+import { Rectangle } from '../../../src/maths/shapes/Rectangle';
 import { RenderTexture } from '../../../src/rendering/renderers/shared/texture/RenderTexture';
+import { TextureSource } from '../../../src/rendering/renderers/shared/texture/sources/TextureSource';
 import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
 import { Container } from '../../../src/scene/container/Container';
 import { Graphics } from '../../../src/scene/graphics/shared/Graphics';
@@ -207,6 +209,47 @@ describe('Sprite', () =>
             const point = new Point(100, 100);
 
             expect(sprite.view.containsPoint(point)).toBe(false);
+        });
+
+        it.only('should return true when point inside a trimmed sprite', () =>
+        {
+            const textureSource = new TextureSource({
+                width: 100,
+                height: 100,
+                resolution: 1,
+            });
+
+            const texture = new Texture({
+                source: textureSource,
+                layout: {
+                    trim: new Rectangle(
+                        0.01652892561983471,
+                        0.014598540145985401,
+                        0.36496350364963503,
+                        0.4132231404958678
+                    ),
+                    frame: new Rectangle(
+                        0.01652892561983471,
+                        0.014598540145985401,
+                        0.36496350364963503,
+                        0.4132231404958678),
+                    orig: new Rectangle(
+                        0,
+                        0,
+                        1.094890510948905,
+                        1.094890510948905),
+                }
+            });
+
+            const sprite = new Sprite({ texture });
+
+            expect(sprite.view.containsPoint(
+                new Point(108, 108)
+            )).toBe(true);
+
+            expect(sprite.view.containsPoint(
+                new Point(1, 1)
+            )).toBe(true);
         });
     });
 

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -252,7 +252,7 @@ describe('getLocalBounds', () =>
     it('should measure trimmed sprite correctly', async () =>
     {
         const textureSource = new TextureSource({
-            width: 100,
+            width: 200,
             height: 200,
             resolution: 1,
         });
@@ -267,7 +267,7 @@ describe('getLocalBounds', () =>
 
         const sprite = new Sprite({ texture });
 
-        expect(sprite.width).toBe(100);
+        expect(sprite.width).toBe(200);
         expect(sprite.height).toBe(200);
     });
 });

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -253,7 +253,7 @@ describe('getLocalBounds', () =>
     {
         const textureSource = new TextureSource({
             width: 100,
-            height: 100,
+            height: 200,
             resolution: 1,
         });
 
@@ -268,6 +268,6 @@ describe('getLocalBounds', () =>
         const sprite = new Sprite({ texture });
 
         expect(sprite.width).toBe(100);
-        expect(sprite.height).toBe(100);
+        expect(sprite.height).toBe(200);
     });
 });

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -1,8 +1,12 @@
+import { Rectangle } from '../../src/maths/shapes/Rectangle';
 import { StencilMask } from '../../src/rendering/mask/stencil/StencilMask';
 import { addMaskLocalBounds } from '../../src/rendering/mask/utils/addMaskLocalBounds';
+import { TextureSource } from '../../src/rendering/renderers/shared/texture/sources/TextureSource';
+import { Texture } from '../../src/rendering/renderers/shared/texture/Texture';
 import { Bounds } from '../../src/scene/container/bounds/Bounds';
 import { getLocalBounds } from '../../src/scene/container/bounds/getLocalBounds';
 import { Container } from '../../src/scene/container/Container';
+import { Sprite } from '../../src/scene/sprite/Sprite';
 import { DummyEffect } from './DummyEffect';
 import { DummyView } from './DummyView';
 
@@ -243,5 +247,27 @@ describe('getLocalBounds', () =>
         getLocalBounds(container, bounds);
 
         expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 150, maxY: 50 });
+    });
+
+    it('should measure trimmed sprite correctly', async () =>
+    {
+        const textureSource = new TextureSource({
+            width: 100,
+            height: 100,
+            resolution: 1,
+        });
+
+        const texture = new Texture({
+            source: textureSource,
+            layout: {
+                trim: new Rectangle(0.1, 0.1, 0.8, 0.8),
+                frame: new Rectangle(0, 0, 1, 1),
+            }
+        });
+
+        const sprite = new Sprite({ texture });
+
+        expect(sprite.width).toBe(100);
+        expect(sprite.height).toBe(100);
     });
 });

--- a/tests/visual/scenes/scene/layer-tint.scene.ts
+++ b/tests/visual/scenes/scene/layer-tint.scene.ts
@@ -6,7 +6,6 @@ import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
     it: 'should tint layers correctly',
-    only: true,
     create: async (scene: Container) =>
     {
         // layer green container..

--- a/tests/visual/scenes/scene/layer-tint.scene.ts
+++ b/tests/visual/scenes/scene/layer-tint.scene.ts
@@ -1,15 +1,13 @@
 import { Container } from '../../../../src/scene/container/Container';
 import { Graphics } from '../../../../src/scene/graphics/shared/Graphics';
 import { GraphicsContext } from '../../../../src/scene/graphics/shared/GraphicsContext';
-import { Text } from '../../../../src/scene/text/Text';
 
-import type { Renderer } from '../../../../src/rendering/renderers/types';
 import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
     it: 'should tint layers correctly',
     only: true,
-    create: async (scene: Container, renderer: Renderer) =>
+    create: async (scene: Container) =>
     {
         // layer green container..
         const squareContext = new GraphicsContext()


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cce4ea1</samp>

### Summary
🐛✅🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is what the first pull request does by fixing the sprite's bounds calculations and tests.
2.  ✅ - This emoji represents a test, which is what the second pull request adds by testing the `getLocalBounds` method with trimmed sprites.
3.  🧹 - This emoji represents a cleanup, which is what the third pull request does by removing unused code from the layer tint scene file.
-->
This pull request improves the `SpriteView` class and its tests. It fixes some bugs and edge cases related to trimmed textures and bounds calculations. It also removes some unused code from the `layer-tint.scene.ts` file.

> _Sing, O Muse, of the skillful coder who refined the SpriteView class_
> _And made it work with trimmed textures, a feat that none surpassed._
> _He fixed the imports and the tests, and cleared the layer-tint scene_
> _Of unused code and parameters, and made it run more clean._

### Walkthrough
*  Simplify and fix `SpriteView` methods for trimmed textures ([link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-ec873ce7abacc5136e469e35fdd0dfccda62949329abfb67727519fd6b2a63e5L85-R89), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-ec873ce7abacc5136e469e35fdd0dfccda62949329abfb67727519fd6b2a63e5L105-R102), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-ec873ce7abacc5136e469e35fdd0dfccda62949329abfb67727519fd6b2a63e5L153-R141), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-0a8b750c0adec1b3abe9459f95441b75c1d3297e2ab9b3d33ff93dd539cf49b9R213-R253), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-07fc4c1603a5e6747eaef03ec8b7a516baf7d114b55913d2d1c92726a5a43bb9R251-R272))
* Remove unused imports and parameters from test files ([link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-0a8b750c0adec1b3abe9459f95441b75c1d3297e2ab9b3d33ff93dd539cf49b9L2-R4), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-07fc4c1603a5e6747eaef03ec8b7a516baf7d114b55913d2d1c92726a5a43bb9L1-R9), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-674a5379865dbea4d25bff8a6b0332c6c3f9634729c096d60c09f3cac47723e4L4-R4), [link](https://github.com/pixijs/pixijs/pull/9882/files?diff=unified&w=0#diff-674a5379865dbea4d25bff8a6b0332c6c3f9634729c096d60c09f3cac47723e4L12-R10))

