### PR TITLE
fix for transform to behave like v7

### DIFF
--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -1,5 +1,6 @@
 import { Color, type ColorSource } from '../../../../color/Color';
 import { Container } from '../../../../scene/container/Container';
+import { updateLocalTransform } from '../../../../scene/container/utils/updateLocalTransform';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
 import { SystemRunner } from './SystemRunner';
 
@@ -199,6 +200,12 @@ export class AbstractRenderer<PIPES, OPTIONS extends PixiMixins.RendererOptions,
             const isRGBAArray = Array.isArray(options.clearColor) && options.clearColor.length === 4;
 
             options.clearColor = isRGBAArray ? options.clearColor : Color.shared.setValue(options.clearColor).toArray();
+        }
+
+        if (!options.transform)
+        {
+            updateLocalTransform(options.container.localTransform, options.container);
+            options.transform = options.container.localTransform;
         }
 
         this.runners.prerender.emit(options);

--- a/src/scene/container/bounds/getFastGlobalBounds.ts
+++ b/src/scene/container/bounds/getFastGlobalBounds.ts
@@ -23,14 +23,18 @@ export function getFastGlobalBounds(target: Container, bounds: Bounds): Bounds
 
     _getGlobalBoundsRecursive(target, bounds);
 
+    if (!bounds.isValid)
+    {
+        bounds.set(0, 0, 0, 0);
+    }
+
     if (!target.isRenderGroupRoot)
     {
         bounds.applyMatrix(target.renderGroup.worldTransform);
     }
-
-    if (!bounds.isValid)
+    else
     {
-        bounds.set(0, 0, 0, 0);
+        bounds.applyMatrix(target.renderGroup.localTransform);
     }
 
     return bounds;

--- a/src/scene/container/utils/buildInstructions.ts
+++ b/src/scene/container/utils/buildInstructions.ts
@@ -98,6 +98,14 @@ function collectAllRenderablesAdvanced(
     isRoot: boolean
 ): void
 {
+    for (let i = 0; i < container.effects.length; i++)
+    {
+        const effect = container.effects[i];
+        const pipe = renderPipes[effect.pipe as keyof RenderPipes]as InstructionPipe<any>;
+
+        pipe.push(effect, container, instructionSet);
+    }
+
     if (isRoot)
     {
         const renderGroup = container.renderGroup;
@@ -114,16 +122,6 @@ function collectAllRenderablesAdvanced(
                 // eslint-disable-next-line max-len
                 (renderPipes[proxyRenderable.view.renderPipeId as keyof RenderPipes] as any).addRenderable(proxyRenderable, instructionSet);
             }
-        }
-    }
-    else
-    {
-        for (let i = 0; i < container.effects.length; i++)
-        {
-            const effect = container.effects[i];
-            const pipe = renderPipes[effect.pipe as keyof RenderPipes]as InstructionPipe<any>;
-
-            pipe.push(effect, container, instructionSet);
         }
     }
 
@@ -157,16 +155,13 @@ function collectAllRenderablesAdvanced(
         }
     }
 
-    if (!isRoot)
+    // loop backwards through effects
+    for (let i = container.effects.length - 1; i >= 0; i--)
     {
-        // loop backwards through effects
-        for (let i = container.effects.length - 1; i >= 0; i--)
-        {
-            const effect = container.effects[i];
-            const pipe = renderPipes[effect.pipe as keyof RenderPipes]as InstructionPipe<any>;
+        const effect = container.effects[i];
+        const pipe = renderPipes[effect.pipe as keyof RenderPipes]as InstructionPipe<any>;
 
-            pipe.pop(effect, container, instructionSet);
-        }
+        pipe.pop(effect, container, instructionSet);
     }
 }
 

--- a/tests/scene/getGlobalFastBounds.tests.ts
+++ b/tests/scene/getGlobalFastBounds.tests.ts
@@ -110,7 +110,7 @@ describe('getGlobalFastBounds', () =>
 
         const bounds = getFastGlobalBounds(container, new Bounds());
 
-        expect(bounds).toMatchObject({ minX: 100, minY: 0, maxX: 200, maxY: 200 });
+        expect(bounds).toMatchObject({ minX: 200, minY: 0, maxX: 300, maxY: 200 });
 
         const child3 = new Container({ label: 'child2', view: new DummyView() });
 


### PR DESCRIPTION
local transform, filters and masks are now taken into account when an item is rendered. Much like v7

