### PR TITLE
Fix: prevent error when creating text with anchor option

### DIFF
--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -164,7 +164,7 @@ export class Text extends Container implements View
             } as TextOptions;
         }
 
-        const { text, renderMode, resolution, style, ...rest } = options as TextOptions;
+        const { text, renderMode, resolution, style, anchor, ...rest } = options as TextOptions;
 
         super({
             //   view: new TextView(definedProps({ style, text, renderMode, resolution })),
@@ -184,12 +184,16 @@ export class Text extends Container implements View
 
         this.allowChildren = false;
 
-        this._anchor = new ObservablePoint({
-            _onUpdate: () =>
+        this._anchor = new ObservablePoint(
             {
-                this.onViewUpdate();
-            }
-        }, 0, 0);
+                _onUpdate: () =>
+                {
+                    this.onViewUpdate();
+                }
+            },
+            anchor?.x ?? 0,
+            anchor?.y ?? 0,
+        );
     }
 
     /**


### PR DESCRIPTION
##### Description of change
Fixes a bug in 8.0.0-rc.1 that caused an error when creating a `Text` object using the `anchor` option.
```
  TypeError: Cannot set properties of undefined (setting 'x')

    219 |     set anchor(value: PointData)
    220 |     {
  > 221 |         this._anchor.x = value.x;
        |                       ^
    222 |         this._anchor.y = value.y;
    223 |     }
    224 |

at Text.set anchor [as anchor] (src/scene/text/Text.ts:221:23)
at assignWithIgnore (src/scene/container/utils/assignWithIgnore.ts:17:24)
at new Container (src/scene/container/Container.ts:564:25)
at new Text (src/scene/text/Text.ts:169:9)
```
##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [?] Tests passed (`npm run test`)
  - There's a test failing for me in the text test file but I think it's unrelated and fails in the same way both with and without the change
