### PR TITLE
little optimisation for our MeshGeometries

### DIFF
--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -12,12 +12,14 @@ export interface MeshGeometryOptions
     uvs?: Float32Array;
     indices?: Uint32Array;
     topology?: Topology;
+    shrinkBuffersToFit?: boolean;
 }
 
 export class MeshGeometry extends Geometry
 {
     public static defaultOptions: MeshGeometryOptions = {
         topology: 'triangle-list',
+        shrinkBuffersToFit: false,
     };
 
     public batchMode: BatchMode = 'auto';
@@ -46,21 +48,26 @@ export class MeshGeometry extends Geometry
         const uvs = options.uvs || new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
         const indices = options.indices || new Uint32Array([0, 1, 2, 0, 2, 3]);
 
+        const shrinkToFit = options.shrinkBuffersToFit;
+
         const positionBuffer = new Buffer({
             data: positions,
             label: 'attribute-mesh-positions',
+            shrinkToFit,
             usage: BufferUsage.VERTEX | BufferUsage.COPY_DST,
         });
 
         const uvBuffer = new Buffer({
             data: uvs,
             label: 'attribute-mesh-uvs',
+            shrinkToFit,
             usage: BufferUsage.VERTEX | BufferUsage.COPY_DST,
         });
 
         const indexBuffer = new Buffer({
             data: indices,
             label: 'index-mesh-buffer',
+            shrinkToFit,
             usage: BufferUsage.INDEX | BufferUsage.COPY_DST,
         });
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e1373e9</samp>

### Summary
🆕🎛️🚀

<!--
1.  🆕 - This emoji conveys the idea of adding something new, which is what the `shrinkBuffersToFit` option is. It could also be used to indicate a new feature or enhancement.
2.  🎛️ - This emoji suggests the idea of adjusting or tweaking something, which is what the `shrinkBuffersToFit` option allows users to do with the buffer sizes. It could also be used to indicate a configuration or setting change.
3.  🚀 - This emoji implies the idea of improving or speeding up something, which is what the `shrinkBuffersToFit` option can do for memory and performance in some cases. It could also be used to indicate a performance or optimization improvement.
-->
Added a new option to `MeshGeometry` to optimize buffer size. This can affect memory and performance depending on the use case.

> _Sing, O Muse, of the cunning coder who devised_
> _A new option for the `MeshGeometry`, a marvel of skill,_
> _To shrink the buffers of vertex data, and thus economize_
> _The memory and performance of the graphics, or leave them still._

### Walkthrough
*  Add `shrinkBuffersToFit` property to `MeshGeometryOptions` interface and `MeshGeometry` constructor to control buffer resizing ([link](https://github.com/pixijs/pixijs/pull/9884/files?diff=unified&w=0#diff-f1b6629e17bbec8a5f8812f65335353f4b1b9a7358ec8124d18fc0e7e8200c22R15), [link](https://github.com/pixijs/pixijs/pull/9884/files?diff=unified&w=0#diff-f1b6629e17bbec8a5f8812f65335353f4b1b9a7358ec8124d18fc0e7e8200c22R22))
*  Pass `shrinkBuffersToFit` property to `Buffer` constructors for `positionBuffer`, `uvBuffer`, and `colorBuffer` in `MeshGeometry` to resize buffers according to data size ([link](https://github.com/pixijs/pixijs/pull/9884/files?diff=unified&w=0#diff-f1b6629e17bbec8a5f8812f65335353f4b1b9a7358ec8124d18fc0e7e8200c22L49-R56), [link](https://github.com/pixijs/pixijs/pull/9884/files?diff=unified&w=0#diff-f1b6629e17bbec8a5f8812f65335353f4b1b9a7358ec8124d18fc0e7e8200c22R63), [link](https://github.com/pixijs/pixijs/pull/9884/files?diff=unified&w=0#diff-f1b6629e17bbec8a5f8812f65335353f4b1b9a7358ec8124d18fc0e7e8200c22R70))

