### PR TITLE
v8 add support for uint16

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -7,6 +7,7 @@ import { BatchTextureArray } from './BatchTextureArray';
 import { MAX_TEXTURES } from './const';
 
 import type { BindGroup } from '../../renderers/gpu/shader/BindGroup';
+import type { IndexBufferArray } from '../../renderers/shared/geometry/Geometry';
 import type { Instruction } from '../../renderers/shared/instructions/Instruction';
 import type { InstructionSet } from '../../renderers/shared/instructions/InstructionSet';
 import type { Texture } from '../../renderers/shared/texture/Texture';
@@ -65,7 +66,7 @@ export interface BatchableObject
         index: number,
         textureId: number,
     ) => void;
-    packIndex: (indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number) => void;
+    packIndex: (indexBuffer: IndexBufferArray, index: number, indicesOffset: number) => void;
 
     texture: Texture;
     blendMode: BLEND_MODES;
@@ -98,7 +99,7 @@ export class Batcher
 
     public uid = uid('batcher');
     public attributeBuffer: ViewableBuffer;
-    public indexBuffer: Uint32Array | Uint16Array;
+    public indexBuffer: IndexBufferArray;
 
     public attributeSize: number;
     public indexSize: number;

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -114,7 +114,9 @@ export class GpuEncoderSystem implements System
 
         this._boundIndexBuffer = buffer;
 
-        this.renderPassEncoder.setIndexBuffer(this._renderer.buffer.updateBuffer(buffer), 'uint32');
+        const indexFormat = buffer.data.BYTES_PER_ELEMENT === 2 ? 'uint16' : 'uint32';
+
+        this.renderPassEncoder.setIndexBuffer(this._renderer.buffer.updateBuffer(buffer), indexFormat);
     }
 
     public setBindGroup(index: number, bindGroup: BindGroup, program: GpuProgram)

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -7,6 +7,8 @@ import { getGeometryBounds } from './utils/getGeometryBounds';
 import type { Buffer, TypedArray } from '../buffer/Buffer';
 import type { Topology, VertexFormat } from './const';
 
