### PR TITLE
Feature: Make Runner type-safe

### DIFF
--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,15 +1,15 @@
 export type RunnerListenerCallback<ARG extends any[]> = (...args: ARG) => unknown;
 
-export type ValidRunnerItem<T extends string, ARG extends unknown[] = any[]> =
+export type RunnerItemValid<T extends string, ARG extends unknown[] = any[]> =
     { [K in T]: RunnerListenerCallback<ARG> | unknown };
 
-export type AnyRunnerItem = Record<string, unknown>;
+export type RunnerItemAny = Record<string, unknown>;
 
-export type EmptyRunnerItem = Record<string, never>;
+export type RunnerItemEmpty = Record<string, never>;
 
 export type RunnerItem<T, ARG extends unknown[] = any[]> =
     T extends string ?
-        ValidRunnerItem<T, ARG> & AnyRunnerItem | EmptyRunnerItem :
+        RunnerItemValid<T, ARG> & RunnerItemAny | RunnerItemEmpty :
         unknown;
 
 /**

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,3 +1,17 @@
+export type RunnerListenerCallback<ARG extends any[]> = (...args: ARG) => unknown;
+
+export type ValidRunnerItem<T extends string, ARG extends unknown[] = any[]> =
+    { [K in T]: RunnerListenerCallback<ARG> | unknown };
+
+export type AnyRunnerItem = Record<string, unknown>;
+
+export type EmptyRunnerItem = Record<string, never>;
+
+export type RunnerItem<T, ARG extends unknown[] = any[]> =
+    T extends string ?
+        ValidRunnerItem<T, ARG> & AnyRunnerItem | EmptyRunnerItem :
+        unknown;
+
 /**
  * A Runner is a highly performant and simple alternative to signals. Best used in situations
  * where events are dispatched to many objects at high frequency (say every frame!)
@@ -41,18 +55,57 @@
  *
  * myGame.update.emit(time);
  * ```
+ *
+ * Type safety:
+ *
+ * ```ts
+ *
+ * let runner: Runner<'update', [number]>;
+ *
+ * // This won't work because the function name 'update' is expected
+ * runner = new Runner('destroy');
+ *
+ * // This is fine
+ * runner = new Runner('update');
+ *
+ * // This won't work because the number is expected
+ * runner.emit("10");
+ *
+ * // This is fine
+ * runner.emit(10);
+ *
+ * // This won't work because provided object does not contain 'update' key
+ * runner.add({
+ *     destroy: function() {
+ *         // Destroy the game
+ *     },
+ * });
+ *
+ * // This is fine
+ * runner.add({
+ *     update: function(time) {
+ *         // Update my gamey state
+ *     },
+ *     destroy: function() {
+ *         // Destroy the game
+ *     },
+ * });
+ *
+ * ```
+ * @template T - The event type.
+ * @template ARG - The argument types for the event handler functions.
  * @memberof PIXI
  */
