### PR TITLE
Fix: Disable usage of signal, undefined behavior

### DIFF
--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -172,7 +172,7 @@ export interface FederatedEventTarget extends utils.EventEmitter, EventTarget
     onwheel: FederatedEventHandler<FederatedWheelEvent> | null;
 }
 
-type AddListenerOptions = boolean | AddEventListenerOptions;
+type AddListenerOptions = boolean | Omit<AddEventListenerOptions, 'signal'>;
 type RemoveListenerOptions = boolean | EventListenerOptions;
 
 export interface IFederatedDisplayObject


### PR DESCRIPTION
Fixes #10043

Disallows the usage of `signal` property to `addEventListener`. Currently, no implemented.