### PR TITLE
v8 rename `onUpdate` to `_onUpdate`

### DIFF
--- a/src/maths/point/ObservablePoint.ts
+++ b/src/maths/point/ObservablePoint.ts
@@ -11,7 +11,7 @@ export interface ObservablePoint extends PixiMixins.ObservablePoint { }
 export interface Observer<T>
 {
     /** Callback to call when the point has updated. */
-    onUpdate: (point?: T) => void;
+    _onUpdate: (point?: T) => void;
 }
 
 /**
@@ -68,7 +68,7 @@ export class ObservablePoint implements PointLike
         {
             this._x = x;
             this._y = y;
-            this._observer.onUpdate(this);
+            this._observer._onUpdate(this);
         }
 
         return this;
@@ -85,7 +85,7 @@ export class ObservablePoint implements PointLike
         {
             this._x = p.x;
             this._y = p.y;
-            this._observer.onUpdate(this);
+            this._observer._onUpdate(this);
         }
 
         return this;
@@ -131,7 +131,7 @@ export class ObservablePoint implements PointLike
         if (this._x !== value)
         {
             this._x = value;
-            this._observer.onUpdate(this);
+            this._observer._onUpdate(this);
         }
     }
 
@@ -146,7 +146,7 @@ export class ObservablePoint implements PointLike
         if (this._y !== value)
         {
             this._y = value;
-            this._observer.onUpdate(this);
+            this._observer._onUpdate(this);
         }
     }
 }

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -677,7 +677,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
     }
 
     /** @ignore */
-    public onUpdate(point?: ObservablePoint)
+    public _onUpdate(point?: ObservablePoint)
     {
         if (point)
         {
@@ -862,7 +862,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
         if (this._rotation !== value)
         {
             this._rotation = value;
-            this.onUpdate(this._skew);
+            this._onUpdate(this._skew);
         }
     }
 
@@ -1005,7 +1005,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
 
         this._updateFlags |= UPDATE_COLOR;
 
-        this.onUpdate();
+        this._onUpdate();
     }
 
     /** The opacity of the object. */
@@ -1025,7 +1025,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
 
         this._updateFlags |= UPDATE_COLOR;
 
-        this.onUpdate();
+        this._onUpdate();
     }
 
     /**
@@ -1056,7 +1056,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
 
         this.localBlendMode = value;
 
-        this.onUpdate();
+        this._onUpdate();
     }
 
     /**
@@ -1091,7 +1091,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
 
         this.localVisibleRenderable = (this.localVisibleRenderable & 0b01) | (valueNumber << 1);
 
-        this.onUpdate();
+        this._onUpdate();
     }
 
     /** Can this object be rendered, if false the object will not be drawn but the transform will still be updated. */
@@ -1115,7 +1115,7 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
             this.renderGroup.structureDidChange = true;
         }
 
