### PR TITLE
v8 webGL - allow ubos to be optional

### DIFF
--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -60,7 +60,14 @@ export class GlBatchAdaptor implements BatcherAdaptor
 
         renderer.shader.bind(this._shader, this._didUpload);
 
-        renderer.shader.bindUniformBlock(renderer.globalUniforms.uniformGroup, 'globalUniforms', 0);
+        if (renderer.supportsUbo)
+        {
+            renderer.shader.bindUniformBlock(renderer.globalUniforms.uniformGroup, 'globalUniforms', 0);
+        }
+        else
+        {
+            renderer.shader.updateUniformGroup(renderer.globalUniforms.uniformGroup);
+        }
 
         renderer.geometry.bind(geometry, this._shader.glProgram);
     }

--- a/src/rendering/high-shader/shader-bits/globalUniformsBit.ts
+++ b/src/rendering/high-shader/shader-bits/globalUniformsBit.ts
@@ -14,8 +14,8 @@ export const globalUniformsBit = {
     }
 };
 
-export const globalUniformsBitGl = {
-    name: 'global-uniforms-bit',
+export const globalUniformsUBOBitGl = {
+    name: 'global-uniforms-ubo-bit',
     vertex: {
         header: /* glsl */`
           uniform globalUniforms {
@@ -26,4 +26,17 @@ export const globalUniformsBitGl = {
           };
         `
     }
+};
+
+export const globalUniformsBitGl = {
+    name: 'global-uniforms-bit',
+    vertex: {
+        header: /* glsl */`
+          uniform mat3 projectionMatrix;
+          uniform mat3 worldTransformMatrix;
+          uniform vec4 worldColorAlpha;
+          uniform vec2 uResolution;
+        `
+    }
+
 };

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -84,6 +84,7 @@ export class WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
             systems,
             renderPipes,
             renderPipeAdaptors,
+            supportsUbo: false,
         };
 
         super(systemConfig);

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -87,7 +87,7 @@ export class GlShaderSystem
                     }
                     else
                     {
-                        this._updateUniformGroup(resource);
+                        this.updateUniformGroup(resource);
                     }
                 }
                 else if (resource instanceof BufferResource)
@@ -126,7 +126,7 @@ export class GlShaderSystem
         }
     }
 
-    private _updateUniformGroup(uniformGroup: UniformGroup): void
+    public updateUniformGroup(uniformGroup: UniformGroup): void
     {
         this._renderer.uniformGroup.updateUniformGroup(uniformGroup, this._activeProgram, defaultSyncData);
     }

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -83,6 +83,7 @@ export class WebGPURenderer<T extends ICanvas = HTMLCanvasElement>
             systems,
             renderPipes,
             renderPipeAdaptors,
+            supportsUbo: true,
         };
 
         super(systemConfig);

--- a/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
@@ -44,6 +44,7 @@ interface GlobalUniformRenderer
     renderTarget: GlRenderTargetSystem | GpuRenderTargetSystem
     renderPipes: Renderer['renderPipes'];
     uniformBuffer: UniformBufferSystem;
+    supportsUbo: boolean;
 }
 
 export class GlobalUniformSystem implements System
@@ -158,7 +159,10 @@ export class GlobalUniformSystem implements System
         }
         else
         {
-            this._renderer.uniformBuffer.updateUniformGroup(uniformGroup as UniformGroup);
+            if (this._renderer.supportsUbo)
+            {
+                this._renderer.uniformBuffer.updateUniformGroup(uniformGroup as UniformGroup);
+            }
 
             bindGroup = this._bindGroupPool.pop() || new BindGroup();
             this._activeBindGroups.push(bindGroup);
@@ -201,7 +205,7 @@ export class GlobalUniformSystem implements System
             worldColorAlpha: { value: new Float32Array(4), type: 'vec4<f32>' },
             uResolution: { value: [0, 0], type: 'vec2<f32>' },
         }, {
-            ubo: true,
+            ubo: this._renderer.supportsUbo,
             isStatic: true,
         });
 

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -23,6 +23,7 @@ interface RendererConfig
     systems: {name: string, value: SystemConstructor}[];
     renderPipes: {name: string, value: PipeConstructor}[];
     renderPipeAdaptors: {name: string, value: any}[];
+    supportsUbo?: boolean;
 }
 
 export interface RenderOptions
@@ -107,6 +108,8 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions,
     public view: ViewSystem;
     public textureGenerator: GenerateTextureSystem;
 
+    public readonly supportsUbo;
+
     protected _initOptions: OPTIONS = {} as OPTIONS;
 
     private _systemsHash: Record<string, System> = Object.create(null);
@@ -119,6 +122,7 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions,
      */
     constructor(config: RendererConfig)
     {
+        this.supportsUbo = config.supportsUbo;
         this.type = config.type;
         this.name = config.name;
 


### PR DESCRIPTION
Part one of my phased approach to get WebGL working

this PR makes UBOs optional - the only places they are being used in webGL2 is in the global uniforms.