### PR TITLE
v8 add `boundsArea`

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -16,6 +16,7 @@ import { LayerGroup } from './LayerGroup';
 import { definedProps } from './utils/definedProps';
 
 import type { PointData } from '../../maths/point/PointData';
+import type { Rectangle } from '../../maths/shapes/Rectangle';
 import type { Renderable } from '../../rendering/renderers/shared/Renderable';
 import type { BLEND_MODES } from '../../rendering/renderers/shared/state/const';
 import type { View } from '../../rendering/renderers/shared/view/View';
@@ -104,6 +105,8 @@ export interface ContainerOptions<T extends View> extends PixiMixins.ContainerOp
     x?: number;
     /** @see scene.Container#y */
     y?: number;
+    /** @see scene.Container#boundArea */
+    boundsArea?: Rectangle;
 }
 
 export interface Container
@@ -489,6 +492,15 @@ export class Container<T extends View = View> extends EventEmitter<ContainerEven
 
     /** A view that is used to render this container. */
     public readonly view: T;
+
+    /**
+     * An optional bounds area for this container. Setting this rectangle will stop the renderer
+     * from recursively measuring the bounds of each children and instead use this single boundArea.
+     * This is great for optimisation! If for example you have a 1000 spinning particles and you know they all sit
+     * within a specific bounds, then setting it will mean the renderer will not need to measure the
+     * 1000 children to find the bounds. Instead it will just use the bounds you set.
+     */
+    public boundsArea: Rectangle;
 
     constructor(options: Partial<ContainerOptions<T>> = {})
     {

--- a/src/scene/container/bounds/getGlobalBounds.ts
+++ b/src/scene/container/bounds/getGlobalBounds.ts
@@ -73,16 +73,24 @@ export function _getGlobalBounds(
         bounds = bounds.clone();
     }
 
-    if (target.view)
+    if (target.boundsArea)
     {
         bounds.setMatrix(worldTransform);
-
-        target.view.addBounds(bounds);
+        bounds.addRect(target.boundsArea);
     }
-
-    for (let i = 0; i < target.children.length; i++)
+    else
     {
-        _getGlobalBounds(target.children[i], bounds, worldTransform, skipUpdateTransform);
+        if (target.view)
+        {
+            bounds.setMatrix(worldTransform);
+
+            target.view.addBounds(bounds);
+        }
+
+        for (let i = 0; i < target.children.length; i++)
+        {
+            _getGlobalBounds(target.children[i], bounds, worldTransform, skipUpdateTransform);
+        }
     }
 
     if (preserveBounds)

--- a/src/scene/container/bounds/getLocalBounds.ts
+++ b/src/scene/container/bounds/getLocalBounds.ts
@@ -60,16 +60,24 @@ function _getLocalBounds(target: Container, bounds: Bounds, parentTransform: Mat
         bounds = new Bounds();
     }
 
-    if (target.view)
+    if (target.boundsArea)
     {
         bounds.setMatrix(relativeTransform);
-
-        target.view.addBounds(bounds);
+        bounds.addRect(target.boundsArea);
     }
-
-    for (let i = 0; i < target.children.length; i++)
+    else
     {
-        _getLocalBounds(target.children[i], bounds, relativeTransform, rootContainer);
+        if (target.view)
+        {
+            bounds.setMatrix(relativeTransform);
+
+            target.view.addBounds(bounds);
+        }
+
+        for (let i = 0; i < target.children.length; i++)
+        {
+            _getLocalBounds(target.children[i], bounds, relativeTransform, rootContainer);
+        }
     }
 
     if (preserveBounds)

--- a/src/scene/container/bounds/getLocalBounds.ts
+++ b/src/scene/container/bounds/getLocalBounds.ts
@@ -18,7 +18,12 @@ export function getLocalBounds(target: Container, bounds: Bounds, relativeMatrix
 
     relativeMatrix ||= new Matrix();
 
-    if (target.view)
+    if (target.boundsArea)
+    {
+        bounds.setMatrix(relativeMatrix);
+        bounds.addRect(target.boundsArea);
+    }
+    else if (target.view)
     {
         bounds.setMatrix(relativeMatrix);
         target.view.addBounds(bounds);

--- a/tests/scene/getGlobalBounds.tests.ts
+++ b/tests/scene/getGlobalBounds.tests.ts
@@ -1,3 +1,4 @@
+import { Rectangle } from '../../src/maths/shapes/Rectangle';
 import { addMaskBounds } from '../../src/rendering/mask/utils/addMaskBounds';
 import { Bounds } from '../../src/scene/container/bounds/Bounds';
 import { getGlobalBounds } from '../../src/scene/container/bounds/getGlobalBounds';
@@ -251,5 +252,19 @@ describe('getGlobalBounds', () =>
         const bounds = getGlobalBounds(container, true, new Bounds());
 
         expect(bounds).toMatchObject({ minX: 250, minY: 0, maxX: 450, maxY: 200 });
+    });
+
+    it('should get global bounds correctly if a container has boundsArea specified', async () =>
+    {
+        const container = new Container({ label: 'container' });
+
+        const child = new Container({ label: 'child', boundsArea: new Rectangle(0, 0, 500, 500) });
+
+        container.addChild(child);
+
+        child.scale.set(0.5);
+        const bounds = getGlobalBounds(container, false, new Bounds());
+
+        expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500 / 2, maxY: 500 / 2 });
     });
 });

--- a/tests/scene/getGlobalBounds.tests.ts
+++ b/tests/scene/getGlobalBounds.tests.ts
@@ -256,6 +256,15 @@ describe('getGlobalBounds', () =>
 
     it('should get global bounds correctly if a container has boundsArea specified', async () =>
     {
+        const container = new Container({ label: 'container', boundsArea: new Rectangle(0, 0, 500, 500) });
+
+        const bounds = getGlobalBounds(container, false, new Bounds());
+
+        expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500, maxY: 500 });
+    });
+
+    it('should get global bounds correctly if a containers children has boundsArea specified', async () =>
+    {
         const container = new Container({ label: 'container' });
 
         const child = new Container({ label: 'child', boundsArea: new Rectangle(0, 0, 500, 500) });

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -268,4 +268,20 @@ describe('getLocalBounds', () =>
         expect(sprite.width).toBe(200);
         expect(sprite.height).toBe(200);
     });
+
+    it('should get local bounds correctly if a container has boundsArea specified', async () =>
+    {
+        const container = new Container({ label: 'container' });
+
+        container.x = 100;
+
+        const child = new Container({ label: 'child', boundsArea: new Rectangle(0, 0, 500, 500) });
+
+        container.addChild(child);
+
+        child.scale.set(0.5);
+        const bounds = getLocalBounds(container, new Bounds());
+
+        expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500 / 2, maxY: 500 / 2 });
+    });
 });

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -271,6 +271,17 @@ describe('getLocalBounds', () =>
 
     it('should get local bounds correctly if a container has boundsArea specified', async () =>
     {
+        const container = new Container({ label: 'container', boundsArea: new Rectangle(0, 0, 500, 500) });
+
+        container.x = 100;
+
+        const bounds = getLocalBounds(container, new Bounds());
+
+        expect(bounds).toMatchObject({ minX: 0, minY: 0, maxX: 500, maxY: 500 });
+    });
+
+    it('should get local bounds correctly if a containers children has boundsArea specified', async () =>
+    {
         const container = new Container({ label: 'container' });
 
         container.x = 100;


### PR DESCRIPTION
Adds a `boundsArea` to `Container`
allows devs to optimise measurements by managing thjis rectangle themselves if they wish. 
Setting this stops Pixi from measuring all the children inside the container.