### PR TITLE
unify view bounds declarations

### DIFF
--- a/src/scene/container/bounds/Bounds.ts
+++ b/src/scene/container/bounds/Bounds.ts
@@ -1,6 +1,15 @@
 import { Matrix } from '../../../maths/matrix/Matrix';
 import { Rectangle } from '../../../maths/shapes/Rectangle';
 
+/** Simple bounds implementation instead of more ambiguous [number, number, number, number] */
+export interface SimpleBounds
+{
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
 // TODO optimisations
 // 1 - setMatrix could set a reference directly, this would save a copy op per object
 // 2 - push and pop matrix could be optimised to use an index counter

--- a/src/scene/sprite-tiling/TilingSpriteView.ts
+++ b/src/scene/sprite-tiling/TilingSpriteView.ts
@@ -6,7 +6,7 @@ import { Transform } from '../../utils/misc/Transform';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { View } from '../../rendering/renderers/shared/view/View';
-import type { Bounds } from '../container/bounds/Bounds';
+import type { Bounds, SimpleBounds } from '../container/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 
 /**
@@ -64,7 +64,7 @@ export class TilingSpriteView implements View
 
     public roundPixels: 0 | 1 = 0;
 
-    private _bounds: [number, number, number, number] = [0, 1, 0, 0];
+    private _bounds: SimpleBounds = { left: 0, right: 1, top: 0, bottom: 0 };
     private _boundsDirty = true;
     private _width: number;
     private _height: number;
@@ -139,11 +139,11 @@ export class TilingSpriteView implements View
         const width = this._width;
         const height = this._height;
 
-        bounds[1] = -anchor._x * width;
-        bounds[0] = bounds[1] + width;
+        bounds.right = -anchor._x * width;
+        bounds.left = bounds.right + width;
 
-        bounds[3] = -anchor._y * height;
-        bounds[2] = bounds[3] + height;
+        bounds.bottom = -anchor._y * height;
+        bounds.top = bounds.bottom + height;
     }
 
     public addBounds(bounds: Bounds)
@@ -151,17 +151,17 @@ export class TilingSpriteView implements View
         const _bounds = this.bounds;
 
         bounds.addFrame(
-            _bounds[0],
-            _bounds[2],
-            _bounds[1],
-            _bounds[3],
+            _bounds.left,
+            _bounds.top,
+            _bounds.right,
+            _bounds.bottom,
         );
     }
 
     public containsPoint(point: PointData)
     {
-        const width = this.bounds[0];
-        const height = this.bounds[2];
+        const width = this.bounds.left;
+        const height = this.bounds.top;
         const x1 = -width * this.anchor.x;
         let y1 = 0;
 

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -2,6 +2,7 @@ import type { Batch, BatchableObject, Batcher } from '../../rendering/batcher/sh
 import type { Renderable } from '../../rendering/renderers/shared/Renderable';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { View } from '../../rendering/renderers/shared/view/View';
+import type { SimpleBounds } from '../container/bounds/Bounds';
 
 export class BatchableSprite implements BatchableObject
 {
@@ -17,7 +18,7 @@ export class BatchableSprite implements BatchableObject
     public location = 0; // location in the buffer
     public batcher: Batcher = null;
     public batch: Batch = null;
-    public bounds: [number, number, number, number];
+    public bounds: SimpleBounds;
     public roundPixels: 0 | 1 = 0;
 
     get blendMode() { return this.renderable.layerBlendMode; }
@@ -43,10 +44,10 @@ export class BatchableSprite implements BatchableObject
 
         const bounds = this.bounds;
 
-        const w0 = bounds[1];
-        const w1 = bounds[0];
-        const h0 = bounds[3];
-        const h1 = bounds[2];
+        const w0 = bounds.right;
+        const w1 = bounds.left;
+        const h0 = bounds.bottom;
+        const h1 = bounds.top;
 
         const uvs = texture._layout.uvs;
 

--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -6,7 +6,7 @@ import { updateQuadBounds } from '../../utils/data/updateQuadBounds';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { View, ViewObserver } from '../../rendering/renderers/shared/view/View';
-import type { Bounds } from '../container/bounds/Bounds';
+import type { Bounds, SimpleBounds } from '../container/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 
 export class SpriteView implements View
@@ -23,8 +23,8 @@ export class SpriteView implements View
     /** @internal */
     public _didUpdate = false;
 
-    private _bounds: [number, number, number, number] = [0, 1, 0, 0];
-    private _sourceBounds: [number, number, number, number] = [0, 1, 0, 0];
+    private _bounds: SimpleBounds = { left: 0, right: 1, top: 0, bottom: 0 };
+    private _sourceBounds: SimpleBounds = { left: 0, right: 1, top: 0, bottom: 0 };
     private _boundsDirty = true;
     private _sourceBoundsDirty = true;
 
@@ -99,7 +99,7 @@ export class SpriteView implements View
     {
         const _bounds = this._texture._layout.trim ? this.sourceBounds : this.bounds;
 
-        bounds.addFrame(_bounds[0], _bounds[2], _bounds[1], _bounds[3]);
+        bounds.addFrame(_bounds.left, _bounds.top, _bounds.right, _bounds.bottom);
     }
 
     /**
@@ -134,11 +134,11 @@ export class SpriteView implements View
         const width = textureSource.width * orig.width;
         const height = textureSource.height * orig.height;
 
-        sourceBounds[0] = -anchor._x * width;
-        sourceBounds[1] = sourceBounds[0] + width;
+        sourceBounds.right = -anchor._x * width;
+        sourceBounds.left = sourceBounds.right + width;
 
-        sourceBounds[2] = -anchor._y * height;
-        sourceBounds[3] = sourceBounds[2] + height;
+        sourceBounds.bottom = -anchor._y * height;
+        sourceBounds.top = sourceBounds.bottom + height;
     }
 
     /**

--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -84,9 +84,9 @@ export class SpriteView implements View
     {
         const bounds = this.sourceBounds;
 
-        if (point.x >= bounds[0] && point.x <= bounds[1])
+        if (point.x >= bounds.right && point.x <= bounds.left)
         {
-            if (point.y >= bounds[2] && point.y <= bounds[3])
+            if (point.y >= bounds.bottom && point.y <= bounds.top)
             {
                 return true;
             }

--- a/src/scene/text/TextView.ts
+++ b/src/scene/text/TextView.ts
@@ -9,7 +9,7 @@ import { ensureTextStyle } from './utils/ensureTextStyle';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { View, ViewObserver } from '../../rendering/renderers/shared/view/View';
-import type { Bounds } from '../container/bounds/Bounds';
+import type { Bounds, SimpleBounds } from '../container/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from './html/HtmlTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
@@ -54,7 +54,7 @@ export class TextView implements View
     public _didUpdate = true;
     public roundPixels?: 0 | 1 = 0;
 
-    private _bounds: [number, number, number, number] = [0, 1, 0, 0];
+    private _bounds: SimpleBounds = { left: 0, right: 1, top: 0, bottom: 0 };
     private _boundsDirty = true;
     private _text: string;
     private readonly _renderMode: string;
@@ -125,17 +125,17 @@ export class TextView implements View
         const _bounds = this.bounds;
 
         bounds.addFrame(
-            _bounds[0],
-            _bounds[2],
-            _bounds[1],
-            _bounds[3],
+            _bounds.left,
+            _bounds.top,
+            _bounds.right,
+            _bounds.bottom,
         );
     }
 
     public containsPoint(point: PointData)
     {
-        const width = this.bounds[1];
-        const height = this.bounds[3];
+        const width = this.bounds.right;
+        const height = this.bounds.bottom;
 
         const x1 = -width * this.anchor.x;
         let y1 = 0;
@@ -180,10 +180,10 @@ export class TextView implements View
             const width = bitmapMeasurement.width * scale;
             const height = bitmapMeasurement.height * scale;
 
-            bounds[0] = (-anchor._x * width) - padding;
-            bounds[1] = bounds[0] + width;
-            bounds[2] = (-anchor._y * (height + offset)) - padding;
-            bounds[3] = bounds[2] + height;
+            bounds.left = (-anchor._x * width) - padding;
+            bounds.right = bounds.left + width;
+            bounds.top = (-anchor._y * (height + offset)) - padding;
+            bounds.bottom = bounds.top + height;
         }
         else if (this.renderPipeId === 'htmlText')
         {
@@ -191,10 +191,10 @@ export class TextView implements View
 
             const { width, height } = htmlMeasurement;
 
-            bounds[0] = (-anchor._x * width) - padding;
-            bounds[1] = bounds[0] + width;
-            bounds[2] = (-anchor._y * height) - padding;
-            bounds[3] = bounds[2] + height;
+            bounds.left = (-anchor._x * width) - padding;
+            bounds.right = bounds.left + width;
+            bounds.top = (-anchor._y * height) - padding;
+            bounds.bottom = bounds.top + height;
         }
         else
         {
@@ -202,10 +202,10 @@ export class TextView implements View
 
             const { width, height } = canvasMeasurement;
 
-            bounds[0] = (-anchor._x * width) - padding;
-            bounds[1] = bounds[0] + width;
-            bounds[2] = (-anchor._y * height) - padding;
-            bounds[3] = bounds[2] + height;
+            bounds.left = (-anchor._x * width) - padding;
+            bounds.right = bounds.left + width;
+            bounds.top = (-anchor._y * height) - padding;
+            bounds.bottom = bounds.top + height;
         }
     }
 

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -169,7 +169,7 @@ export class CanvasTextPipe implements RenderPipe<TextView>
         };
 
         gpuTextData.batchableSprite.renderable = renderable;
-        gpuTextData.batchableSprite.bounds = [0, 1, 0, 0];
+        gpuTextData.batchableSprite.bounds = { left: 0, right: 1, top: 0, bottom: 0 };
         gpuTextData.batchableSprite.roundPixels = (this._renderer._roundPixels | renderable.view.roundPixels) as 0 | 1;
 
         this._gpuText[renderable.uid] = gpuTextData;

--- a/src/scene/text/html/HTMLTextPipe.ts
+++ b/src/scene/text/html/HTMLTextPipe.ts
@@ -185,7 +185,7 @@ export class HTMLTextPipe implements RenderPipe<TextView>
 
         batchableSprite.renderable = renderable;
         batchableSprite.texture = Texture.EMPTY;
-        batchableSprite.bounds = [0, 1, 0, 0];
+        batchableSprite.bounds = { left: 0, right: 1, top: 0, bottom: 0 };
         batchableSprite.roundPixels = (this._renderer._roundPixels | renderable.view.roundPixels) as 0 | 1;
 
         this._gpuText[renderable.uid] = gpuTextData;

--- a/src/utils/data/updateQuadBounds.ts
+++ b/src/utils/data/updateQuadBounds.ts
@@ -1,8 +1,9 @@
 import type { ObservablePoint } from '../../maths/point/ObservablePoint';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
+import type { SimpleBounds } from '../../scene/container/bounds/Bounds';
 
 export function updateQuadBounds(
-    bounds: [number, number, number, number],
+    bounds: SimpleBounds,
     anchor: ObservablePoint,
     texture: Texture,
     padding: number
@@ -26,20 +27,20 @@ export function updateQuadBounds(
         const sourceWidth = textureSourceWidth * trim.width;
         const sourceHeight = textureSourceHeight * trim.height;
 
-        bounds[0] = (trim.x * textureSourceWidth) - (anchor._x * width) - padding;
-        bounds[1] = bounds[0] + sourceWidth;
+        bounds.left = (trim.x * textureSourceWidth) - (anchor._x * width) - padding;
+        bounds.right = bounds.left + sourceWidth;
 
-        bounds[2] = (trim.y * textureSourceHeight) - (anchor._y * height) - padding;
-        bounds[3] = bounds[2] + sourceHeight;
+        bounds.top = (trim.y * textureSourceHeight) - (anchor._y * height) - padding;
+        bounds.bottom = bounds.top + sourceHeight;
     }
 
     else
     {
-        bounds[0] = (-anchor._x * width) - padding;
-        bounds[1] = bounds[0] + width;
+        bounds.left = (-anchor._x * width) - padding;
+        bounds.right = bounds.left + width;
 
-        bounds[2] = (-anchor._y * height) - padding;
-        bounds[3] = bounds[2] + height;
+        bounds.top = (-anchor._y * height) - padding;
+        bounds.bottom = bounds.top + height;
     }
 
     return;

--- a/tests/accessibility/AccessibilitySystem.tests.ts
+++ b/tests/accessibility/AccessibilitySystem.tests.ts
@@ -40,7 +40,7 @@ describe('AccessibilitySystem', () =>
             globalThis.document.dispatchEvent(new MouseEvent('mousemove', { movementX: 10, movementY: 10 }));
             expect(system.isActive).toBe(false);
             done();
-        }, 0);
+        }, 10);
     });
 
     // eslint-disable-next-line jest/no-done-callback
@@ -63,6 +63,6 @@ describe('AccessibilitySystem', () =>
         {
             expect(system.isActive).toBe(true);
             done();
-        }, 0);
+        }, 10);
     });
 });


### PR DESCRIPTION
> Note: Bunnymark benchmark tested and no drop in performance. Multiple refreshes on this branch vs `next-v8` give the same results

![Screenshot 2023-11-22 at 7 13 29 pm](https://github.com/pixijs/pixijs/assets/91103690/3d872ebe-0910-4baa-bd05-c0605aefbe3f)

I used a simple type replacement from `[number, number, number, number]` to `{left: number, right: number, right: number, bottom: number}` vs using the `Rectangle`. The existing code was performing set operations on the object and `Rectangle` does not have setters. This approach creates the least disturbance to the existing code, and reducing any additional function calls or dynamic calculations (for example the `right` getter of `Rectangle`).

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b05be15</samp>

This pull request introduces a new interface `SimpleBounds` that defines a simple bounds object with four properties: `left`, `top`, `right`, and `bottom`. It refactors various classes and functions that deal with bounds, such as `TilingSpriteView`, `BatchableSprite`, `SpriteView`, `TextView`, `updateQuadBounds`, `CanvasTextPipe`, and `HTMLTextPipe`, to use the `SimpleBounds` interface instead of an array of numbers. This improves the readability, consistency, and quality of the code, and avoids potential errors or confusion when accessing or modifying the bounds values.