### PR TITLE
Fix: path.join incorrectly joining urls that contain periods (v8)

### DIFF
--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -229,7 +229,8 @@ export interface Path
      */
     parse: (path: string) => { root?: string, dir?: string, base?: string, ext?: string, name?: string };
     sep: string,
-    delimiter: string
+    delimiter: string,
+    joinExtensions: string[],
 }
 
 /**
@@ -407,7 +408,7 @@ export const path: Path = {
                 {
                     const prevArg = segments[i - 1] ?? '';
 
-                    if (this.extname(prevArg))
+                    if (this.joinExtensions.includes(this.extname(prevArg).toLowerCase()))
                     {
                         joined += `/../${arg}`;
                     }
@@ -782,5 +783,6 @@ export const path: Path = {
     },
 
     sep: '/',
-    delimiter: ':'
+    delimiter: ':',
+    joinExtensions: ['.html'],
 } as Path;

--- a/tests/renderering/utils/path.test.ts
+++ b/tests/renderering/utils/path.test.ts
@@ -120,6 +120,10 @@ describe('Paths', () =>
         expect(path.join('http://foo.com/bar/index.html?var=a#hash', '../baz/file')).toBe('http://foo.com/baz/file');
         expect(path.join('http://foo.com/bar/index.html#hash', '../baz/file')).toBe('http://foo.com/baz/file');
 
+        expect(path.join('http://foo.com/bar3.0/', './baz/file')).toBe('http://foo.com/bar3.0/baz/file');
+        expect(path.join('http://foo.com/bar3.0/', '../baz/file')).toBe('http://foo.com/baz/file');
+        expect(path.join('http://foo.com/bar/', '../baz3.0/file')).toBe('http://foo.com/baz3.0/file');
+
         expect(path.join('http://foo.com', '../bar/baz/file')).toBe('http://foo.com/bar/baz/file');
         expect(path.join('https://foo.com', '../bar/baz/file')).toBe('https://foo.com/bar/baz/file');
         expect(path.join('file:///foo', '../bar/baz/file')).toBe('file:///bar/baz/file');
@@ -237,6 +241,16 @@ describe('Paths', () =>
         expect(path.parse('/domain/path')).toEqual(expect.objectContaining(
             { root: '/', dir: '/domain', base: 'path', ext: '', name: 'path' }
         ));
+
+        expect(path.parse('http://0.0.0.0:8080/games/game3.0/resources/config.json')).toEqual(expect.objectContaining(
+            {
+                root: 'http://0.0.0.0:8080/',
+                dir: 'http://0.0.0.0:8080/games/game3.0/resources',
+                base: 'config.json',
+                ext: '.json',
+                name: 'config'
+            }
+        ));
     });
 
     it('should create absolute urls', () =>
@@ -254,6 +268,26 @@ describe('Paths', () =>
         expect(path.toAbsolute('windows.png', 'C:\\foo\\bar\\')).toEqual(`C:/foo/bar/windows.png`);
         expect(path.toAbsolute('mac.png', '/foo/bar/')).toEqual(`/foo/bar/mac.png`);
         expect(path.toAbsolute('mac.png', '/foo/bar')).toEqual(`/foo/bar/mac.png`);
+
+        // dots in path
+        expect(path.toAbsolute('./img3.0/browser.png', 'http://example.com/page-1/'))
+            .toEqual(`http://example.com/page-1/img3.0/browser.png`);
+
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/browser.png`);
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/bar3.0'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('windows.png', 'C:/foo/bar/baz3.0')).toEqual(`C:/foo/bar/baz3.0/windows.png`);
+        expect(path.toAbsolute('mac.png', '/foo/bar/baz3.0')).toEqual(`/foo/bar/baz3.0/mac.png`);
+
+        expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/browser.png`);
+        expect(path.toAbsolute('./img/browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
+        expect(path.toAbsolute('img/browser.png', 'http://example.com/page-1/bar3.0?var=a#hash'))
+            .toEqual(`http://example.com/page-1/bar3.0/img/browser.png`);
 
         // paths with extensions
         expect(path.toAbsolute('./browser.png', 'http://example.com/page-1/index.html'))


### PR DESCRIPTION
copy of #10030 