### PR TITLE
Add strict null checks to @pixi/ticker

### DIFF
--- a/packages/ticker/src/Ticker.ts
+++ b/packages/ticker/src/Ticker.ts
@@ -3,7 +3,7 @@ import { TickerListener } from './TickerListener';
 
 import type { TickerCallback, TickerListenerContext } from './TickerListener';
 
-export { TickerCallback };
+export type { TickerCallback };
 
 /**
  * A Ticker class that runs an update loop that other objects listen to.

--- a/packages/ticker/src/TickerPlugin.ts
+++ b/packages/ticker/src/TickerPlugin.ts
@@ -36,8 +36,8 @@ export class TickerPlugin
 
     static start: () => void;
     static stop: () => void;
-    static _ticker: Ticker;
-    static ticker: Ticker;
+    static _ticker: Ticker | null;
+    static ticker: Ticker | null;
 
     /**
      * Initialize the plugin with scope of application instance
@@ -82,7 +82,7 @@ export class TickerPlugin
          */
         this.stop = (): void =>
         {
-            this._ticker.stop();
+            this._ticker?.stop();
         };
 
         /**
@@ -93,7 +93,7 @@ export class TickerPlugin
          */
         this.start = (): void =>
         {
-            this._ticker.start();
+            this._ticker?.start();
         };
 
         /**

--- a/packages/ticker/test/Ticker.tests.ts
+++ b/packages/ticker/test/Ticker.tests.ts
@@ -1,5 +1,7 @@
 import { Ticker, UPDATE_PRIORITY } from '@pixi/ticker';
 
+import type { TickerListener } from '../src/TickerListener';
+
 const { shared, system } = Ticker;
 
 describe('Ticker', () =>
@@ -17,7 +19,7 @@ describe('Ticker', () =>
                 return 0;
             }
 
-            let listener = ticker['_head'].next;
+            let listener: TickerListener | null = ticker['_head'].next;
             let i = 0;
 
             while (listener)

--- a/packages/ticker/test/TickerPlugin.tests.ts
+++ b/packages/ticker/test/TickerPlugin.tests.ts
@@ -4,8 +4,8 @@ describe('TickerPlugin', () =>
 {
     interface App
     {
-        _ticker?: Ticker;
-        ticker?: Ticker;
+        _ticker?: Ticker | null;
+        ticker?: Ticker | null;
         render?(): void;
         start?(): void;
     }
@@ -13,16 +13,16 @@ describe('TickerPlugin', () =>
 
     it('should not start application before calling start method if options.autoStart is false', (done) =>
     {
-        const appp = {} as App;
+        const appp: App = {};
 
         TickerPlugin.init.call(appp, { autoStart: false });
 
         expect(appp.ticker).toBeInstanceOf(Ticker);
-        expect(appp.ticker.started).toBe(false);
+        expect(appp.ticker?.started).toBe(false);
 
-        appp.start();
+        appp.start?.();
 
-        appp.ticker.addOnce(() =>
+        appp.ticker?.addOnce(() =>
         {
             TickerPlugin.destroy.call(appp);
             done();
@@ -41,7 +41,7 @@ describe('TickerPlugin', () =>
             };
             TickerPlugin.init.call(app);
             /* remove default listener to prevent uncaught exception */
-            app._ticker.remove(app.render, app);
+            app._ticker?.remove(app.render as () => void, app);
         });
 
         afterAll(() =>
@@ -67,10 +67,10 @@ describe('TickerPlugin', () =>
 
         it('should assign ticker if no ticker', () =>
         {
-            const ticker = { add: jest.fn() };
+            const ticker = { add: jest.fn() } as unknown as Ticker;
 
             app._ticker = null;
-            app.ticker = ticker as unknown as Ticker;
+            app.ticker = ticker;
 
             expect(app._ticker).toEqual(ticker);
             expect(ticker.add).toHaveBeenCalledOnce();

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -61,7 +61,7 @@ const pathPrefixs = [
     // 'packages/text/',
     // 'packages/text-bitmap/',
     'packages/text-html/',
-    // 'packages/ticker/',
+    'packages/ticker/',
     'packages/unsafe-eval/',
     'packages/utils/',
     'scripts/',


### PR DESCRIPTION
##### Description of change

Ref https://github.com/pixijs/pixijs/issues/8852

I have made the following adjustments to resolve the strict null check errors occurring under the packages/ticker directory.

[packages/ticker/src/TickerPlugin.ts](https://github.com/pixijs/pixijs/pull/10087/files#diff-2dd43e1902cf45a5c2f73ba17c20286886683f9906e240e9091cf47b37e6a743)

- Made `_ticker` and `ticker` nullable and added optional chaining when referenced.

[packages/ticker/src/TickerListener.ts](https://github.com/pixijs/pixijs/pull/10087/files#diff-e1e288f1edb157d67a51a66dde73bb2ee0420e9fb9ab355f8a4ec170fc29c515)

- Due to a circular reference issue, defined `TickerCallback` within this file.
- In the `emit` method, to enable type inference for the `fn` property, set the type of TickerCallback to a union type.
- To make the type definition more strict, changed the type argument `T` of the class `TickerListener` from `any` to `Record<string, any> | null`.
  ```diff
  - export class TickerListener<T = any>
  + TickerListenerContext = Record<string, any> | null
  + export class TickerListener<T extends TickerListenerContext = TickerListenerContext>
  ```
- Integrated the definitions of the properties `fn`, `context`, `priority`, and `once` with the constructor's parameter definitions. This prevents redundant type management between the properties and constructor parameters. Additionally, since `null` is set to `fn` and `context` within the destroy method, made them nullable.
  ```diff
  - public priority: number;
  - private fn: TickerCallback<T>;
  - private context: T;
  - private once: boolean;
  - constructor(fn: TickerCallback<T>, context: T = null, priority = 0, once = false)
  - {
  -     this.fn = fn;
  -     this.context = context;
  -     this.priority = priority;
  -     this.once = once;
  + constructor(
  +     private fn: TickerCallback<T> | null,
  +     private context: T | null = null,
  +     public priority = 0,
  +     private once = false)
  ```

[packages/ticker/src/Ticker.ts](https://github.com/pixijs/pixijs/pull/10087/files#diff-8370bd094408139eddb3b1053b8031f0fe189c99d7c710cd64665ecd92ef84cc)

- Since `null` is set to `_head` and `_requestId` within the destroy method, made them nullable.
- Added null check processing for the nullable `_head`.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
