### PR TITLE
Docs: Remove Accessibility Namespace Default Value

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -28,6 +28,7 @@ import type { isMobileResult } from '../utils/browser/isMobile';
  * @namespace accessibility
  */
 
+/** @ignore */
 const KEY_CODE_TAB = 9;
 
 const DIV_TOUCH_SIZE = 100;


### PR DESCRIPTION
Resolves [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=46755362).

- JSDoc seems to infer that the `KEY_CODE_TAB` const after the namespace declaration is its default value. Here we can simply ignore it.