### PR TITLE
Add support for 'once' option to FederatedEventTarget.addEventListener

### DIFF
--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -721,12 +721,22 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
     {
         const capture = (typeof options === 'boolean' && options)
             || (typeof options === 'object' && options.capture);
+        const once = typeof options === 'object' ? (options.once === true) : false;
         const context = typeof listener === 'function' ? undefined : listener;
 
         type = capture ? `${type}capture` : type;
         listener = typeof listener === 'function' ? listener : listener.handleEvent;
 
-        (this as unknown as utils.EventEmitter).on(type, listener, context);
+        const emitter = (this as unknown as utils.EventEmitter);
+
+        if (once)
+        {
+            emitter.once(type, listener, context);
+        }
+        else
+        {
+            emitter.on(type, listener, context);
+        }
     },
 
     /**

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -1031,4 +1031,39 @@ describe('EventSystem', () =>
 
         expect(eventSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should respect \'once\' option', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        graphics.addEventListener('pointertap', (e) =>
+        {
+            expect(e.type).toEqual('click');
+            eventSpy();
+        }, { once: true });
+
+        const click = () =>
+        {
+            const event = new PointerEvent('pointerdown', { clientX: 25, clientY: 25 });
+
+            renderer.events.onPointerDown(event);
+            const e = new PointerEvent('pointerup', { clientX: 30, clientY: 20 });
+            // so it isn't a pointerupoutside
+
+            Object.defineProperty(e, 'target', {
+                writable: false,
+                value: renderer.view
+            });
+            renderer.events.onPointerUp(e);
+        };
+
+        click(); // Once
+        click(); // Twice
+
+        expect(eventSpy).toHaveBeenCalledOnce();
+    });
 });


### PR DESCRIPTION
This change brings the addEventListener implementation more in line with the DOM implementation.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Adds support for the 'once' option to the addEventListener method of FederatedEventTarget. This makes this method more congruent with the DOM implementation.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X ] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