+export type IndexBufferArray = Uint16Array | Uint32Array;
+
 /**
  * The attribute data for a geometries attributes
  * @memberof rendering

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -1,6 +1,7 @@
 import { mixColors } from '../../container/utils/mixColors';
 
 import type { Batch, BatchableObject, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { IndexBufferArray } from '../../../rendering/renderers/shared/geometry/Geometry';
 import type { Renderable } from '../../../rendering/renderers/shared/Renderable';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { GraphicsView } from './GraphicsView';
@@ -35,7 +36,7 @@ export class BatchableGraphics implements BatchableObject
         return 'normal';
     }
 
-    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: IndexBufferArray, index: number, indicesOffset: number)
     {
         const indices = this.geometryData.indices;
 

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -35,7 +35,7 @@ export class BatchableGraphics implements BatchableObject
         return 'normal';
     }
 
-    public packIndex(indexBuffer: Uint32Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
     {
         const indices = this.geometryData.indices;
 

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -1,4 +1,5 @@
 import type { Batch, BatchableObject, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { IndexBufferArray } from '../../../rendering/renderers/shared/geometry/Geometry';
 import type { Renderable } from '../../../rendering/renderers/shared/Renderable';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { MeshView } from './MeshView';
@@ -24,7 +25,7 @@ export class BatchableMesh implements BatchableObject
         this.batch = null;
     }
 
-    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: IndexBufferArray, index: number, indicesOffset: number)
     {
         const indices = this.renderable.view.geometry.indices;
 

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -24,7 +24,7 @@ export class BatchableMesh implements BatchableObject
         this.batch = null;
     }
 
-    public packIndex(indexBuffer: Uint32Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
     {
         const indices = this.renderable.view.geometry.indices;
 

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -97,7 +97,7 @@ export class BatchableSprite implements BatchableObject
         uint32View[index + 23] = textureIdAndRound;
     }
 
-    public packIndex(indexBuffer: Uint32Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
     {
         indexBuffer[index] = indicesOffset + 0;
         indexBuffer[index + 1] = indicesOffset + 1;

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -1,4 +1,5 @@
 import type { Batch, BatchableObject, Batcher } from '../../rendering/batcher/shared/Batcher';
+import type { IndexBufferArray } from '../../rendering/renderers/shared/geometry/Geometry';
 import type { Renderable } from '../../rendering/renderers/shared/Renderable';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { View } from '../../rendering/renderers/shared/view/View';
@@ -97,7 +98,7 @@ export class BatchableSprite implements BatchableObject
         uint32View[index + 23] = textureIdAndRound;
     }
 
-    public packIndex(indexBuffer: Uint32Array | Uint16Array, index: number, indicesOffset: number)
+    public packIndex(indexBuffer: IndexBufferArray, index: number, indicesOffset: number)
     {
         indexBuffer[index] = indicesOffset + 0;
         indexBuffer[index + 1] = indicesOffset + 1;

--- a/tests/renderering/batch/Batcher.test.ts
+++ b/tests/renderering/batch/Batcher.test.ts
@@ -37,6 +37,7 @@ describe('Batcher', () =>
         });
 
         expect(batcher.indexBuffer).toHaveLength(2);
+        expect(batcher.indexBuffer.BYTES_PER_ELEMENT).toBe(2);
 
         batcher.ensureIndexBuffer(30);
 
@@ -46,12 +47,18 @@ describe('Batcher', () =>
 
         const ref = batcher.indexBuffer;
 
-        expect(batcher.indexBuffer).toHaveLength(60);
+        expect(batcher.indexBuffer).toHaveLength(46);
 
         batcher.ensureIndexBuffer(36);
 
-        expect(batcher.indexBuffer).toHaveLength(60);
+        expect(batcher.indexBuffer).toHaveLength(46);
+        expect(batcher.indexBuffer.BYTES_PER_ELEMENT).toBe(2);
 
         expect(batcher.indexBuffer).toBe(ref);
+
+        batcher.ensureIndexBuffer(70000);
+
+        expect(batcher.indexBuffer).toHaveLength(70000);
+        expect(batcher.indexBuffer.BYTES_PER_ELEMENT).toBe(4);
     });
 });

--- a/tests/renderering/batch/checkCanUseTexture.tests.ts
+++ b/tests/renderering/batch/checkCanUseTexture.tests.ts
@@ -12,7 +12,7 @@ class DummyBatchableObject implements BatchableObject
     {
         //
     };
-    packIndex = (_indexBuffer: Uint32Array, _index: number, _indicesOffset: number) =>
+    packIndex = (_indexBuffer: Uint32Array | Uint16Array, _index: number, _indicesOffset: number) =>
     {
         //
     };

--- a/tests/renderering/batch/checkCanUseTexture.tests.ts
+++ b/tests/renderering/batch/checkCanUseTexture.tests.ts
@@ -3,6 +3,7 @@ import { InstructionSet } from '../../../src/rendering/renderers/shared/instruct
 import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
 import '../../../src/rendering/renderers/shared/texture/sources/ImageSource';
 
+import type { IndexBufferArray } from '../../../src/rendering/renderers/shared/geometry/Geometry';
 import type { BLEND_MODES } from '../../../src/rendering/renderers/shared/state/const';
 
 class DummyBatchableObject implements BatchableObject
@@ -12,7 +13,7 @@ class DummyBatchableObject implements BatchableObject
     {
         //
     };
-    packIndex = (_indexBuffer: Uint32Array | Uint16Array, _index: number, _indicesOffset: number) =>
+    packIndex = (_indexBuffer: IndexBufferArray, _index: number, _indicesOffset: number) =>
     {
         //
     };

--- a/tests/visual/scenes/compressed-textures/dds.scene.ts
+++ b/tests/visual/scenes/compressed-textures/dds.scene.ts
@@ -6,7 +6,7 @@ import type { Container } from '../../../../src/scene/container/Container';
 import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
-    it: 'should a dds texture',
+    it: 'should load a dds texture',
     create: async (scene: Container) =>
     {
         const texture = await Assets.load('explosion_dxt5_mip.dds');


### PR DESCRIPTION
Adds support for `Uint16Array` as an indexBuffer type

if a batch is smaller than 10000ish (which is most often the case!) 
we should use `Uint16Array` as they are half the size of `Uint32Arrays`.



