### PR TITLE
Fix type error in `ISpritesheetData`

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -224,7 +224,7 @@ export class Spritesheet<S extends ISpritesheetData = ISpritesheetData>
         this._texture = texture instanceof Texture ? texture : null;
         this.baseTexture = texture instanceof BaseTexture ? texture : this._texture.baseTexture;
         this.textures = {} as Record<keyof S['frames'], Texture>;
-        this.animations = {} as Record<keyof S['animations'], Texture[]>;
+        this.animations = {} as Record<keyof NonNullable<S['animations']>, Texture[]>;
         this.data = data;
 
         const resource = this.baseTexture.resource as ImageResource;

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -36,7 +36,7 @@ export interface ISpritesheetFrameData
  */
 export interface ISpritesheetData
 {
-    animations: utils.Dict<string[]>;
+    animations?: utils.Dict<string[]>;
     frames: utils.Dict<ISpritesheetFrameData>;
     meta: {
         app?: string;
@@ -177,7 +177,7 @@ export class Spritesheet<S extends ISpritesheetData = ISpritesheetData>
      *
      * new AnimatedSprite(sheet.animations['anim_name']);
      */
-    public animations: Record<keyof S['animations'], Texture[]>;
+    public animations: Record<keyof NonNullable<S['animations']>, Texture[]>;
 
     /**
      * Reference to the original JSON data.

--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -36,7 +36,7 @@ export interface ISpritesheetFrameData
  */
 export interface ISpritesheetData
 {
-    animations?: utils.Dict<string[]>;
+    animations: utils.Dict<string[]>;
     frames: utils.Dict<ISpritesheetFrameData>;
     meta: {
         app?: string;


### PR DESCRIPTION
##### Description of change

Removes the `?` on the `animations` key of the `ISpritesheetData` type. This is because it results in the type `Record<never, ...>` for the `Spritesheet` class member `animations` [here](https://github.com/Nearoo/pixijs/blob/503605c14078bd66f8a7d0a14bfba2b47b05184b/packages/spritesheet/src/Spritesheet.ts#L180), making it impossible to use `animations` without type error in typescript.

The reason for this is that `animation` of `ISpritesheetData` is of type `Record<keyof S['animations'], Texture[]>`, where, due to the `?`, `keyof S['animations']` will evaluate to `undefined & utils.Dict<string[]>`, which is `never`. 

Since `Spritesheet.animations` is always initialized ([here](https://github.com/Nearoo/pixijs/blob/503605c14078bd66f8a7d0a14bfba2b47b05184b/packages/spritesheet/src/Spritesheet.ts#L227)), it shouldn't cause an issue. However, I don't have a broad overview over the codebase, someone might want to verify that.




##### Pre-Merge Checklist

I didn't add any tests because the error is on a type level, and the change is literally one character.

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
