### PR TITLE
v8 fix contains point issue with transforms

### DIFF
--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -747,18 +747,15 @@ export class GraphicsContext extends EventEmitter<{
 
                 const transform = shapes[i].transform;
 
-                if (transform)
-                {
-                    point = transform.applyInverse(point, tmpPoint);
-                }
+                const transformedPoint = transform ? transform.applyInverse(point, tmpPoint) : point;
 
                 if (instruction.action === 'fill')
                 {
-                    hasHit = shape.contains(point.x, point.y);
+                    hasHit = shape.contains(transformedPoint.x, transformedPoint.y);
                 }
                 else
                 {
-                    hasHit = shape.strokeContains(point.x, point.y, (style as ConvertedStrokeStyle).width);
+                    hasHit = shape.strokeContains(transformedPoint.x, transformedPoint.y, (style as ConvertedStrokeStyle).width);
                 }
 
                 const holes = data.hole;
@@ -771,7 +768,7 @@ export class GraphicsContext extends EventEmitter<{
                     {
                         for (let j = 0; j < holeShapes.length; j++)
                         {
-                            if (holeShapes[j].shape.contains(point.x, point.y))
+                            if (holeShapes[j].shape.contains(transformedPoint.x, transformedPoint.y))
                             {
                                 hasHit = false;
                             }

--- a/tests/renderering/graphics/Graphics.Bounds.test.ts
+++ b/tests/renderering/graphics/Graphics.Bounds.test.ts
@@ -214,7 +214,7 @@ describe('Graphics Bounds', () =>
 
         // note: Mat to look into, may be bug
         // ticket: https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=44799288
-        it.skip('should take a matrix into account', () =>
+        it('should take a matrix into account', () =>
         {
             const g = new Graphics();
 

--- a/tests/renderering/graphics/Graphics.Bounds.test.ts
+++ b/tests/renderering/graphics/Graphics.Bounds.test.ts
@@ -212,8 +212,6 @@ describe('Graphics Bounds', () =>
             expect(graphics.context.containsPoint(new Point(6, 6))).toBe(true);
         });
 
-        // note: Mat to look into, may be bug
-        // ticket: https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=44799288
         it('should take a matrix into account', () =>
         {
             const g = new Graphics();


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 21d61fd</samp>

### Summary
✅🔧🚀

<!--
1.  ✅ - This emoji represents the enabling of a skipped test that was previously marked as a potential bug. It conveys the idea of passing a test, fixing a bug, or verifying a functionality.
2.  🔧 - This emoji represents the refactoring of hit detection code in `GraphicsContext` to avoid redundant inverse transforms and improve performance. It conveys the idea of improving or optimizing the code, fixing a technical issue, or tweaking a feature.
3.  🚀 - This emoji represents the improvement of performance by refactoring the hit detection code. It conveys the idea of speeding up the code, enhancing the user experience, or delivering a faster feature.
-->
Refactor and optimize graphics hit detection and bounds calculation. Enable a previously skipped graphics bounds test.

> _A test for `Graphics` was skipped_
> _It seemed that the bounds were not clipped_
> _But the bug was a myth_
> _Or someone fixed it_
> _And now the code is more equipped_

### Walkthrough
*  Refactor hit detection code to avoid redundant inverse transform calculations ([link](https://github.com/pixijs/pixijs/pull/9902/files?diff=unified&w=0#diff-14805a3bea6f2de36c750d13ee44f9c2ac1a351ca18a0ad794e3e738cece1590L750-R758), [link](https://github.com/pixijs/pixijs/pull/9902/files?diff=unified&w=0#diff-14805a3bea6f2de36c750d13ee44f9c2ac1a351ca18a0ad794e3e738cece1590L774-R771)) in `src/scene/graphics/shared/GraphicsContext.ts`

