### PR TITLE
Fix layer renderable uid assignment

### DIFF
--- a/src/rendering/renderers/shared/LayerRenderable.ts
+++ b/src/rendering/renderers/shared/LayerRenderable.ts
@@ -36,6 +36,9 @@ export class LayerRenderable<T extends View = View> extends EventEmitter impleme
         this.layerTransform = new Matrix();
         this.layerVisibleRenderable = 0b11;
 
+        // layer renderable should match the original id as we use it to reference
+        // the gpu counter part on various systems
+        this.uid = original.uid;
         this.view.owner = this;
     }
 


### PR DESCRIPTION
this was causing the updated layer renderable to not be able to find its gpu counterpart as it is stored against on the orignal containers uid.