### PR TITLE
Chore/v8/flatten TextStyle dropShadow properties

### DIFF
--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -157,7 +157,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
             }
 
             const xAdvance = (width / fontScale)
-                - (style.dropShadow?.distance ?? 0)
+                - (style.dropShadow ? style.dropShadowDistance : 0)
                 - (style._stroke?.width ?? 0);
 
             // This is in coord space of the measurements.. not the texture
@@ -321,16 +321,15 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
 
         if (style.dropShadow)
         {
-            const shadowOptions = style.dropShadow;
-            const rgb = Color.shared.setValue(shadowOptions.color).toArray();
+            const rgb = Color.shared.setValue(style.dropShadowColor).toArray();
 
-            const dropShadowBlur = shadowOptions.blur * resolution;
-            const dropShadowDistance = shadowOptions.distance * resolution;
+            const dropShadowBlur = style.dropShadowBlur * resolution;
+            const dropShadowDistance = style.dropShadowDistance * resolution;
 
-            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${shadowOptions.alpha})`;
+            context.shadowColor = `rgba(${rgb[0] * 255},${rgb[1] * 255},${rgb[2] * 255},${style.dropShadowAlpha})`;
             context.shadowBlur = dropShadowBlur;
-            context.shadowOffsetX = Math.cos(shadowOptions.angle) * dropShadowDistance;
-            context.shadowOffsetY = Math.sin(shadowOptions.angle) * dropShadowDistance;
+            context.shadowOffsetX = Math.cos(style.dropShadowAngle) * dropShadowDistance;
+            context.shadowOffsetY = Math.sin(style.dropShadowAngle) * dropShadowDistance;
         }
         else
         {

--- a/src/scene/text-html/utils/textStyleToCSS.ts
+++ b/src/scene/text-html/utils/textStyleToCSS.ts
@@ -1,7 +1,6 @@
 import { Color } from '../../../color/Color';
 
 import type { StrokeStyle } from '../../graphics/shared/GraphicsContext';
-import type { TextStyle } from '../../text/TextStyle';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../HtmlTextStyle';
 
 /**
@@ -31,7 +30,7 @@ export function textStyleToCSS(style: HTMLTextStyle): string
             `max-width: ${style.wordWrapWidth}px`
         ] : [],
         ...stroke ? [strokeToCSS(stroke)] : [],
-        ...style.dropShadow ? [dropShadowToCSS(style.dropShadow)] : [],
+        ...style.dropShadow ? [dropShadowToCSS(style)] : [],
         ...style.cssOverrides,
     ].join(';');
 
@@ -42,17 +41,17 @@ export function textStyleToCSS(style: HTMLTextStyle): string
     return cssStyles.join(' ');
 }
 
-function dropShadowToCSS(dropShadowStyle: TextStyle['dropShadow']): string
+function dropShadowToCSS(style: HTMLTextStyle): string
 {
-    const color = Color.shared.setValue(dropShadowStyle.color).setAlpha(dropShadowStyle.alpha).toHexa();
-    const x = Math.round(Math.cos(dropShadowStyle.angle) * dropShadowStyle.distance);
-    const y = Math.round(Math.sin(dropShadowStyle.angle) * dropShadowStyle.distance);
+    const color = Color.shared.setValue(style.dropShadowColor).setAlpha(style.dropShadowAlpha).toHexa();
+    const x = Math.round(Math.cos(style.dropShadowAngle) * style.dropShadowDistance);
+    const y = Math.round(Math.sin(style.dropShadowAngle) * style.dropShadowDistance);
 
     const position = `${x}px ${y}px`;
 
-    if (dropShadowStyle.blur > 0)
+    if (style.dropShadowBlur > 0)
     {
-        return `text-shadow: ${position} ${dropShadowStyle.blur}px ${color}`;
+        return `text-shadow: ${position} ${style.dropShadowBlur}px ${color}`;
     }
 
     return `text-shadow: ${position} ${color}`;
@@ -89,7 +88,6 @@ const transform = {
     fill: (value: string) => `color: ${Color.shared.setValue(value).toHex()}`,
     breakWords: (value: string) => `word-wrap: ${value ? 'break-all' : 'break-word'}`,
     stroke: strokeToCSS,
-    dropShadow: dropShadowToCSS
 };
 
 function tagStyleToCSS(tagStyles: Record<string, HTMLTextStyleOptions>, out: string[])

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -275,12 +275,12 @@ export class TextStyle extends EventEmitter<{
             this.fontSize = fullStyle.fontSize as number;
         }
 
-        this._dropShadow = style.dropShadow ?? defaultStyle.dropShadow;
-        this._dropShadowAlpha = style.dropShadowAlpha ?? defaultStyle.dropShadowAlpha;
-        this._dropShadowAngle = style.dropShadowAngle ?? defaultStyle.dropShadowAngle;
-        this._dropShadowBlur = style.dropShadowBlur ?? defaultStyle.dropShadowBlur;
-        this._dropShadowColor = style.dropShadowColor ?? defaultStyle.dropShadowColor;
-        this._dropShadowDistance = style.dropShadowDistance ?? defaultStyle.dropShadowDistance;
+        this._dropShadow = fullStyle.dropShadow;
+        this._dropShadowAlpha = fullStyle.dropShadowAlpha;
+        this._dropShadowAngle = fullStyle.dropShadowAngle;
+        this._dropShadowBlur = fullStyle.dropShadowBlur;
+        this._dropShadowColor = fullStyle.dropShadowColor;
+        this._dropShadowDistance = fullStyle.dropShadowDistance;
 
         this.update();
     }

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -270,7 +270,7 @@ export class CanvasTextMetrics
 
         if (style.dropShadow)
         {
-            width += style.dropShadow.distance;
+            width += style.dropShadowDistance;
         }
 
         const lineHeight = style.lineHeight || fontProperties.fontSize + strokeWidth;
@@ -280,7 +280,7 @@ export class CanvasTextMetrics
 
         if (style.dropShadow)
         {
-            height += style.dropShadow.distance;
+            height += style.dropShadowDistance;
         }
 
         const measurements = new CanvasTextMetrics(

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -211,22 +211,17 @@ export class CanvasTextSystem implements System
                 context.fillStyle = 'black';
                 context.strokeStyle = 'black';
 
-                const shadowOptions = style.dropShadow;
-
-                const dropShadowColor = shadowOptions.color;
-                const dropShadowAlpha = shadowOptions.alpha;
-
                 context.shadowColor = Color.shared
-                    .setValue(dropShadowColor)
-                    .setAlpha(dropShadowAlpha)
+                    .setValue(style.dropShadowColor)
+                    .setAlpha(style.dropShadowAlpha)
                     .toRgbaString();
 
-                const dropShadowBlur = shadowOptions.blur * resolution;
-                const dropShadowDistance = shadowOptions.distance * resolution;
+                const dropShadowBlur = style.dropShadowBlur * resolution;
+                const dropShadowDistance = style.dropShadowDistance * resolution;
 
                 context.shadowBlur = dropShadowBlur;
-                context.shadowOffsetX = Math.cos(shadowOptions.angle) * dropShadowDistance;
-                context.shadowOffsetY = (Math.sin(shadowOptions.angle) * dropShadowDistance) + dsOffsetShadow;
+                context.shadowOffsetX = Math.cos(style.dropShadowAngle) * dropShadowDistance;
+                context.shadowOffsetY = (Math.sin(style.dropShadowAngle) * dropShadowDistance) + dsOffsetShadow;
             }
             else
             {

--- a/tests/visual/scenes/graphics/rect-fills.scene.ts
+++ b/tests/visual/scenes/graphics/rect-fills.scene.ts
@@ -10,6 +10,7 @@ import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
     it: 'should render rects with fills, strokes, gradients using textures',
+    pixelMatch: 150,
     create: async (scene: Container) =>
     {
         const texture = await Assets.load<Texture>({

--- a/tests/visual/scenes/text/text-trim.scene.ts
+++ b/tests/visual/scenes/text/text-trim.scene.ts
@@ -5,7 +5,7 @@ import type { Container } from '../../../../src/scene/container/Container';
 import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
-    it: 'should render text correctly if style changes',
+    it: 'should render trimmed text correctly if style changes',
     create: async (scene: Container, renderer: Renderer) =>
     {
         const text = new Text({

--- a/tests/visual/scenes/text/text.scene.ts
+++ b/tests/visual/scenes/text/text.scene.ts
@@ -5,7 +5,7 @@ import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
     it: 'should render text correctly if style changes',
-    pixelMatch: 1000,
+    pixelMatch: 910,
     create: async (scene: Container) =>
     {
         const text = new Text({
@@ -17,15 +17,13 @@ export const scene: TestScene = {
                 lineHeight: 15,
                 letterSpacing: 6,
                 align: 'center',
-                dropShadow: {
-                    alpha: 1,
-                    angle: Math.PI / 6,
-                    blur: 5,
-                    color: 'blue',
-                    distance: 5,
-                },
+                dropShadow: true,
+                dropShadowAlpha: 1,
+                dropShadowAngle: Math.PI / 6,
+                dropShadowBlur: 5,
+                dropShadowColor: 'blue',
+                dropShadowDistance: 5,
             },
-            // renderMode: 'bitmap'
         });
 
         scene.addChild(text);


### PR DESCRIPTION
Flatten `TextStyle.dropShadow*` properties from object to separate properties.
Essentially reverts back to v7 format.
