### PR TITLE
Add strict null checks to @pixijs/runner

### DIFF
--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -168,8 +168,8 @@ export class Runner
     public destroy(): void
     {
         this.removeAll();
-        this.items = null;
-        this._name = null;
+        this.items = [];
+        this._name = '';
     }
 
     /**

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -168,7 +168,7 @@ export class Runner
     public destroy(): void
     {
         this.removeAll();
-        this.items = [];
+        this.items.length = 0;
         this._name = '';
     }
 

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -224,7 +224,7 @@ export class Runner<T = any, ARG extends unknown[] = any[]>
     {
         this.removeAll();
         this.items.length = 0;
-        this._name = '';
+        this._name = '' as T;
     }
 
     /**

--- a/packages/runner/test/Runner.tests.ts
+++ b/packages/runner/test/Runner.tests.ts
@@ -24,7 +24,7 @@ describe('Runner', () =>
         complete.emit();
         expect(callback).toBeCalledTimes(3);
         complete.destroy();
-        expect(!complete.items).toBe(true);
+        expect(complete.items.length === 0).toBe(true);
         expect(!complete.name).toBe(true);
     });
 

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -52,7 +52,7 @@ const pathPrefixs = [
     'packages/mixin-get-global-position/',
     // 'packages/particle-container/',
     // 'packages/prepare/',
-    // 'packages/runner/',
+    'packages/runner/',
     'packages/settings/',
     // 'packages/sprite/',
     // 'packages/sprite-animated/',


### PR DESCRIPTION
##### Description of change

Ref https://github.com/pixijs/pixijs/issues/8852

To resolve the strict null check error in `packages/runner/src/Runner.ts`, I modified the `destroy` method to set each property value from null to an empty array or an empty string.

I also considered making each property nullable, but decided not to change the type for the following reasons:

- If I make each property nullable, it would require implementing null check processing in the calling code, leading to broader implications.
- There is currently no handling in the calling code to anticipate cases where the property value might be null.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
