### PR TITLE
assign @memberof to all documented symbols

### DIFF
--- a/src/events/FederatedEvent.ts
+++ b/src/events/FederatedEvent.ts
@@ -33,6 +33,7 @@ export interface PixiTouch extends Touch
  * An DOM-compatible synthetic event implementation that is "forwarded" on behalf of an original
  * FederatedEvent or native {@link https://dom.spec.whatwg.org/#event Event}.
  * @typeParam N - The type of native event held.
+ * @memberof events
  */
 export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch> implements UIEvent
 {

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -82,7 +82,10 @@ export interface FilterData
     backTexture?: Texture,
 }
 
-// eslint-disable-next-line max-len
+/**
+ * System that manages the filter pipeline
+ * @memberof rendering
+ */
 export class FilterSystem implements System
 {
     /** @ignore */

--- a/src/filters/blend-modes/ColorBurnBlend.ts
+++ b/src/filters/blend-modes/ColorBurnBlend.ts
@@ -6,8 +6,9 @@ import { BlendModeFilter } from './BlendModeFilter';
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
 /**
- Looks at the color information in each channel and darkens the base color to
- reflect the blend color by increasing the contrast between the two.
+ * Looks at the color information in each channel and darkens the base color to
+ * reflect the blend color by increasing the contrast between the two.
+ * @memberof filters
  */
 export class ColorBurnBlend extends BlendModeFilter
 {

--- a/src/filters/blend-modes/ColorDodgeBlend.ts
+++ b/src/filters/blend-modes/ColorDodgeBlend.ts
@@ -6,7 +6,8 @@ import { BlendModeFilter } from './BlendModeFilter';
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
 /**
-  Looks at the color information in each channel and brightens the base color to reflect the blend color by decreasing contrast between the two.
+ * Looks at the color information in each channel and brightens the base color to reflect the blend color by decreasing contrast between the two.
+ * @memberof filters
  */
 export class ColorDodgeBlend extends BlendModeFilter
 {

--- a/src/filters/blend-modes/DarkenBlend.ts
+++ b/src/filters/blend-modes/DarkenBlend.ts
@@ -3,7 +3,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Uses each color channel to select the darker of the following two values; base or blend color */
+/**
+ * Uses each color channel to select the darker of the following two values; base or blend color
+ * @memberof filters
+ */
 export class DarkenBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/blend-modes/DivideBlend.ts
+++ b/src/filters/blend-modes/DivideBlend.ts
@@ -5,7 +5,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Divides the blend from the base color using each color channel */
+/**
+ * Divides the blend from the base color using each color channel
+ * @memberof filters
+ */
 export class DivideBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/blend-modes/HardMixBlend.ts
+++ b/src/filters/blend-modes/HardMixBlend.ts
@@ -8,6 +8,7 @@ import type { ExtensionMetadata } from '../../extensions/Extensions';
 /**
  * Hard defines each of the color channel values of the blend color to the RGB values of the base color.
  * If the sum of a channel is 255, it receives a value of 255; if less than 255, a value of 0.
+ * @memberof filters
  */
 export class HardMixBlend extends BlendModeFilter
 {

--- a/src/filters/blend-modes/LinearBurnBlend.ts
+++ b/src/filters/blend-modes/LinearBurnBlend.ts
@@ -8,6 +8,7 @@ import type { ExtensionMetadata } from '../../extensions/Extensions';
 /**
  Looks at the color information in each channel and darkens the base color to
  reflect the blend color by increasing the contrast between the two.
+ @memberof filters
  */
 export class LinearBurnBlend extends BlendModeFilter
 {

--- a/src/filters/blend-modes/LinearDodgeBlend.ts
+++ b/src/filters/blend-modes/LinearDodgeBlend.ts
@@ -5,7 +5,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Looks at the color information in each channel and brightens the base color to reflect the blend color by decreasing contrast between the two.  */
+/**
+ * Looks at the color information in each channel and brightens the base color to reflect the blend color by decreasing contrast between the two.
+ * @memberof filters
+ */
 export class LinearDodgeBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/blend-modes/LinearLightBlend.ts
+++ b/src/filters/blend-modes/LinearLightBlend.ts
@@ -5,7 +5,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Increase or decrease brightness by durning or dodging color values, based on the blend color */
+/**
+ * Increase or decrease brightness by burning or dodging color values, based on the blend color
+ * @memberof filters
+ */
 export class LinearLightBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/blend-modes/PinLightBlend.ts
+++ b/src/filters/blend-modes/PinLightBlend.ts
@@ -5,7 +5,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Replaces colors based on the blend color. */
+/**
+ * Replaces colors based on the blend color.
+ * @memberof filters
+ */
 export class PinLightBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/blend-modes/SubtractBlend.ts
+++ b/src/filters/blend-modes/SubtractBlend.ts
@@ -5,7 +5,10 @@ import { BlendModeFilter } from './BlendModeFilter';
 
 import type { ExtensionMetadata } from '../../extensions/Extensions';
 
-/** Subtracts the blend from the base color using each color channel */
+/**
+ * Subtracts the blend from the base color using each color channel
+ * @memberof filters
+ */
 export class SubtractBlend extends BlendModeFilter
 {
     /** @ignore */

--- a/src/filters/defaults/blur/BlurFilter.ts
+++ b/src/filters/defaults/blur/BlurFilter.ts
@@ -39,6 +39,7 @@ export interface BlurFilterOptions extends Partial<FilterOptions>
  * The BlurFilter applies a Gaussian blur to an object.
  *
  * The strength of the blur can be set for the x-axis and y-axis separately.
+ * @memberof filters
  */
 export class BlurFilter extends Filter
 {

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -17,6 +17,7 @@ export type PrepareQueueItem = TextureSource | TextView | GraphicsContext;
 /**
  * Part of the prepare system. Responsible for uploading all the items to the GPU.
  * This class provides the base functionality and handles processing the queue asynchronously.
+ * @memberof rendering
  */
 export abstract class PrepareBase
 {

--- a/src/prepare/PrepareQueue.ts
+++ b/src/prepare/PrepareQueue.ts
@@ -17,6 +17,7 @@ import type { PrepareQueueItem, PrepareSourceItem } from './PrepareBase';
 /**
  * Part of the prepare system. Responsible for uploading all the items to the GPU.
  * This class extends the base functionality and resolves given resource items ready for the queue.
+ * @memberof rendering
  */
 export abstract class PrepareQueue extends PrepareBase
 {

--- a/src/prepare/PrepareSystem.ts
+++ b/src/prepare/PrepareSystem.ts
@@ -30,6 +30,7 @@ import type { System } from '../rendering/renderers/shared/system/System';
  * app.renderer.prepare.upload(app.stage, () => {
  *     app.start();
  * });
+ * @memberof rendering
  */
 export class PrepareSystem extends PrepareUpload implements System
 {

--- a/src/prepare/PrepareUpload.ts
+++ b/src/prepare/PrepareUpload.ts
@@ -10,6 +10,7 @@ import type { PrepareQueueItem } from './PrepareBase';
 /**
  * Part of the prepare system. Responsible for uploading all the items to the GPU.
  * This class extends the resolver functionality and uploads the given queue items.
+ * @memberof rendering
  */
 export abstract class PrepareUpload extends PrepareQueue
 {

--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -15,6 +15,10 @@ import type { Geometry } from '../../renderers/shared/geometry/Geometry';
 import type { Batch } from '../shared/Batcher';
 import type { BatcherAdaptor, BatcherPipe } from '../shared/BatcherPipe';
 
+/**
+ * A BatcherAdaptor that uses WebGL to render batches.
+ * @memberof rendering
+ */
 export class GlBatchAdaptor implements BatcherAdaptor
 {
     /** @ignore */

--- a/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
+++ b/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
@@ -16,6 +16,10 @@ import type { BatcherAdaptor, BatcherPipe } from '../shared/BatcherPipe';
 
 const tempState = State.for2d();
 
+/**
+ * A BatcherAdaptor that uses the GPU to render batches.
+ * @memberof rendering
+ */
 export class GpuBatchAdaptor implements BatcherAdaptor
 {
     /** @ignore */

--- a/src/rendering/batcher/shared/BatchTextureArray.ts
+++ b/src/rendering/batcher/shared/BatchTextureArray.ts
@@ -1,6 +1,9 @@
 import type { TextureSource } from '../../renderers/shared/texture/sources/TextureSource';
 
-/** Used by the batcher to build texture batches. Holds list of textures and their respective locations. */
+/**
+ * Used by the batcher to build texture batches. Holds list of textures and their respective locations.
+ * @memberof rendering
+ */
 export class BatchTextureArray
 {
     /** Inside textures array. */

--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -13,6 +13,10 @@ import type { Texture } from '../../renderers/shared/texture/Texture';
 
 export type BatchAction = 'startBatch' | 'renderBatch';
 
+/**
+ * A batch pool is used to store batches when they are not currently in use.
+ * @memberof rendering
+ */
 export class Batch implements Instruction
 {
     public renderPipeId = 'batch';
@@ -89,6 +93,10 @@ export interface BatcherOptions
     indexSize?: number;
 }
 
+/**
+ * A batcher is used to batch together objects with the same texture.
+ * @memberof rendering
+ */
 export class Batcher
 {
     public static defaultOptions: BatcherOptions = {

--- a/src/rendering/mask/MaskEffectManager.ts
+++ b/src/rendering/mask/MaskEffectManager.ts
@@ -10,6 +10,10 @@ interface MaskConversionTest
     maskClass: new (item: any) => Effect & PoolItem;
 }
 
+/**
+ * A class that manages the conversion of masks to mask effects.
+ * @memberof rendering
+ */
 export class MaskEffectManagerClass
 {
     /**

--- a/src/rendering/renderers/gl/GlRenderTarget.ts
+++ b/src/rendering/renderers/gl/GlRenderTarget.ts
@@ -1,3 +1,7 @@
+/**
+ * Represents a render target.
+ * @memberof rendering
+ */
 export class GlRenderTarget
 {
     public width = -1;

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -67,6 +67,10 @@ export interface WebGLOptions
     PixiMixins.WebGLOptions {}
 
 /** The default WebGL renderer, uses WebGL2 contexts. */
+/**
+ * The default WebGL renderer, uses WebGL2 contexts.
+ * @memberof rendering
+ */
 export interface WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
     extends AbstractRenderer<WebGLPipes, WebGLOptions, T>,
     WebGLSystems {}

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -25,6 +25,7 @@ import type { WebGLRenderer } from '../WebGLRenderer';
  * them. With this system, you never need to work directly with GPU buffers, but instead work with
  * the Buffer class.
  * @class
+ * @memberof rendering
  */
 export class GlBufferSystem implements System
 {

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -40,7 +40,10 @@ export interface ContextSystemOptions
     antialias?: boolean;
 }
 
-/** System plugin to the renderer to manage the context. */
+/**
+ * System plugin to the renderer to manage the context
+ * @memberof rendering
+ */
 export class GlContextSystem implements System<ContextSystemOptions>
 {
     /** @ignore */

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -19,7 +19,10 @@ const topologyToGlMap = {
     'triangle-strip': 0x0005
 };
 
-/** System plugin to the renderer to manage geometry. */
+/**
+ * System plugin to the renderer to manage geometry.
+ * @memberof rendering
+ */
 export class GlGeometrySystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -17,6 +17,10 @@ const defaultSyncData = {
     blockIndex: 0,
 };
 
+/**
+ * System plugin to the renderer to manage the shaders.
+ * @memberof rendering
+ */
 export class GlShaderSystem
 {
     /** @ignore */

--- a/src/rendering/renderers/gl/state/GlStateSystem.ts
+++ b/src/rendering/renderers/gl/state/GlStateSystem.ts
@@ -13,7 +13,10 @@ const DEPTH_TEST = 3;
 const WINDING = 4;
 const DEPTH_MASK = 5;
 
-/** System plugin to the renderer to manage WebGL state machines. */
+/**
+ * System plugin to the renderer to manage WebGL state machines
+ * @memberof rendering
+ */
 export class GlStateSystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/gl/texture/GlTexture.ts
+++ b/src/rendering/renderers/gl/texture/GlTexture.ts
@@ -1,6 +1,9 @@
 import { GL_FORMATS, GL_TARGETS, GL_TYPES } from './const';
 
-/** Internal texture for WebGL context. */
+/**
+ * Internal texture for WebGL context
+ * @memberof rendering
+ */
 export class GlTexture
 {
     public target: GL_TARGETS = GL_TARGETS.TEXTURE_2D;

--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -26,6 +26,7 @@ export interface GpuContextOptions
 /**
  * System plugin to the renderer to manage the context.
  * @class
+ * @memberof rendering
  */
 export class GpuDeviceSystem implements System<GpuContextOptions>
 {

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -6,7 +6,7 @@ import { AbstractRenderer } from '../shared/system/AbstractRenderer';
 import { SharedRenderPipes, SharedSystems } from '../shared/system/SharedSystems';
 import { RendererType } from '../types';
 import { BindGroupSystem } from './BindGroupSystem';
-import { BufferSystem } from './buffer/GpuBufferSystem';
+import { GpuBufferSystem } from './buffer/GpuBufferSystem';
 import { GpuColorMaskSystem } from './GpuColorMaskSystem';
 import { type GPU, GpuDeviceSystem } from './GpuDeviceSystem';
 import { GpuEncoderSystem } from './GpuEncoderSystem';
@@ -27,7 +27,7 @@ const DefaultWebGPUSystems = [
     ...SharedSystems,
     GpuEncoderSystem,
     GpuDeviceSystem,
-    BufferSystem,
+    GpuBufferSystem,
     GpuTextureSystem,
     GpuRenderTargetSystem,
     GpuShaderSystem,

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -5,7 +5,11 @@ import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 
-export class BufferSystem implements System
+/**
+ * System plugin to the renderer to manage buffers.
+ * @memberof rendering
+ */
+export class GpuBufferSystem implements System
 {
     /** @ignore */
     public static extension = {

--- a/src/rendering/renderers/gpu/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GlRenderTargetAdaptor.ts
@@ -10,7 +10,10 @@ import type { RenderTarget } from '../../shared/renderTarget/RenderTarget';
 import type { RenderTargetAdaptor, RenderTargetSystem } from '../../shared/renderTarget/RenderTargetSystem';
 import type { Texture } from '../../shared/texture/Texture';
 
-/** the WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGL renderer */
+/**
+ * The WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGL renderer
+ * @memberof rendering
+ */
 export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget>
 {
     private _renderTargetSystem: RenderTargetSystem<GlRenderTarget>;

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
@@ -1,5 +1,9 @@
 import type { TextureSource } from '../../shared/texture/sources/TextureSource';
 
+/**
+ * A class which holds the canvas contexts and textures for a render target.
+ * @memberof rendering
+ */
 export class GpuRenderTarget
 {
     public contexts: GPUCanvasContext[] = [];

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -12,8 +12,9 @@ import type { Texture } from '../../shared/texture/Texture';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
 /**
- * the WebGPPU adaptor for the render target system. Allows the Render Target System to
+ * The WebGPU adaptor for the render target system. Allows the Render Target System to
  * be used with the WebGPU renderer
+ * @memberof rendering
  */
 export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarget>
 {

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -5,7 +5,10 @@ import { GpuRenderTargetAdaptor } from './GpuRenderTargetAdaptor';
 import type { WebGPURenderer } from '../WebGPURenderer';
 import type { GpuRenderTarget } from './GpuRenderTarget';
 
-/** the WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGl renderer */
+/**
+ * The WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGl renderer
+ * @memberof rendering
+ */
 export class GpuRenderTargetSystem extends RenderTargetSystem<GpuRenderTarget>
 {
     /** @ignore */

--- a/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
+++ b/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
@@ -4,6 +4,10 @@ import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 import type { GpuProgram } from './GpuProgram';
 
+/**
+ * A system that manages the rendering of GpuPrograms.
+ * @memberof rendering
+ */
 export class GpuShaderSystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/gpu/state/GpuStateSystem.ts
+++ b/src/rendering/renderers/gpu/state/GpuStateSystem.ts
@@ -6,7 +6,10 @@ import type { BLEND_MODES } from '../../shared/state/const';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 
-/** System plugin to the renderer to manage WebGL state machines. */
+/**
+ * System plugin to the renderer to manage WebGL state machines.
+ * @memberof rendering
+ */
 export class GpuStateSystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/gpu/texture/utils/GpuMipmapGenerator.ts
+++ b/src/rendering/renderers/gpu/texture/utils/GpuMipmapGenerator.ts
@@ -1,7 +1,8 @@
 /**
- *
- * thanks to @toji for the original implementation
+ * A class which generates mipmaps for a GPUTexture.
+ * Thanks to @toji for the original implementation
  * https://github.com/toji/web-texture-tool/blob/main/src/webgpu-mipmap-generator.js
+ * @memberof rendering
  */
 export class GpuMipmapGenerator
 {

--- a/src/rendering/renderers/shared/RGRenderable.ts
+++ b/src/rendering/renderers/shared/RGRenderable.ts
@@ -13,6 +13,7 @@ import type { View } from './view/View';
  *
  * This proxy allows us to override the values. This saves us a lot of extra if statements in the core loop
  * for what is normally a very rare use case!
+ * @memberof rendering
  */
 export class RGRenderable<T extends View = View> extends EventEmitter implements Renderable<T>
 {

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -34,6 +34,7 @@ export type ExtractOptions = BaseExtractOptions | ExtractImageOptions | ExtractD
 /**
  * System plugin to the renderer to manage texture garbage collection on the GPU,
  * ensuring that it does not get clogged up with textures that are no longer being used.
+ * @memberof rendering
  */
 export class ExtractSystem implements System
 {

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -36,7 +36,10 @@ const tempRect = new Rectangle();
 const tempBounds = new Bounds();
 const noColor: ColorSource = [0, 0, 0, 0];
 
-/** System that manages the generation of textures from the renderer. */
+/**
+ * System that manages the generation of textures from the renderer
+ * @memberof rendering
+ */
 export class GenerateTextureSystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -125,6 +125,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends GlRenderTarget | GpuR
  *
  * // draw something!
  * ```
+ * @memberof rendering
  */
 export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRenderTarget> implements System
 {

--- a/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
+++ b/src/rendering/renderers/shared/shader/UniformBufferSystem.ts
@@ -10,6 +10,10 @@ import type { UniformGroup } from './UniformGroup';
 import type { UBOElement, UniformBufferLayout } from './utils/createUBOElements';
 import type { UniformsSyncCallback } from './utils/createUniformBufferSyncTypes';
 
+/**
+ * System plugin to the renderer to manage uniform buffers.
+ * @memberof rendering
+ */
 export class UniformBufferSystem implements System
 {
     /** @ignore */

--- a/src/rendering/renderers/shared/startup/HelloSystem.ts
+++ b/src/rendering/renderers/shared/startup/HelloSystem.ts
@@ -13,7 +13,11 @@ export interface HelloSystemOptions
     /** Whether to log the version and type information of renderer to console. */
     hello: boolean;
 }
-/** A simple system responsible for initiating the renderer. */
+
+/**
+ * A simple system responsible for initiating the renderer.
+ * @memberof rendering
+ */
 export class HelloSystem implements System<HelloSystemOptions>
 {
     /** @ignore */

--- a/src/rendering/renderers/shared/state/State.ts
+++ b/src/rendering/renderers/shared/state/State.ts
@@ -24,6 +24,7 @@ const DEPTH_MASK = 5;
  *
  * Each mesh rendered may require WebGL to be in a different state.
  * For example you may want different blend mode or to enable polygon offsets
+ * @memberof rendering
  */
 export class State
 {

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -57,6 +57,7 @@ type Runners = {[key in DefaultRunners]: SystemRunner} & {
 /**
  * The SystemManager is a class that provides functions for managing a set of systems
  * This is a base class, that is generic (no render code or knowledge at all)
+ * @memberof rendering
  */
 export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions, CANVAS extends ICanvas = HTMLCanvasElement>
 {

--- a/src/rendering/renderers/shared/system/SystemRunner.ts
+++ b/src/rendering/renderers/shared/system/SystemRunner.ts
@@ -38,6 +38,7 @@
  *
  * myGame.update.emit(time);
  * ```
+ * @memberof rendering
  */
 export class SystemRunner
 {

--- a/src/rendering/renderers/shared/texture/CanvasPool.ts
+++ b/src/rendering/renderers/shared/texture/CanvasPool.ts
@@ -17,6 +17,8 @@ export interface CanvasAndContext
  *
  * If you use custom RenderTexturePool for your filters, you can use methods
  * `getFilterTexture` and `returnFilterTexture` same as in
+ * @name CanvasPool
+ * @memberof rendering
  */
 export class CanvasPoolClass
 {

--- a/src/rendering/renderers/shared/texture/RenderTexture.ts
+++ b/src/rendering/renderers/shared/texture/RenderTexture.ts
@@ -3,6 +3,11 @@ import { Texture } from './Texture';
 
 import type { TextureSourceOptions } from './sources/TextureSource';
 
+/**
+ * A render texture, extends `Texture`.
+ * @see {@link rendering.Texture}
+ * @memberof rendering
+ */
 export class RenderTexture extends Texture
 {
     public static create(options: TextureSourceOptions): Texture

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -101,7 +101,7 @@ export type TextureSourceLike = TextureSource | TextureSourceOptions | BufferSou
  *
  * If you didn't pass the texture frame to constructor, it enables `noFrame` mode:
  * it subscribes on baseTexture events, it automatically resizes at the same time as baseTexture.
- * @namespace core
+ * @memberof rendering
  * @class
  */
 export class Texture extends EventEmitter<{

--- a/src/rendering/renderers/shared/texture/TextureGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/TextureGCSystem.ts
@@ -12,6 +12,7 @@ export interface TextureGCSystemOptions
 /**
  * System plugin to the renderer to manage texture garbage collection on the GPU,
  * ensuring that it does not get clogged up with textures that are no longer being used.
+ * @memberof rendering
  */
 export class TextureGCSystem implements System
 {

--- a/src/rendering/renderers/shared/texture/TextureMatrix.ts
+++ b/src/rendering/renderers/shared/texture/TextureMatrix.ts
@@ -17,6 +17,7 @@ const tempMat = new Matrix();
  * @see Texture
  * @see Mesh
  * @see TilingSprite
+ * @memberof rendering
  */
 export class TextureMatrix
 {

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -13,7 +13,9 @@ let count = 0;
  * Stores collection of temporary pow2 or screen-sized renderTextures
  *
  * If you use custom RenderTexturePool for your filters, you can use methods
- * `getFilterTexture` and `returnFilterTexture` same as in
+ * `getFilterTexture` and `returnFilterTexture` same as in default pool
+ * @memberof rendering
+ * @name TexturePool
  */
 export class TexturePoolClass
 {

--- a/src/rendering/renderers/shared/texture/TextureStyle.ts
+++ b/src/rendering/renderers/shared/texture/TextureStyle.ts
@@ -49,6 +49,10 @@ export interface TextureStyleOptions extends Partial<TextureStyle>
 
 }
 
+/**
+ * A texture style describes how a texture should be sampled by a shader.
+ * @memberof rendering
+ */
 export class TextureStyle extends EventEmitter<{
     change: TextureStyle,
     destroy: TextureStyle,

--- a/src/rendering/renderers/shared/texture/TextureUvs.ts
+++ b/src/rendering/renderers/shared/texture/TextureUvs.ts
@@ -15,6 +15,7 @@ import type { Rectangle } from '../../../../maths/shapes/Rectangle';
  * | Bottom-Right | `(x2,y2)`   |
  * | Bottom-Left  | `(x3,y3)`   |
  * @protected
+ * @memberof rendering
  */
 export class TextureUvs
 {

--- a/src/rendering/renderers/shared/texture/sources/VideoSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/VideoSource.ts
@@ -32,6 +32,10 @@ export interface VideoResourceOptionsElement
     mime: string;
 }
 
+/**
+ * A source for video-based textures.
+ * @memberof rendering
+ */
 export class VideoSource extends TextureSource<VideoResource>
 {
     public static extension: ExtensionMetadata = ExtensionType.TextureSource;

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -34,6 +34,7 @@ export interface ViewSystemOptions
 /**
  * The view system manages the main canvas that is attached to the DOM.
  * This main role is to deal with how the holding the view reference and dealing with how it is resized.
+ * @memberof rendering
  */
 export class ViewSystem implements System
 {

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -7,6 +7,11 @@ import type { RGRenderable } from '../../rendering/renderers/shared/RGRenderable
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { Container } from './Container';
 
+/**
+ * The render group is the base class for all render groups
+ * It is used to render a group of containers together
+ * @memberof rendering
+ */
 export class RenderGroup implements Instruction
 {
     public renderPipeId = 'renderGroup';

--- a/src/scene/container/RenderGroupSystem.ts
+++ b/src/scene/container/RenderGroupSystem.ts
@@ -15,8 +15,8 @@ import type { RenderGroup } from './RenderGroup';
 /**
  * The view system manages the main canvas that is attached to the DOM.
  * This main role is to deal with how the holding the view reference and dealing with how it is resized.
+ * @memberof rendering
  */
-
 export class RenderGroupSystem implements System
 {
     /** @ignore */

--- a/src/scene/container/bounds/Bounds.ts
+++ b/src/scene/container/bounds/Bounds.ts
@@ -15,6 +15,11 @@ const defaultMatrix = new Matrix();
 // TODO optimisations
 // 1 - get rectangle could use a dirty flag, rather than setting the data each time is called
 // 2- getFrame ALWAYS assumes a matrix, could be optimised to avoid the matrix calculation if not needed
+
+/**
+ * A representation of an AABB bounding box.
+ * @memberof rendering
+ */
 export class Bounds
 {
     public minX = Infinity;

--- a/src/scene/graphics/gl/GlGraphicsAdaptor.ts
+++ b/src/scene/graphics/gl/GlGraphicsAdaptor.ts
@@ -16,6 +16,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
 import type { GraphicsView } from '../shared/GraphicsView';
 
+/**
+ * A GraphicsAdaptor that uses WebGL to render graphics.
+ * @memberof rendering
+ */
 export class GlGraphicsAdaptor implements GraphicsAdaptor
 {
     /** @ignore */

--- a/src/scene/graphics/gpu/GpuGraphicsAdaptor.ts
+++ b/src/scene/graphics/gpu/GpuGraphicsAdaptor.ts
@@ -17,6 +17,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
 import type { GraphicsView } from '../shared/GraphicsView';
 
+/**
+ * A GraphicsAdaptor that uses the GPU to render graphics.
+ * @memberof rendering
+ */
 export class GpuGraphicsAdaptor implements GraphicsAdaptor
 {
     /** @ignore */

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -5,6 +5,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { GraphicsView } from './GraphicsView';
 
+/**
+ * A batchable graphics object.
+ * @memberof rendering
+ */
 export class BatchableGraphics implements BatchableObject
 {
     public indexStart: number;

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -89,6 +89,10 @@ export type GraphicsInstructions = FillInstruction | StrokeInstruction | Texture
 
 const tempMatrix = new Matrix();
 
+/**
+ * A class that holds the render data for a GraphicsContext.
+ * @memberof scene
+ */
 export class GraphicsContext extends EventEmitter<{
     update: GraphicsContext
     destroy: GraphicsContext

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -11,12 +11,20 @@ import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
 import type { GraphicsContext } from './GraphicsContext';
 
+/**
+ * A class that holds batchable graphics data for a GraphicsContext.
+ * @memberof rendering
+ */
 export class GpuGraphicsContext
 {
     public isBatchable: boolean;
     public batches: BatchableGraphics[];
 }
 
+/**
+ * A class that holds the render data for a GraphicsContext.
+ * @memberof rendering
+ */
 export class GraphicsContextRenderData
 {
     public geometry = new BatchGeometry();
@@ -33,6 +41,10 @@ export interface GraphicsContextSystemOptions
     bezierSmoothness?: number;
 }
 
+/**
+ * A system that manages the rendering of GraphicsContexts.
+ * @memberof rendering
+ */
 export class GraphicsContextSystem implements System<GraphicsContextSystemOptions>
 {
     /** @ignore */

--- a/src/scene/graphics/shared/GraphicsView.ts
+++ b/src/scene/graphics/shared/GraphicsView.ts
@@ -7,6 +7,10 @@ import type { View } from '../../../rendering/renderers/shared/view/View';
 import type { Bounds } from '../../container/bounds/Bounds';
 import type { ContextDestroyOptions, TextureDestroyOptions, TypeOrBool } from '../../container/destroyTypes';
 
+/**
+ * A GraphicsView is a view that renders a GraphicsContext.
+ * @memberof scene
+ */
 export class GraphicsView implements View
 {
     public readonly uid = uid('graphicsView');

--- a/src/scene/graphics/shared/path/ShapePath.ts
+++ b/src/scene/graphics/shared/path/ShapePath.ts
@@ -20,6 +20,11 @@ import type { RoundedPoint } from './roundShape';
 
 const tempRectangle = new Rectangle();
 
+/**
+ * A helper class for Graphics - converts its API calls
+ * to a shape that can be used by the Graphics2D renderer.
+ * @memberof scene
+ */
 export class ShapePath
 {
     public shapePrimitives: { shape: ShapePrimitive, transform?: Matrix }[] = [];

--- a/src/scene/mesh-nine-slice/NineSliceGeometry.ts
+++ b/src/scene/mesh-nine-slice/NineSliceGeometry.ts
@@ -14,6 +14,10 @@ export interface NineSliceGeometryOptions
     textureMatrix?: Matrix
 }
 
+/**
+ * The NineSliceGeometry class allows you to create a NineSlicePlane object.
+ * @memberof scene
+ */
 export class NineSliceGeometry extends PlaneGeometry
 {
     public static defaultOptions: NineSliceGeometryOptions = {

--- a/src/scene/mesh-nine-slice/NineSliceSprite.ts
+++ b/src/scene/mesh-nine-slice/NineSliceSprite.ts
@@ -225,7 +225,10 @@ export class NineSliceSprite extends Container<MeshView<NineSliceGeometry>>
     }
 }
 
-/** @deprecated since 8.0.0 */
+/**
+ * @deprecated since 8.0.0
+ * @memberof scene
+ */
 export class NineSlicePlane extends NineSliceSprite
 {
     constructor(options: NineSliceSpriteOptions | Texture);

--- a/src/scene/mesh/gl/GlMeshAdaptor.ts
+++ b/src/scene/mesh/gl/GlMeshAdaptor.ts
@@ -10,6 +10,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
 import type { MeshView } from '../shared/MeshView';
 
+/**
+ * A MeshAdaptor that uses the WebGL to render meshes.
+ * @memberof rendering
+ */
 export class GlMeshAdaptor implements MeshAdaptor
 {
     public static extension = {

--- a/src/scene/mesh/gpu/GpuMeshAdapter.ts
+++ b/src/scene/mesh/gpu/GpuMeshAdapter.ts
@@ -11,6 +11,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
 import type { MeshView } from '../shared/MeshView';
 
+/**
+ * The WebGL adaptor for the mesh system. Allows the Mesh System to be used with the WebGl renderer
+ * @memberof rendering
+ */
 export class GpuMeshAdapter implements MeshAdaptor
 {
     /** @ignore */

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -3,6 +3,10 @@ import type { Renderable } from '../../../rendering/renderers/shared/Renderable'
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { MeshView } from './MeshView';
 
+/**
+ * A batchable mesh object.
+ * @memberof rendering
+ */
 export class BatchableMesh implements BatchableObject
 {
     public indexStart: number;

--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -15,6 +15,10 @@ export interface MeshGeometryOptions
     shrinkBuffersToFit?: boolean;
 }
 
+/**
+ * A geometry used to batch multiple meshes with the same texture.
+ * @memberof scene
+ */
 export class MeshGeometry extends Geometry
 {
     public static defaultOptions: MeshGeometryOptions = {

--- a/src/scene/mesh/shared/MeshView.ts
+++ b/src/scene/mesh/shared/MeshView.ts
@@ -28,6 +28,10 @@ export interface MeshViewOptions<
     texture?: Texture;
 }
 
+/**
+ * The MeshView class allows you to render a mesh.
+ * @memberof scene
+ */
 export class MeshView<
     GEOMETRY extends MeshGeometry = MeshGeometry,
     SHADER extends TextureShader = TextureShader

--- a/src/scene/sprite-tiling/TilingSpriteView.ts
+++ b/src/scene/sprite-tiling/TilingSpriteView.ts
@@ -38,6 +38,10 @@ export interface TilingSpriteViewOptions
     applyAnchorToTexture?: boolean
 }
 
+/**
+ * A tiling sprite renderable.
+ * @memberof scene
+ */
 export class TilingSpriteView implements View
 {
     public static defaultOptions: TilingSpriteViewOptions = {

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -4,6 +4,10 @@ import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { BoundsData } from '../container/bounds/Bounds';
 
+/**
+ * A batchable sprite object.
+ * @memberof rendering
+ */
 export class BatchableSprite implements BatchableObject
 {
     public indexStart: number;

--- a/src/scene/sprite/SpriteView.ts
+++ b/src/scene/sprite/SpriteView.ts
@@ -9,6 +9,10 @@ import type { View, ViewObserver } from '../../rendering/renderers/shared/view/V
 import type { Bounds, BoundsData } from '../container/bounds/Bounds';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 
+/**
+ * A sprite view.
+ * @memberof scene
+ */
 export class SpriteView implements View
 {
     public readonly renderPipeId = 'sprite';

--- a/src/scene/text-bitmap/AbstractBitmapFont.ts
+++ b/src/scene/text-bitmap/AbstractBitmapFont.ts
@@ -71,6 +71,10 @@ interface BitmapFontEvents<Type>
     destroy: [Type];
 }
 
+/**
+ * An abstract representation of a bitmap font.
+ * @memberof text
+ */
 export abstract class AbstractBitmapFont<FontType>
     extends EventEmitter<BitmapFontEvents<FontType>>
     implements Omit<BitmapFontData, 'chars' | 'pages' | 'fontSize'>

--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -9,6 +9,11 @@ import type { BitmapFontInstallOptions } from './AbstractBitmapFont';
 import type { BitmapFont } from './BitmapFont';
 import type { BitmapTextLayoutData } from './utils/getBitmapTextLayout';
 
+/**
+ * The BitmapFontManager is a helper class that exists to install and uninstall fonts
+ * into the cache for BitmapText objects.
+ * @memberof text
+ */
 class BitmapFontManagerClass
 {
     /**

--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -24,6 +24,10 @@ export interface DynamicBitmapFontOptions
     padding?: number
 }
 
+/**
+ * A BitmapFont that generates its glyphs dynamically.
+ * @memberof text
+ */
 export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
 {
     // this is a resolution modifier for the font size..

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -59,6 +59,10 @@ interface HTMLTextTexture
     promise: Promise<Texture>,
 }
 
+/**
+ * System plugin to the renderer to manage HTMLText
+ * @memberof rendering
+ */
 export class HTMLTextSystem implements System
 {
     /** @ignore */

--- a/src/scene/text-html/HtmlTextStyle.ts
+++ b/src/scene/text-html/HtmlTextStyle.ts
@@ -13,6 +13,10 @@ export interface HTMLTextStyleOptions extends Omit<TextStyleOptions, 'leading' |
     tagStyles?: Record<string, HTMLTextStyleOptions>;
 }
 
+/**
+ * A TextStyle object rendered by the HTMLTextSystem.
+ * @memberof text
+ */
 export class HTMLTextStyle extends TextStyle
 {
     private _cssOverrides: string[] = [];

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -25,6 +25,11 @@ export type TextStyleTextBaseline = 'alphabetic' | 'top' | 'hanging' | 'middle' 
 export type TextStyleWhiteSpace = 'normal' | 'pre' | 'pre-line';
 
 /**
+ * The namespace for Text related objects.
+ * @namespace text
+ */
+
+/**
  * A drop shadow effect.
  * @memberof scene
  */
@@ -118,7 +123,7 @@ export interface TextStyleOptions
  * A TextStyle Object contains information to decorate a Text objects.
  *
  * An instance can be shared between multiple Text objects; then changing the style will update all text objects using it.
- * @memberof scene
+ * @memberof text
  * @example
  * import { TextStyle } from 'pixi.js';
  * const style = new TextStyle({

--- a/src/scene/text/TextView.ts
+++ b/src/scene/text/TextView.ts
@@ -39,6 +39,10 @@ const map = {
     bitmap: 'bitmapText',
 };
 
+/**
+ * A text view.
+ * @memberof text
+ */
 export class TextView implements View
 {
     public readonly uid: number = uid('textView');

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -53,6 +53,7 @@ const contextSettings: ICanvasRenderingContext2DSettings = {
  *     align: 'center',
  * });
  * const textMetrics = TextMetrics.measureText('Your text', style);
+ * @memberof text
  */
 export class CanvasTextMetrics
 {

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -21,6 +21,10 @@ interface CanvasAndContext
     context: ICanvasRenderingContext2D;
 }
 
+/**
+ * System that manages the generation of textures from the renderer
+ * @memberof rendering
+ */
 export class CanvasTextSystem implements System
 {
     /** @ignore */


### PR DESCRIPTION
Ensure all symbols which are documented are assigned a `@memberof` doc tag.
This ensures there are no loose symbols and everything has a namespace home.

* Introduced `text` namespace to separate text specific classes away from the display objects in the `scene` namespace.
* Moved a lot of stuff into the `rendering` namespace as that already had a description about it containing systems and other rendering related classes.