### PR TITLE
Defer early allocation of canvas in Texture

### DIFF
--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -380,47 +380,48 @@ export class Texture extends EventEmitter<{
         return this._source;
     }
 
+    private static _emptyTexture: Texture;
+    private static _whiteTexture: Texture;
+
     /** an Empty Texture used internally by the engine */
-    public static EMPTY: Texture;
+    public static get EMPTY(): Texture {
+        if (!this._emptyTexture) {
+            const texture = new Texture({});
+            texture.label = "EMPTY";
+            texture.destroy = NOOP;
+            this._emptyTexture = texture;
+        }
+        return this._emptyTexture;
+    }
+
     /** a White texture used internally by the engine */
-    public static WHITE: Texture;
+    public static get WHITE(): Texture {
+        if (!this._whiteTexture) {
+            // create a white canvas
+            const canvas = DOMAdapter.get().createCanvas();
+
+            const size = 1;
+
+            canvas.width = size;
+            canvas.height = size;
+
+            const ctx = canvas.getContext("2d");
+
+            ctx.fillStyle = "#ffffff";
+            ctx.fillRect(0, 0, size, size);
+
+            const texture = new Texture({
+                source: new ImageSource({
+                    resource: canvas,
+                    alphaMode: "premultiply-alpha-on-upload",
+                }),
+            });
+
+            texture.label = "WHITE";
+            texture.destroy = NOOP;
+
+            this._whiteTexture = texture;
+        }
+        return this._whiteTexture;
+    }
 }
-
-Texture.EMPTY = new Texture({
-
-});
-
-Texture.EMPTY.label = 'EMPTY';
-Texture.EMPTY.destroy = NOOP;
-
-// create a white canvas
-const canvas = DOMAdapter.get().createCanvas();
-
-const size = 1;
-
-canvas.width = size;
-canvas.height = size;
-
-const ctx = canvas.getContext('2d');
-
-ctx.fillStyle = '#ffffff';
-ctx.fillRect(0, 0, size, size);
-
-// draw red triangle
-ctx.beginPath();
-ctx.moveTo(0, 0);
-ctx.lineTo(size, 0);
-ctx.lineTo(size, size);
-ctx.closePath();
-ctx.fillStyle = '#ffffff';
-ctx.fill();
-
-Texture.WHITE = new Texture({
-    source: new ImageSource({
-        resource: canvas,
-        alphaMode: 'premultiply-alpha-on-upload'
-    }),
-});
-
-Texture.WHITE.label = 'WHITE';
-Texture.WHITE.destroy = NOOP;


### PR DESCRIPTION
Attempts to fix #9946.

`Texture.WHITE` is being generated using a Canvas object. Doing so in the global scope of the file means that when we call `DOMAdapter.get().createCanvas()` we might get the wrong adapter. For example, if Pixi is being used in a Web Worker, the DOMAdapter should have been set to a different one than the default. Because this texture is being generated in the global scope however, users of the library don't have time to set the right adapter before the wrong adapter is invoked.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
