### PR TITLE
invert texture fill matrix

### DIFF
--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -82,7 +82,7 @@ export function convertFillInputToFillStyle(
     {
         if (style.texture !== Texture.WHITE)
         {
-            const m = style.matrix ? style.matrix.invert() : new Matrix();
+            const m = style.matrix?.invert() || new Matrix();
 
             m.scale(
                 1 / style.texture.frame.width,

--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -82,7 +82,7 @@ export function convertFillInputToFillStyle(
     {
         if (style.texture !== Texture.WHITE)
         {
-            const m = style.matrix || new Matrix();
+            const m = style.matrix ? style.matrix.invert() : new Matrix();
 
             m.scale(
                 1 / style.texture.frame.width,

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -39,9 +39,9 @@ describe('Graphics', () =>
         });
     });
 
-    describe('lineTextureStyle', () =>
+    describe('Stroke & Fill', () =>
     {
-        it('should support object parameter', () =>
+        it('should support stroke object parameter and use defaults', () =>
         {
             const graphics = new Graphics();
             const matrix = new Matrix();
@@ -76,6 +76,52 @@ describe('Graphics', () =>
             });
 
             graphics.destroy();
+        });
+
+        it('should support fill object parameter and use defaults', () =>
+        {
+            const graphics = new Graphics();
+            const matrix = new Matrix();
+            const texture = Texture.WHITE;
+
+            graphics.fillStyle = {
+                color: 0xff0000,
+                alpha: 0.5,
+                matrix,
+                texture,
+            };
+
+            expect(graphics.fillStyle).toEqual({
+                ...GraphicsContext.defaultFillStyle,
+                color: 0xff0000,
+                alpha: 0.5,
+                matrix,
+                texture,
+            });
+
+            // expect defaults from empty assignment
+            graphics.fillStyle = {};
+
+            expect(graphics.fillStyle).toEqual({
+                ...GraphicsContext.defaultFillStyle,
+                matrix: null,
+                texture: Texture.WHITE,
+            });
+
+            graphics.destroy();
+        });
+
+        it('should invert matrix when used with texture fill', () =>
+        {
+            const matrix = new Matrix();
+            const texture = Texture.EMPTY;
+
+            matrix.scale(2, 3);
+
+            const style = convertFillInputToFillStyle({ texture, matrix }, GraphicsContext.defaultFillStyle);
+
+            expect(style.matrix.a).toBe(1 / 2);
+            expect(style.matrix.d).toBe(1 / 3);
         });
     });
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9107ec3</samp>

Improved the graphics API and fixed a texture fill bug. Added and updated test cases for `Graphics.test.ts` and corrected the matrix inversion logic in `convertFillInputToFillStyle.ts`.