### PR TITLE
v8 little tweaks for texture unloading

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -222,7 +222,7 @@ export class GlTextureSystem implements System, CanvasGenerator
     {
         const gl = this._gl;
 
-        const glTexture = this._glTextures[source.uid];
+        const glTexture = this.getGlSource(source);
 
         gl.bindTexture(gl.TEXTURE_2D, glTexture.texture);
 

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -166,7 +166,11 @@ export class GpuTextureSystem implements System, CanvasGenerator
     {
         const gpuTexture = this._gpuSources[source.uid];
 
-        if (gpuTexture.width !== source.pixelWidth || gpuTexture.height !== source.pixelHeight)
+        if (!gpuTexture)
+        {
+            this.initSource(source);
+        }
+        else if (gpuTexture.width !== source.pixelWidth || gpuTexture.height !== source.pixelHeight)
         {
             this._textureViewHash[source.uid] = null;
             this._bindGroupHash[source.uid] = null;


### PR DESCRIPTION
should catch any issues where a texture may have been unloaded,

but then access a gpu texture is required before its uploaded again in the render loop