### PR TITLE
Chore/v8/filter-uniform-name-tidy

### DIFF
--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -163,7 +163,7 @@ export class Filter extends Shader
         this.blendRequired = options.blendRequired;
 
         this.addResource('filterUniforms', 0, 0);
-        this.addResource('uSampler', 0, 1);
+        this.addResource('uTexture', 0, 1);
     }
 
     /**

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -100,12 +100,12 @@ export class FilterSystem implements System
     private _filterStack: FilterData[] = [];
 
     private readonly _filterGlobalUniforms = new UniformGroup({
-        inputSize: { value: new Float32Array(4), type: 'vec4<f32>' },
-        inputPixel: { value: new Float32Array(4), type: 'vec4<f32>' },
-        inputClamp: { value: new Float32Array(4), type: 'vec4<f32>' },
-        outputFrame: { value: new Float32Array(4), type: 'vec4<f32>' },
-        globalFrame: { value: new Float32Array(4), type: 'vec4<f32>' },
-        outputTexture: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uInputSize: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uInputPixel: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uInputClamp: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uOutputFrame: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uGlobalFrame: { value: new Float32Array(4), type: 'vec4<f32>' },
+        uOutputTexture: { value: new Float32Array(4), type: 'vec4<f32>' },
     });
 
     private readonly _globalFilterBindGroup: BindGroup = new BindGroup({});
@@ -438,12 +438,12 @@ export class FilterSystem implements System
         const filterUniforms = this._filterGlobalUniforms;
         const uniforms = filterUniforms.uniforms;
 
-        const outputFrame = uniforms.outputFrame;
-        const inputSize = uniforms.inputSize;
-        const inputPixel = uniforms.inputPixel;
-        const inputClamp = uniforms.inputClamp;
-        const globalFrame = uniforms.globalFrame;
-        const outputTexture = uniforms.outputTexture;
+        const outputFrame = uniforms.uOutputFrame;
+        const inputSize = uniforms.uInputSize;
+        const inputPixel = uniforms.uInputPixel;
+        const inputClamp = uniforms.uInputClamp;
+        const globalFrame = uniforms.uGlobalFrame;
+        const outputTexture = uniforms.uOutputTexture;
 
         // are we rendering back to the original surface?
         if (isFinalTarget)

--- a/src/filters/blend-modes/BlendModeFilter.ts
+++ b/src/filters/blend-modes/BlendModeFilter.ts
@@ -61,7 +61,7 @@ export class BlendModeFilter extends Filter
             blendRequired: true,
             resources: {
                 blendUniforms: uniformGroup,
-                backTexture: Texture.EMPTY
+                uBackTexture: Texture.EMPTY
             }
         });
     }

--- a/src/filters/blend-modes/blend-template.frag
+++ b/src/filters/blend-modes/blend-template.frag
@@ -6,7 +6,7 @@ out vec4 finalColor;
 
 uniform float uBlend;
 
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 uniform sampler2D backTexture;
 
 {FUNCTIONS}
@@ -14,7 +14,7 @@ uniform sampler2D backTexture;
 void main()
 { 
     vec4 back = texture(backTexture, vTextureCoord);
-    vec4 front = texture(uSampler, vTextureCoord);
+    vec4 front = texture(uTexture, vTextureCoord);
 
     {MAIN}
 }

--- a/src/filters/blend-modes/blend-template.frag
+++ b/src/filters/blend-modes/blend-template.frag
@@ -7,13 +7,13 @@ out vec4 finalColor;
 uniform float uBlend;
 
 uniform sampler2D uTexture;
-uniform sampler2D backTexture;
+uniform sampler2D uBackTexture;
 
 {FUNCTIONS}
 
 void main()
 { 
-    vec4 back = texture(backTexture, vTextureCoord);
+    vec4 back = texture(uBackTexture, vTextureCoord);
     vec4 front = texture(uTexture, vTextureCoord);
 
     {MAIN}

--- a/src/filters/blend-modes/blend-template.vert
+++ b/src/filters/blend-modes/blend-template.vert
@@ -2,24 +2,23 @@ in vec2 aPosition;
 out vec2 vTextureCoord;
 out vec2 backgroundUv;
 
-uniform vec4 inputSize;
-uniform vec4 outputFrame;
-uniform vec4 backgroundFrame;
-uniform vec4 outputTexture;
+uniform vec4 uInputSize;
+uniform vec4 uOutputFrame;
+uniform vec4 uOutputTexture;
 
 vec4 filterVertexPosition( void )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
     
-    position.x = position.x * (2.0 / outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*outputTexture.z / outputTexture.y) - outputTexture.z;
+    position.x = position.x * (2.0 / uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*uOutputTexture.z / uOutputTexture.y) - uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 vec2 filterTextureCoord( void )
 {
-    return aPosition * (outputFrame.zw * inputSize.zw);
+    return aPosition * (uOutputFrame.zw * uInputSize.zw);
 }
 
 void main(void)

--- a/src/filters/blend-modes/blend-template.wgsl
+++ b/src/filters/blend-modes/blend-template.wgsl
@@ -13,8 +13,8 @@ struct BlendUniforms {
 };
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 @group(0) @binding(3) var backTexture: texture_2d<f32>;
 
 @group(1) @binding(0) var<uniform> blendUniforms : BlendUniforms;
@@ -63,8 +63,8 @@ fn mainFragment(
 ) -> @location(0) vec4<f32> {
 
 
-   var back =  textureSample(backTexture, mySampler, uv);
-   var front = textureSample(uSampler, mySampler, uv);
+   var back =  textureSample(backTexture, uSampler, uv);
+   var front = textureSample(uTexture, uSampler, uv);
    
    var out = vec4<f32>(0.0,0.0,0.0,0.0);
 

--- a/src/filters/blend-modes/blend-template.wgsl
+++ b/src/filters/blend-modes/blend-template.wgsl
@@ -15,7 +15,7 @@ struct BlendUniforms {
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
 @group(0) @binding(1) var uTexture: texture_2d<f32>;
 @group(0) @binding(2) var uSampler : sampler;
-@group(0) @binding(3) var backTexture: texture_2d<f32>;
+@group(0) @binding(3) var uBackTexture: texture_2d<f32>;
 
 @group(1) @binding(0) var<uniform> blendUniforms : BlendUniforms;
 
@@ -63,7 +63,7 @@ fn mainFragment(
 ) -> @location(0) vec4<f32> {
 
 
-   var back =  textureSample(backTexture, uSampler, uv);
+   var back =  textureSample(uBackTexture, uSampler, uv);
    var front = textureSample(uTexture, uSampler, uv);
    
    var out = vec4<f32>(0.0,0.0,0.0,0.0);

--- a/src/filters/blend-modes/blend-template.wgsl
+++ b/src/filters/blend-modes/blend-template.wgsl
@@ -1,11 +1,11 @@
 
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct BlendUniforms {
@@ -27,22 +27,22 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
   
 @vertex

--- a/src/filters/defaults/alpha/alpha.frag
+++ b/src/filters/defaults/alpha/alpha.frag
@@ -4,9 +4,9 @@ in vec2 vTextureCoord;
 out vec4 finalColor;
 
 uniform float uAlpha;
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 
 void main()
 {
-    finalColor =  texture(uSampler, vTextureCoord) * uAlpha;
+    finalColor =  texture(uTexture, vTextureCoord) * uAlpha;
 }

--- a/src/filters/defaults/alpha/alpha.wgsl
+++ b/src/filters/defaults/alpha/alpha.wgsl
@@ -1,10 +1,10 @@
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct AlphaUniforms {
@@ -24,27 +24,27 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 
 fn getSize() -> vec2<f32>
 {
-  return gfu.globalFrame.zw;
+  return gfu.uGlobalFrame.zw;
 }
   
 @vertex

--- a/src/filters/defaults/alpha/alpha.wgsl
+++ b/src/filters/defaults/alpha/alpha.wgsl
@@ -12,8 +12,8 @@ struct AlphaUniforms {
 };
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> alphaUniforms : AlphaUniforms;
 
@@ -63,7 +63,7 @@ fn mainFragment(
   @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
  
-    var sample = textureSample(uSampler, mySampler, uv);
+    var sample = textureSample(uTexture, uSampler, uv);
     
     return sample * alphaUniforms.uAlpha;
 }

--- a/src/filters/defaults/blur/BlurFilterPass.ts
+++ b/src/filters/defaults/blur/BlurFilterPass.ts
@@ -64,7 +64,7 @@ export class BlurFilterPass extends Filter
             gpuProgram,
             resources: {
                 blurUniforms: {
-                    strength: { value: 0, type: 'f32' },
+                    uStrength: { value: 0, type: 'f32' },
                 }
             },
             ...options
@@ -95,7 +95,7 @@ export class BlurFilterPass extends Filter
         clearMode: boolean
     ): void
     {
-        this._uniforms.strength = this.strength / this.passes;
+        this._uniforms.uStrength = this.strength / this.passes;
 
         if (this.passes === 1)
         {

--- a/src/filters/defaults/blur/gl/generateBlurFragSource.ts
+++ b/src/filters/defaults/blur/gl/generateBlurFragSource.ts
@@ -2,7 +2,7 @@ import { GAUSSIAN_VALUES } from '../const';
 
 const fragTemplate = [
     'in vec2 vBlurTexCoords[%size%];',
-    'uniform sampler2D uSampler;',
+    'uniform sampler2D uTexture;',
     'out vec4 finalColor;',
 
     'void main(void)',
@@ -21,7 +21,7 @@ export function generateBlurFragSource(kernelSize: number): string
     let fragSource = fragTemplate;
 
     let blurLoop = '';
-    const template = 'finalColor += texture(uSampler, vBlurTexCoords[%index%]) * %value%;';
+    const template = 'finalColor += texture(uTexture, vBlurTexCoords[%index%]) * %value%;';
     let value: number;
 
     for (let i = 0; i < kernelSize; i++)

--- a/src/filters/defaults/blur/gl/generateBlurVertSource.ts
+++ b/src/filters/defaults/blur/gl/generateBlurVertSource.ts
@@ -1,35 +1,34 @@
 const vertTemplate = `
     in vec2 aPosition;
 
-    uniform float strength;
+    uniform float uStrength;
 
     out vec2 vBlurTexCoords[%size%];
 
-    uniform vec4 inputSize;
-    uniform vec4 outputFrame;
-    uniform vec4 inputPixel;
-    uniform vec4 outputTexture;
+    uniform vec4 uInputSize;
+    uniform vec4 uOutputFrame;
+    uniform vec4 uOutputTexture;
 
     vec4 filterVertexPosition( void )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
     
-    position.x = position.x * (2.0 / outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*outputTexture.z / outputTexture.y) - outputTexture.z;
+    position.x = position.x * (2.0 / uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*uOutputTexture.z / uOutputTexture.y) - uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
     vec2 filterTextureCoord( void )
     {
-        return aPosition * (outputFrame.zw * inputSize.zw);
+        return aPosition * (uOutputFrame.zw * uInputSize.zw);
     }
 
     void main(void)
     {
         gl_Position = filterVertexPosition();
 
-        float pixelStrength = inputSize.%dimension% * strength;
+        float pixelStrength = uInputSize.%dimension% * uStrength;
 
         vec2 textureCoord = filterTextureCoord();
         %blur%

--- a/src/filters/defaults/blur/gpu/blur-template.wgsl
+++ b/src/filters/defaults/blur/gpu/blur-template.wgsl
@@ -1,16 +1,16 @@
 
 
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct BlurUniforms {
-  strength:f32,
+  uStrength:f32,
 };
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
@@ -27,27 +27,27 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 
 fn getSize() -> vec2<f32>
 {
-  return gfu.globalFrame.zw;
+  return gfu.uGlobalFrame.zw;
 }
 
 
@@ -58,7 +58,7 @@ fn mainVertex(
 
   let filteredCord = filterTextureCoord(aPosition);
 
-  let strength = gfu.inputSize.w * blurUniforms.strength;
+  let strength = gfu.uInputSize.w * blurUniforms.uStrength;
 
   return VSOutput(
    filterVertexPosition(aPosition),

--- a/src/filters/defaults/blur/gpu/blur-template.wgsl
+++ b/src/filters/defaults/blur/gpu/blur-template.wgsl
@@ -14,8 +14,8 @@ struct BlurUniforms {
 };
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> blurUniforms : BlurUniforms;
 

--- a/src/filters/defaults/blur/gpu/generateBlurProgram.ts
+++ b/src/filters/defaults/blur/gpu/generateBlurProgram.ts
@@ -27,7 +27,7 @@ export function generateBlurProgram(horizontal: boolean, kernelSize: number)
         const kernelIndex = i < halfLength ? i : (kernelSize - i - 1);
         const kernelValue = kernel[kernelIndex].toString();
 
-        blurSamplingSource[i] = `finalColor += textureSample(uSampler, mySampler, offset${i}) * ${kernelValue};`;
+        blurSamplingSource[i] = `finalColor += textureSample(uTexture, uSampler, offset${i}) * ${kernelValue};`;
     }
 
     const blurStruct = blurStructSource.join('\n');

--- a/src/filters/defaults/color-matrix/colorMatrixFilter.frag
+++ b/src/filters/defaults/color-matrix/colorMatrixFilter.frag
@@ -7,7 +7,7 @@ out vec4 finalColor;
 uniform float uColorMatrix[20];
 uniform float uAlpha;
 
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 
 float rand(vec2 co)
 {
@@ -16,7 +16,7 @@ float rand(vec2 co)
 
 void main()
 {
-    vec4 color = texture(uSampler, vTextureCoord);
+    vec4 color = texture(uTexture, vTextureCoord);
     float randomValue = rand(gl_FragCoord.xy * 0.2);
     float diff = (randomValue - 0.5) *  0.5;
 

--- a/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
+++ b/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
@@ -16,7 +16,6 @@ struct ColorMatrixUniforms {
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
 @group(0) @binding(1) var uTexture: texture_2d<f32>;
 @group(0) @binding(2) var uSampler : sampler;
-@group(0) @binding(3) var backTexture: texture_2d<f32>;
 @group(1) @binding(0) var<uniform> colorMatrixUniforms : ColorMatrixUniforms;
 
 

--- a/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
+++ b/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
@@ -14,8 +14,8 @@ struct ColorMatrixUniforms {
 
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 @group(0) @binding(3) var backTexture: texture_2d<f32>;
 @group(1) @binding(0) var<uniform> colorMatrixUniforms : ColorMatrixUniforms;
 
@@ -57,7 +57,7 @@ fn mainFragment(
 ) -> @location(0) vec4<f32> {
 
 
-  var c = textureSample(uSampler, mySampler, uv);
+  var c = textureSample(uTexture, uSampler, uv);
   
   if (colorMatrixUniforms.uAlpha == 0.0) {
     return c;

--- a/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
+++ b/src/filters/defaults/color-matrix/colorMatrixFilter.wgsl
@@ -1,10 +1,10 @@
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct ColorMatrixUniforms {
@@ -26,17 +26,17 @@ struct VSOutput {
   
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+  return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 @vertex

--- a/src/filters/defaults/defaultFilter.vert
+++ b/src/filters/defaults/defaultFilter.vert
@@ -1,26 +1,23 @@
 in vec2 aPosition;
 out vec2 vTextureCoord;
 
-uniform vec4 inputSize;
-uniform vec4 outputFrame;
-uniform vec4 outputTexture;
-// uniform vec4 globalFrame;
-// uniform float flipped;
-
+uniform vec4 uInputSize;
+uniform vec4 uOutputFrame;
+uniform vec4 uOutputTexture;
 
 vec4 filterVertexPosition( void )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
     
-    position.x = position.x * (2.0 / outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*outputTexture.z / outputTexture.y) - outputTexture.z;
+    position.x = position.x * (2.0 / uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*uOutputTexture.z / uOutputTexture.y) - uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 vec2 filterTextureCoord( void )
 {
-    return aPosition * (outputFrame.zw * inputSize.zw);
+    return aPosition * (uOutputFrame.zw * uInputSize.zw);
 }
 
 void main(void)

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -63,9 +63,9 @@ export class DisplacementFilter extends Filter
         }
 
         const filterUniforms = new UniformGroup({
-            filterMatrix: { value: new Matrix(), type: 'mat3x3<f32>' },
-            scale: { value: scale, type: 'vec2<f32>' },
-            rotation: { value: new Float32Array([0, 0, 0, 0]), type: 'vec4<f32>' },
+            uFilterMatrix: { value: new Matrix(), type: 'mat3x3<f32>' },
+            uScale: { value: scale, type: 'vec2<f32>' },
+            uRotation: { value: new Float32Array([0, 0, 0, 0]), type: 'vec4<f32>' },
         });
 
         const glProgram = GlProgram.from({
@@ -118,7 +118,7 @@ export class DisplacementFilter extends Filter
         const uniforms = this.resources.filterUniforms.uniforms;
 
         filterManager.calculateSpriteMatrix(
-            uniforms.filterMatrix,
+            uniforms.uFilterMatrix,
             this._sprite
         );
 
@@ -129,10 +129,10 @@ export class DisplacementFilter extends Filter
 
         if (lenX !== 0 && lenY !== 0)
         {
-            uniforms.rotation[0] = wt.a / lenX;
-            uniforms.rotation[1] = wt.b / lenX;
-            uniforms.rotation[2] = wt.c / lenY;
-            uniforms.rotation[3] = wt.d / lenY;
+            uniforms.uRotation[0] = wt.a / lenX;
+            uniforms.uRotation[1] = wt.b / lenX;
+            uniforms.uRotation[2] = wt.c / lenY;
+            uniforms.uRotation[3] = wt.d / lenY;
         }
 
         this.resources.uMapTexture = this._sprite.texture.source;

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -92,8 +92,8 @@ export class DisplacementFilter extends Filter
             glProgram,
             resources: {
                 filterUniforms,
-                mapTexture: textureSource,
-                mapSampler: textureSource.style,
+                uMapTexture: textureSource,
+                uMapSampler: textureSource.style,
             }
         });
 
@@ -135,7 +135,7 @@ export class DisplacementFilter extends Filter
             uniforms.rotation[3] = wt.d / lenY;
         }
 
-        this.resources.mapTexture = this._sprite.texture.source;
+        this.resources.uMapTexture = this._sprite.texture.source;
 
         filterManager.applyFilter(this, input, output, clearMode);
     }

--- a/src/filters/defaults/displacement/displacement.frag
+++ b/src/filters/defaults/displacement/displacement.frag
@@ -5,7 +5,7 @@ in vec2 vFilterUv;
 out vec4 finalColor;
 
 uniform sampler2D uTexture;
-uniform sampler2D mapTexture;
+uniform sampler2D uMapTexture;
 
 uniform vec4 filterArea;
 uniform vec4 filterClamp;
@@ -17,7 +17,7 @@ uniform vec2 scale;
 
 void main()
 {
-vec4 map = texture(mapTexture, vFilterUv);
+vec4 map = texture(uMapTexture, vFilterUv);
     
     vec2 offset = inputSize.zw * (rotation * (map.xy - 0.5)) * scale; 
 

--- a/src/filters/defaults/displacement/displacement.frag
+++ b/src/filters/defaults/displacement/displacement.frag
@@ -7,19 +7,16 @@ out vec4 finalColor;
 uniform sampler2D uTexture;
 uniform sampler2D uMapTexture;
 
-uniform vec4 filterArea;
-uniform vec4 filterClamp;
-uniform vec4 inputClamp;
-uniform highp vec4 inputSize;
-uniform mat2 rotation;
-uniform vec2 scale;
-
+uniform vec4 uInputClamp;
+uniform highp vec4 uInputSize;
+uniform mat2 uRotation;
+uniform vec2 uScale;
 
 void main()
 {
-vec4 map = texture(uMapTexture, vFilterUv);
+    vec4 map = texture(uMapTexture, vFilterUv);
     
-    vec2 offset = inputSize.zw * (rotation * (map.xy - 0.5)) * scale; 
+    vec2 offset = uInputSize.zw * (uRotation * (map.xy - 0.5)) * uScale; 
 
-    finalColor = texture(uTexture, clamp(vTextureCoord + offset, inputClamp.xy, inputClamp.zw));
+    finalColor = texture(uTexture, clamp(vTextureCoord + offset, uInputClamp.xy, uInputClamp.zw));
 }

--- a/src/filters/defaults/displacement/displacement.frag
+++ b/src/filters/defaults/displacement/displacement.frag
@@ -4,7 +4,7 @@ in vec2 vFilterUv;
 
 out vec4 finalColor;
 
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 uniform sampler2D mapTexture;
 
 uniform vec4 filterArea;
@@ -21,5 +21,5 @@ vec4 map = texture(mapTexture, vFilterUv);
     
     vec2 offset = inputSize.zw * (rotation * (map.xy - 0.5)) * scale; 
 
-    finalColor = texture(uSampler, clamp(vTextureCoord + offset, inputClamp.xy, inputClamp.zw));
+    finalColor = texture(uTexture, clamp(vTextureCoord + offset, inputClamp.xy, inputClamp.zw));
 }

--- a/src/filters/defaults/displacement/displacement.vert
+++ b/src/filters/defaults/displacement/displacement.vert
@@ -3,30 +3,30 @@ out vec2 vTextureCoord;
 out vec2 vFilterUv;
 
 
-uniform vec4 inputSize;
-uniform vec4 outputFrame;
-uniform vec4 outputTexture;
+uniform vec4 uInputSize;
+uniform vec4 uOutputFrame;
+uniform vec4 uOutputTexture;
 
-uniform mat3 filterMatrix;
+uniform mat3 uFilterMatrix;
 
 vec4 filterVertexPosition( void )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
     
-    position.x = position.x * (2.0 / outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*outputTexture.z / outputTexture.y) - outputTexture.z;
+    position.x = position.x * (2.0 / uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*uOutputTexture.z / uOutputTexture.y) - uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 vec2 filterTextureCoord( void )
 {
-    return aPosition * (outputFrame.zw * inputSize.zw);
+    return aPosition * (uOutputFrame.zw * uInputSize.zw);
 }
 
 vec2 getFilterCoord( void )
 {
-  return ( filterMatrix * vec3( filterTextureCoord(), 1.0)  ).xy;
+  return ( uFilterMatrix * vec3( filterTextureCoord(), 1.0)  ).xy;
 }
 
 

--- a/src/filters/defaults/displacement/displacement.wgsl
+++ b/src/filters/defaults/displacement/displacement.wgsl
@@ -1,17 +1,17 @@
 
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct DisplacementUniforms {
-  filterMatrix:mat3x3<f32>,
-  scale:vec2<f32>,
-  rotation:mat2x2<f32>
+  uFilterMatrix:mat3x3<f32>,
+  uScale:vec2<f32>,
+  uRotation:mat2x2<f32>
 };
 
 
@@ -32,34 +32,34 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 
 fn getFilterCoord(aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return ( filterUniforms.filterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
+  return ( filterUniforms.uFilterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
 }
 
 fn getSize() -> vec2<f32>
 {
 
   
-  return gfu.globalFrame.zw;
+  return gfu.uGlobalFrame.zw;
 }
   
 @vertex
@@ -82,7 +82,7 @@ fn mainFragment(
 
     var map = textureSample(uMapTexture, uMapSampler, filterUv);
     
-    var offset =  gfu.inputSize.zw * (filterUniforms.rotation * (map.xy - 0.5)) * filterUniforms.scale; 
+    var offset =  gfu.uInputSize.zw * (filterUniforms.uRotation * (map.xy - 0.5)) * filterUniforms.uScale; 
    
-     return textureSample(uTexture, uSampler, clamp(uv + offset, gfu.inputClamp.xy, gfu.inputClamp.zw));
+     return textureSample(uTexture, uSampler, clamp(uv + offset, gfu.uInputClamp.xy, gfu.uInputClamp.zw));
 }

--- a/src/filters/defaults/displacement/displacement.wgsl
+++ b/src/filters/defaults/displacement/displacement.wgsl
@@ -21,8 +21,8 @@ struct DisplacementUniforms {
 @group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> filterUniforms : DisplacementUniforms;
-@group(1) @binding(1) var mapTexture: texture_2d<f32>;
-@group(1) @binding(2) var mapSampler : sampler;
+@group(1) @binding(1) var uMapTexture: texture_2d<f32>;
+@group(1) @binding(2) var uMapSampler : sampler;
 
 struct VSOutput {
     @builtin(position) position: vec4<f32>,
@@ -80,7 +80,7 @@ fn mainFragment(
   @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    var map = textureSample(mapTexture, mapSampler, filterUv);
+    var map = textureSample(uMapTexture, uMapSampler, filterUv);
     
     var offset =  gfu.inputSize.zw * (filterUniforms.rotation * (map.xy - 0.5)) * filterUniforms.scale; 
    

--- a/src/filters/defaults/displacement/displacement.wgsl
+++ b/src/filters/defaults/displacement/displacement.wgsl
@@ -17,8 +17,8 @@ struct DisplacementUniforms {
 
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> filterUniforms : DisplacementUniforms;
 @group(1) @binding(1) var mapTexture: texture_2d<f32>;
@@ -84,5 +84,5 @@ fn mainFragment(
     
     var offset =  gfu.inputSize.zw * (filterUniforms.rotation * (map.xy - 0.5)) * filterUniforms.scale; 
    
-     return textureSample(uSampler, mySampler, clamp(uv + offset, gfu.inputClamp.xy, gfu.inputClamp.zw));
+     return textureSample(uTexture, uSampler, clamp(uv + offset, gfu.inputClamp.xy, gfu.inputClamp.zw));
 }

--- a/src/filters/defaults/noise/noise.frag
+++ b/src/filters/defaults/noise/noise.frag
@@ -6,7 +6,7 @@ out vec4 finalColor;
 
 uniform float uNoise;
 uniform float uSeed;
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 
 float rand(vec2 co)
 {
@@ -15,7 +15,7 @@ float rand(vec2 co)
 
 void main()
 {
-    vec4 color = texture(uSampler, vTextureCoord);
+    vec4 color = texture(uTexture, vTextureCoord);
     float randomValue = rand(gl_FragCoord.xy * 0.2);
     float diff = (randomValue - 0.5) *  0.5;
 

--- a/src/filters/defaults/noise/noise.wgsl
+++ b/src/filters/defaults/noise/noise.wgsl
@@ -17,7 +17,6 @@ struct NoiseUniforms {
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
 @group(0) @binding(1) var uTexture: texture_2d<f32>;
 @group(0) @binding(2) var uSampler : sampler;
-@group(0) @binding(3) var backTexture: texture_2d<f32>;
 
 @group(1) @binding(0) var<uniform> noiseUniforms : NoiseUniforms;
 

--- a/src/filters/defaults/noise/noise.wgsl
+++ b/src/filters/defaults/noise/noise.wgsl
@@ -15,8 +15,8 @@ struct NoiseUniforms {
 };
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 @group(0) @binding(3) var backTexture: texture_2d<f32>;
 
 @group(1) @binding(0) var<uniform> noiseUniforms : NoiseUniforms;
@@ -77,7 +77,7 @@ fn mainFragment(
     var pixelPosition =  globalTextureCoord(position.xy);// / (getSize());//-  gfu.outputFrame.xy);
   
     
-    var sample = textureSample(uSampler, mySampler, uv);
+    var sample = textureSample(uTexture, uSampler, uv);
     var randomValue =  rand(pixelPosition.xy * noiseUniforms.uSeed);
     var diff = (randomValue - 0.5) * noiseUniforms.uNoise;
   

--- a/src/filters/defaults/noise/noise.wgsl
+++ b/src/filters/defaults/noise/noise.wgsl
@@ -1,12 +1,12 @@
 
 
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,
 };
 
 struct NoiseUniforms {
@@ -27,27 +27,27 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 
 fn getSize() -> vec2<f32>
 {
-  return gfu.globalFrame.zw;
+  return gfu.uGlobalFrame.zw;
 }
   
 @vertex
@@ -73,7 +73,7 @@ fn mainFragment(
   @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    var pixelPosition =  globalTextureCoord(position.xy);// / (getSize());//-  gfu.outputFrame.xy);
+    var pixelPosition =  globalTextureCoord(position.xy);// / (getSize());//-  gfu.uOutputFrame.xy);
   
     
     var sample = textureSample(uTexture, uSampler, uv);

--- a/src/filters/defaults/shockwave/shockwave.frag
+++ b/src/filters/defaults/shockwave/shockwave.frag
@@ -12,7 +12,7 @@ uniform float uTime;
 uniform float uSpeed;
 uniform vec4 uWave;
 
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 
 
 const float PI = 3.14159;
@@ -32,7 +32,7 @@ void main()
 
     if (maxRadius > 0.0) {
         if (currentRadius > maxRadius) {
-            finalColor = texture(uSampler, vTextureCoord);
+            finalColor = texture(uTexture, vTextureCoord);
             return;
         }
         fade = 1.0 - pow(currentRadius / maxRadius, 2.0);
@@ -43,7 +43,7 @@ void main()
     float dist = length(dir);
 
     if (dist <= 0.0 || dist < currentRadius - halfWavelength || dist > currentRadius + halfWavelength) {
-        finalColor = texture(uSampler, vTextureCoord);
+        finalColor = texture(uTexture, vTextureCoord);
         return;
     }
 
@@ -61,13 +61,13 @@ void main()
     // Do clamp :
     vec2 coord = vTextureCoord + offset;
     vec2 clampedCoord = clamp(coord, inputClamp.xy, inputClamp.zw);
-    vec4 color = texture(uSampler, clampedCoord);
+    vec4 color = texture(uTexture, clampedCoord);
     if (coord != clampedCoord) {
         color *= max(0.0, 1.0 - length(coord - clampedCoord));
     }
 
     // No clamp :
-    // finalColor = texture(uSampler, vTextureCoord + offset);
+    // finalColor = texture(uTexture, vTextureCoord + offset);
 
     color.rgb *= 1.0 + (uBrightness - 1.0) * p * fade;
 

--- a/src/filters/defaults/shockwave/shockwave.vert
+++ b/src/filters/defaults/shockwave/shockwave.vert
@@ -1,18 +1,18 @@
 in vec2 aPosition;
 out vec2 vTextureCoord;
 
-uniform vec4 inputSize;
-uniform vec4 outputFrame;
+uniform vec4 uInputSize;
+uniform vec4 uOutputFrame;
 
 vec4 filterVertexPosition( void )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
     return vec4((projectionMatrix * vec3(position, 1.0)).xy, 0.0, 1.0);
 }
 
 vec2 filterTextureCoord( void )
 {
-    return aPosition * (outputFrame.zw * inputSize.zw);
+    return aPosition * (uOutputFrame.zw * uInputSize.zw);
 }
 
 void main(void)

--- a/src/filters/defaults/shockwave/shockwave.wgsl
+++ b/src/filters/defaults/shockwave/shockwave.wgsl
@@ -18,7 +18,7 @@ struct ShockWaveUniforms {
 @group(1) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
 @group(1) @binding(1) var uTexture: texture_2d<f32>;
 @group(1) @binding(2) var uSampler : sampler;
-@group(1) @binding(3) var backTexture: texture_2d<f32>;
+
 @group(2) @binding(0) var<uniform> shockwaveUniforms : ShockWaveUniforms;
 
 struct VSOutput {

--- a/src/filters/defaults/shockwave/shockwave.wgsl
+++ b/src/filters/defaults/shockwave/shockwave.wgsl
@@ -1,11 +1,11 @@
 
 struct GlobalFilterUniforms {
-    inputSize:vec4<f32>,
-    inputPixel:vec4<f32>,
-    inputClamp:vec4<f32>,
-    outputFrame:vec4<f32>,
-    backgroundFrame:vec4<f32>,
-    globalFrame:vec4<f32>,
+    uInputSize:vec4<f32>,
+    uInputPixel:vec4<f32>,
+    uInputClamp:vec4<f32>,
+    uOutputFrame:vec4<f32>,
+    uBackgroundFrame:vec4<f32>,
+    uGlobalFrame:vec4<f32>,
 };
 
 struct ShockWaveUniforms {
@@ -29,13 +29,13 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
     return vec4((globalUniforms.projectionMatrix * vec3(position, 1.0)).xy, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn filterBackgroundTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
@@ -45,11 +45,11 @@ fn filterBackgroundTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+    return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 fn getSize() -> vec2<f32>
 {
-    return gfu.globalFrame.zw;
+    return gfu.uGlobalFrame.zw;
 }
 
 @vertex
@@ -77,9 +77,9 @@ fn mainFragment(
     let uWavelength = shockwaveUniforms.uWave[1];
     let uBrightness = shockwaveUniforms.uWave[2];
     let uRadius = shockwaveUniforms.uWave[3];
-    let halfWavelength: f32 = uWavelength * 0.5 / gfu.inputSize.x;
-    let maxRadius: f32 = uRadius / gfu.inputSize.x;
-    let currentRadius: f32 = uTime * uSpeed / gfu.inputSize.x;
+    let halfWavelength: f32 = uWavelength * 0.5 / gfu.uInputSize.x;
+    let maxRadius: f32 = uRadius / gfu.uInputSize.x;
+    let currentRadius: f32 = uTime * uSpeed / gfu.uInputSize.x;
     var fade: f32 = 1.0;
     var returnColorOnly: bool = false;
     
@@ -89,8 +89,8 @@ fn mainFragment(
         }
         fade = 1.0 - pow(currentRadius / maxRadius, 2.0);
     }
-    var dir: vec2<f32> = vec2<f32>(uv - uOffset / gfu.inputSize.xy);
-    dir.y *= gfu.inputSize.y / gfu.inputSize.x;
+    var dir: vec2<f32> = vec2<f32>(uv - uOffset / gfu.uInputSize.xy);
+    dir.y *= gfu.uInputSize.y / gfu.uInputSize.x;
 
     let dist:f32 = length(dir);
 
@@ -102,10 +102,10 @@ fn mainFragment(
     let diff: f32 = (dist - currentRadius) / halfWavelength;
     let p: f32 = 1.0 - pow(abs(diff), 2.0);
     let powDiff: f32 = 1.25 * sin(diff * PI) * p * ( uAmplitude * fade );
-    let offset: vec2<f32> = diffUV * powDiff / gfu.inputSize.xy;
+    let offset: vec2<f32> = diffUV * powDiff / gfu.uInputSize.xy;
     // Do clamp :
     let coord: vec2<f32> = uv + offset;
-    let clampedCoord: vec2<f32> = clamp(coord, gfu.inputClamp.xy, gfu.inputClamp.zw);
+    let clampedCoord: vec2<f32> = clamp(coord, gfu.uInputClamp.xy, gfu.uInputClamp.zw);
 
     var clampedColor: vec4<f32> = textureSample(uTexture, uSampler, clampedCoord);
     

--- a/src/filters/defaults/shockwave/shockwave.wgsl
+++ b/src/filters/defaults/shockwave/shockwave.wgsl
@@ -16,8 +16,8 @@ struct ShockWaveUniforms {
 };
 @group(0) @binding(0) var<uniform> globalUniforms : GlobalUniforms;
 @group(1) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(1) @binding(1) var uSampler: texture_2d<f32>;
-@group(1) @binding(2) var mySampler : sampler;
+@group(1) @binding(1) var uTexture: texture_2d<f32>;
+@group(1) @binding(2) var uSampler : sampler;
 @group(1) @binding(3) var backTexture: texture_2d<f32>;
 @group(2) @binding(0) var<uniform> shockwaveUniforms : ShockWaveUniforms;
 
@@ -107,14 +107,14 @@ fn mainFragment(
     let coord: vec2<f32> = uv + offset;
     let clampedCoord: vec2<f32> = clamp(coord, gfu.inputClamp.xy, gfu.inputClamp.zw);
 
-    var clampedColor: vec4<f32> = textureSample(uSampler, mySampler, clampedCoord);
+    var clampedColor: vec4<f32> = textureSample(uTexture, uSampler, clampedCoord);
     
     if (boolVec2(coord, clampedCoord)) 
     {
         clampedColor *= max(0.0, 1.0 - length(coord - clampedCoord));
     }
     // No clamp :
-    return select(clampedColor * vec4<f32>(vec3<f32>(1.0 + (uBrightness - 1.0) * p * fade), clampedColor.a), textureSample(uSampler, mySampler, uv), returnColorOnly);
+    return select(clampedColor * vec4<f32>(vec3<f32>(1.0 + (uBrightness - 1.0) * p * fade), clampedColor.a), textureSample(uTexture, uSampler, uv), returnColorOnly);
 }
 
 fn boolVec2(x: vec2<f32>, y: vec2<f32>) -> bool

--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -55,7 +55,7 @@ export class MaskFilter extends Filter
             glProgram,
             resources: {
                 filterUniforms,
-                mapTexture: sprite.texture.source,
+                uMaskTexture: sprite.texture.source,
             }
         });
 
@@ -79,7 +79,7 @@ export class MaskFilter extends Filter
             this.sprite
         ).prepend(this._textureMatrix.mapCoord);
 
-        this.resources.mapTexture = this.sprite.texture.source;
+        this.resources.uMaskTexture = this.sprite.texture.source;
 
         filterManager.applyFilter(this, input, output, clearMode);
     }

--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -28,9 +28,9 @@ export class MaskFilter extends Filter
         const textureMatrix = new TextureMatrix(sprite.texture);
 
         const filterUniforms = new UniformGroup({
-            filterMatrix: { value: new Matrix(), type: 'mat3x3<f32>' },
-            maskClamp: { value: textureMatrix.uClampFrame, type: 'vec4<f32>' },
-            alpha: { value: 1, type: 'f32' },
+            uFilterMatrix: { value: new Matrix(), type: 'mat3x3<f32>' },
+            uMaskClamp: { value: textureMatrix.uClampFrame, type: 'vec4<f32>' },
+            uAlpha: { value: 1, type: 'f32' },
         });
 
         const gpuProgram = new GpuProgram({
@@ -75,7 +75,7 @@ export class MaskFilter extends Filter
         this._textureMatrix.texture = this.sprite.texture;
 
         filterManager.calculateSpriteMatrix(
-            this.resources.filterUniforms.uniforms.filterMatrix as Matrix,
+            this.resources.filterUniforms.uniforms.uFilterMatrix as Matrix,
             this.sprite
         ).prepend(this._textureMatrix.mapCoord);
 

--- a/src/filters/mask/mask.frag
+++ b/src/filters/mask/mask.frag
@@ -4,26 +4,26 @@ in vec2 vTextureCoord;
 uniform sampler2D uTexture;
 uniform sampler2D uMaskTexture;
 
-uniform float alpha;
-uniform vec4 maskClamp;
+uniform float uAlpha;
+uniform vec4 uMaskClamp;
 
 out vec4 finalColor;
 
 void main(void)
 {
     float clip = step(3.5,
-        step(maskClamp.x, vMaskCoord.x) +
-        step(maskClamp.y, vMaskCoord.y) +
-        step(vMaskCoord.x, maskClamp.z) +
-        step(vMaskCoord.y, maskClamp.w));
+        step(uMaskClamp.x, vMaskCoord.x) +
+        step(uMaskClamp.y, vMaskCoord.y) +
+        step(vMaskCoord.x, uMaskClamp.z) +
+        step(vMaskCoord.y, uMaskClamp.w));
 
     // TODO look into why this is needed
-    float npmAlpha = alpha; 
+    float npmAlpha = uAlpha; 
     vec4 original = texture(uTexture, vTextureCoord);
     vec4 masky = texture(uMaskTexture, vMaskCoord);
     float alphaMul = 1.0 - npmAlpha * (1.0 - masky.a);
 
-    original *= (alphaMul * masky.r * alpha * clip);
+    original *= (alphaMul * masky.r * uAlpha * clip);
 
     finalColor = original;
 }

--- a/src/filters/mask/mask.frag
+++ b/src/filters/mask/mask.frag
@@ -1,7 +1,7 @@
 in vec2 vMaskCoord;
 in vec2 vTextureCoord;
 
-uniform sampler2D uSampler;
+uniform sampler2D uTexture;
 uniform sampler2D mapTexture;
 
 uniform float alpha;
@@ -19,7 +19,7 @@ void main(void)
 
     // TODO look into why this is needed
     float npmAlpha = alpha; 
-    vec4 original = texture(uSampler, vTextureCoord);
+    vec4 original = texture(uTexture, vTextureCoord);
     vec4 masky = texture(mapTexture, vMaskCoord);
     float alphaMul = 1.0 - npmAlpha * (1.0 - masky.a);
 

--- a/src/filters/mask/mask.frag
+++ b/src/filters/mask/mask.frag
@@ -2,7 +2,7 @@ in vec2 vMaskCoord;
 in vec2 vTextureCoord;
 
 uniform sampler2D uTexture;
-uniform sampler2D mapTexture;
+uniform sampler2D uMaskTexture;
 
 uniform float alpha;
 uniform vec4 maskClamp;
@@ -20,7 +20,7 @@ void main(void)
     // TODO look into why this is needed
     float npmAlpha = alpha; 
     vec4 original = texture(uTexture, vTextureCoord);
-    vec4 masky = texture(mapTexture, vMaskCoord);
+    vec4 masky = texture(uMaskTexture, vMaskCoord);
     float alphaMul = 1.0 - npmAlpha * (1.0 - masky.a);
 
     original *= (alphaMul * masky.r * alpha * clip);

--- a/src/filters/mask/mask.vert
+++ b/src/filters/mask/mask.vert
@@ -4,29 +4,29 @@ out vec2 vTextureCoord;
 out vec2 vMaskCoord;
 
 
-uniform vec4 inputSize;
-uniform vec4 outputFrame;
-uniform vec4 outputTexture;
-uniform mat3 filterMatrix;
+uniform vec4 uInputSize;
+uniform vec4 uOutputFrame;
+uniform vec4 uOutputTexture;
+uniform mat3 uFilterMatrix;
 
 vec4 filterVertexPosition(  vec2 aPosition )
 {
-    vec2 position = aPosition * outputFrame.zw + outputFrame.xy;
+    vec2 position = aPosition * uOutputFrame.zw + uOutputFrame.xy;
        
-    position.x = position.x * (2.0 / outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*outputTexture.z / outputTexture.y) - outputTexture.z;
+    position.x = position.x * (2.0 / uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*uOutputTexture.z / uOutputTexture.y) - uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 vec2 filterTextureCoord(  vec2 aPosition )
 {
-    return aPosition * (outputFrame.zw * inputSize.zw);
+    return aPosition * (uOutputFrame.zw * uInputSize.zw);
 }
 
 vec2 getFilterCoord( vec2 aPosition )
 {
-    return  ( filterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
+    return  ( uFilterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
 }   
 
 void main(void)

--- a/src/filters/mask/mask.wgsl
+++ b/src/filters/mask/mask.wgsl
@@ -19,7 +19,7 @@ struct MaskUniforms {
 @group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> filterUniforms : MaskUniforms;
-@group(1) @binding(1) var mapTexture: texture_2d<f32>;
+@group(1) @binding(1) var uMaskTexture: texture_2d<f32>;
 
 struct VSOutput {
     @builtin(position) position: vec4<f32>,
@@ -85,7 +85,7 @@ fn mainFragment(
         step(filterUv.x, maskClamp.z) +
         step(filterUv.y, maskClamp.w));
 
-    var mask = textureSample(mapTexture, uSampler, filterUv);
+    var mask = textureSample(uMaskTexture, uSampler, filterUv);
     var source = textureSample(uTexture, uSampler, uv);
     
     var npmAlpha = 0.0;

--- a/src/filters/mask/mask.wgsl
+++ b/src/filters/mask/mask.wgsl
@@ -1,16 +1,16 @@
 struct GlobalFilterUniforms {
-  inputSize:vec4<f32>,
-  inputPixel:vec4<f32>,
-  inputClamp:vec4<f32>,
-  outputFrame:vec4<f32>,
-  globalFrame:vec4<f32>,
-  outputTexture:vec4<f32>,  
+  uInputSize:vec4<f32>,
+  uInputPixel:vec4<f32>,
+  uInputClamp:vec4<f32>,
+  uOutputFrame:vec4<f32>,
+  uGlobalFrame:vec4<f32>,
+  uOutputTexture:vec4<f32>,  
 };
 
 struct MaskUniforms {
-  filterMatrix:mat3x3<f32>,
-  maskClamp:vec4<f32>,
-  alpha:f32,
+  uFilterMatrix:mat3x3<f32>,
+  uMaskClamp:vec4<f32>,
+  uAlpha:f32,
 };
 
 
@@ -29,34 +29,34 @@ struct VSOutput {
 
 fn filterVertexPosition(aPosition:vec2<f32>) -> vec4<f32>
 {
-    var position = aPosition * gfu.outputFrame.zw + gfu.outputFrame.xy;
+    var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
 
-    position.x = position.x * (2.0 / gfu.outputTexture.x) - 1.0;
-    position.y = position.y * (2.0*gfu.outputTexture.z / gfu.outputTexture.y) - gfu.outputTexture.z;
+    position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+    position.y = position.y * (2.0*gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
 
     return vec4(position, 0.0, 1.0);
 }
 
 fn filterTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-    return aPosition * (gfu.outputFrame.zw * gfu.inputSize.zw);
+    return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
 }
 
 fn globalTextureCoord( aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return  (aPosition.xy / gfu.globalFrame.zw) + (gfu.globalFrame.xy / gfu.globalFrame.zw);  
+  return  (aPosition.xy / gfu.uGlobalFrame.zw) + (gfu.uGlobalFrame.xy / gfu.uGlobalFrame.zw);  
 }
 
 fn getFilterCoord(aPosition:vec2<f32> ) -> vec2<f32>
 {
-  return ( filterUniforms.filterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
+  return ( filterUniforms.uFilterMatrix * vec3( filterTextureCoord(aPosition), 1.0)  ).xy;
 }
 
 fn getSize() -> vec2<f32>
 {
 
   
-  return gfu.globalFrame.zw;
+  return gfu.uGlobalFrame.zw;
 }
   
 @vertex
@@ -77,7 +77,7 @@ fn mainFragment(
   @builtin(position) position: vec4<f32>
 ) -> @location(0) vec4<f32> {
 
-    var maskClamp = filterUniforms.maskClamp;
+    var maskClamp = filterUniforms.uMaskClamp;
 
      var clip = step(3.5,
         step(maskClamp.x, filterUv.x) +

--- a/src/filters/mask/mask.wgsl
+++ b/src/filters/mask/mask.wgsl
@@ -15,8 +15,8 @@ struct MaskUniforms {
 
 
 @group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
-@group(0) @binding(1) var uSampler: texture_2d<f32>;
-@group(0) @binding(2) var mySampler : sampler;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler : sampler;
 
 @group(1) @binding(0) var<uniform> filterUniforms : MaskUniforms;
 @group(1) @binding(1) var mapTexture: texture_2d<f32>;
@@ -85,8 +85,8 @@ fn mainFragment(
         step(filterUv.x, maskClamp.z) +
         step(filterUv.y, maskClamp.w));
 
-    var mask = textureSample(mapTexture, mySampler, filterUv);
-    var source = textureSample(uSampler, mySampler, uv);
+    var mask = textureSample(mapTexture, uSampler, filterUv);
+    var source = textureSample(uTexture, uSampler, uv);
     
     var npmAlpha = 0.0;
 

--- a/src/rendering/high-shader/shader-bits/generateTextureBatchBit.ts
+++ b/src/rendering/high-shader/shader-bits/generateTextureBatchBit.ts
@@ -126,7 +126,7 @@ function generateSampleGlSrc(maxTextures: number): string
         }
 
         src.push('{');
-        src.push(`\toutColor = texture(uSamplers[${i}], vUV);`);
+        src.push(`\toutColor = texture(uTextures[${i}], vUV);`);
         src.push('}');
     }
 
@@ -159,7 +159,7 @@ export function generateTextureBatchBitGl(maxTextures: number): HighShaderBit
                 header: `
                 in float vTextureId;
     
-                uniform sampler2D uSamplers[${maxTextures}];
+                uniform sampler2D uTextures[${maxTextures}];
               
             `,
                 main: `

--- a/src/rendering/renderers/gl/shader/batchSamplersUniformGroup.ts
+++ b/src/rendering/renderers/gl/shader/batchSamplersUniformGroup.ts
@@ -9,5 +9,5 @@ for (let i = 0; i < MAX_TEXTURES; i++)
 }
 
 export const batchSamplersUniformGroup = new UniformGroup({
-    uSamplers: { value: sampleValues, type: `u32`, size: MAX_TEXTURES }
+    uTextures: { value: sampleValues, type: `u32`, size: MAX_TEXTURES }
 }, { isStatic: true });

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -9,7 +9,7 @@ import type { BindResource } from './BindResource';
  * // Create a bind group with a single texture and sampler
  * const bindGroup = new BindGroup({
  *    uTexture: texture.source,
- *    uSampler: texture.style,
+ *    uTexture: texture.style,
  * });
  *
  * Bind groups resources must implement the {@link BindResource} interface.

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -96,15 +96,15 @@ type ShaderDescriptor = ShaderWithGroupsDescriptor & ShaderWithResourcesDescript
  *     glProgram: glProgram,
  *     gpuProgram: gpuProgram,
  *     resources: {
- *         uSampler: texture.source,
- *         mySampler: texture.sampler,
+ *         uTexture: texture.source,
+ *         uSampler: texture.sampler,
  *         uColor: [1, 0, 0, 1],
  *     },
  * });
  *
  * // update the uniforms
  * shader.resources.uColor[1] = 1;
- * shader.resources.uSampler = texture2.source;
+ * shader.resources.uTexture = texture2.source;
  * @class
  * @memberof rendering
  */


### PR DESCRIPTION
tidied up all filter names

`uSampler` -> `uTexture`
`mySampler` -> `uSampler`

all uniforms are prefixed with `u`
