### PR TITLE
fix depthTexture issue

### DIFF
--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -90,6 +90,7 @@ export class RenderTarget
                     height: this.height,
                     resolution: this.resolution,
                     format: 'stencil8',
+                    autoGenerateMipmaps: false,
                 // sampleCount: handled by the render target system..
                 });
             }

--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -91,6 +91,8 @@ export class RenderTarget
                     resolution: this.resolution,
                     format: 'stencil8',
                     autoGenerateMipmaps: false,
+                    antialias: false,
+                    mipLevelCount: 1,
                 // sampleCount: handled by the render target system..
                 });
             }


### PR DESCRIPTION
fix issue with setting 

`TextureSource.defaultOptions.autoGenerateMipmaps = true;`

this breaks the depthTextures used in the RenderTarget