-export class Runner
+export class Runner<T = any, ARG extends unknown[] = any[]>
 {
     public items: any[];
-    private _name: string;
+    private _name: T;
     private _aliasCount: number;
 
     /**
      * @param name - The function name that will be executed on the listeners added to this Runner.
      */
-    constructor(name: string)
+    constructor(name: T)
     {
         this.items = [];
         this._name = name;
@@ -65,8 +118,8 @@ export class Runner
      * @param {...any} params - (optional) parameters to pass to each listener
      */
     /*  eslint-enable jsdoc/require-param, jsdoc/check-param-names */
-    public emit(a0?: unknown, a1?: unknown, a2?: unknown, a3?: unknown,
-        a4?: unknown, a5?: unknown, a6?: unknown, a7?: unknown): this
+    public emit(a0?: ARG[0], a1?: ARG[1], a2?: ARG[2], a3?: ARG[3],
+        a4?: ARG[4], a5?: ARG[5], a6?: ARG[6], a7?: ARG[7]): this
     {
         if (arguments.length > 8)
         {
@@ -117,7 +170,7 @@ export class Runner
      * The scope used will be the object itself.
      * @param {any} item - The object that will be listening.
      */
-    public add(item: unknown): this
+    public add(item: RunnerItem<T, ARG>): this
     {
         if ((item as any)[this._name])
         {
@@ -133,7 +186,7 @@ export class Runner
      * Remove a single listener from the dispatch queue.
      * @param {any} item - The listener that you would like to remove.
      */
-    public remove(item: unknown): this
+    public remove(item: RunnerItem<T, ARG>): this
     {
         const index = this.items.indexOf(item);
 
@@ -150,7 +203,7 @@ export class Runner
      * Check to see if the listener is already in the Runner
      * @param {any} item - The listener that you would like to check.
      */
-    public contains(item: unknown): boolean
+    public contains(item: RunnerItem<T, ARG>): boolean
     {
         return this.items.includes(item);
     }
@@ -185,7 +238,7 @@ export class Runner
      * The name of the runner.
      * @readonly
      */
-    public get name(): string
+    public get name(): T
     {
         return this._name;
     }

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,11 +1,11 @@
 export type RunnerListenerCallback<ARG extends unknown[] = any[]> = (...args: ARG) => unknown;
 
-export type RunnerItemValid<T extends string, ARG extends unknown[] = any[]> =
+type RunnerItemValid<T extends string, ARG extends unknown[] = any[]> =
     { [K in T]: RunnerListenerCallback<ARG> | unknown };
 
-export type RunnerItemAny = Record<string, unknown>;
+type RunnerItemAny = Record<string, unknown>;
 
-export type RunnerItemEmpty = Record<string, never>;
+type RunnerItemEmpty = Record<string, never>;
 
 export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
     T extends string ?

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -62,7 +62,7 @@ export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
  *
  * import { Runner } from '@pixi/runner';
  *
- * const runner: Runner<'update', [number]>;
+ * let runner: Runner<'update', [number]>;
  *
  * // This won't work because the function name 'update' is expected
  * runner = new Runner('destroy');

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -105,7 +105,7 @@ export class Runner<T = any, ARG extends unknown[] = any[]>
     private _aliasCount: number;
 
     /**
-     * @param name - The function name that will be executed on the listeners added to this Runner.
+     * @param {string} name - The function name that will be executed on the listeners added to this Runner.
      */
     constructor(name: T)
     {
@@ -238,7 +238,7 @@ export class Runner<T = any, ARG extends unknown[] = any[]>
 
     /**
      * The name of the runner.
-     * @readonly
+     * @type {string}
      */
     public get name(): T
     {

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -60,7 +60,9 @@ export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
  *
  * ```ts
  *
- * let runner: Runner<'update', [number]>;
+ * import { Runner } from '@pixi/runner';
+ *
+ * const runner: Runner<'update', [number]>;
  *
  * // This won't work because the function name 'update' is expected
  * runner = new Runner('destroy');

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,4 +1,4 @@
-export type RunnerListenerCallback<ARG extends any[]> = (...args: ARG) => unknown;
+export type RunnerListenerCallback<ARG extends unknown[] = any[]> = (...args: ARG) => unknown;
 
 export type RunnerItemValid<T extends string, ARG extends unknown[] = any[]> =
     { [K in T]: RunnerListenerCallback<ARG> | unknown };
@@ -7,7 +7,7 @@ export type RunnerItemAny = Record<string, unknown>;
 
 export type RunnerItemEmpty = Record<string, never>;
 
-export type RunnerItem<T, ARG extends unknown[] = any[]> =
+export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
     T extends string ?
         RunnerItemValid<T, ARG> & RunnerItemAny | RunnerItemEmpty :
         unknown;

--- a/packages/runner/test/Runner.tests.ts
+++ b/packages/runner/test/Runner.tests.ts
@@ -21,10 +21,19 @@ describe('Runner', () =>
             },
         };
 
-        runner.emit(10);
         runner.add(item);
+        runner.emit(10);
 
-        expect(item).toHaveBeenCalledWith(10);
+        expect(item.update).toHaveBeenCalledWith(
+            10,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+        );
     });
 
     it('should implement emit', () =>

--- a/packages/runner/test/Runner.tests.ts
+++ b/packages/runner/test/Runner.tests.ts
@@ -8,6 +8,25 @@ describe('Runner', () =>
         expect(typeof Runner).toEqual('function');
     });
 
+    it('should instantiate a type safe runner', () =>
+    {
+        const runner = new Runner<'update', [number]>('update');
+
+        const item = {
+            id: 0,
+            update: jest.fn(),
+            destroy()
+            {
+                // Destroy the game
+            },
+        };
+
+        runner.emit(10);
+        runner.add(item);
+
+        expect(item).toHaveBeenCalledWith(10);
+    });
+
     it('should implement emit', () =>
     {
         const complete = new Runner('complete');


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
I migrated my TypeScript project from Signals to Runner, and it's amazing! However, I thought that adding some type safety to it wouldn't hurt.

The feature is 100% backward compatible. The previous syntax will continue working.

Here's the new syntax for the instantiation of type-safe Runner:

``` typescript
let runner: Runner<'update', [number]>;

// This won't work because the function name 'update' is expected
runner = new Runner('destroy');

// This is fine
runner = new Runner('update');

// This won't work because the number is expected
runner.emit("10");

// This is fine
runner.emit(10);

// This won't work because provided object does not contain 'update' key
runner.add({
    destroy: function() {
        // Destroy the game
    },
});

// This is fine
runner.add({
    update: function(time) {
        // Update my gamey state
    },
    destroy: function() {
        // Destroy the game
    },
});
```

Will be appreciated for review.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
