### PR TITLE
fix: calling FederatedEventTarget.off() with original listener now works when using signal

### DIFF
--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -721,21 +721,40 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
     {
         const capture = (typeof options === 'boolean' && options)
             || (typeof options === 'object' && options.capture);
+        const signal = typeof options === 'object' ? options.signal : undefined;
         const once = typeof options === 'object' ? (options.once === true) : false;
         const context = typeof listener === 'function' ? undefined : listener;
 
         type = capture ? `${type}capture` : type;
-        listener = typeof listener === 'function' ? listener : listener.handleEvent;
+        let listenerFn = typeof listener === 'function' ? listener : listener.handleEvent;
 
         const emitter = (this as unknown as utils.EventEmitter);
 
+        if (signal)
+        {
+            const extractedListenerFn = listenerFn;
+
+            listenerFn = (e: Event) =>
+            {
+                if (signal.aborted)
+                {
+                    return;
+                }
+                extractedListenerFn(e);
+            };
+            signal.addEventListener('abort', () =>
+            {
+                emitter.off(type, listenerFn, context);
+            });
+        }
+
         if (once)
         {
-            emitter.once(type, listener, context);
+            emitter.once(type, listenerFn, context);
         }
         else
         {
-            emitter.on(type, listener, context);
+            emitter.on(type, listenerFn, context);
         }
     },
 

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -726,22 +726,12 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
         const context = typeof listener === 'function' ? undefined : listener;
 
         type = capture ? `${type}capture` : type;
-        let listenerFn = typeof listener === 'function' ? listener : listener.handleEvent;
+        const listenerFn = typeof listener === 'function' ? listener : listener.handleEvent;
 
         const emitter = (this as unknown as utils.EventEmitter);
 
         if (signal)
         {
-            const extractedListenerFn = listenerFn;
-
-            listenerFn = (e: Event) =>
-            {
-                if (signal.aborted)
-                {
-                    return;
-                }
-                extractedListenerFn(e);
-            };
             signal.addEventListener('abort', () =>
             {
                 emitter.off(type, listenerFn, context);

--- a/packages/events/src/FederatedEventTarget.ts
+++ b/packages/events/src/FederatedEventTarget.ts
@@ -721,12 +721,22 @@ export const FederatedDisplayObject: IFederatedDisplayObject = {
     {
         const capture = (typeof options === 'boolean' && options)
             || (typeof options === 'object' && options.capture);
+        const once = typeof options === 'object' ? (options.once === true) : false;
         const context = typeof listener === 'function' ? undefined : listener;
 
         type = capture ? `${type}capture` : type;
         listener = typeof listener === 'function' ? listener : listener.handleEvent;
 
-        (this as unknown as utils.EventEmitter).on(type, listener, context);
+        const emitter = (this as unknown as utils.EventEmitter);
+
+        if (once)
+        {
+            emitter.once(type, listener, context);
+        }
+        else
+        {
+            emitter.on(type, listener, context);
+        }
     },
 
     /**

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -1031,4 +1031,39 @@ describe('EventSystem', () =>
 
         expect(eventSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should respect \'once\' option', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        graphics.addEventListener('pointertap', (e) =>
+        {
+            expect(e.type).toEqual('click');
+            eventSpy();
+        }, { once: true });
+
+        const click = () =>
+        {
+            const event = new PointerEvent('pointerdown', { clientX: 25, clientY: 25 });
+
+            renderer.events.onPointerDown(event);
+            const e = new PointerEvent('pointerup', { clientX: 30, clientY: 20 });
+            // so it isn't a pointerupoutside
+
+            Object.defineProperty(e, 'target', {
+                writable: false,
+                value: renderer.view
+            });
+            renderer.events.onPointerUp(e);
+        };
+
+        click(); // Once
+        click(); // Twice
+
+        expect(eventSpy).toHaveBeenCalledOnce();
+    });
 });

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -1112,4 +1112,41 @@ describe('EventSystem', () =>
 
         expect(eventSpy).toHaveBeenCalledTimes(2);
     });
+
+    it('should allow explicit removal of a listener even when the signal option is used', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+        const controller = new AbortController();
+
+        const listener = (e: Event) => {
+            expect(e.type).toEqual('click');
+            eventSpy();
+        };
+
+        graphics.addEventListener('pointertap', listener, { signal: controller.signal });
+
+        const click = () =>
+        {
+            const event = new PointerEvent('pointerdown', { clientX: 25, clientY: 25 });
+
+            renderer.events.onPointerDown(event);
+            const e = new PointerEvent('pointerup', { clientX: 30, clientY: 20 });
+            // so it isn't a pointerupoutside
+
+            Object.defineProperty(e, 'target', {
+                writable: false,
+                value: renderer.view
+            });
+            renderer.events.onPointerUp(e);
+        };
+
+        click(); // Once
+        graphics.removeEventListener('pointertap', listener);
+        click(); // Twice
+        expect(eventSpy).toHaveBeenCalledOnce();
+    });
 });

--- a/packages/events/test/EventSystem.tests.ts
+++ b/packages/events/test/EventSystem.tests.ts
@@ -1066,4 +1066,50 @@ describe('EventSystem', () =>
 
         expect(eventSpy).toHaveBeenCalledOnce();
     });
+
+    it('should respect AbortController signals', () =>
+    {
+        const renderer = createRenderer();
+        const [stage, graphics] = createScene();
+        const eventSpy = jest.fn();
+
+        renderer.render(stage);
+
+        const controller = new AbortController();
+
+        let count = 0;
+
+        graphics.addEventListener('pointertap', (e) =>
+        {
+            expect(e.type).toEqual('click');
+            count = count + 1;
+            if (count >= 2)
+            {
+                controller.abort();
+            }
+
+            eventSpy();
+        }, { signal: controller.signal });
+
+        const click = () =>
+        {
+            const event = new PointerEvent('pointerdown', { clientX: 25, clientY: 25 });
+
+            renderer.events.onPointerDown(event);
+            const e = new PointerEvent('pointerup', { clientX: 30, clientY: 20 });
+            // so it isn't a pointerupoutside
+
+            Object.defineProperty(e, 'target', {
+                writable: false,
+                value: renderer.view
+            });
+            renderer.events.onPointerUp(e);
+        };
+
+        click(); // Once
+        click(); // Twice
+        click(); // Three times
+
+        expect(eventSpy).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

    The initial implementation for signal support wrapped the provided listener
    function to add an additional check for the signal's state. This made it
    impossible to manually remove the listener by calling off() as there was no way
    to get a reference to the wrapped listener function. Luckily, this
    additional check was superfluous given the single threaded nature of
    JavaScript's event loop.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
