### PR TITLE
Fix [Assets] path containing period does not load correctly

### DIFF
--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -311,19 +311,7 @@ export const path: Path = {
             if (arg.length > 0)
             {
                 if (joined === undefined) joined = arg;
-                else
-                {
-                    const prevArg = segments[i - 1] ?? '';
-
-                    if (this.extname(prevArg))
-                    {
-                        joined += `/../${arg}`;
-                    }
-                    else
-                    {
-                        joined += `/${arg}`;
-                    }
-                }
+                else joined += `/${arg}`;
             }
         }
         if (joined === undefined) { return '.'; }

--- a/packages/utils/test/path.tests.ts
+++ b/packages/utils/test/path.tests.ts
@@ -113,12 +113,12 @@ describe('Paths', () =>
     it('should join paths', () =>
     {
         expect(path.join('http://foo.com/index.html', '../bar/baz/file')).toBe('http://foo.com/bar/baz/file');
-        expect(path.join('http://foo.com/bar/index.html', '../baz/file')).toBe('http://foo.com/baz/file');
-        expect(path.join('http://foo.com/bar/index.html', './baz/file')).toBe('http://foo.com/bar/baz/file');
-        expect(path.join('http://foo.com/bar/index.html', 'baz/file')).toBe('http://foo.com/bar/baz/file');
-        expect(path.join('http://foo.com/bar/index.html?var=a', '../baz/file')).toBe('http://foo.com/baz/file');
-        expect(path.join('http://foo.com/bar/index.html?var=a#hash', '../baz/file')).toBe('http://foo.com/baz/file');
-        expect(path.join('http://foo.com/bar/index.html#hash', '../baz/file')).toBe('http://foo.com/baz/file');
+        expect(path.join('http://foo.com/bar/index.html', '../baz/file')).toBe('http://foo.com/bar/baz/file');
+        expect(path.join('http://foo.com/bar/', './baz/file')).toBe('http://foo.com/bar/baz/file');
+        expect(path.join('http://foo.com/bar/', 'baz/file')).toBe('http://foo.com/bar/baz/file');
+        expect(path.join('http://foo.com/bar/index.html?var=a', '../baz/file')).toBe('http://foo.com/bar/baz/file');
+        expect(path.join('http://foo.com/bar/index.html?var=a#hash', '../baz/file')).toBe('http://foo.com/bar/baz/file');
+        expect(path.join('http://foo.com/bar/index.html#hash', '../baz/file')).toBe('http://foo.com/bar/baz/file');
 
         expect(path.join('http://foo.com', '../bar/baz/file')).toBe('http://foo.com/bar/baz/file');
         expect(path.join('https://foo.com', '../bar/baz/file')).toBe('https://foo.com/bar/baz/file');
@@ -140,6 +140,9 @@ describe('Paths', () =>
         expect(path.join('/foo', 'bar/baz/file', '../test')).toBe('/foo/bar/baz/test');
         expect(path.join('C:/foo', 'bar/baz/file', '../test')).toBe('C:/foo/bar/baz/test');
         expect(path.join('C:\\foo', 'bar/baz/file', '../test')).toBe('C:/foo/bar/baz/test');
+
+        expect(path.join('http://foo.com/baz3.0', '/bar/file')).toBe('http://foo.com/baz3.0/bar/file');
+        expect(path.join('http://foo.com/baz3.0', '../bar/file')).toBe('http://foo.com/bar/file');
     });
 
     it('should get the directory name', () =>
@@ -256,21 +259,21 @@ describe('Paths', () =>
         expect(path.toAbsolute('mac.png', '/foo/bar')).toEqual(`/foo/bar/mac.png`);
 
         // paths with extensions
-        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/index.html'))
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/'))
             .toEqual(`http://example.com/page-1/browser.png`);
-        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/index.html'))
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/'))
             .toEqual(`http://example.com/page-1/img/browser.png`);
-        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/index.html'))
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/'))
             .toEqual(`http://example.com/page-1/img/browser.png`);
-        expect(path.toAbsolute('windows.png', 'C:/foo/bar/index.html')).toEqual(`C:/foo/bar/windows.png`);
-        expect(path.toAbsolute('mac.png', '/foo/bar/index.html')).toEqual(`/foo/bar/mac.png`);
+        expect(path.toAbsolute('windows.png', 'C:/foo/bar/')).toEqual(`C:/foo/bar/windows.png`);
+        expect(path.toAbsolute('mac.png', '/foo/bar/')).toEqual(`/foo/bar/mac.png`);
 
         // path with query string
-        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/index.html?var=a#hash'))
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1?var=a#hash'))
             .toEqual(`http://example.com/page-1/browser.png`);
-        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/index.html?var=a#hash'))
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1?var=a#hash'))
             .toEqual(`http://example.com/page-1/img/browser.png`);
-        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/index.html?var=a#hash'))
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1?var=a#hash'))
             .toEqual(`http://example.com/page-1/img/browser.png`);
         expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1?var=a#hash'))
             .toEqual(`http://example.com/page-1/img/browser.png`);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix for #9393 
I did as @SuperSodaSea suggested:

> In my opinion we should not remove the filename based on its "extension" in the` join()` / `toAbsolute()`, but remove it if needed manually before calling them.

Some tests have been updated as they are no longer relevant.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
