### PR TITLE
Only compile filters once where possible

### DIFF
--- a/src/filters/defaults/alpha/AlphaFilter.ts
+++ b/src/filters/defaults/alpha/AlphaFilter.ts
@@ -8,6 +8,9 @@ import source from './alpha.wgsl';
 
 import type { FilterOptions } from '../../Filter';
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 /**
  * Options for AlphaFilter
  * @memberof filters
@@ -46,7 +49,7 @@ export class AlphaFilter extends Filter
     {
         options = { ...AlphaFilter.defaultOptions, ...options };
 
-        const gpuProgram = new GpuProgram({
+        gpuProgram ??= new GpuProgram({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',
@@ -57,7 +60,7 @@ export class AlphaFilter extends Filter
             },
         });
 
-        const glProgram = new GlProgram({
+        glProgram ??= new GlProgram({
             vertex,
             fragment,
             name: 'alpha-filter'

--- a/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
+++ b/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
@@ -10,6 +10,9 @@ import source from './colorMatrixFilter.wgsl';
 import type { ColorSource } from '../../../color/Color';
 import type { ArrayFixed } from '../../../utils/types';
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 /**
  * 5x4 matrix for transforming RGBA color and alpha
  * @memberof filters
@@ -50,7 +53,7 @@ export class ColorMatrixFilter extends Filter
             }
         });
 
-        const gpuProgram = GpuProgram.from({
+        gpuProgram ??= GpuProgram.from({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',
@@ -61,7 +64,7 @@ export class ColorMatrixFilter extends Filter
             },
         });
 
-        const glProgram = GlProgram.from({
+        glProgram ??= GlProgram.from({
             vertex,
             fragment,
             name: 'color-matrix-filter'

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -14,6 +14,9 @@ import type { PointData } from '../../../maths/point/PointData';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { FilterSystem } from '../../FilterSystem';
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 /**
  * Options for DisplacementFilter
  * @memberof filters
@@ -68,13 +71,13 @@ export class DisplacementFilter extends Filter
             uRotation: { value: new Float32Array([0, 0, 0, 0]), type: 'vec4<f32>' },
         });
 
-        const glProgram = GlProgram.from({
+        glProgram ??= GlProgram.from({
             vertex,
             fragment,
             name: 'displacement-filter'
         });
 
-        const gpuProgram = GpuProgram.from({
+        gpuProgram ??= GpuProgram.from({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',

--- a/src/filters/defaults/noise/NoiseFilter.ts
+++ b/src/filters/defaults/noise/NoiseFilter.ts
@@ -6,6 +6,9 @@ import vertex from '../defaultFilter.vert';
 import fragment from './noise.frag';
 import source from './noise.wgsl';
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 /**
  * Options for NoiseFilter
  * @memberof filters
@@ -39,7 +42,7 @@ export class NoiseFilter extends Filter
             }, ...options
         };
 
-        const gpuProgram = new GpuProgram({
+        gpuProgram ??= new GpuProgram({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',
@@ -50,7 +53,7 @@ export class NoiseFilter extends Filter
             },
         });
 
-        const glProgram = new GlProgram({
+        glProgram ??= new GlProgram({
             vertex,
             fragment,
             name: 'noise-filter'

--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -12,6 +12,9 @@ import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { Sprite } from '../../scene/sprite/Sprite';
 import type { FilterSystem } from '../FilterSystem';
 
+let gpuProgram: GpuProgram;
+let glProgram: GlProgram;
+
 export interface MaskFilterOptions
 {
     sprite: Sprite,
@@ -33,7 +36,7 @@ export class MaskFilter extends Filter
             uAlpha: { value: 1, type: 'f32' },
         });
 
-        const gpuProgram = GpuProgram.from({
+        gpuProgram ??= GpuProgram.from({
             vertex: {
                 source,
                 entryPoint: 'mainVertex',
@@ -44,7 +47,7 @@ export class MaskFilter extends Filter
             },
         });
 
-        const glProgram = GlProgram.from({
+        glProgram ??= GlProgram.from({
             vertex,
             fragment,
             name: 'mask-filter',


### PR DESCRIPTION
##### Description of change
Attempts to address some performance issues I encountered when spawning a lot of objects with the same filter at the same time (in my case `AlphaFilter`). The renderer would compile the program for each filter separately, despite them all sharing the same code. Implementation is based on how `TilingSpriteShader` does it, though I'm not 100% if reusing the programs will work across multiple PIXI instances.

I've made a little example that showcases the issue. 
https://www.pixiplayground.com/#/edit/_1N5rSl_W1_lbspwvjOQ3

The performance impact seems to be much bigger in webgl compared to webgpu, spending about 500ms compiling the shaders when creating 100 alpha filter instances on my end.
![image](https://github.com/pixijs/pixijs/assets/8039761/69b32516-130c-43ed-bb20-b69a3c323abd)

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
