### PR TITLE
add setFillStyle setStrokeStyle methods to graphics api

### DIFF
--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -1,16 +1,15 @@
 import { deprecation } from '../../../utils/logging/deprecation';
 import { Container } from '../../container/Container';
 import { GraphicsContext } from './GraphicsContext';
-// @ts-expect-error - used for jsdoc typedefs
-// eslint-disable-next-line @typescript-eslint/no-duplicate-imports
-import { ConvertedFillStyle, ConvertedStrokeStyle } from './GraphicsContext';
 import { GraphicsView } from './GraphicsView';
 
 import type { ColorSource } from '../../../color/Color';
 import type { Matrix } from '../../../maths/matrix/Matrix';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { ContainerOptions } from '../../container/Container';
-import type { FillStyleInputs } from './GraphicsContext';
+// @ts-expect-error - used for jsdoc typedefs
+// eslint-disable-next-line @typescript-eslint/no-duplicate-imports
+import type { ConvertedFillStyle, ConvertedStrokeStyle, FillStyleInputs } from './GraphicsContext';
 
 /**
  * Options for the Graphics.
@@ -77,6 +76,14 @@ export class Graphics extends Container<GraphicsView>
     }
 
     // --------------------------------------- GraphicsContext methods ---------------------------------------
+    public setFillStyle(style: FillStyleInputs): this
+    {
+        return this._callContextMethod('setFillStyle', [style]);
+    }
+    public setStrokeStyle(style: FillStyleInputs): this
+    {
+        return this._callContextMethod('setStrokeStyle', [style]);
+    }
     /** @deprecated 8.0.0 */
     public fill(color: ColorSource, alpha: number): this;
     public fill(style?: FillStyleInputs): this;

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -153,6 +153,20 @@ export class GraphicsContext extends EventEmitter<{
         this._strokeStyle = convertFillInputToFillStyle(value, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
     }
 
+    public setFillStyle(style: FillStyleInputs): this
+    {
+        this._fillStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultFillStyle);
+
+        return this;
+    }
+
+    public setStrokeStyle(style: FillStyleInputs): this
+    {
+        this._strokeStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
+
+        return this;
+    }
+
     public texture(texture: Texture): this;
     public texture(texture: Texture, tint: ColorSource): this;
     public texture(texture: Texture, tint: ColorSource, dx: number, dy: number): this;

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -110,6 +110,8 @@ describe('Graphics', () =>
                 .ellipse(100, 100, 50, 75)
                 .circle(100, 100, 50)
                 .path(new GraphicsPath())
+                .setStrokeStyle({ width: 1, color: 0xffffff, alpha: 1, texture })
+                .setFillStyle({ color: 0xffffff, alpha: 1, texture })
                 .lineTo(200, 200)
                 .moveTo(100, 100)
                 .quadraticCurveTo(100, 100, 200, 200)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e032337</samp>

Added `setFillStyle` and `setStrokeStyle` methods to `Graphics` class to allow setting fill and stroke styles with different inputs, such as textures. Updated `GraphicsContext` class to handle the conversion and validation of the style inputs. Added tests for the new methods in `Graphics.test.ts`.