-        this.onUpdate();
+        this._onUpdate();
     }
 
     /** Whether or not the object should be rendered. */

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -201,7 +201,7 @@ export class TilingSprite extends Container implements View, Instruction
 
         this._tileTransform = new Transform({
             observer: {
-                onUpdate: () => this.onTilingSpriteUpdate(),
+                _onUpdate: () => this.onTilingSpriteUpdate(),
             }
         });
 

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -106,7 +106,7 @@ export class Sprite extends Container implements View
 
         this._anchor = new ObservablePoint(
             {
-                onUpdate: () =>
+                _onUpdate: () =>
                 {
                     this.onViewUpdate();
                 }

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -156,7 +156,7 @@ export class HTMLTextPipe implements RenderPipe<Text>
         gpuText.generatingTexture = false;
 
         gpuText.textureNeedsUploading = true;
-        htmlText.onUpdate();
+        htmlText._onUpdate();
 
         const padding = htmlText._style.padding;
 

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -185,7 +185,7 @@ export class Text extends Container implements View
         this.allowChildren = false;
 
         this._anchor = new ObservablePoint({
-            onUpdate: () =>
+            _onUpdate: () =>
             {
                 this.onViewUpdate();
             }

--- a/src/utils/misc/Transform.ts
+++ b/src/utils/misc/Transform.ts
@@ -12,7 +12,7 @@ export interface TransformOptions
     /** The matrix to use. */
     matrix?: Matrix;
     /** The observer to use. */
-    observer?: {onUpdate: (transform: Transform) => void}
+    observer?: {_onUpdate: (transform: Transform) => void}
 }
 
 /**
@@ -122,7 +122,7 @@ export class Transform
      * @internal
      * @private
      */
-    public onUpdate(point?: ObservablePoint): void
+    public _onUpdate(point?: ObservablePoint): void
     {
         this.dirty = true;
 
@@ -131,7 +131,7 @@ export class Transform
             this.updateSkew();
         }
 
-        this.observer?.onUpdate(this);
+        this.observer?._onUpdate(this);
     }
 
     /** Called when the skew or the rotation changes. */

--- a/tests/math-extras/Point.tests.ts
+++ b/tests/math-extras/Point.tests.ts
@@ -4,7 +4,7 @@ import '../../src/math-extras/init';
 
 describe('Point', () =>
 {
-    const observer = { onUpdate: () => { /* empty */ } };
+    const observer = { _onUpdate: () => { /* empty */ } };
 
     describe('add', () =>
     {

--- a/tests/math/ObservablePoint.tests.ts
+++ b/tests/math/ObservablePoint.tests.ts
@@ -4,7 +4,7 @@ describe('ObservablePoint', () =>
 {
     it('should create a new observable point', () =>
     {
-        const cb = { onUpdate: jest.fn() };
+        const cb = { _onUpdate: jest.fn() };
         const pt = new ObservablePoint(cb);
 
         expect(pt.x).toEqual(0);
@@ -14,7 +14,7 @@ describe('ObservablePoint', () =>
         expect(pt.x).toEqual(2);
         expect(pt.y).toEqual(5);
 
-        expect(cb.onUpdate).toHaveBeenCalled();
+        expect(cb._onUpdate).toHaveBeenCalled();
 
         pt.set(2, 6);
         expect(pt.x).toEqual(2);
@@ -28,12 +28,12 @@ describe('ObservablePoint', () =>
         expect(pt.x).toEqual(0);
         expect(pt.y).toEqual(0);
 
-        expect(cb.onUpdate.mock.calls).toHaveLength(4);
+        expect(cb._onUpdate.mock.calls).toHaveLength(4);
     });
 
     it('should copy a new observable point', () =>
     {
-        const cb = { onUpdate() { /** do nothing */ } };
+        const cb = { _onUpdate() { /** do nothing */ } };
 
         const p1 = new ObservablePoint(cb, 10, 20);
         const p2 = new ObservablePoint(cb, 5, 2);

--- a/tests/scene/DummyView.ts
+++ b/tests/scene/DummyView.ts
@@ -29,7 +29,7 @@ export class DummyView extends Container implements View
     public renderPipeId = 'dummy';
     public renderableUpdateRequested: boolean;
     public _roundPixels: 1 | 0 = 0;
-    public onUpdate: () => void;
+    public _onUpdate: () => void;
     public get bounds(): BoundsData
     {
         return {

--- a/tests/scene/transform-tint.tests.ts
+++ b/tests/scene/transform-tint.tests.ts
@@ -33,7 +33,7 @@ describe('Transform Tints', () =>
     {
         const root = new Container();
 
-        root.onUpdate = jest.fn();
+        root._onUpdate = jest.fn();
 
         root.alpha = 0.5;
 
@@ -41,28 +41,28 @@ describe('Transform Tints', () =>
 
         root.alpha = 0.5;
 
-        expect(root.onUpdate).toHaveBeenCalledTimes(1);
+        expect(root._onUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('should set and return tints correctly', async () =>
     {
         const root = new Container();
 
-        root.onUpdate = jest.fn();
+        root._onUpdate = jest.fn();
 
         root.tint = 0xFF0000;
 
         expect((root.tint)).toEqual(0xFF0000);
         root.tint = 0xFF0000;
 
-        expect(root.onUpdate).toHaveBeenCalledTimes(1);
+        expect(root._onUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('should set and return both alpha and tint correctly', async () =>
     {
         const root = new Container();
 
-        root.onUpdate = jest.fn();
+        root._onUpdate = jest.fn();
 
         root.tint = 0xFF00FF;
         root.alpha = 0.5;
@@ -72,7 +72,7 @@ describe('Transform Tints', () =>
         expect((root.alpha)).toEqual(0.5);
         expect((root.localColor)).toEqual(0xFF00FF);
 
-        expect(root.onUpdate).toHaveBeenCalledTimes(2);
+        expect(root._onUpdate).toHaveBeenCalledTimes(2);
     });
 
     it('should update global alpha correctly', async () =>


### PR DESCRIPTION
this should prevent clashes for other libs in the future.

onUpdate is a very common function name, and as ours internal - figured we prefix it with an _

