### PR TITLE
Fix: path.join incorrectly joining urls that contain periods

### DIFF
--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -315,7 +315,7 @@ export const path: Path = {
                 {
                     const prevArg = segments[i - 1] ?? '';
 
-                    if (this.extname(prevArg))
+                    if (this.extname(prevArg) === '.html')
                     {
                         joined += `/../${arg}`;
                     }

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -148,7 +148,8 @@ export interface Path
     extname: (path: string) => string;
     parse: (path: string) => { root?: string, dir?: string, base?: string, ext?: string, name?: string };
     sep: string,
-    delimiter: string
+    delimiter: string,
+    joinExtensions: string[],
 }
 
 export const path: Path = {
@@ -315,7 +316,7 @@ export const path: Path = {
                 {
                     const prevArg = segments[i - 1] ?? '';
 
-                    if (this.extname(prevArg) === '.html')
+                    if (this.joinExtensions.includes(this.extname(prevArg).toLowerCase()))
                     {
                         joined += `/../${arg}`;
                     }
@@ -690,5 +691,6 @@ export const path: Path = {
     },
 
     sep: '/',
-    delimiter: ':'
+    delimiter: ':',
+    joinExtensions: ['.html'],
 } as Path;

--- a/packages/utils/test/path.tests.ts
+++ b/packages/utils/test/path.tests.ts
@@ -120,6 +120,10 @@ describe('Paths', () =>
         expect(path.join('http://foo.com/bar/index.html?var=a#hash', '../baz/file')).toBe('http://foo.com/baz/file');
         expect(path.join('http://foo.com/bar/index.html#hash', '../baz/file')).toBe('http://foo.com/baz/file');
 
+        expect(path.join('http://foo.com/bar3.0/', './baz/file')).toBe('http://foo.com/bar3.0/baz/file');
+        expect(path.join('http://foo.com/bar3.0/', '../baz/file')).toBe('http://foo.com/baz/file');
+        expect(path.join('http://foo.com/bar/', '../baz3.0/file')).toBe('http://foo.com/baz3.0/file');
+
         expect(path.join('http://foo.com', '../bar/baz/file')).toBe('http://foo.com/bar/baz/file');
         expect(path.join('https://foo.com', '../bar/baz/file')).toBe('https://foo.com/bar/baz/file');
         expect(path.join('file:///foo', '../bar/baz/file')).toBe('file:///bar/baz/file');
@@ -237,6 +241,16 @@ describe('Paths', () =>
         expect(path.parse('/domain/path')).toEqual(expect.objectContaining(
             { root: '/', dir: '/domain', base: 'path', ext: '', name: 'path' }
         ));
+
+        expect(path.parse('http://0.0.0.0:8080/games/game3.0/resources/config.json')).toEqual(expect.objectContaining(
+            {
+                root: 'http://0.0.0.0:8080/',
+                dir: 'http://0.0.0.0:8080/games/game3.0/resources',
+                base: 'config.json',
+                ext: '.json',
+                name: 'config'
+            }
+        ));
     });
 
     it('should create absolute urls', () =>
@@ -254,6 +268,10 @@ describe('Paths', () =>
         expect(path.toAbsolute('windows.png', 'C:\\foo\\bar\\')).toEqual(`C:/foo/bar/windows.png`);
         expect(path.toAbsolute('mac.png', '/foo/bar/')).toEqual(`/foo/bar/mac.png`);
         expect(path.toAbsolute('mac.png', '/foo/bar')).toEqual(`/foo/bar/mac.png`);
+
+        // dots in path
+        expect(path.toAbsolute('./img3.0/browser.png', 'http://example.com/page-1/'))
+            .toEqual(`http://example.com/page-1/img3.0/browser.png`);
 
         // paths with extensions
         expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/index.html'))

--- a/packages/utils/test/path.tests.ts
+++ b/packages/utils/test/path.tests.ts
@@ -273,6 +273,22 @@ describe('Paths', () =>
         expect(path.toAbsolute('./img3.0/browser.png', 'http://example.com/page-1/'))
             .toEqual(`http://example.com/page-1/img3.0/browser.png`);
 
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/browser.png`);
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('windows.png', 'C:/foo/bar/baz3.0')).toEqual(`C:/foo/bar/baz3.0/windows.png`);
+        expect(path.toAbsolute('mac.png', '/foo/bar/baz3.0')).toEqual(`/foo/bar/baz3.0/mac.png`);
+
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/browser.png`);
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+
         // paths with extensions
         expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/index.html'))
             .toEqual(`http://example.com/page-1/browser.png`);


### PR DESCRIPTION
fixes: #9393

https://github.com/pixijs/pixijs/pull/8614 introduced a bug that caused any segment that ended in a file extension to be handled differently. This PR now explicitly allows you to define what extensions should be handled differently with the default being `['.html']`

The `.html` default is because the original issue was around how these two urls are the same when `Assets` does its `path.toAbsolute` when setting a `basePath`
`http://example.com/index.html` and `http://example.com/`
