### PR TITLE
Add number type support to `scale` field of `ISpritesheetData` 

### DIFF
--- a/packages/spritesheet/src/Spritesheet.ts
+++ b/packages/spritesheet/src/Spritesheet.ts
@@ -53,7 +53,7 @@ export interface ISpritesheetData
             name: string;
             opacity: number;
         }[];
-        scale: string;
+        scale: string | number;
         size?: {
             h: number;
             w: number;
@@ -254,7 +254,7 @@ export class Spritesheet<S extends ISpritesheetData = ISpritesheetData>
         if (resolution === null)
         {
             // Use the scale value or default to 1
-            resolution = parseFloat(scale ?? '1');
+            resolution = typeof scale === 'number' ? scale : parseFloat(scale ?? '1');
         }
 
         // For non-1 resolutions, update baseTexture

--- a/packages/spritesheet/test/Spritesheet.tests.ts
+++ b/packages/spritesheet/test/Spritesheet.tests.ts
@@ -230,4 +230,30 @@ describe('Spritesheet', () =>
             done();
         });
     });
+
+    it('should parse scale correctly', () =>
+    {
+        [
+            {
+                frames: {},
+                meta: { scale: '1' } // scale can be a string
+            },
+            {
+                frames: {},
+                meta: { scale: 1 } // scale can be a number
+            },
+            {
+                frames: {},
+                meta: {} // if scale not set, default to 1
+            } as unknown as ISpritesheetData,
+        ].forEach((toTest) =>
+        {
+            const baseTexture = new BaseTexture();
+            const spritesheet = new Spritesheet(baseTexture, toTest);
+
+            expect(spritesheet.resolution).toEqual(1);
+
+            spritesheet.destroy(true);
+        });
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
In type `ISpritesheetData`, the type of `meta.scale` is `string`, which fits the output Json of TexturePacker.

```
"meta": {
	"app": "https://www.codeandweb.com/texturepacker",
	"version": "1.0",
	"image": "building1.png",
	"format": "RGBA8888",
	"size": {"w":128,"h":126},
	"scale": "0.5",
	"smartupdate": "$TexturePacker:SmartUpdate:1cb0f14cbdd5e7bcecd332ecd0eaa9f7:8acde9d234ecca966a410602c71bffad:6046b8eb706ddefaa771c33ceb7cb6d5$"
}
```

However, when using pixijs/assetpack to generate spritesheets, the output `scale` type is `number`.

```
    "meta": {
        "app": "http://github.com/odrick/free-tex-packer-core",
        "version": "0.3.4",
        "image": "spritesheet.png",
        "format": "RGBA8888",
        "size": {
            "w": 134,
            "h": 126
        },
        "scale": 1
    }
```

Pass the Json to `Spritesheet` constructor

```javascript
const sheet = new Spritesheet(baseTexture, data);
```

will cause a Typescript error:

```
TS2345: Argument of type
{ frames: { frame: ISpritesheetFrameData; }; meta: { scale: number; }; }
is not assignable to parameter of type  ISpritesheetData 
The types of  meta.scale  are incompatible between these types.
Type  number  is not assignable to type  string 
```

This PR changes the signature of `scale` to `string | number` to support both cases.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
