### PR TITLE
fix: calling FederatedEventTarget.off() with original listener now works when using signal 

### DIFF
--- a/src/events/FederatedEventTarget.ts
+++ b/src/events/FederatedEventTarget.ts
@@ -727,40 +727,30 @@ export const FederatedContainer: IFederatedContainer = {
     {
         const capture = (typeof options === 'boolean' && options)
         || (typeof options === 'object' && options.capture);
+        const signal = typeof options === 'object' ? options.signal : undefined;
         const once = typeof options === 'object' ? (options.once === true) : false;
-        const signal = typeof options === 'object' ? options.signal : null;
         const context = typeof listener === 'function' ? undefined : listener;
 
         type = capture ? `${type}capture` : type;
-        listener = typeof listener === 'function' ? listener : listener.handleEvent;
+        const listenerFn = typeof listener === 'function' ? listener : listener.handleEvent;
 
         const emitter = (this as unknown as EventEmitter);
 
         if (signal)
         {
-            const extractedListenerFn = listener;
-
-            listener = (e: Event) =>
-            {
-                if (signal.aborted)
-                {
-                    return;
-                }
-                extractedListenerFn(e);
-            };
             signal.addEventListener('abort', () =>
             {
-                emitter.off(type, listener as EventListener, context);
+                emitter.off(type, listenerFn, context);
             });
         }
 
         if (once)
         {
-            emitter.once(type, listener, context);
+            emitter.once(type, listenerFn, context);
         }
         else
         {
-            emitter.on(type, listener, context);
+            emitter.on(type, listenerFn, context);
         }
     },
 


### PR DESCRIPTION
port of #10074