### PR TITLE
Fix: environment extensions being treeshaken

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,8 @@
   "sideEffects": [
     "./lib/environment-browser/browserAll.*",
     "./lib/environment-webworker/webworkerAll.*",
+    "./lib/index.*",
+    "./lib/rendering/renderers/shared/texture/sources/resourceToTexture.*",
     "./lib/accessibility/init.*",
     "./lib/filters/blend-modes/init.*",
     "./lib/app/init.*",

--- a/scripts/utils/exports.ts
+++ b/scripts/utils/exports.ts
@@ -70,6 +70,8 @@ const exportFields: Record<string, ExportField> = {
 const sideEffects = [
     './lib/environment-browser/browserAll.*',
     './lib/environment-webworker/webworkerAll.*',
+    './lib/index.*',
+    './lib/rendering/renderers/shared/texture/sources/resourceToTexture.*',
 ];
 
 for (const [name, path] of subImports)

--- a/src/rendering/init.ts
+++ b/src/rendering/init.ts
@@ -6,6 +6,7 @@ import { BufferImageSource } from './renderers/shared/texture/sources/BufferSour
 import { CanvasSource } from './renderers/shared/texture/sources/CanvasSource';
 import { ImageSource } from './renderers/shared/texture/sources/ImageSource';
 import { VideoSource } from './renderers/shared/texture/sources/VideoSource';
+import './renderers/shared/texture/sources/resourceToTexture';
 
 /**
  * The rendering namespace contains all the classes used for core rendering in PixiJS


### PR DESCRIPTION
It seems that webpack behaves differently to some of the other bundlers i've been testing on and it requires me to set the `index.ts` file as a side effect in order to include the `browserExt` and `webworkerExt`