### PR TITLE
allow tiling sprite constructor to accept a texture

### DIFF
--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -1,11 +1,11 @@
 import { Cache } from '../../assets/cache/Cache';
+import { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import { Container } from '../container/Container';
 import { definedProps } from '../container/utils/definedProps';
 import { TilingSpriteView } from './TilingSpriteView';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { PointLike } from '../../maths/point/PointLike';
-import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { ContainerOptions } from '../container/Container';
 import type { TilingSpriteViewOptions } from './TilingSpriteView';
 
@@ -80,8 +80,13 @@ export class TilingSprite extends Container<TilingSpriteView>
     /**
      * @param options - The options for creating the tiling sprite.
      */
-    constructor(options?: TilingSpriteOptions)
+    constructor(options?: Texture | TilingSpriteOptions)
     {
+        if (options instanceof Texture)
+        {
+            options = { texture: options };
+        }
+
         const { texture, width, height, applyAnchorToTexture, ...rest } = options ?? {};
 
         super({

--- a/src/scene/sprite-tiling/shader/TilingSpriteShader.ts
+++ b/src/scene/sprite-tiling/shader/TilingSpriteShader.ts
@@ -9,6 +9,8 @@ import { Shader } from '../../../rendering/renderers/shared/shader/Shader';
 import { UniformGroup } from '../../../rendering/renderers/shared/shader/UniformGroup';
 import { tilingBit, tilingBitGl } from './tilingBit';
 
+import type { GlProgram } from '../../../rendering/renderers/gl/shader/GlProgram';
+import type { GpuProgram } from '../../../rendering/renderers/gpu/shader/GpuProgram';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { TextureShader } from '../../mesh/shared/MeshView';
 
@@ -17,13 +19,16 @@ interface TilingSpriteOptions
     texture: Texture;
 }
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 export class TilingSpriteShader extends Shader implements TextureShader
 {
     private _texture: Texture;
 
     constructor(options: TilingSpriteOptions)
     {
-        const gpuProgram = compileHighShaderGpuProgram({
+        gpuProgram ??= compileHighShaderGpuProgram({
             name: 'tiling-sprite-shader',
             bits: [
                 localUniformBit,
@@ -32,7 +37,7 @@ export class TilingSpriteShader extends Shader implements TextureShader
             ],
         });
 
-        const glProgram = compileHighShaderGlProgram({
+        glProgram ??= compileHighShaderGlProgram({
             name: 'tiling-sprite-shader',
             bits: [
                 localUniformBitGl,


### PR DESCRIPTION
easy one!

Allows for the following constructor style:

```
const tilingSprite = new TilingSprite(texture);
```