### PR TITLE
Add strict null checks to @pixi/extensions

### DIFF
--- a/packages/extensions/src/index.ts
+++ b/packages/extensions/src/index.ts
@@ -121,13 +121,13 @@ const normalizePriority = (ext: ExtensionFormatLoose | any, defaultPriority: num
 const extensions = {
 
     /** @ignore */
-    _addHandlers: {} as Record<ExtensionType, ExtensionHandler>,
+    _addHandlers: {} as Partial<Record<ExtensionType, ExtensionHandler>>,
 
     /** @ignore */
-    _removeHandlers: {} as Record<ExtensionType, ExtensionHandler>,
+    _removeHandlers: {} as Partial<Record<ExtensionType, ExtensionHandler>>,
 
     /** @ignore */
-    _queue: {} as Record<ExtensionType, ExtensionFormat[]>,
+    _queue: {} as Partial<Record<ExtensionType, ExtensionFormat[]>>,
 
     /**
      * Remove extensions from PixiJS.
@@ -162,11 +162,11 @@ const extensions = {
                 if (!handlers[type])
                 {
                     queue[type] = queue[type] || [];
-                    queue[type].push(ext);
+                    queue[type]?.push(ext);
                 }
                 else
                 {
-                    handlers[type](ext);
+                    handlers[type]?.(ext);
                 }
             });
         });
@@ -203,7 +203,7 @@ const extensions = {
         // Process any plugins that have been registered before the handler
         if (queue[type])
         {
-            queue[type].forEach((ext) => onAdd(ext));
+            queue[type]?.forEach((ext) => onAdd(ext));
             delete queue[type];
         }
 
@@ -221,11 +221,17 @@ const extensions = {
         return this.handle(type,
             (extension) =>
             {
-                map[extension.name] = extension.ref;
+                if (extension.name)
+                {
+                    map[extension.name] = extension.ref;
+                }
             },
             (extension) =>
             {
-                delete map[extension.name];
+                if (extension.name)
+                {
+                    delete map[extension.name];
+                }
             }
         );
     },

--- a/packages/extensions/test/extensions.tests.ts
+++ b/packages/extensions/test/extensions.tests.ts
@@ -20,10 +20,10 @@ describe('extensions', () =>
 {
     afterEach(() =>
     {
-        extensions['_addHandlers'][exampleType] = undefined;
-        extensions['_removeHandlers'][exampleType] = undefined;
-        extensions['_addHandlers'][exampleType2] = undefined;
-        extensions['_removeHandlers'][exampleType2] = undefined;
+        delete extensions['_addHandlers'][exampleType];
+        delete extensions['_removeHandlers'][exampleType];
+        delete extensions['_addHandlers'][exampleType2];
+        delete extensions['_removeHandlers'][exampleType2];
     });
 
     describe('handle', () =>

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -33,7 +33,7 @@ const pathPrefixs = [
     // 'packages/core/',
     // 'packages/display/',
     // 'packages/events/',
-    // 'packages/extensions/',
+    'packages/extensions/',
     'packages/extract/',
     'packages/filter-alpha/',
     'packages/filter-blur/',


### PR DESCRIPTION
##### Description of change

Ref https://github.com/pixijs/pixijs/issues/8852

To resolve the strict null check error in `packages/extensions/src/index.ts`, I have added a null check when using the nullable value `ExtensionFormat['name']`.

```diff
- map[extension.name] = extension.ref;
+ if (extension.name)
+ {
+   map[extension.name] = extension.ref;
+ }
```

Furthermore, empty objects were forcefully converted to the Record types using the 'as' keyword.
This led to type mismatches in certain areas, so I have now used 'Partial' to appropriately set the type for the empty objects.

```diff
- _addHandlers: {} as Record<ExtensionType, ExtensionHandler>,
+ _addHandlers: {} as Partial<Record<ExtensionType, ExtensionHandler>>,
```

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
