### PR TITLE
enhance assets documentation

### DIFF
--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -10,25 +10,52 @@ import type { ResolveURLParser } from './resolver/types';
  * @example
  * import { AssetExtension, extensions } from 'pixi.js';
  *
+ * // create the CacheParser
+ * const cache = {
+ *    test(asset: item): boolean {
+ *       // Gets called by the cache when a dev caches an asset
+ *    },
+ *    getCacheableAssets(keys: string[], asset: item): Record<string, any> {
+ *       // If the test passes, this function is called to get the cacheable assets
+ *       // an example may be that a spritesheet object will return all the sub textures it has so they can
+ *       // be cached.
+ *    },
+ * };
+ *
+ * // create the ResolveURLParser
+ * const resolver = {
+ *    test(value: string): boolean {
+ *       // the test to perform on the url to determine if it should be parsed
+ *    },
+ *    parse(value: string): ResolvedAsset {
+ *       // the function that will convert the url into an object
+ *    },
+ * };
+ *
+ * // create the LoaderParser
+ * const loader = {
+ *    name: 'itemLoader',
+ *    extension: {
+ *       type: ExtensionType.LoadParser,
+ *    },
+ *    async testParse(asset: any, options: ResolvedAsset) {
+ *       // This function is used to test if the parse function should be run on the asset
+ *    },
+ *    async parse(asset: any, options: ResolvedAsset, loader: Loader) {
+ *       // Gets called on the asset it testParse passes. Useful to convert a raw asset into something more useful
+ *    },
+ *    unload(item: any) {
+ *       // If an asset is parsed using this parser, the unload function will be called when the user requests an asset
+ *       // to be unloaded. This is useful for things like sounds or textures that can be unloaded from memory
+ *    },
+ * };
+ *
+ * // put it all together and create the AssetExtension
  * extensions.add({
  *     extension: ExtensionType.Asset,
- *     cache: {
- *         test: (asset: item) => {},
- *         getCacheableAssets: (keys: string[], asset: item) => {},
- *     },
- *     resolver: {
- *         test: (value: string): boolean =>{},
- *         parse: (value: string): UnresolvedAsset =>{},
- *     },
- *     loader: {
- *         name: 'itemLoader',
- *         extension: {
- *             type: ExtensionType.LoadParser,
- *         },
- *         async testParse(asset: any, options: ResolvedAsset) {},
- *         async parse(asset: any, options: ResolvedAsset, loader: Loader) {},
- *         unload(item: any){},
- *     },
+ *     cache,
+ *     resolver,
+ *     loader,
  * }
  * @memberof assets
  */

--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { extensions, ExtensionType } from '../extensions/Extensions';
 import { warn } from '../utils/logging/warn';
 import { BackgroundLoader } from './BackgroundLoader';
@@ -68,29 +69,21 @@ export interface AssetInitOptions
  * Super modern and easy to use, with enough flexibility to customize and do what you need!
  * @namespace assets
  *
- * Only one Asset Class exists accessed via the Global Assets object. See [here]{@link assets.Assets},
- * for full documentation.
+ * Use the singleton class [Assets]{@link assets.Assets} to easily load and manage all your assets.
  *
- * <br>
+ * ```typescript
+ * import { Assets, Texture } from 'pixi.js';
  *
- * **It has four main responsibilities:**
- * 1. Allows users to map URLs to keys and resolve them according to the user's browser capabilities
- * 2. Loads the resources and transforms them into assets that developers understand.
- * 3. Caches the assets and provides a way to access them.
- * 4. Allow developers to unload assets and clear the cache.
+ * const bunnyTexture = await Assets.load<Texture>('bunny.png');
  *
- * <br>
+ * const sprite = new Sprite(bunnyTexture);
+ * ```
  *
- * **It also has a few advanced features:**
- * 1. Allows developers to provide a manifest upfront of all assets and help manage them via 'bundles'.
- * 2. Allows users to background load assets. Shortening (or eliminating) load times and improving UX. With this feature,
- * in-game loading bars can be a thing of the past!
- *
- * <br>
+ * Check out the sections below for more information on how to deal with assets.
  *
  * <details id="assets-loading">
  *
- * <summary>Assets Loading</summary>
+ * <summary>Asset Loading</summary>
  *
  * Do not be afraid to load things multiple times - under the hood, it will **NEVER** load anything more than once.
  *
@@ -107,15 +100,16 @@ export interface AssetInitOptions
  *
  * Here both promises will be the same. Once resolved... Forever resolved! It makes for really easy resource management!
  *
- * *Out of the box it supports the following files:*
- * - Textures (**_avif_**, **_webp_**, **_png_**, **_jpg_**, **_gif_**, **_svg_**)
- * - Sprite sheets (**_json_**)
- * - Bitmap fonts (**_xml_**, **_fnt_**, **_txt_**)
- * - Web fonts (**_ttf_**, **_woff_**, **_woff2_**)
- * - JSON files (**_json_**)
- * - Text Files (**_txt_**)
- *
- * More types can be added fairly easily by creating additional loader parsers.
+ * Out of the box Pixi supports the following files:
+ * - Textures (**_avif_**, **_webp_**, **_png_**, **_jpg_**, **_gif_**, **_svg_**) via {@link assets.loadTextures}, {@link assets.loadSvg}
+ * - Video Textures (**_mp4_**, **_m4v_**, **_webm_**, **_ogg_**, **_ogv_**, **_h264_**, **_avi_**, **_mov_**) via {@link assets.loadVideoTextures}
+ * - Sprite sheets (**_json_**) via {@link assets.spritesheetAsset}
+ * - Bitmap fonts (**_xml_**, **_fnt_**, **_txt_**) via {@link assets.loadBitmapFont}
+ * - Web fonts (**_ttf_**, **_woff_**, **_woff2_**) via {@link assets.loadWebFont}
+ * - JSON files (**_json_**) via {@link assets.loadJson}
+ * - Text Files (**_txt_**) via {@link assets.loadTxt}
+ * <br/>
+ * More types can be added fairly easily by creating additional {@link assets.LoaderParser LoaderParsers}.
  * </details>
  *
  * <details id="textures">
@@ -125,7 +119,8 @@ export interface AssetInitOptions
  * - Textures are loaded as ImageBitmap on a worker thread where possible. Leading to much less janky load + parse times.
  * - By default, we will prefer to load AVIF and WebP image files if you specify them.
  * But if the browser doesn't support AVIF or WebP we will fall back to png and jpg.
- * - Textures can also be accessed via `Texture.from(...)` and now use this asset manager under the hood!
+ * - Textures can also be accessed via `Texture.from()` (see {@link core.from|Texture.from})
+ * and now use this asset manager under the hood!
  * - Don't worry if you set preferences for textures that don't exist
  * (for example you prefer 2x resolutions images but only 1x is available for that texture,
  * the Assets manager will pick that up as a fallback automatically)
@@ -134,7 +129,7 @@ export interface AssetInitOptions
  * - It's hard to know what resolution a sprite sheet is without loading it first, to address this
  * there is a naming convention we have added that will let Pixi understand the image format and resolution
  * of the spritesheet via its file name: `my-spritesheet{resolution}.{imageFormat}.json`
- * <br><br>*For example:*
+ * <br><br>For example:
  *   - `my-spritesheet@2x.webp.json`* // 2x resolution, WebP sprite sheet*
  *   - `my-spritesheet@0.5x.png.json`* // 0.5x resolution, png sprite sheet*
  * - This is optional! You can just load a sprite sheet as normal.
@@ -182,8 +177,8 @@ export interface AssetInitOptions
  *
  * <summary>Manifest and Bundles</summary>
  *
- * - Manifest is a JSON file that contains a list of all assets and their properties.
- * - Bundles are a way to group assets together.
+ * - {@link assets.AssetsManifest Manifest} is a descriptor that contains a list of all assets and their properties.
+ * - {@link assets.AssetsBundle Bundles} are a way to group assets together.
  *
  * ```js
  * import { Assets } from 'pixi.js';
@@ -232,6 +227,21 @@ export interface AssetInitOptions
 
 /**
  * The global Assets class, it's a singleton so you don't need to instantiate it.
+ *
+ * <br>
+ * **The `Assets` class has four main responsibilities:**
+ * 1. Allows users to map URLs to keys and resolve them according to the user's browser capabilities
+ * 2. Loads the resources and transforms them into assets that developers understand.
+ * 3. Caches the assets and provides a way to access them.
+ * 4. Allow developers to unload assets and clear the cache.
+ *
+ * <br>
+ *
+ * **It also has a few advanced features:**
+ * 1. Allows developers to provide a {@link assets.Manifest} upfront of all assets and help manage
+ * them via {@link assets.AssetsBundles Bundles}.
+ * 2. Allows users to background load assets. Shortening (or eliminating) load times and improving UX. With this feature,
+ * in-game loading bars can be a thing of the past!
  * @example
  * import { Assets } from 'pixi.js';
  *

--- a/src/assets/cache/parsers/cacheTextureArray.ts
+++ b/src/assets/cache/parsers/cacheTextureArray.ts
@@ -5,8 +5,6 @@ import type { CacheParser } from '../CacheParser';
 
 /**
  * Returns an object of textures from an array of textures to be cached
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const cacheTextureArray: CacheParser<Texture[]> = {

--- a/src/assets/detections/parsers/detectAvif.ts
+++ b/src/assets/detections/parsers/detectAvif.ts
@@ -5,8 +5,6 @@ import type { FormatDetectionParser } from '../types';
 
 /**
  * Detects if the browser supports the AVIF image format.
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectAvif: FormatDetectionParser = {

--- a/src/assets/detections/parsers/detectDefaults.ts
+++ b/src/assets/detections/parsers/detectDefaults.ts
@@ -6,8 +6,6 @@ const imageFormats = ['png', 'jpg', 'jpeg'];
 
 /**
  * Adds some default image formats to the detection parser
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectDefaults = {

--- a/src/assets/detections/parsers/detectMp4.ts
+++ b/src/assets/detections/parsers/detectMp4.ts
@@ -5,8 +5,6 @@ import type { FormatDetectionParser } from '../types';
 
 /**
  * Detects if the browser supports the MP4 video format.
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectMp4 = {

--- a/src/assets/detections/parsers/detectOgv.ts
+++ b/src/assets/detections/parsers/detectOgv.ts
@@ -5,8 +5,6 @@ import type { FormatDetectionParser } from '../types';
 
 /**
  * Detects if the browser supports the OGV video format.
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectOgv = {

--- a/src/assets/detections/parsers/detectWebm.ts
+++ b/src/assets/detections/parsers/detectWebm.ts
@@ -5,8 +5,6 @@ import type { FormatDetectionParser } from '../types';
 
 /**
  * Detects if the browser supports the WebM video format.
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectWebm = {

--- a/src/assets/detections/parsers/detectWebp.ts
+++ b/src/assets/detections/parsers/detectWebp.ts
@@ -5,8 +5,6 @@ import type { FormatDetectionParser } from '../types';
 
 /**
  * Detects if the browser supports the WebP image format.
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const detectWebp = {

--- a/src/assets/loader/parsers/LoaderParser.ts
+++ b/src/assets/loader/parsers/LoaderParser.ts
@@ -20,18 +20,21 @@ export enum LoaderParserPriority
 }
 
 /**
- * All functions are optional here. The flow:
+ * The interface to define a loader parser *(all functions are optional)*.
  *
- * for every asset,
+ * When you create a `parser` object, the flow for every asset loaded is:
  *
- * 1. `parser.test()`: Test the asset url.
- * 2. `parser.load()`: If test passes call the load function with the url
- * 3. `parser.testParse()`: Test to see if the asset should be parsed by the plugin
- * 4. `parse.parse()`: If test is parsed, then run the parse function on the asset.
+ * 1. `parser.test()` - Each URL to load will be tested here, if the test is passed the assets are
+ * loaded using the load function below. Good place to test for things like file extensions!
+ * 2. `parser.load()` - This is the promise that loads the URL provided resolves with a loaded asset
+ * if returned by the parser.
+ * 3. `parser.testParse()` - This function is used to test if the parse function should be run on the
+ *  asset If this returns true then parse is called with the asset
+ * 4. `parse.parse()` - Gets called on the asset it testParse passes. Useful to convert a raw asset
+ *  into something more useful
  *
- * some plugins may only be used for parsing,
- * some only for loading
- * and some for both!
+ * <br/>
+ * Some loaders may only be used for parsing, some only for loading, and some for both!
  * @memberof assets
  */
 export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<string, any>>
@@ -46,7 +49,7 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
     name: string;
 
     /**
-     * each URL to load will be tested here,
+     * Each URL to load will be tested here,
      * if the test is passed the assets are loaded using the load function below.
      * Good place to test for things like file extensions!
      * @param url - The URL to test
@@ -74,7 +77,7 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
     testParse?: (asset: ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<boolean>;
 
     /**
-     * Gets called on the asset it testParse passes. Useful to convert a raw asset into something more useful than
+     * Gets called on the asset it testParse passes. Useful to convert a raw asset into something more useful
      * @param asset - The loaded asset data
      * @param resolvedAsset - Any custom additional information relevant to the asset being loaded
      * @param loader - The loader instance

--- a/src/assets/loader/parsers/loadJson.ts
+++ b/src/assets/loader/parsers/loadJson.ts
@@ -11,8 +11,6 @@ const validJSONMIME = 'application/json';
 
 /**
  * A simple loader plugin for loading json data
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const loadJson = {

--- a/src/assets/loader/parsers/loadTxt.ts
+++ b/src/assets/loader/parsers/loadTxt.ts
@@ -11,8 +11,6 @@ const validTXTMIME = 'text/plain';
 
 /**
  * A simple loader plugin for loading text data
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const loadTxt = {

--- a/src/assets/loader/parsers/loadWebFont.ts
+++ b/src/assets/loader/parsers/loadWebFont.ts
@@ -116,8 +116,6 @@ function encodeURIWhenNeeded(uri: string)
 
 /**
  * A loader plugin for handling web fonts
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @example
  * import { Assets } from 'pixi.js';
  *

--- a/src/assets/loader/parsers/textures/loadSVG.ts
+++ b/src/assets/loader/parsers/textures/loadSVG.ts
@@ -18,8 +18,6 @@ const validSVGMIME = 'image/svg+xml';
 
 /**
  * A simple loader plugin for loading json data
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const loadSvg = {

--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -75,26 +75,25 @@ export async function loadImageBitmap(url: string): Promise<ImageBitmap>
 
 /**
  * A simple plugin to load our textures!
- * this makes use of imageBitmaps where available.
- * We load the ImageBitmap on a different thread using the WorkerManager
- * We can then use the ImageBitmap as a source for a Pixi Texture
+ * This makes use of imageBitmaps where available.
+ * We load the `ImageBitmap` on a different thread using workers if possible.
+ * We can then use the `ImageBitmap` as a source for a Pixi texture
  *
  * You can customize the behavior of this loader by setting the `config` property.
  * Which can be found [here]{@link assets.LoadTextureConfig}
  * ```js
  * // Set the config
  * import { loadTextures } from 'pixi.js';
+ *
  * loadTextures.config = {
  *    // If true we will use a worker to load the ImageBitmap
  *    preferWorkers: true,
- *    // If false we will use new Image() instead of createImageBitmap
- *    // If false then this will also disable the use of workers as it requires createImageBitmap
+ *    // If false we will use new Image() instead of createImageBitmap,
+ *    // we'll also disable the use of workers as it requires createImageBitmap
  *    preferCreateImageBitmap: true,
  *    crossOrigin: 'anonymous',
  * };
  * ```
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const loadTextures = {

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -101,9 +101,7 @@ export function determineCrossOrigin(url: string, loc: Location = globalThis.loc
 }
 
 /**
- * A simple plugin to video textures
- *
- * This will be added automatically if `pixi.js/assets` is imported
+ * A simple plugin to load video textures.
  *
  * You can pass VideoSource options to the loader via the .data property of the asset descriptor
  * when using Asset.load().

--- a/src/assets/resolver/parsers/resolveTextureUrl.ts
+++ b/src/assets/resolver/parsers/resolveTextureUrl.ts
@@ -7,8 +7,6 @@ import type { ResolveURLParser } from '../types';
 
 /**
  * A parser that will resolve a texture url
- *
- * This will be added automatically if `pixi.js/assets` is imported
  * @memberof assets
  */
 export const resolveTextureUrl = {

--- a/src/assets/types.ts
+++ b/src/assets/types.ts
@@ -45,7 +45,7 @@ export interface ResolvedAsset<T=any>
  * @memberof assets
  */
 // NOTE: Omit does not seem to work here
-export type ResolvedSrc = Pick<ResolvedAsset, 'src' | 'format' | 'loadParser' | 'data'> & {[key: string]: any;};
+export type ResolvedSrc = Pick<ResolvedAsset, 'src' | 'format' | 'loadParser' | 'data'> & { [key: string]: any; };
 
 /**
  * A valid asset src. This can be a string, or a [ResolvedSrc]{@link assets.ResolvedSrc},
@@ -69,7 +69,7 @@ export type UnresolvedAsset<T=any> = Pick<ResolvedAsset<T>, 'data' | 'format' | 
 };
 
 /**
- * Structure of a bundle found in a manifest file
+ * Structure of a bundle found in a {@link assets.AssetsManifest Manifest} file
  * @memberof assets
  */
 export interface AssetsBundle
@@ -81,7 +81,7 @@ export interface AssetsBundle
 }
 
 /**
- * The expected format of a manifest. This would normally be auto generated or made by the developer
+ * The expected format of a manifest. This could be auto generated or hand made
  * @memberof assets
  */
 export interface AssetsManifest

--- a/src/spritesheet/spritesheetAsset.ts
+++ b/src/spritesheet/spritesheetAsset.ts
@@ -54,8 +54,6 @@ function getCacheableAssets(keys: string[], asset: Spritesheet, ignoreMultiPack:
 
 /**
  * Asset extension for loading spritesheets
- *
- * This will be added automatically if `pixi.js/spritesheet` is imported
  * @example
  * import { Assets } from 'pixi.js';
  *


### PR DESCRIPTION
Enhance docs for assets.

Moved "Assets" info into "assets.html" as it was confusing on the main "assets" page header and more appropriate there. Linked to it.

Removed a lot of references to "This will be added automatically if `pixi.js/assets` is imported"
- There is no clear general explanation of the docs on how to custom load the library
- Feels like this API documentation should just focus on describing what things are rather than build composition details