### PR TITLE
Fix: transparency for WebGPU and default tint for BitmapText

### DIFF
--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -211,9 +211,11 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
         {
             if (CanvasSource.test(colorTexture.resource))
             {
-                const context = renderTarget.colorTexture.resource.getContext(
+                const context = colorTexture.resource.getContext(
                     'webgpu'
                 ) as unknown as GPUCanvasContext;
+
+                const alphaMode = (colorTexture as CanvasSource).transparent ? 'premultiplied' : 'opaque';
 
                 try
                 {
@@ -225,7 +227,7 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
                             | GPUTextureUsage.RENDER_ATTACHMENT
                             | GPUTextureUsage.COPY_SRC,
                         format: 'bgra8unorm',
-                        alphaMode: 'opaque',
+                        alphaMode,
                     });
                 }
                 catch (e)

--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -8,7 +8,10 @@ import type { TextureSourceOptions } from './TextureSource';
 
 export interface CanvasSourceOptions extends TextureSourceOptions<ICanvas>
 {
+    /** should the canvas be resized to preserve its screen width and height regardless of the resolution of the renderer */
     autoDensity?: boolean;
+    /** if true, this canvas will be set up to be transparent where possible */
+    transparent?: boolean;
 }
 
 export class CanvasSource extends TextureSource<ICanvas>
@@ -17,6 +20,7 @@ export class CanvasSource extends TextureSource<ICanvas>
 
     public uploadMethodId = 'image';
     public autoDensity: boolean;
+    public transparent: boolean;
 
     constructor(options: CanvasSourceOptions)
     {
@@ -55,6 +59,8 @@ export class CanvasSource extends TextureSource<ICanvas>
         {
             this.resizeCanvas();
         }
+
+        this.transparent = !!options.transparent;
     }
 
     public resizeCanvas()

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -7,7 +7,7 @@ import { getCanvasTexture } from '../texture/utils/getCanvasTexture';
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
 import type { TypeOrBool } from '../../../../scene/container/destroyTypes';
 import type { System } from '../system/System';
-import type { CanvasSourceOptions } from '../texture/sources/CanvasSource';
+import type { CanvasSource, CanvasSourceOptions } from '../texture/sources/CanvasSource';
 import type { Texture } from '../texture/Texture';
 
 /** Options passed to the ViewSystem */
@@ -29,6 +29,8 @@ export interface ViewSystemOptions
     antialias?: boolean;
     /** TODO: multiView */
     multiView?: boolean;
+
+    backgroundAlpha?: number;
 }
 
 export interface ViewSystemDestroyOptions
@@ -131,6 +133,7 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
         this.canvas = options.canvas || DOMAdapter.get().createCanvas();
         this.antialias = !!options.antialias;
         this.texture = getCanvasTexture(this.canvas, options as CanvasSourceOptions);
+        (this.texture.source as CanvasSource).transparent = options.backgroundAlpha < 1;
         this.multiView = !!options.multiView;
 
         if (this.autoDensity)

--- a/src/scene/container/utils/buildInstructions.ts
+++ b/src/scene/container/utils/buildInstructions.ts
@@ -29,7 +29,7 @@ export function buildInstructions(renderGroup: RenderGroup, renderPipes: RenderP
     renderPipes.batch.buildEnd(instructionSet);
     renderPipes.blendMode.buildEnd(instructionSet);
 
-    instructionSet.log();
+    // instructionSet.log();
 }
 
 export function collectAllRenderables(

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -176,12 +176,12 @@ export class Text extends Container implements View
 
         this._renderMode = renderMode ?? detectRenderType(style);
 
+        this.style = style;
+
         if (this._renderMode === 'bitmap')
         {
-            style.fill ??= 0xffffff;
+            this.style.fill ??= 0xffffff;
         }
-
-        this.style = style;
 
         this.renderPipeId = map[this._renderMode];
 

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -176,6 +176,11 @@ export class Text extends Container implements View
 
         this._renderMode = renderMode ?? detectRenderType(style);
 
+        if (this._renderMode === 'bitmap')
+        {
+            style.fill ??= 0xffffff;
+        }
+
         this.style = style;
 
         this.renderPipeId = map[this._renderMode];

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -162,7 +162,7 @@ export class TextStyle extends EventEmitter<{
          * See {@link TextStyle.fill}
          * @type {string|string[]|number|number[]|CanvasGradient|CanvasPattern}
          */
-        fill: 'black',
+        fill: 'white',
         /**
          * See {@link TextStyle.fontFamily}
          * @type {string|string[]}

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -162,7 +162,7 @@ export class TextStyle extends EventEmitter<{
          * See {@link TextStyle.fill}
          * @type {string|string[]|number|number[]|CanvasGradient|CanvasPattern}
          */
-        fill: 'white',
+        fill: 'black',
         /**
          * See {@link TextStyle.fontFamily}
          * @type {string|string[]}


### PR DESCRIPTION
- Set default text tint to white
- fix up transparency for WebGPU