### PR TITLE
Chore: Remove peer utils from assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18537,8 +18537,7 @@
         "@types/css-font-loading-module": "^0.0.7"
       },
       "peerDependencies": {
-        "@pixi/core": "file:../core",
-        "@pixi/utils": "file:../utils"
+        "@pixi/core": "file:../core"
       }
     },
     "packages/basis": {

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -46,7 +46,6 @@
     "@types/css-font-loading-module": "^0.0.7"
   },
   "peerDependencies": {
-    "@pixi/core": "file:../core",
-    "@pixi/utils": "file:../utils"
+    "@pixi/core": "file:../core"
   }
 }


### PR DESCRIPTION
This issue is being thrown installing 7.3.2.

`@pixi/utils` should only be imported by core or things core imports. From the reset of the packages `utils` is something thats imported from `core`.

```
warning "pixi.js > @pixi/assets@7.3.2" has unmet peer dependency "@pixi/utils@7.3.2".
```