### PR TITLE
add linting for jest tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -130,6 +130,8 @@
     "overrides": [
         {
             "files": ["*.tests.ts", "*.test.ts"],
+            "plugins": ["jest"],
+            "extends": ["plugin:jest/recommended"],
             "globals": {
                 "expect": false,
                 "assert": false,
@@ -146,7 +148,17 @@
                         "allowIndexSignaturePropertyAccess": true
                     }
                 ],
-                "dot-notation": 0
+                "dot-notation": 0,
+                "jest/no-disabled-tests": "off",
+                "jest/no-conditional-expect": "off",
+                "jest/no-standalone-expect": "off",
+                "jest/expect-expect": [
+                    "error",
+                    {
+                      "assertFunctionNames": ["expect", "check32BitColorMatches", "assertRemovedFromParent"],
+                      "additionalTestBlockFunctions": [""]
+                    }
+                  ]
             }
         }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "esbuild": "^0.17.18",
         "eslint": "^8.38.0",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^27.6.0",
         "eslint-plugin-jsdoc": "^41.1.2",
         "eslint-plugin-no-mixed-operators": "^1.1.1",
         "eslint-plugin-simple-import-sort": "^10.0.0",
@@ -6627,6 +6628,31 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.0.tgz",
+      "integrity": "sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
+        "eslint": "^7.0.0 || ^8.0.0",
+        "jest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
@@ -22198,6 +22224,15 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.0.tgz",
+      "integrity": "sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "esbuild": "^0.17.18",
     "eslint": "^8.38.0",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.6.0",
     "eslint-plugin-jsdoc": "^41.1.2",
     "eslint-plugin-no-mixed-operators": "^1.1.1",
     "eslint-plugin-simple-import-sort": "^10.0.0",

--- a/tests/Pool.test.ts
+++ b/tests/Pool.test.ts
@@ -27,7 +27,7 @@ describe('Pool', () =>
         const pool = new Pool(TestItem, 5);
 
         expect(pool['_count']).toBe(5);
-        expect(pool['_pool'].length).toBe(5);
+        expect(pool['_pool']).toHaveLength(5);
     });
 
     it('should create a pool with no initial size', () =>
@@ -35,7 +35,7 @@ describe('Pool', () =>
         const pool = new Pool(TestItem);
 
         expect(pool['_count']).toBe(0);
-        expect(pool['_pool'].length).toBe(0);
+        expect(pool['_pool']).toHaveLength(0);
     });
 
     it('should prepopulate the pool with the specified number of items', () =>
@@ -45,7 +45,7 @@ describe('Pool', () =>
         pool.prepopulate(5);
 
         expect(pool['_count']).toBe(5);
-        expect(pool['_pool'].length).toBe(5);
+        expect(pool['_pool']).toHaveLength(5);
     });
 
     it('should get an item from the pool', () =>

--- a/tests/accessibility/AccessibilitySystem.tests.ts
+++ b/tests/accessibility/AccessibilitySystem.tests.ts
@@ -27,6 +27,7 @@ describe('AccessibilitySystem', () =>
         renderer.destroy();
     });
 
+    // eslint-disable-next-line jest/no-done-callback
     it('should activate when tab is pressed and deactivate when mouse moved', async (done) =>
     {
         const renderer = await getRenderer();
@@ -42,6 +43,7 @@ describe('AccessibilitySystem', () =>
         }, 0);
     });
 
+    // eslint-disable-next-line jest/no-done-callback
     it('should not crash when scene graph contains Containers without children', async (done) =>
     {
         class CompleteContainer extends Container
@@ -56,7 +58,7 @@ describe('AccessibilitySystem', () =>
 
         globalThis.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9, key: 'tab' }));
 
