### PR TITLE
set transparent as default renderer background color

### DIFF
--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -86,7 +86,7 @@ export class BackgroundSystem implements System
         this._backgroundColor = new Color(0x000000);
 
         this.color = this._backgroundColor; // run bg color setter
-        this.alpha = 1;
+        this.alpha = 0;
     }
 
     /**
@@ -97,11 +97,11 @@ export class BackgroundSystem implements System
     {
         options = { ...BackgroundSystem.defaultOptions, ...options };
 
+        const optionsHasBackgroundColor = !!(options.background || options.backgroundColor);
+
         this.clearBeforeRender = options.clearBeforeRender;
         this.color = options.background || options.backgroundColor || this._backgroundColor; // run bg color setter
-        this.alpha = options.backgroundAlpha;
-
-        this._backgroundColor.setAlpha(options.backgroundAlpha);
+        this.alpha = optionsHasBackgroundColor ? options.backgroundAlpha : 0;
     }
 
     /** The background color to fill if not transparent */

--- a/tests/renderering/BackgroundSystem.test.ts
+++ b/tests/renderering/BackgroundSystem.test.ts
@@ -1,4 +1,8 @@
 import { BackgroundSystem } from '../../src/rendering/renderers/shared/background/BackgroundSystem';
+import '../../src/rendering/init';
+import '../../src/scene/graphics/init';
+
+import type { BackgroundSystemOptions } from '../../src/rendering/renderers/shared/background/BackgroundSystem';
 
 describe('BackgroundSystem', () =>
 {
@@ -19,5 +23,36 @@ describe('BackgroundSystem', () =>
 
         expect(backgroundSystem.alpha).toEqual(1);
         expect(backgroundSystem.colorRgba).toEqual([1, 0, 0, 1]);
+    });
+
+    it('should use transparent alpha if no background set with options', async () =>
+    {
+        const backgroundSystem = new BackgroundSystem();
+
+        backgroundSystem.init({} as BackgroundSystemOptions);
+
+        expect(backgroundSystem.alpha).toEqual(0);
+    });
+
+    it('should use non-transparent alpha if background set with options', async () =>
+    {
+        const backgroundSystem = new BackgroundSystem();
+
+        backgroundSystem.init({ backgroundColor: 'red' } as BackgroundSystemOptions);
+
+        expect(backgroundSystem.alpha).toEqual(1);
+    });
+
+    it('should use non-transparent alpha if background set after options', async () =>
+    {
+        const backgroundSystem = new BackgroundSystem();
+
+        backgroundSystem.init({} as BackgroundSystemOptions);
+
+        expect(backgroundSystem.alpha).toEqual(0);
+
+        backgroundSystem.color = 'red';
+
+        expect(backgroundSystem.alpha).toEqual(1);
     });
 });


### PR DESCRIPTION
Fixes this [ticket](https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=47556362).

Sets a default alpha of `0` to the `BackgroundSystem`. This creates a transparent rendering background.
If a color is passed to either the initial rendering options, or later via `renderer.background.color` then the alpha will become `1`, so the color is visible.

Tested these variations in the blaze playground, added unit tests for each case.