### PR TITLE
adjust texture.WHITE creation

### DIFF
--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -1,17 +1,15 @@
 import EventEmitter from 'eventemitter3';
 import { Cache } from '../../../../assets/cache/Cache';
-import { DOMAdapter } from '../../../../environment/adapter';
 import { groupD8 } from '../../../../maths/matrix/groupD8';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { uid } from '../../../../utils/data/uid';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
 import { NOOP } from '../../../../utils/misc/NOOP';
-import { ImageSource } from './sources/ImageSource';
+import { BufferImageSource, type BufferSourceOptions } from './sources/BufferSource';
 import { resourceToTexture } from './sources/resourceToTexture';
 import { TextureSource } from './sources/TextureSource';
 import { TextureMatrix } from './TextureMatrix';
 
-import type { BufferSourceOptions } from './sources/BufferSource';
 import type { TextureSourceOptions } from './sources/TextureSource';
 
 /** Stores the width of the non-scalable borders, for example when used with {@link scene.NineSlicePlane} texture. */
@@ -387,40 +385,19 @@ export class Texture extends EventEmitter<{
 }
 
 Texture.EMPTY = new Texture({
-
+    label: 'EMPTY',
 });
 
-Texture.EMPTY.label = 'EMPTY';
 Texture.EMPTY.destroy = NOOP;
 
-// create a white canvas
-const canvas = DOMAdapter.get().createCanvas();
-
-const size = 1;
-
-canvas.width = size;
-canvas.height = size;
-
-const ctx = canvas.getContext('2d');
-
-ctx.fillStyle = '#ffffff';
-ctx.fillRect(0, 0, size, size);
-
-// draw red triangle
-ctx.beginPath();
-ctx.moveTo(0, 0);
-ctx.lineTo(size, 0);
-ctx.lineTo(size, size);
-ctx.closePath();
-ctx.fillStyle = '#ffffff';
-ctx.fill();
-
 Texture.WHITE = new Texture({
-    source: new ImageSource({
-        resource: canvas,
+    source: new BufferImageSource({
+        resource: new Uint8Array([255, 255, 255, 255]),
+        width: 1,
+        height: 1,
         alphaMode: 'premultiply-alpha-on-upload'
     }),
+    label: 'WHITE',
 });
 
-Texture.WHITE.label = 'WHITE';
 Texture.WHITE.destroy = NOOP;


### PR DESCRIPTION
hey @Zyie! Heard `Texture.WHITE` was giving us jip!

After a chat with @bigtimebuddy, we realised it did not need to be created from a canvas and instead could be created from a Buffer.

Hope this helps to solve the Webworker issues!