-        expect(() => renderer.render(stage)).not.toThrowError();
+        expect(() => renderer.render(stage)).not.toThrow();
         setTimeout(() =>
         {
             expect(system.isActive).toBe(true);

--- a/tests/app/Application.tests.ts
+++ b/tests/app/Application.tests.ts
@@ -150,11 +150,12 @@ describe('Application', () =>
             forceResizeApp(200, 400);
             forceResizeApp(300, 500);
 
-            expect(spy).toBeCalledTimes(2);
+            expect(spy).toHaveBeenCalledTimes(2);
 
             cleanup();
         });
 
+        // eslint-disable-next-line jest/no-done-callback
         it('should throttle multiple resizes', async (done) =>
         {
             const { app, forceQueueResizeApp, cleanup } = await getAppWithDiv();
@@ -178,6 +179,7 @@ describe('Application', () =>
             forceQueueResizeApp(300, 500);
         });
 
+        // eslint-disable-next-line jest/no-done-callback
         it('should cancel resize on destroy', async (done) =>
         {
             const spy = jest.fn();
@@ -189,12 +191,13 @@ describe('Application', () =>
 
             requestAnimationFrame(() =>
             {
-                expect(spy).not.toBeCalled();
+                expect(spy).not.toHaveBeenCalled();
                 cleanup(false); // don't destroy, we already did
                 done();
             });
         });
 
+        // eslint-disable-next-line jest/no-done-callback
         it('should resize cancel resize queue', async (done) =>
         {
             const spy = jest.fn();
@@ -207,7 +210,7 @@ describe('Application', () =>
 
             requestAnimationFrame(() =>
             {
-                expect(spy).toBeCalledTimes(1);
+                expect(spy).toHaveBeenCalledTimes(1);
                 cleanup(false); // don't destroy, we already did
                 done();
             });

--- a/tests/assets/Resolver.tests.ts
+++ b/tests/assets/Resolver.tests.ts
@@ -6,7 +6,7 @@ import { manifest } from './sampleManifest';
 
 import type { FormatDetectionParser } from '../../src/assets/detections/types';
 
-export const testDetector = {
+const testDetector = {
     extension: {
         type: ExtensionType.DetectionParser,
         priority: 2,

--- a/tests/assets/TextFormat.test.ts
+++ b/tests/assets/TextFormat.test.ts
@@ -11,7 +11,7 @@ char id=33 x=244 y=107 width=8 height=30 xoffset=4 yoffset=0 xadvance=15 page=0 
 
 describe('TextFormat', () =>
 {
-    it('should parse text chars, if no letter or char property is present ', async () =>
+    it('should parse text chars, if no letter or char property is present', async () =>
     {
         const parsedText = bitmapFontTextParser.parse(rawFontString);
 

--- a/tests/assets/XMLStringFormat.test.ts
+++ b/tests/assets/XMLStringFormat.test.ts
@@ -16,7 +16,7 @@ const rawFontString = `<?xml version="1.0"?>
 
 describe('XMLStringFormat', () =>
 {
-    it('should parse text chars, if no letter or char property is present ', async () =>
+    it('should parse text chars, if no letter or char property is present', async () =>
     {
         const parsedText = bitmapFontXMLStringParser.parse(rawFontString);
 

--- a/tests/assets/basePath.ts
+++ b/tests/assets/basePath.ts
@@ -1,4 +1,4 @@
-const isCI = process.env.GITHUB_ACTIONS === 'true';
+export const isCI = process.env.GITHUB_ACTIONS === 'true';
 const GITHUB_SHA = (process.env.GITHUB_SHA || 'master');
 
 export const basePath = isCI

--- a/tests/assets/bundle.tests.ts
+++ b/tests/assets/bundle.tests.ts
@@ -160,7 +160,7 @@ describe('Assets bundles', () =>
         expect(resources.character).not.toBe(resources2.character);
     });
 
-    it('should load bundles with clashing names correctly', async () =>
+    it('should load bundles with clashing names correctly with custom connector', async () =>
     {
         const manifest = {
             bundles: [
@@ -302,6 +302,7 @@ describe('Assets bundles', () =>
         await Assets.init({ manifest, basePath });
 
         // expect promise to throw an error..
+        // eslint-disable-next-line jest/valid-expect
         expect(async () => await Assets.init({ manifest, basePath }));
 
         const bundle = Assets.resolver.resolveBundle('bunny1');

--- a/tests/compressed/CompressedTextures.test.ts
+++ b/tests/compressed/CompressedTextures.test.ts
@@ -69,7 +69,9 @@ describe('Compressed Loader', () =>
         Assets['_detections'].push(detectCompressed);
         Assets['_detections'].push(detectBasis);
         await Assets.init();
+        // eslint-disable-next-line jest/expect-expect
         expect((Assets.resolver['_preferredOrder'][0].params.format as string[]).includes('basis')).toBe(true);
+        // eslint-disable-next-line jest/expect-expect
         expect((Assets.resolver['_preferredOrder'][0].params.format as string[]).includes('bc3')).toBe(true);
     });
 
@@ -77,7 +79,9 @@ describe('Compressed Loader', () =>
     {
         detectCompressed.test = jest.fn(async () => false);
         await Assets.init();
+        // eslint-disable-next-line jest/expect-expect
         expect(Assets.resolver['_preferredOrder'][0].params.format.every(
+            // eslint-disable-next-line jest/expect-expect
             (f: string) => !['bc3', 'bc2'].includes(f))).toBeTrue();
     });
 });

--- a/tests/events/EventBoundary.tests.ts
+++ b/tests/events/EventBoundary.tests.ts
@@ -4,7 +4,7 @@ import { Container } from '../../src/scene/container/Container';
 import { Graphics } from '../../src/scene/graphics/shared/Graphics';
 import { getApp } from '../utils/getApp';
 
-export function graphicsWithRect(x: number, y: number, width: number, height: number)
+function graphicsWithRect(x: number, y: number, width: number, height: number)
 {
     const graphics = new Graphics();
 
@@ -13,7 +13,7 @@ export function graphicsWithRect(x: number, y: number, width: number, height: nu
     return graphics;
 }
 
-export function id(container: Container, id: string)
+function id(container: Container, id: string)
 {
     (container as any).__id = id;
 
@@ -65,7 +65,7 @@ describe('EventBoundary', () =>
         stage.addEventListener('click', stageSpy);
         boundary.dispatchEvent(event);
 
-        expect(eventSpy).toBeCalledTimes(2);
+        expect(eventSpy).toHaveBeenCalledTimes(2);
         expect(captureSpy).toHaveBeenCalledOnce();
         expect(captureSpy).toHaveBeenCalledBefore(eventSpy);
         expect(stageSpy).not.toHaveBeenCalled();
@@ -289,13 +289,13 @@ describe('EventBoundary', () =>
         boundary.mapEvent(off);
 
         // "pressed" unmounted so it shouldn't get a pointerupoutside
-        expect(eventSpy).not.toBeCalled();
+        expect(eventSpy).not.toHaveBeenCalled();
 
         // "container" still mounted so it should get pointerupoutside
         expect(containerSpy).toHaveBeenCalledOnce();
 
         // "stage" still ancestor of the hit "outside" on pointerup, so it get pointerup instead
-        expect(stageOutsideSpy).not.toBeCalled();
+        expect(stageOutsideSpy).not.toHaveBeenCalled();
         // not a "pointerupoutside"
         expect(stageSpy).toHaveBeenCalledOnce();
     });
@@ -351,7 +351,7 @@ describe('EventBoundary', () =>
         over.destroy();
         boundary.mapEvent(off);
 
-        expect(outSpy).not.toBeCalled();
+        expect(outSpy).not.toHaveBeenCalled();
         expect(containerOutSpy).toHaveBeenCalledOnce();
         expect(toOverSpy).toHaveBeenCalledOnce();
     });

--- a/tests/events/EventSystem.tests.ts
+++ b/tests/events/EventSystem.tests.ts
@@ -100,8 +100,10 @@ class CustomElement extends HTMLElement
     view = document.createElement('canvas');
     constructor()
     {
+        // eslint-disable-next-line jest/expect-expect
         super();
 
+        // eslint-disable-next-line jest/expect-expect
         const shadowRoot = this.attachShadow({ mode: 'closed' });
 
         shadowRoot.appendChild(this.view);
@@ -225,7 +227,9 @@ describe('EventSystem', () =>
         it.each(staticPointerEventTests)('Pointer Event %s', async (event) =>
         {
             const events = Array.isArray(event) ? event : [event];
+            // eslint-disable-next-line jest/expect-expect
             const isMouseEvent = events[0].type.startsWith('mouse');
+            // eslint-disable-next-line jest/expect-expect
             const isTouchEvent = events[0].type.startsWith('touch');
 
             const renderer = await createRenderer(view, isMouseEvent);
@@ -280,6 +284,7 @@ describe('EventSystem', () =>
                     event = new MouseEvent(native || type, { clientX, clientY });
                 }
 
+                // eslint-disable-next-line jest/expect-expect
                 (renderer.events as any)[handler](event);
 
                 expect(eventSpy).toHaveBeenCalledOnce();
@@ -316,10 +321,11 @@ describe('EventSystem', () =>
             })
         );
 
-        expect(eventSpy).not.toBeCalled();
+        expect(eventSpy).not.toHaveBeenCalled();
         expect(renderer.canvas.style.cursor).toEqual('inherit');
     });
 
+    // eslint-disable-next-line jest/no-done-callback
     it('should provide the correct global position', async (done) =>
     {
         const renderer = await createRenderer();
@@ -435,7 +441,7 @@ describe('EventSystem', () =>
         expect(secondaryMoveSpy).toHaveBeenCalledOnce();
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
         expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
-        expect(secondaryOutSpy).not.toBeCalledTimes(1);
+        expect(secondaryOutSpy).not.toHaveBeenCalledTimes(1);
     });
 
     it('should dispatch synthetic over/out events on pointermove with hitArea', async () =>
@@ -528,7 +534,7 @@ describe('EventSystem', () =>
         expect(secondaryMoveSpy).toHaveBeenCalledOnce();
         expect(primaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
         expect(secondaryMoveGlobalSpy).toHaveBeenCalledTimes(2);
-        expect(secondaryOutSpy).not.toBeCalledTimes(1);
+        expect(secondaryOutSpy).not.toHaveBeenCalledTimes(1);
     });
 
     it('should not dispatch pointer events if not interactive', async () =>
@@ -680,6 +686,7 @@ describe('EventSystem', () =>
         expect(eventSpy).toHaveBeenCalledOnce();
     });
 
+    // eslint-disable-next-line jest/no-done-callback
     it('should set the detail of click events to the click count', async (done) =>
     {
         const renderer = await createRenderer();
@@ -711,7 +718,7 @@ describe('EventSystem', () =>
             renderer.events['_onPointerUp'](e);
         }
 
-        expect(eventSpy).toBeCalledTimes(3);
+        expect(eventSpy).toHaveBeenCalledTimes(3);
 
         graphics.removeAllListeners();
 

--- a/tests/extensions/extensions.tests.ts
+++ b/tests/extensions/extensions.tests.ts
@@ -34,7 +34,7 @@ describe('extensions', () =>
             expect(() =>
             {
                 extensions.handle(exampleType, () => null, () => null);
-            }).toThrowError(`Extension type ${exampleType} already has a handler`);
+            }).toThrow(`Extension type ${exampleType} already has a handler`);
         });
     });
 
@@ -72,7 +72,7 @@ describe('extensions', () =>
             extensions.handleByList(exampleType, list);
             extensions.add(example);
             extensions.add(example);
-            expect(list.length).toBe(1);
+            expect(list).toHaveLength(1);
         });
 
         it('should add extensions in order of priority', () =>
@@ -115,10 +115,10 @@ describe('extensions', () =>
 
             extensions.handleByList(exampleType, list);
             extensions.add(example2);
-            expect(list.length).toBe(1);
+            expect(list).toHaveLength(1);
             expect(list[0]).toBe(example2);
             extensions.remove(example2);
-            expect(list.length).toBe(0);
+            expect(list).toHaveLength(0);
         });
 
         it('should support spread', () =>
@@ -127,9 +127,9 @@ describe('extensions', () =>
 
             extensions.handleByList(exampleType, list);
             extensions.add(example2, example);
-            expect(list.length).toBe(2);
+            expect(list).toHaveLength(2);
             extensions.remove(example2, example);
-            expect(list.length).toBe(0);
+            expect(list).toHaveLength(0);
         });
 
         it('should immedately register extension before handle', () =>
@@ -138,10 +138,10 @@ describe('extensions', () =>
 
             extensions.handleByList(exampleType, list);
             extensions.add(example);
-            expect(list.length).toBe(1);
+            expect(list).toHaveLength(1);
             expect(list[0]).toBe(example);
             extensions.remove(example);
-            expect(list.length).toBe(0);
+            expect(list).toHaveLength(0);
         });
 
         it('should immedately register extension after handle', () =>
@@ -150,10 +150,10 @@ describe('extensions', () =>
 
             extensions.add(example);
             extensions.handleByList(exampleType, list);
-            expect(list.length).toBe(1);
+            expect(list).toHaveLength(1);
             expect(list[0]).toBe(example);
             extensions.remove(example);
-            expect(list.length).toBe(0);
+            expect(list).toHaveLength(0);
         });
 
         it('should support multiple types', () =>
@@ -169,13 +169,13 @@ describe('extensions', () =>
             extensions.handleByList(exampleType, list);
             extensions.handleByList(exampleType2, list2);
             extensions.add(example3);
-            expect(list.length).toBe(1);
-            expect(list2.length).toBe(1);
+            expect(list).toHaveLength(1);
+            expect(list2).toHaveLength(1);
             expect(list[0]).toBe(example3);
             expect(list2[0]).toBe(example3);
             extensions.remove(example3);
-            expect(list.length).toBe(0);
-            expect(list2.length).toBe(0);
+            expect(list).toHaveLength(0);
+            expect(list2).toHaveLength(0);
         });
     });
 });

--- a/tests/filter-color-matrix/ColorMatrixFilter.tests.ts
+++ b/tests/filter-color-matrix/ColorMatrixFilter.tests.ts
@@ -22,6 +22,7 @@ describe('ColorMatrixFilter', () =>
     it('should run all operations without multiply', () =>
     {
         const filter = new ColorMatrixFilter();
+        const multiplySpy = jest.spyOn(filter, '_multiply' as any);
 
         filter.brightness(0.5, false);
         filter.tint(0xff0000, false);
@@ -46,11 +47,14 @@ describe('ColorMatrixFilter', () =>
         filter.reset();
 
         filter.destroy();
+
+        expect(multiplySpy).toHaveBeenCalledTimes(0);
     });
 
     it('should run all operations with multiply', () =>
     {
         const filter = new ColorMatrixFilter();
+        const multiplySpy = jest.spyOn(filter, '_multiply' as any);
 
         filter.brightness(0.5, true);
         filter.tint(0xff0000, true);
@@ -75,5 +79,6 @@ describe('ColorMatrixFilter', () =>
         filter.reset();
 
         filter.destroy();
+        expect(multiplySpy).toHaveBeenCalledTimes(19);
     });
 });

--- a/tests/graphics/Graphics.tests.ts
+++ b/tests/graphics/Graphics.tests.ts
@@ -291,7 +291,7 @@ describe('Graphics', () =>
             const actions = instruction.data.path.instructions.map((i) => i.action);
             const data = instruction.data.path.instructions.map((i) => i.data);
 
-            expect(graphics.context.instructions.length).toBe(1);
+            expect(graphics.context.instructions).toHaveLength(1);
             expect(actions).toEqual(['moveTo', 'lineTo', 'lineTo']);
             expect(data).toEqual([[0, 0], [0, 0], [10, 0]]);
         });
@@ -646,7 +646,7 @@ describe('Graphics', () =>
 
             graphics.strokeStyle = { width: 4, color: 0x00FF00, alpha: 1 };
 
-            expect(() => graphics.beginPath().arc(300, 100, 20, 0, Math.PI).fill().closePath()).not.toThrowError();
+            expect(() => graphics.beginPath().arc(300, 100, 20, 0, Math.PI).fill().closePath()).not.toThrow();
         });
     });
 
@@ -757,7 +757,7 @@ describe('Graphics', () =>
             const fill1Data = fill1.data.path.instructions.map((i) => i.data).flat();
             const fill2Data = fill2.data.path.instructions.map((i) => i.data).flat();
 
-            expect(data.length).toEqual(2);
+            expect(data).toHaveLength(2);
             expect(fill1Data).toEqual([50, 50, 250, 50, 100, 100, 50, 50]);
             expect(fill2Data).toEqual([250, 50, 450, 50, 300, 100, 250, 50]);
         });
@@ -782,7 +782,7 @@ describe('Graphics', () =>
             const fill1Data = fill1.data.path.instructions.map((i) => i.data).flat();
             const fill2Data = fill2.data.path.instructions.map((i) => i.data).flat();
 
-            expect(data.length).toEqual(2);
+            expect(data).toHaveLength(2);
             expect(fill1Data).toEqual([50, 50, 250, 50]);
             expect(fill2Data).toEqual([250, 50, 100, 100, 50, 50]);
         });
@@ -790,6 +790,7 @@ describe('Graphics', () =>
 
     // todo: all these tests should be moved to GraphicsContext.test.ts, with equivalent changes for api
     // ticket: https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=44801478
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it.skip('should support adaptive curves', () =>
     // {
     //     const defMode = Graphics.curves.adaptive;
@@ -814,8 +815,10 @@ describe('Graphics', () =>
     //     Graphics.curves.maxLength = defMaxLen;
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // describe('geometry', () =>
     // {
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('validateBatching should return false if any of textures is invalid', () =>
     //     {
     //         const graphics = new Graphics();
@@ -839,6 +842,7 @@ describe('Graphics', () =>
     //         // expect(geometry['validateBatching']()).toBe(false);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('validateBatching should return true if all textures is valid', () =>
     //     {
     //         const graphics = new Graphics();
@@ -854,6 +858,7 @@ describe('Graphics', () =>
     //         expect(geometry['validateBatching']()).toBe(true);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('should be batchable if graphicsData is empty', () =>
     //     {
     //         const graphics = new Graphics();
@@ -863,6 +868,7 @@ describe('Graphics', () =>
     //         expect(geometry.batchable).toBe(true);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('_compareStyles should return true for identical styles', () =>
     //     {
     //         const graphics = new Graphics();
@@ -889,6 +895,7 @@ describe('Graphics', () =>
     //         expect(geometry['_compareStyles'](firstLine, secondLine)).toBe(true);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('should be 1 batch for same styles', () =>
     //     {
     //         const graphics = new Graphics();
@@ -903,6 +910,7 @@ describe('Graphics', () =>
     //         expect(geometry.batches).toHaveLength(1);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('should be 2 batches for 2 different styles', () =>
     //     {
     //         const graphics = new Graphics();
@@ -924,6 +932,7 @@ describe('Graphics', () =>
     //         expect(geometry.batches).toHaveLength(2);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('should be 1 batch if fill and line are the same', () =>
     //     {
     //         const graphics = new Graphics();
@@ -939,6 +948,7 @@ describe('Graphics', () =>
     //         expect(geometry.batches).toHaveLength(1);
     //     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     //     it('should not use fill if triangulation does nothing', () =>
     //     {
     //         const graphics = new Graphics();

--- a/tests/math/Matrix.tests.ts
+++ b/tests/math/Matrix.tests.ts
@@ -27,7 +27,7 @@ describe('Matrix', () =>
 
         let output = matrix.toArray(true);
 
-        expect(output.length).toEqual(9);
+        expect(output).toHaveLength(9);
         expect(output[0]).toEqual(0);
         expect(output[1]).toEqual(1);
         expect(output[3]).toEqual(3);
@@ -37,7 +37,7 @@ describe('Matrix', () =>
 
         output = matrix.toArray(false);
 
-        expect(output.length).toEqual(9);
+        expect(output).toHaveLength(9);
         expect(output[0]).toEqual(0);
         expect(output[1]).toEqual(3);
         expect(output[2]).toEqual(2);

--- a/tests/math/ObservablePoint.tests.ts
+++ b/tests/math/ObservablePoint.tests.ts
@@ -14,7 +14,7 @@ describe('ObservablePoint', () =>
         expect(pt.x).toEqual(2);
         expect(pt.y).toEqual(5);
 
-        expect(cb.onUpdate).toBeCalled();
+        expect(cb.onUpdate).toHaveBeenCalled();
 
         pt.set(2, 6);
         expect(pt.x).toEqual(2);

--- a/tests/math/Polygon.tests.ts
+++ b/tests/math/Polygon.tests.ts
@@ -9,7 +9,7 @@ describe('Polygon', () =>
         {
             const polygon = new Polygon(0, 0, 10, 0, 0, 10);
 
-            expect(polygon.points.length).toEqual(6);
+            expect(polygon.points).toHaveLength(6);
         });
 
         it('should accept a spread of points', () =>
@@ -20,14 +20,14 @@ describe('Polygon', () =>
                 new Point(0, 10)
             );
 
-            expect(polygon.points.length).toEqual(6);
+            expect(polygon.points).toHaveLength(6);
         });
 
         it('should accept an array of values', () =>
         {
             const polygon = new Polygon([0, 0, 10, 0, 0, 10]);
 
-            expect(polygon.points.length).toEqual(6);
+            expect(polygon.points).toHaveLength(6);
         });
 
         it('should accept an array of points', () =>
@@ -38,7 +38,7 @@ describe('Polygon', () =>
                 new Point(0, 10),
             ]);
 
-            expect(polygon.points.length).toEqual(6);
+            expect(polygon.points).toHaveLength(6);
         });
     });
 
@@ -52,8 +52,8 @@ describe('Polygon', () =>
 
             const polygon2 = polygon1.clone();
 
-            expect(polygon1.points.length).toEqual(6);
-            expect(polygon1.points.length).toEqual(6);
+            expect(polygon1.points).toHaveLength(6);
+            expect(polygon1.points).toHaveLength(6);
 
             for (let i = 0; i < 6; i++)
             {
@@ -63,8 +63,8 @@ describe('Polygon', () =>
             expect(polygon1.closePath).toEqual(polygon2.closePath);
             polygon2.points.push(0, 0);
 
-            expect(polygon1.points.length).toEqual(6);
-            expect(polygon2.points.length).toEqual(8);
+            expect(polygon1.points).toHaveLength(6);
+            expect(polygon2.points).toHaveLength(8);
         });
     });
 

--- a/tests/renderering/BindGroup.test.ts
+++ b/tests/renderering/BindGroup.test.ts
@@ -54,15 +54,15 @@ describe('BindGroup', () =>
 
         expect(bufferId).toBe(buffer._resourceId);
 
-        expect(updateListener).toBeCalledTimes(1);
-        expect(changeListener).toBeCalledTimes(0);
+        expect(updateListener).toHaveBeenCalledTimes(1);
+        expect(changeListener).toHaveBeenCalledTimes(0);
 
         buffer.data = new Float32Array(50);
 
         expect(bufferId).not.toBe(buffer._resourceId);
 
-        expect(updateListener).toBeCalledTimes(1);
-        expect(changeListener).toBeCalledTimes(1);
+        expect(updateListener).toHaveBeenCalledTimes(1);
+        expect(changeListener).toHaveBeenCalledTimes(1);
     });
 
     it('should let a BindGroup know if buffer has changed correctly', () =>

--- a/tests/renderering/GlobalUniformSystem.test.ts
+++ b/tests/renderering/GlobalUniformSystem.test.ts
@@ -172,25 +172,25 @@ describe('GlobalUniformSystem', () =>
             worldTransformMatrix: new Matrix(2, 2, 2, 2, 2, 2),
         });
 
-        expect(globalUniformSystem['_activeUniforms'].length).toEqual(3);
-        expect(globalUniformSystem['_activeBindGroups'].length).toEqual(3);
+        expect(globalUniformSystem['_activeUniforms']).toHaveLength(3);
+        expect(globalUniformSystem['_activeBindGroups']).toHaveLength(3);
 
         globalUniformSystem.pop();
 
-        expect(globalUniformSystem['_activeBindGroups'].length).toEqual(3);
+        expect(globalUniformSystem['_activeBindGroups']).toHaveLength(3);
 
         globalUniformSystem.push({
             worldTransformMatrix: new Matrix(2, 2, 2, 2, 2, 2),
         });
 
-        expect(globalUniformSystem['_activeBindGroups'].length).toEqual(4);
+        expect(globalUniformSystem['_activeBindGroups']).toHaveLength(4);
 
         // start again!
         globalUniformSystem.reset();
 
         expect(globalUniformSystem['_stackIndex']).toEqual(0);
-        expect(globalUniformSystem['_activeUniforms'].length).toEqual(0);
-        expect(globalUniformSystem['_activeBindGroups'].length).toEqual(0);
+        expect(globalUniformSystem['_activeUniforms']).toHaveLength(0);
+        expect(globalUniformSystem['_activeBindGroups']).toHaveLength(0);
     });
 
     it('should store color correctly second time', async () =>

--- a/tests/renderering/RoundPixels.test.ts
+++ b/tests/renderering/RoundPixels.test.ts
@@ -93,7 +93,7 @@ describe('Round Pixels', () =>
         expect(tilingSprite.view.roundPixels).toBe(1);
     });
 
-    it('renderer round pixels should override batched items round pixels if false ', async () =>
+    it('renderer round pixels should override batched items round pixels if false', async () =>
     {
         const renderer = new WebGLRenderer();
 
@@ -132,7 +132,7 @@ describe('Round Pixels', () =>
         expect(batchableTilingSprite.view.roundPixels).toBe(1);
     });
 
-    it('renderer round pixels should override text items round pixels if false ', async () =>
+    it('renderer round pixels should override text items round pixels if false', async () =>
     {
         const renderer = new WebGLRenderer();
 
@@ -155,7 +155,7 @@ describe('Round Pixels', () =>
         expect(batchableTextHTMLData.batchableSprite.roundPixels).toBe(1);
     });
 
-    it('renderer round pixels should override non batched items round pixels if false ', async () =>
+    it('renderer round pixels should override non batched items round pixels if false', async () =>
     {
         const renderer = new WebGLRenderer();
 

--- a/tests/renderering/State.test.ts
+++ b/tests/renderering/State.test.ts
@@ -5,7 +5,7 @@ import type { GlStateSystem } from '../../src/rendering/renderers/gl/state/GlSta
 
 describe('State', () =>
 {
-    it('should default to normal state ', async () =>
+    it('should default to normal state', async () =>
     {
         const stateSystem = (await getRenderer()).state as GlStateSystem;
 

--- a/tests/renderering/animation/AnimatedSprite.test.ts
+++ b/tests/renderering/animation/AnimatedSprite.test.ts
@@ -74,11 +74,13 @@ describe('AnimatedSprite', () =>
             expect(sprite.playing).toBe(false);
         });
 
+        // eslint-disable-next-line jest/expect-expect
         it('should stop playing if it is playing', () =>
         {
             sprite['_playing'] = true;
         });
 
+        // eslint-disable-next-line jest/expect-expect
         it('should do nothing if it is not playing', () =>
         {
             sprite['_playing'] = false;
@@ -106,11 +108,13 @@ describe('AnimatedSprite', () =>
             expect(sprite.playing).toBe(true);
         });
 
+        // eslint-disable-next-line jest/expect-expect
         it('should start playing if it is not playing', () =>
         {
             sprite['_playing'] = false;
         });
 
+        // eslint-disable-next-line jest/expect-expect
         it('should do nothing if it is playing', () =>
         {
             sprite['_playing'] = true;
@@ -135,29 +139,31 @@ describe('AnimatedSprite', () =>
         });
 
         // eslint-disable-next-line func-names
-        it('should fire onComplete', (done) =>
-        {
-            jest.setTimeout(5000);
-            sprite.onComplete = () =>
+        it('should fire onComplete', () =>
+            new Promise<void>((done) =>
             {
-                sprite.onComplete = null;
-                done();
-            };
-            sprite.play();
-            expect(sprite.playing).toBe(true);
-        });
+                jest.setTimeout(5000);
+                sprite.onComplete = () =>
+                {
+                    sprite.onComplete = null;
+                    done();
+                };
+                sprite.play();
+                expect(sprite.playing).toBe(true);
+            }));
 
-        it('should the current texture be the last item in textures', (done) =>
-        {
-            jest.setTimeout(5000);
-            sprite.play();
-            sprite.onComplete = () =>
+        it('should the current texture be the last item in textures', () =>
+            new Promise<void>((done) =>
             {
-                expect(sprite.texture === sprite.textures[sprite.currentFrame]).toBe(true);
-                sprite.onComplete = null;
-                done();
-            };
-        });
+                jest.setTimeout(5000);
+                sprite.play();
+                sprite.onComplete = () =>
+                {
+                    expect(sprite.texture === sprite.textures[sprite.currentFrame]).toBe(true);
+                    sprite.onComplete = null;
+                    done();
+                };
+            }));
     });
 
     describe('.gotoAndPlay()', () =>
@@ -177,26 +183,27 @@ describe('AnimatedSprite', () =>
             sprite = null;
         });
 
-        it('should fire frame after start frame during one play and fire onComplete', (done) =>
-        {
-            jest.setTimeout(5000);
-            const frameIds = [] as number[];
+        it('should fire frame after start frame during one play and fire onComplete', () =>
+            new Promise<void>((done) =>
+            {
+                jest.setTimeout(5000);
+                const frameIds = [] as number[];
 
-            sprite.onComplete = () =>
-            {
-                expect(frameIds).toEqual(expect.arrayContaining([1, 2]));
-                expect(sprite.playing).toBe(false);
-                sprite.onComplete = null;
-                sprite.onFrameChange = null;
-                done();
-            };
-            sprite.onFrameChange = (frame) =>
-            {
-                frameIds.push(frame);
-            };
-            sprite.gotoAndPlay(1);
-            expect(sprite.playing).toBe(true);
-        });
+                sprite.onComplete = () =>
+                {
+                    expect(frameIds).toEqual(expect.arrayContaining([1, 2]));
+                    expect(sprite.playing).toBe(false);
+                    sprite.onComplete = null;
+                    sprite.onFrameChange = null;
+                    done();
+                };
+                sprite.onFrameChange = (frame) =>
+                {
+                    frameIds.push(frame);
+                };
+                sprite.gotoAndPlay(1);
+                expect(sprite.playing).toBe(true);
+            }));
     });
 
     describe('.gotoAndStop()', () =>
@@ -221,21 +228,22 @@ describe('AnimatedSprite', () =>
             sprite['_playing'] = false;
         });
 
-        it('should fire onFrameChange on target frame', (done) =>
-        {
-            const targetFrame = 1;
-
-            sprite.onFrameChange = (frame) =>
+        it('should fire onFrameChange on target frame', () =>
+            new Promise<void>((done) =>
             {
-                expect(frame).toEqual(targetFrame);
+                const targetFrame = 1;
+
+                sprite.onFrameChange = (frame) =>
+                {
+                    expect(frame).toEqual(targetFrame);
+                    expect(sprite.playing).toBe(false);
+                    sprite.onComplete = null;
+                    sprite.onFrameChange = null;
+                    done();
+                };
+                sprite.gotoAndStop(targetFrame);
                 expect(sprite.playing).toBe(false);
-                sprite.onComplete = null;
-                sprite.onFrameChange = null;
-                done();
-            };
-            sprite.gotoAndStop(targetFrame);
-            expect(sprite.playing).toBe(false);
-        });
+            }));
 
         it('should not fire onFrameChange on target frame if current is already target', () =>
         {
@@ -271,118 +279,122 @@ describe('AnimatedSprite', () =>
             sprite = null;
         });
 
-        it('should fire every frame(except current) during one play', (done) =>
-        {
-            jest.setTimeout(10000);
-            const frameIds = [] as number[];
+        it('should fire every frame(except current) during one play', () =>
+            new Promise<void>((done) =>
+            {
+                jest.setTimeout(10000);
+                const frameIds = [] as number[];
 
-            sprite.gotoAndStop(0);
-            sprite.onComplete = () =>
-            {
-                expect(frameIds).toEqual(expect.arrayContaining([1, 2])); // from 0 to 2, triggers onFrameChange at 1,2.
-                expect(sprite.currentFrame).toEqual(2);
-                sprite.onComplete = null;
-                sprite.onFrameChange = null;
-                done();
-            };
-            sprite.onFrameChange = (frame) =>
-            {
-                frameIds.push(frame);
-            };
-            sprite.autoUpdate = false;
-            sprite.play();
-            expect(sprite.playing).toBe(true);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-        });
+                sprite.gotoAndStop(0);
+                sprite.onComplete = () =>
+                {
+                    expect(frameIds).toEqual(expect.arrayContaining([1, 2])); // from 0 to 2, triggers onFrameChange at 1,2.
+                    expect(sprite.currentFrame).toEqual(2);
+                    sprite.onComplete = null;
+                    sprite.onFrameChange = null;
+                    done();
+                };
+                sprite.onFrameChange = (frame) =>
+                {
+                    frameIds.push(frame);
+                };
+                sprite.autoUpdate = false;
+                sprite.play();
+                expect(sprite.playing).toBe(true);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+            }));
 
-        it('should fire every frame(except current) during one play - reverse', (done) =>
-        {
-            jest.setTimeout(10000);
-            const frameIds = [] as number[];
+        it('should fire every frame(except current) during one play - reverse', () =>
+            new Promise<void>((done) =>
+            {
+                jest.setTimeout(10000);
+                const frameIds = [] as number[];
 
-            sprite.gotoAndStop(2);
-            sprite.animationSpeed = -1;
-            sprite.onComplete = () =>
-            {
-                expect(frameIds).toEqual(expect.arrayContaining([1, 0])); // from 2 to 0, triggers onFrameChange at 1,0.
-                expect(sprite.currentFrame).toEqual(0);
-                sprite.onComplete = null;
-                sprite.onFrameChange = null;
-                done();
-            };
-            sprite.onFrameChange = (frame) =>
-            {
-                frameIds.push(frame);
-            };
-            sprite.autoUpdate = false;
-            sprite.play();
-            expect(sprite.playing).toBe(true);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-        });
+                sprite.gotoAndStop(2);
+                sprite.animationSpeed = -1;
+                sprite.onComplete = () =>
+                {
+                    expect(frameIds).toEqual(expect.arrayContaining([1, 0])); // from 2 to 0, triggers onFrameChange at 1,0.
+                    expect(sprite.currentFrame).toEqual(0);
+                    sprite.onComplete = null;
+                    sprite.onFrameChange = null;
+                    done();
+                };
+                sprite.onFrameChange = (frame) =>
+                {
+                    frameIds.push(frame);
+                };
+                sprite.autoUpdate = false;
+                sprite.play();
+                expect(sprite.playing).toBe(true);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+            }));
 
-        it('should fire every frame(except current) during one play - from not start/end', (done) =>
-        {
-            jest.setTimeout(10000);
-            const frameIds = [] as number[];
+        it('should fire every frame(except current) during one play - from not start/end', () =>
+            new Promise<void>((done) =>
+            {
+                jest.setTimeout(10000);
+                const frameIds = [] as number[];
 
-            sprite.gotoAndStop(1);
-            sprite.animationSpeed = -1;
-            sprite.onComplete = () =>
-            {
-                expect(frameIds).toEqual(expect.arrayContaining([0])); // from 1 to 0, triggers onFrameChange at 0.
-                expect(sprite.currentFrame).toEqual(0);
-                sprite.onComplete = null;
-                sprite.onFrameChange = null;
-                done();
-            };
-            sprite.onFrameChange = (frame) =>
-            {
-                frameIds.push(frame);
-            };
-            sprite.autoUpdate = false;
-            sprite.play();
-            expect(sprite.playing).toBe(true);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-            sprite.update(ticker1);
-        });
+                sprite.gotoAndStop(1);
+                sprite.animationSpeed = -1;
+                sprite.onComplete = () =>
+                {
+                    expect(frameIds).toEqual(expect.arrayContaining([0])); // from 1 to 0, triggers onFrameChange at 0.
+                    expect(sprite.currentFrame).toEqual(0);
+                    sprite.onComplete = null;
+                    sprite.onFrameChange = null;
+                    done();
+                };
+                sprite.onFrameChange = (frame) =>
+                {
+                    frameIds.push(frame);
+                };
+                sprite.autoUpdate = false;
+                sprite.play();
+                expect(sprite.playing).toBe(true);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+                sprite.update(ticker1);
+            }));
     });
 
     describe('.textures', () =>
     {
-        it('should set the first frame when setting new textures', (done) =>
-        {
-            const orig1 = new Texture();
-            const orig2 = new Texture();
-            const orig3 = new Texture();
-            const sprite = new AnimatedSprite([orig1, orig2, orig3]);
-
-            sprite.gotoAndPlay(0);
-            sprite.loop = false;
-
-            sprite.onComplete = () =>
+        it('should set the first frame when setting new textures', () =>
+            new Promise<void>((done) =>
             {
-                sprite.gotoAndStop(0);
+                const orig1 = new Texture();
+                const orig2 = new Texture();
+                const orig3 = new Texture();
+                const sprite = new AnimatedSprite([orig1, orig2, orig3]);
 
-                const frame1 = new Texture();
-                const frame2 = new Texture();
-                const frame3 = new Texture();
+                sprite.gotoAndPlay(0);
+                sprite.loop = false;
 
-                sprite.textures = [frame1, frame2, frame3];
+                sprite.onComplete = () =>
+                {
+                    sprite.gotoAndStop(0);
 
-                expect(sprite.currentFrame).toEqual(0);
-                expect(sprite.texture).toEqual(frame1);
+                    const frame1 = new Texture();
+                    const frame2 = new Texture();
+                    const frame3 = new Texture();
 
-                done();
-            };
-        });
+                    sprite.textures = [frame1, frame2, frame3];
+
+                    expect(sprite.currentFrame).toEqual(0);
+                    expect(sprite.texture).toEqual(frame1);
+
+                    done();
+                };
+            }));
     });
 
     describe('.currentFrame', () =>
@@ -408,37 +420,38 @@ describe('AnimatedSprite', () =>
             expect(sprite.currentFrame).toBe(1);
         });
 
-        it('should throw on out-of-bounds', (done) =>
-        {
-            jest.setTimeout(10000);
-
-            const notExistIndexes = [-1, 3];
-
-            notExistIndexes.forEach((i) =>
+        it('should throw on out-of-bounds', () =>
+            new Promise<void>((done) =>
             {
-                expect(() =>
-                {
-                    sprite.currentFrame = i;
-                }).toThrowError();
+                jest.setTimeout(10000);
 
-                expect(() =>
-                {
-                    sprite.gotoAndPlay(i);
-                }).toThrowError();
+                const notExistIndexes = [-1, 3];
 
-                expect(() =>
+                notExistIndexes.forEach((i) =>
                 {
-                    sprite.gotoAndStop(i);
-                }).toThrowError();
-            });
+                    expect(() =>
+                    {
+                        sprite.currentFrame = i;
+                    }).toThrow();
 
-            sprite.onComplete = () =>
-            {
-                sprite.onComplete = null;
-                done();
-            };
-            sprite.play();
-        });
+                    expect(() =>
+                    {
+                        sprite.gotoAndPlay(i);
+                    }).toThrow();
+
+                    expect(() =>
+                    {
+                        sprite.gotoAndStop(i);
+                    }).toThrow();
+                });
+
+                sprite.onComplete = () =>
+                {
+                    sprite.onComplete = null;
+                    done();
+                };
+                sprite.play();
+            }));
     });
 
     describe('.onLoop()', () =>

--- a/tests/renderering/batch/Batcher.test.ts
+++ b/tests/renderering/batch/Batcher.test.ts
@@ -10,21 +10,21 @@ describe('Batcher', () =>
             indexSize: 1,
         });
 
-        expect(batcher.attributeBuffer.float32View.length).toBe(2 * 6);
+        expect(batcher.attributeBuffer.float32View).toHaveLength(2 * 6);
 
         batcher.ensureAttributeBuffer(30);
 
-        expect(batcher.attributeBuffer.float32View.length).toBe(30);
+        expect(batcher.attributeBuffer.float32View).toHaveLength(30);
 
         batcher.ensureAttributeBuffer(34);
 
         const ref = batcher.attributeBuffer;
 
-        expect(batcher.attributeBuffer.float32View.length).toBe(60);
+        expect(batcher.attributeBuffer.float32View).toHaveLength(60);
 
         batcher.ensureAttributeBuffer(36);
 
-        expect(batcher.attributeBuffer.float32View.length).toBe(60);
+        expect(batcher.attributeBuffer.float32View).toHaveLength(60);
 
         expect(batcher.attributeBuffer).toBe(ref);
     });
@@ -36,21 +36,21 @@ describe('Batcher', () =>
             indexSize: 2,
         });
 
-        expect(batcher.indexBuffer.length).toBe(2);
+        expect(batcher.indexBuffer).toHaveLength(2);
 
         batcher.ensureIndexBuffer(30);
 
-        expect(batcher.indexBuffer.length).toBe(30);
+        expect(batcher.indexBuffer).toHaveLength(30);
 
         batcher.ensureIndexBuffer(34);
 
         const ref = batcher.indexBuffer;
 
-        expect(batcher.indexBuffer.length).toBe(60);
+        expect(batcher.indexBuffer).toHaveLength(60);
 
         batcher.ensureIndexBuffer(36);
 
-        expect(batcher.indexBuffer.length).toBe(60);
+        expect(batcher.indexBuffer).toHaveLength(60);
 
         expect(batcher.indexBuffer).toBe(ref);
     });

--- a/tests/renderering/extract/Extract.test.ts
+++ b/tests/renderering/extract/Extract.test.ts
@@ -96,7 +96,7 @@ describe('GenerateTexture', () =>
             const renderTexture = getTexture({ width: 10, height: 10 });
             const pixels = renderer.extract.pixels(renderTexture);
 
-            expect(pixels.pixels.length).toBe(renderTexture.width * renderTexture.height * 4);
+            expect(pixels.pixels).toHaveLength(renderTexture.width * renderTexture.height * 4);
             expect(pixels.width).toBe(renderTexture.width);
             expect(pixels.height).toBe(renderTexture.height);
         });
@@ -220,6 +220,7 @@ describe('GenerateTexture', () =>
         expect(height).toEqual(2);
     });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract canvas from render texture correctly', async () =>
     // {
     //     const renderer = new Renderer({ width: 2, height: 2 });
@@ -248,6 +249,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract pixels with resolution !== 1', async () =>
     // {
     //     const renderer = new Renderer({ width: 2, height: 2, resolution: 2 });
@@ -281,6 +283,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract canvas with resolution !== 1', async () =>
     // {
     //     const renderer = new Renderer({ width: 2, height: 2, resolution: 2 });
@@ -320,6 +323,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract an sprite', async () =>
     // {
     //     const renderer = new Renderer();
@@ -335,6 +339,7 @@ describe('GenerateTexture', () =>
     //     sprite.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract with no arguments', async () =>
     // {
     //     const renderer = new Renderer();
@@ -348,6 +353,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract a render texture', async () =>
     // {
     //     const renderer = new Renderer();
@@ -368,6 +374,7 @@ describe('GenerateTexture', () =>
     //     sprite.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract with multisample', async () =>
     // {
     //     const renderer = new Renderer({ antialias: true });
@@ -383,6 +390,7 @@ describe('GenerateTexture', () =>
     //     sprite.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract from object with frame correctly', async () =>
     // {
     //     const renderer = new Renderer({ width: 2, height: 2 });
@@ -420,6 +428,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should unpremultiply alpha correctly', () =>
     // {
     //     const pixels1 = new Uint8Array(4);
@@ -467,6 +476,7 @@ describe('GenerateTexture', () =>
     //     }
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should extract from multisampled render texture', async () =>
     // {
     //     const renderer = new Renderer();
@@ -491,6 +501,7 @@ describe('GenerateTexture', () =>
     //     sprite.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should not throw an error if frame is empty', async () =>
     // {
     //     const renderer = new Renderer();
@@ -525,6 +536,7 @@ describe('GenerateTexture', () =>
     //     renderer.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should unpremultiply if premultiplied alpha', async () =>
     // {
     //     const renderer = new Renderer({
@@ -568,6 +580,7 @@ describe('GenerateTexture', () =>
     //     renderTexture.destroy();
     // });
 
+    // eslint-disable-next-line jest/no-commented-out-tests
     // it('should not unpremultiply if no premultiplied alpha', async () =>
     // {
     //     const renderer = new Renderer({

--- a/tests/renderering/scene/Container.test.ts
+++ b/tests/renderering/scene/Container.test.ts
@@ -9,15 +9,16 @@ describe('Container', () =>
             const container = new Container();
             const child = new Container();
 
-            expect(container.children.length).toEqual(0);
+            expect(container.children).toHaveLength(0);
             container.addChild(child);
-            expect(container.children.length).toEqual(1);
+            expect(container.children).toHaveLength(1);
             expect(child.parent).toEqual(container);
         });
     });
 
     describe('events', () =>
     {
+        // eslint-disable-next-line jest/no-commented-out-tests
         // it('should trigger "added", "removed", "childAdded", and "childRemoved" events on itself and children', () =>
         // {
         //     const container = new Container();
@@ -101,7 +102,7 @@ describe('Container', () =>
             container.addChild(new Container());
             container.addChildAt(child, 0);
 
-            expect(container.children.length).toEqual(2);
+            expect(container.children).toHaveLength(2);
             expect(container.children[0]).toEqual(child);
         });
 
@@ -113,7 +114,7 @@ describe('Container', () =>
             container.addChild(new Container());
             container.addChildAt(child, 1);
 
-            expect(container.children.length).toEqual(2);
+            expect(container.children).toHaveLength(2);
             expect(container.children[1]).toEqual(child);
         });
 
@@ -124,8 +125,8 @@ describe('Container', () =>
 
             container.addChild(new Container());
 
-            expect(() => container.addChildAt(child, -1)).toThrowError('The index -1 supplied is out of bounds 1');
-            expect(() => container.addChildAt(child, 2)).toThrowError('The index 2 supplied is out of bounds 1');
+            expect(() => container.addChildAt(child, -1)).toThrow('The index -1 supplied is out of bounds 1');
+            expect(() => container.addChildAt(child, 2)).toThrow('The index 2 supplied is out of bounds 1');
         });
 
         it('should remove from current parent', () =>
@@ -149,7 +150,7 @@ describe('Container', () =>
 
             container.removeChild(new Container());
 
-            expect(container.children.length).toEqual(1);
+            expect(container.children).toHaveLength(1);
         });
 
         it('should remove all children supplied', () =>
@@ -160,11 +161,11 @@ describe('Container', () =>
 
             container.addChild(child1, child2);
 
-            expect(container.children.length).toEqual(2);
+            expect(container.children).toHaveLength(2);
 
             container.removeChild(child1, child2);
 
-            expect(container.children.length).toEqual(0);
+            expect(container.children).toHaveLength(0);
         });
     });
 
@@ -186,7 +187,7 @@ describe('Container', () =>
             const child = new Container();
 
             expect(() => container.getChildIndex(child))
-                .toThrowError('The supplied Container must be a child of the caller');
+                .toThrow('The supplied Container must be a child of the caller');
         });
     });
 
@@ -196,8 +197,8 @@ describe('Container', () =>
         {
             const container = new Container();
 
-            expect(() => container.getChildAt(-1)).toThrowError('getChildAt: Index (-1) does not exist.');
-            expect(() => container.getChildAt(1)).toThrowError('getChildAt: Index (1) does not exist.');
+            expect(() => container.getChildAt(-1)).toThrow('getChildAt: Index (-1) does not exist.');
+            expect(() => container.getChildAt(1)).toThrow('getChildAt: Index (1) does not exist.');
         });
     });
 
@@ -210,8 +211,8 @@ describe('Container', () =>
 
             container.addChild(child);
 
-            expect(() => container.setChildIndex(child, -1)).toThrowError('The index -1 supplied is out of bounds 1');
-            expect(() => container.setChildIndex(child, 1)).toThrowError('The index 1 supplied is out of bounds 1');
+            expect(() => container.setChildIndex(child, -1)).toThrow('The index -1 supplied is out of bounds 1');
+            expect(() => container.setChildIndex(child, 1)).toThrow('The index 1 supplied is out of bounds 1');
         });
 
         it('should throw when child does not belong', () =>
@@ -222,7 +223,7 @@ describe('Container', () =>
             container.addChild(new Container());
 
             expect(() => container.setChildIndex(child, 0))
-                .toThrowError('The supplied Container must be a child of the caller');
+                .toThrow('The supplied Container must be a child of the caller');
         });
 
         it('should set index', () =>
@@ -254,9 +255,9 @@ describe('Container', () =>
             container.addChild(child, new Container());
 
             expect(() => container.swapChildren(child, new Container()))
-                .toThrowError('The supplied Container must be a child of the caller');
+                .toThrow('The supplied Container must be a child of the caller');
             expect(() => container.swapChildren(new Container(), child))
-                .toThrowError('The supplied Container must be a child of the caller');
+                .toThrow('The supplied Container must be a child of the caller');
         });
 
         it('should result in swapped child positions', () =>
@@ -286,12 +287,12 @@ describe('Container', () =>
 
             container.addChild(new Container(), new Container(), new Container());
 
-            expect(container.children.length).toEqual(3);
+            expect(container.children).toHaveLength(3);
 
             removed = container.removeChildren();
 
-            expect(container.children.length).toEqual(0);
-            expect(removed.length).toEqual(3);
+            expect(container.children).toHaveLength(0);
+            expect(removed).toHaveLength(3);
         });
 
         it('should return empty array if no children', () =>
@@ -299,7 +300,7 @@ describe('Container', () =>
             const container = new Container();
             const removed = container.removeChildren();
 
-            expect(removed.length).toEqual(0);
+            expect(removed).toHaveLength(0);
         });
 
         it('should handle a range greater than length', () =>
@@ -310,7 +311,7 @@ describe('Container', () =>
             container.addChild(new Container());
 
             removed = container.removeChildren(0, 2);
-            expect(removed.length).toEqual(1);
+            expect(removed).toHaveLength(1);
         });
 
         it('should throw outside acceptable range', () =>
@@ -320,11 +321,11 @@ describe('Container', () =>
             container.addChild(new Container());
 
             expect(() => container.removeChildren(2))
-                .toThrowError('removeChildren: numeric values are outside the acceptable range.');
+                .toThrow('removeChildren: numeric values are outside the acceptable range.');
             expect(() => container.removeChildren(-1))
-                .toThrowError('removeChildren: numeric values are outside the acceptable range.');
+                .toThrow('removeChildren: numeric values are outside the acceptable range.');
             expect(() => container.removeChildren(-1, 1))
-                .toThrowError('removeChildren: numeric values are outside the acceptable range.');
+                .toThrow('removeChildren: numeric values are outside the acceptable range.');
         });
     });
 
@@ -338,7 +339,7 @@ describe('Container', () =>
             container.addChild(child);
             container.destroy();
 
-            expect(container.children.length).toEqual(0);
+            expect(container.children).toHaveLength(0);
             expect(child.position).not.toBeNull();
         });
 
@@ -350,7 +351,7 @@ describe('Container', () =>
             container.addChild(child);
             container.destroy({ children: true });
 
-            expect(container.children.length).toEqual(0);
+            expect(container.children).toHaveLength(0);
             expect(container.position).toBeNull();
             expect(child.position).toBeNull();
 
@@ -360,7 +361,7 @@ describe('Container', () =>
             container.addChild(child);
             container.destroy(true);
 
-            expect(container.children.length).toEqual(0);
+            expect(container.children).toHaveLength(0);
             expect(container.position).toBeNull();
             expect(child.position).toBeNull();
         });
@@ -370,12 +371,12 @@ describe('Container', () =>
     {
         parent.addChild(child);
 
-        expect(parent.children.length).toEqual(1);
+        expect(parent.children).toHaveLength(1);
         expect(child.parent).toEqual(parent);
 
         functionToAssert();
 
-        expect(parent.children.length).toEqual(0);
+        expect(parent.children).toHaveLength(0);
         expect(child.parent).toEqual(container);
     }
 });

--- a/tests/renderering/sprite/spritesheetAsset.tests.ts
+++ b/tests/renderering/sprite/spritesheetAsset.tests.ts
@@ -87,9 +87,9 @@ describe('spritesheetAsset', () =>
         const spritesheet2 = await loader.load<Spritesheet>(`${basePath}spritesheet/atlas-multipack-wrong-type.json`);
         const spritesheet3 = await loader.load<Spritesheet>(`${basePath}spritesheet/atlas-multipack-wrong-array.json`);
 
-        expect(spritesheet.linkedSheets.length).toEqual(1);
-        expect(spritesheet2.linkedSheets.length).toEqual(0);
-        expect(spritesheet3.linkedSheets.length).toEqual(0);
+        expect(spritesheet.linkedSheets).toHaveLength(1);
+        expect(spritesheet2.linkedSheets).toHaveLength(0);
+        expect(spritesheet3.linkedSheets).toHaveLength(0);
     });
 
     it('should unload a spritesheet', async () =>

--- a/tests/renderering/text/extractFontFamilies.test.ts
+++ b/tests/renderering/text/extractFontFamilies.test.ts
@@ -3,7 +3,7 @@ import { extractFontFamilies } from '../../../src/scene/text/html/utils/extractF
 
 describe('extractFontFamilies', () =>
 {
-    it('should extract font string correctly if embedded in the text string', async () =>
+    it('should extract font family correctly if embedded in the text string', async () =>
     {
         const families = extractFontFamilies(
             'Hello<br /><span style="font-family:Cabin">World<span>',

--- a/tests/renderering/textures/GLTextureSystem.test.ts
+++ b/tests/renderering/textures/GLTextureSystem.test.ts
@@ -22,7 +22,7 @@ describe('GLTextureSystem', () =>
         const texture = getTexture({ width: 10, height: 10 });
         const pixelInfo = renderer.texture.getPixels(texture);
 
-        expect(pixelInfo.pixels.length).toBe(texture.width * texture.height * 4);
+        expect(pixelInfo.pixels).toHaveLength(texture.width * texture.height * 4);
         expect(pixelInfo.width).toBe(texture.width);
         expect(pixelInfo.height).toBe(texture.height);
     });

--- a/tests/renderering/textures/Textures.test.ts
+++ b/tests/renderering/textures/Textures.test.ts
@@ -9,7 +9,7 @@ describe('Texture', () =>
         const texture = new Texture();
 
         texture.destroy(true);
-        texture.destroy(true);
+        expect(() => { texture.destroy(true); }).not.toThrow();
     });
 
     it('should return the same texture if the resource is the same', () =>

--- a/tests/scene/Container.tests.ts
+++ b/tests/scene/Container.tests.ts
@@ -19,7 +19,7 @@ describe('Container Tests', () =>
         expect(container.angle).toBe(angle);
         expect(container.children).toContain(children[0]);
         expect(container.children).toContain(children[1]);
-        expect(addedSpy).toBeCalledTimes(1);
+        expect(addedSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should a global position correctly', async () =>
@@ -83,7 +83,7 @@ describe('Container Tests', () =>
         expect(child.toLocal({ x: 0, y: 0 })).toEqual({ x: -10, y: -10 });
     });
 
-    it('should a local position correctly', async () =>
+    it('should a local position correctly when nested', async () =>
     {
         const root = new Container({
             label: 'root',

--- a/tests/scene/scene.tests.ts
+++ b/tests/scene/scene.tests.ts
@@ -10,7 +10,7 @@ describe('Scene', () =>
 
         container.addChild(child);
 
-        expect(container.children.length).toEqual(1);
+        expect(container.children).toHaveLength(1);
         expect(container.children[0]).toEqual(child);
     });
 
@@ -24,7 +24,7 @@ describe('Scene', () =>
 
         container.removeChild(child);
 
-        expect(container.children.length).toEqual(0);
+        expect(container.children).toHaveLength(0);
     });
 
     it('should re-parent a child', async () =>
@@ -39,8 +39,8 @@ describe('Scene', () =>
 
         child.addChild(child2);
 
-        expect(container.children.length).toEqual(1);
-        expect(child.children.length).toEqual(1);
+        expect(container.children).toHaveLength(1);
+        expect(child.children).toHaveLength(1);
     });
 
     it('should set correct render group a child', async () =>
@@ -57,8 +57,8 @@ describe('Scene', () =>
 
         container.addChild(childPost);
 
-        expect(container.children.length).toEqual(2);
-        expect(container.layerGroup['_children'].length).toEqual(2);
+        expect(container.children).toHaveLength(2);
+        expect(container.layerGroup['_children']).toHaveLength(2);
 
         expect(childPre.layerGroup).toEqual(container.layerGroup);
         expect(childPost.layerGroup).toEqual(container.layerGroup);
@@ -99,8 +99,8 @@ describe('Scene', () =>
         container2.addChild(child2);
         container2.addChild(child3);
 
-        expect(container.children.length).toEqual(2);
-        expect(container.layerGroup['_children'].length).toEqual(4);
+        expect(container.children).toHaveLength(2);
+        expect(container.layerGroup['_children']).toHaveLength(4);
 
         expect(child2.layerGroup).toEqual(container.layerGroup);
         expect(child3.layerGroup).toEqual(container.layerGroup);
@@ -137,8 +137,8 @@ describe('Scene', () =>
         container2.addChild(child3);
 
         expect(container.layerGroup === container2.layerGroup).toBeFalse();
-        expect(container.layerGroup['_children'].length).toEqual(2);
-        expect(container2.layerGroup['_children'].length).toEqual(2);
+        expect(container.layerGroup['_children']).toHaveLength(2);
+        expect(container2.layerGroup['_children']).toHaveLength(2);
 
         expect(container.layerGroup).toEqual(container.layerGroup);
         expect(container2.layerGroup).toEqual(container2.layerGroup);
@@ -147,8 +147,8 @@ describe('Scene', () =>
         expect(child2.layerGroup).toEqual(container2.layerGroup);
         expect(child3.layerGroup).toEqual(container2.layerGroup);
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
     });
 
     it('should set reparent from one layer to another group', async () =>
@@ -185,8 +185,8 @@ describe('Scene', () =>
         container2.addChild(child);
 
         expect(container.layerGroup === container2.layerGroup).toBeFalse();
-        expect(container.layerGroup['_children'].length).toEqual(1);
-        expect(container2.layerGroup['_children'].length).toEqual(3);
+        expect(container.layerGroup['_children']).toHaveLength(1);
+        expect(container2.layerGroup['_children']).toHaveLength(3);
 
         expect(container.layerGroup).toEqual(container.layerGroup);
         expect(container2.layerGroup).toEqual(container2.layerGroup);
@@ -195,8 +195,8 @@ describe('Scene', () =>
         expect(child2.layerGroup).toEqual(container2.layerGroup);
         expect(child3.layerGroup).toEqual(container2.layerGroup);
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
 
         // |- contianer // renderGroup
         //    |- container2 // renderGroup
@@ -206,8 +206,8 @@ describe('Scene', () =>
 
         container.addChild(child3);
 
-        expect(container.layerGroup['_children'].length).toEqual(2);
-        expect(container2.layerGroup['_children'].length).toEqual(2);
+        expect(container.layerGroup['_children']).toHaveLength(2);
+        expect(container2.layerGroup['_children']).toHaveLength(2);
 
         expect(container.layerGroup).toEqual(container.layerGroup);
         expect(container2.layerGroup).toEqual(container2.layerGroup);
@@ -216,8 +216,8 @@ describe('Scene', () =>
         expect(child2.layerGroup).toEqual(container2.layerGroup);
         expect(child3.layerGroup).toEqual(container.layerGroup);
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
     });
 
     // REparents a rendergroup..
@@ -261,15 +261,15 @@ describe('Scene', () =>
         expect(child3.layerGroup).toBe(container2.layerGroup);
 
         expect(container.layerGroup === container2.layerGroup).toBeFalse();
-        expect(container.layerGroup['_children'].length).toEqual(2);
-        expect(container2.layerGroup['_children'].length).toEqual(2);
+        expect(container.layerGroup['_children']).toHaveLength(2);
+        expect(container2.layerGroup['_children']).toHaveLength(2);
 
         expect(container2.parent).toBe(child);
 
-        expect(child.children.length).toEqual(1);
+        expect(child.children).toHaveLength(1);
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
 
         child.layer = true;
 
@@ -279,20 +279,20 @@ describe('Scene', () =>
         //           |- child2
         //           |- child3
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(child.layerGroup.layerGroupChildren.length).toEqual(1);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
-        expect(child.layerGroup['_children'].length).toEqual(1);
-        expect(container2.layerGroup['_children'].length).toEqual(2);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(child.layerGroup.layerGroupChildren).toHaveLength(1);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
+        expect(child.layerGroup['_children']).toHaveLength(1);
+        expect(container2.layerGroup['_children']).toHaveLength(2);
 
         container.addChild(container2);
 
-        expect(container.layerGroup.layerGroupChildren.length).toEqual(2);
-        expect(container.children.length).toEqual(2);
-        expect(child.layerGroup.layerGroupChildren.length).toEqual(0);
-        expect(container2.layerGroup.layerGroupChildren.length).toEqual(0);
-        expect(child.layerGroup['_children'].length).toEqual(0);
-        expect(container2.layerGroup['_children'].length).toEqual(2);
+        expect(container.layerGroup.layerGroupChildren).toHaveLength(2);
+        expect(container.children).toHaveLength(2);
+        expect(child.layerGroup.layerGroupChildren).toHaveLength(0);
+        expect(container2.layerGroup.layerGroupChildren).toHaveLength(0);
+        expect(child.layerGroup['_children']).toHaveLength(0);
+        expect(container2.layerGroup['_children']).toHaveLength(2);
 
         expect(container.relativeLayerDepth).toEqual(0);
         expect(child.relativeLayerDepth).toEqual(1);
@@ -612,11 +612,11 @@ describe('Scene', () =>
 
         container.addChild(child);
         container.addChild(child);
-        expect(container.children.length).toEqual(1);
+        expect(container.children).toHaveLength(1);
 
         container.removeChild(child);
 
-        expect(container.children.length).toEqual(0);
+        expect(container.children).toHaveLength(0);
         expect(child.parent).toEqual(null);
         // container.removeChild(child);
     });

--- a/tests/scene/transform-visibiity.tests.ts
+++ b/tests/scene/transform-visibiity.tests.ts
@@ -90,17 +90,6 @@ describe('Transform Visibility', () =>
 
         root.renderable = false;
 
-        expect(root.layerGroup.structureDidChange).toEqual(false);
-    });
-
-    it('should not cause a rebuild if renderable is changed on a layer', async () =>
-    {
-        const root = new Container({ layer: true });
-
-        root.layerGroup.structureDidChange = false;
-
-        root.renderable = false;
-
         expect(root.renderable).toEqual(false);
 
         expect(root.layerGroup.structureDidChange).toEqual(false);

--- a/tests/scene/transform.tests.ts
+++ b/tests/scene/transform.tests.ts
@@ -256,6 +256,6 @@ describe('Transform updates', () =>
 
         updateLayerGroupTransforms(root.layerGroup, true);
 
-        expect(updateRenderable).toBeCalledTimes(0);
+        expect(updateRenderable).toHaveBeenCalledTimes(0);
     });
 });

--- a/tests/system-runner/SystemRunner.tests.ts
+++ b/tests/system-runner/SystemRunner.tests.ts
@@ -17,12 +17,12 @@ describe('Runner', () =>
 
         complete.add({ complete: callback });
         complete.emit();
-        expect(callback).toBeCalled();
-        expect(callback).toBeCalledTimes(1);
+        expect(callback).toHaveBeenCalled();
+        expect(callback).toHaveBeenCalledTimes(1);
         complete.emit();
-        expect(callback).toBeCalledTimes(2);
+        expect(callback).toHaveBeenCalledTimes(2);
         complete.emit();
-        expect(callback).toBeCalledTimes(3);
+        expect(callback).toHaveBeenCalledTimes(3);
         complete.destroy();
         expect(!complete.items).toBe(true);
         expect(!complete.name).toBe(true);
@@ -52,8 +52,8 @@ describe('Runner', () =>
 
         update.add({ update: callback });
         update.emit(1, 2);
-        expect(callback).toBeCalled();
-        expect(callback).toBeCalledTimes(1);
+        expect(callback).toHaveBeenCalled();
+        expect(callback).toHaveBeenCalledTimes(1);
     });
 
     it('should implement multiple targets', () =>
@@ -69,15 +69,15 @@ describe('Runner', () =>
         expect(complete.contains(obj2)).toBe(true);
         complete.emit();
         expect(!complete.empty).toBe(true);
-        expect(complete.items.length).toEqual(2);
-        expect(obj.complete).toBeCalled();
-        expect(obj.complete).toBeCalledTimes(1);
-        expect(obj2.complete).toBeCalled();
-        expect(obj2.complete).toBeCalledTimes(1);
+        expect(complete.items).toHaveLength(2);
+        expect(obj.complete).toHaveBeenCalled();
+        expect(obj.complete).toHaveBeenCalledTimes(1);
+        expect(obj2.complete).toHaveBeenCalled();
+        expect(obj2.complete).toHaveBeenCalledTimes(1);
         complete.remove(obj);
-        expect(complete.items.length).toEqual(1);
+        expect(complete.items).toHaveLength(1);
         complete.remove(obj2);
-        expect(complete.items.length).toEqual(0);
+        expect(complete.items).toHaveLength(0);
         expect(complete.empty).toBe(true);
     });
 
@@ -95,7 +95,7 @@ describe('Runner', () =>
             .add(obj2)
             .add(obj3);
 
-        expect(complete.items.length).toEqual(2);
+        expect(complete.items).toHaveLength(2);
 
         complete.removeAll();
         expect(complete.empty).toBe(true);
@@ -108,6 +108,6 @@ describe('Runner', () =>
         const obj = { complete() { } };
 
         complete.add(obj).add(obj);
-        expect(complete.items.length).toEqual(1);
+        expect(complete.items).toHaveLength(1);
     });
 });

--- a/tests/ticker/Ticker.tests.ts
+++ b/tests/ticker/Ticker.tests.ts
@@ -100,12 +100,12 @@ describe('Ticker', () =>
         shared.add(listener);
         shared.update();
 
-        expect(listener).toBeCalledTimes(1);
+        expect(listener).toHaveBeenCalledTimes(1);
 
         shared.remove(listener);
         shared.update();
 
-        expect(listener).toBeCalledTimes(1);
+        expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('should update a listener twice and remove once', () =>
@@ -116,13 +116,13 @@ describe('Ticker', () =>
         shared.add(listener).add(listener);
         shared.update();
 
-        expect(listener).toBeCalledTimes(2);
+        expect(listener).toHaveBeenCalledTimes(2);
         expect(length()).toEqual(len + 2);
 
         shared.remove(listener);
         shared.update();
 
-        expect(listener).toBeCalledTimes(2);
+        expect(listener).toHaveBeenCalledTimes(2);
         expect(length()).toEqual(len);
     });
 
@@ -191,7 +191,7 @@ describe('Ticker', () =>
 
         shared.update();
 
-        expect(listener).toBeCalledTimes(1);
+        expect(listener).toHaveBeenCalledTimes(1);
         expect(length()).toEqual(len);
     });
 
@@ -241,9 +241,9 @@ describe('Ticker', () =>
 
         shared.update();
 
-        expect(listener1).toBeCalledTimes(2);
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener3).toBeCalledTimes(2);
+        expect(listener1).toHaveBeenCalledTimes(2);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener3).toHaveBeenCalledTimes(2);
 
         shared.remove(listener1).remove(listener3);
 
@@ -267,9 +267,9 @@ describe('Ticker', () =>
 
         expect(length()).toEqual(len + 3);
 
-        expect(mainListener).toBeCalledTimes(1);
-        expect(lowListener).toBeCalledTimes(1);
-        expect(highListener).not.toBeCalled();
+        expect(mainListener).toHaveBeenCalledTimes(1);
+        expect(lowListener).toHaveBeenCalledTimes(1);
+        expect(highListener).not.toHaveBeenCalled();
 
         shared.remove(mainListener)
             .remove(highListener)
@@ -293,8 +293,8 @@ describe('Ticker', () =>
 
         expect(length()).toEqual(len + 2);
 
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener1).toBeCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener1).toHaveBeenCalledTimes(1);
 
         shared.remove(listener1)
             .remove(listener2);
@@ -321,8 +321,8 @@ describe('Ticker', () =>
 
         expect(length()).toEqual(len + 1);
 
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener1).toBeCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener1).toHaveBeenCalledTimes(1);
 
         shared.remove(listener2);
 
@@ -349,12 +349,12 @@ describe('Ticker', () =>
         expect(length()).toEqual(len + 1);
 
         expect(listener2).not.toHaveBeenCalled();
-        expect(listener1).toBeCalledTimes(1);
+        expect(listener1).toHaveBeenCalledTimes(1);
 
         shared.update();
 
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener1).toBeCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener1).toHaveBeenCalledTimes(1);
 
         shared.remove(listener2);
 
@@ -387,17 +387,17 @@ describe('Ticker', () =>
 
         expect(length()).toEqual(len + 2);
 
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener3).not.toBeCalled();
-        expect(listener4).toBeCalledTimes(1);
-        expect(listener1).toBeCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener3).not.toHaveBeenCalled();
+        expect(listener4).toHaveBeenCalledTimes(1);
+        expect(listener1).toHaveBeenCalledTimes(1);
 
         shared.update();
 
-        expect(listener2).toBeCalledTimes(1);
-        expect(listener3).not.toBeCalled();
-        expect(listener4).toBeCalledTimes(2);
-        expect(listener1).toBeCalledTimes(2);
+        expect(listener2).toHaveBeenCalledTimes(1);
+        expect(listener3).not.toHaveBeenCalled();
+        expect(listener4).toHaveBeenCalledTimes(2);
+        expect(listener1).toHaveBeenCalledTimes(2);
 
         shared.remove(listener1)
             .remove(listener4);
@@ -405,50 +405,52 @@ describe('Ticker', () =>
         expect(length()).toEqual(len);
     });
 
-    it('should destroy on listener', (done) =>
-    {
-        const ticker = new Ticker();
-        const listener2 = jest.fn();
-        const listener = jest.fn(() =>
+    it('should destroy on listener', () =>
+        new Promise<void>((done) =>
         {
-            ticker.destroy();
-            setTimeout(() =>
+            const ticker = new Ticker();
+            const listener2 = jest.fn();
+            const listener = jest.fn(() =>
             {
-                expect(listener2).not.toHaveBeenCalled();
-                expect(listener).toBeCalledTimes(1);
+                ticker.destroy();
+                setTimeout(() =>
+                {
+                    expect(listener2).not.toHaveBeenCalled();
+                    expect(listener).toHaveBeenCalledTimes(1);
+                    done();
+                }, 0);
+            });
+
+            ticker.add(listener);
+            ticker.add(listener2, null, UPDATE_PRIORITY.LOW);
+            ticker.start();
+        }));
+
+    it('should Ticker call destroyed listener "next" pointer after destroy', () =>
+        new Promise<void>((done) =>
+        {
+            const ticker = new Ticker();
+
+            const listener1 = jest.fn();
+            const listener2 = jest.fn(() =>
+            {
+                ticker.remove(listener2);
+            });
+
+            const listener3 = jest.fn(() =>
+            {
+                ticker.stop();
+
+                expect(listener1).toHaveBeenCalledTimes(1);
+                expect(listener2).toHaveBeenCalledTimes(1);
+                expect(listener3).toHaveBeenCalledTimes(1);
                 done();
-            }, 0);
-        });
+            });
 
-        ticker.add(listener);
-        ticker.add(listener2, null, UPDATE_PRIORITY.LOW);
-        ticker.start();
-    });
+            ticker.add(listener1, null, UPDATE_PRIORITY.HIGH);
+            ticker.add(listener2, null, UPDATE_PRIORITY.HIGH);
+            ticker.add(listener3, null, UPDATE_PRIORITY.HIGH);
 
-    it('should Ticker call destroyed listener "next" pointer after destroy', (done) =>
-    {
-        const ticker = new Ticker();
-
-        const listener1 = jest.fn();
-        const listener2 = jest.fn(() =>
-        {
-            ticker.remove(listener2);
-        });
-
-        const listener3 = jest.fn(() =>
-        {
-            ticker.stop();
-
-            expect(listener1).toBeCalledTimes(1);
-            expect(listener2).toBeCalledTimes(1);
-            expect(listener3).toBeCalledTimes(1);
-            done();
-        });
-
-        ticker.add(listener1, null, UPDATE_PRIORITY.HIGH);
-        ticker.add(listener2, null, UPDATE_PRIORITY.HIGH);
-        ticker.add(listener3, null, UPDATE_PRIORITY.HIGH);
-
-        ticker.start();
-    });
+            ticker.start();
+        }));
 });

--- a/tests/ticker/TickerPlugin.tests.ts
+++ b/tests/ticker/TickerPlugin.tests.ts
@@ -13,23 +13,24 @@ describe('TickerPlugin', () =>
     }
     let app: App;
 
-    it('should not start application before calling start method if options.autoStart is false', (done) =>
-    {
-        const app = {} as App;
-
-        TickerPlugin.init.call(app, { autoStart: false });
-
-        expect(app.ticker).toBeInstanceOf(Ticker);
-        expect(app.ticker.started).toBe(false);
-
-        app.start();
-
-        app.ticker.addOnce(() =>
+    it('should not start application before calling start method if options.autoStart is false', () =>
+        new Promise<void>((done) =>
         {
-            TickerPlugin.destroy.call(app);
-            done();
-        });
-    });
+            const app = {} as App;
+
+            TickerPlugin.init.call(app, { autoStart: false });
+
+            expect(app.ticker).toBeInstanceOf(Ticker);
+            expect(app.ticker.started).toBe(false);
+
+            app.start();
+
+            app.ticker.addOnce(() =>
+            {
+                TickerPlugin.destroy.call(app);
+                done();
+            });
+        }));
 
     describe('set ticker', () =>
     {
@@ -60,11 +61,11 @@ describe('TickerPlugin', () =>
             app.ticker = ticker as unknown as Ticker;
 
             expect(_ticker.remove).toHaveBeenCalledOnce();
-            expect(_ticker.remove).toBeCalledWith(app.render, app);
+            expect(_ticker.remove).toHaveBeenCalledWith(app.render, app);
 
             expect(app._ticker).toEqual(ticker);
             expect(ticker.add).toHaveBeenCalledOnce();
-            expect(ticker.add).toBeCalledWith(app.render, app, UPDATE_PRIORITY.LOW);
+            expect(ticker.add).toHaveBeenCalledWith(app.render, app, UPDATE_PRIORITY.LOW);
         });
 
         it('should assign ticker if no ticker', () =>
@@ -76,7 +77,7 @@ describe('TickerPlugin', () =>
 
             expect(app._ticker).toEqual(ticker);
             expect(ticker.add).toHaveBeenCalledOnce();
-            expect(ticker.add).toBeCalledWith(app.render, app, UPDATE_PRIORITY.LOW);
+            expect(ticker.add).toHaveBeenCalledWith(app.render, app, UPDATE_PRIORITY.LOW);
         });
 
         it('should assign null ticker', () =>
@@ -87,7 +88,7 @@ describe('TickerPlugin', () =>
             app.ticker = null;
 
             expect(_ticker.remove).toHaveBeenCalledOnce();
-            expect(_ticker.remove).toBeCalledWith(app.render, app);
+            expect(_ticker.remove).toHaveBeenCalledWith(app.render, app);
 
             expect(app._ticker).toBeNull();
         });

--- a/tests/visual/visuals.test.ts
+++ b/tests/visual/visuals.test.ts
@@ -1,6 +1,7 @@
 import glob from 'glob';
 import path from 'path';
 import { Assets } from '../../src/assets/Assets';
+import { isCI } from '../assets/basePath';
 import { renderTest } from './tester';
 
 const paths = glob.sync('**/*.scene.ts', { cwd: path.join(process.cwd(), './tests') });
@@ -12,7 +13,15 @@ const scenes = paths.map((p) =>
     return { path: p, data: require(`./${relativePath}`).scene };
 });
 
-const onlyScenes = scenes.filter((s) => s.data.only);
+const onlyScenes = scenes.filter((s) =>
+{
+    if (isCI && s.data.only)
+    {
+        throw new Error(`only: true should not be committed to the repo. Please remove from ${path.basename(s.path)}`);
+    }
+
+    return s.data.only;
+});
 const scenesToTest = onlyScenes.length ? onlyScenes : scenes;
 
 function setAssetBasePath(): void


### PR DESCRIPTION
Added the `eslint-plugin-jest` with its recommended settings

This should help us avoid committing things like `it.only`

I've also added a `throw` for when the visual tests are pushed to CI with `only: true`. 