### PR TITLE
Add data.texture and data.imageFilename to spritesheetLoader

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -146,6 +146,33 @@ export interface ISpritesheetData
  * Default anchor points (see {@link PIXI.Texture#defaultAnchor}), default 9-slice borders
  * (see {@link PIXI.Texture#defaultBorders}) and grouping of animation sprites are currently only
  * supported by TexturePacker.
+ *
+ * Alternative ways for loading spritesheet image if you need more control:
+ *
+ * ```js
+ * import { Assets } from 'pixi.js';
+ *
+ * const sheetTexture = await Assets.load('images/spritesheet.png');
+ * Assets.add({
+ *     alias: 'atlas',
+ *     src: 'images/spritesheet.json'
+ *     data: {texture: sheetTexture} // using of preloaded texture
+ * });
+ * const sheet = await Assets.load('atlas')
+ * ```
+ *
+ * or:
+ *
+ * ```js
+ * import { Assets } from 'pixi.js';
+ *
+ * Assets.add({
+ *     alias: 'atlas',
+ *     src: 'images/spritesheet.json'
+ *     data: {imageFilename: 'my-spritesheet.2x.avif'} // using of custom filename located in "images/my-spritesheet.2x.avif"
+ * });
+ * const sheet = await Assets.load('atlas')
+ * ```
  * @memberof PIXI
  */
 export class Spritesheet<S extends ISpritesheetData = ISpritesheetData>

--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -103,6 +103,11 @@ export const spritesheetAsset = {
 
         async parse(asset: SpriteSheetJson, options: ResolvedAsset, loader: Loader): Promise<Spritesheet>
         {
+            const {
+                texture: imageTexture, // if user need to use preloaded texture
+                imageFilename // if user need to use custom filename (not from jsonFile.meta.image)
+            } = options?.data || { texture: undefined, imageFilename: undefined };
+
             let basePath = utils.path.dirname(options.src);
 
             if (basePath && basePath.lastIndexOf('/') !== (basePath.length - 1))
@@ -110,12 +115,32 @@ export const spritesheetAsset = {
                 basePath += '/';
             }
 
-            let imagePath = basePath + asset.meta.image;
+            let texture: Texture;
 
-            imagePath = copySearchParams(imagePath, options.src);
+            if (imageTexture && imageTexture.baseTexture)
+            {
+                texture = imageTexture;
+            }
+            else
+            {
+                let imagePath = '';
 
-            const assets = await loader.load<Texture>([imagePath]);
-            const texture = assets[imagePath];
+                if (imageFilename)
+                {
+                    imagePath = basePath + imageFilename;
+                }
+                else
+                {
+                    imagePath = basePath + asset.meta.image;
+                }
+
+                imagePath = copySearchParams(imagePath, options.src);
+
+                const assets = await loader.load<Texture>([imagePath]);
+
+                texture = assets[imagePath];
+            }
+
             const spritesheet = new Spritesheet(
                 texture.baseTexture,
                 asset,

--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -106,7 +106,7 @@ export const spritesheetAsset = {
             const {
                 texture: imageTexture, // if user need to use preloaded texture
                 imageFilename // if user need to use custom filename (not from jsonFile.meta.image)
-            } = options?.data || { texture: undefined, imageFilename: undefined };
+            } = options?.data ?? {};
 
             let basePath = utils.path.dirname(options.src);
 
@@ -123,18 +123,7 @@ export const spritesheetAsset = {
             }
             else
             {
-                let imagePath = '';
-
-                if (imageFilename)
-                {
-                    imagePath = basePath + imageFilename;
-                }
-                else
-                {
-                    imagePath = basePath + asset.meta.image;
-                }
-
-                imagePath = copySearchParams(imagePath, options.src);
+                const imagePath = copySearchParams(basePath + (imageFilename ?? asset.meta.image), options.src);
 
                 const assets = await loader.load<Texture>([imagePath]);
 

--- a/packages/spritesheet/test/spritesheetAsset.tests.ts
+++ b/packages/spritesheet/test/spritesheetAsset.tests.ts
@@ -1,9 +1,10 @@
 import { Cache, loadJson, loadTextures } from '@pixi/assets';
-import { Texture, utils } from '@pixi/core';
+import { BaseTexture, Texture, utils } from '@pixi/core';
 import { Spritesheet, spritesheetAsset } from '@pixi/spritesheet';
 import { Loader } from '../../assets/src/loader/Loader';
 
 import type { CacheParser } from '@pixi/assets';
+import type { SpriteSheetJson } from '@pixi/spritesheet';
 
 describe('spritesheetAsset', () =>
 {
@@ -43,6 +44,38 @@ describe('spritesheetAsset', () =>
         expect(senseiTexture.baseTexture.valid).toBe(true);
         expect(senseiTexture.width).toBe(125);
         expect(senseiTexture.height).toBe(125);
+    });
+
+    it('should use preloaded texture via data.texture instead of loading texture using imagePath', async () =>
+    {
+        const spritesheetJsonUrl = `${serverPath}spritesheet.json`;
+        const preloadedTexture = Texture.from(new BaseTexture());
+        const json = await loadJson.load<SpriteSheetJson>(spritesheetJsonUrl);
+        const spritesheet = await spritesheetAsset.loader.parse<Spritesheet>(
+            json,
+            {
+                src: spritesheetJsonUrl,
+                data: { texture: preloadedTexture }
+            });
+
+        expect(spritesheet.baseTexture).toEqual(preloadedTexture.baseTexture);
+    });
+
+    it('should use image filename via data.imageFilename instead of meta.image', async () =>
+    {
+        const spritesheetJsonUrl = `${serverPath}spritesheet.json`;
+        const customImageFilename = 'multi-pack-1.png';
+        const json = await loadJson.load<SpriteSheetJson>(spritesheetJsonUrl);
+        const spritesheet = await spritesheetAsset.loader.parse<Spritesheet>(
+            json,
+            {
+                src: spritesheetJsonUrl,
+                data: { imageFilename: customImageFilename }
+            }, loader);
+
+        const texture = await loader.load({ src: `${serverPath}${customImageFilename}` });
+
+        expect(spritesheet.baseTexture).toEqual(texture.baseTexture);
     });
 
     it('should do nothing if the resource is not JSON', async () =>


### PR DESCRIPTION
This PR add new features for [spritesheetLoader](https://github.com/pixijs/pixijs/blob/c04c09c50874fef9296555af23e25fe58cc808a9/packages/spritesheet/src/spritesheetAsset.ts#L92) that helps control loading of spritesheet image (for example if you want to manage progress or resolution/format by yourself).

Features:
1. Use preloaded texture via `{data: {texture: myTexture}}` instead of loading texture using imagePath
2. Use image custom filename via `{data: {imageFilename: 'myFilename.2x.avif'}}` instead of jsonFile.meta.image

PR Checklist:
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
