### PR TITLE
Chore/v8-antialias-extract

### DIFF
--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -24,6 +24,7 @@ export interface BaseExtractOptions
     frame?: Rectangle;
     resolution?: number;
     clearColor?: ColorSource;
+    antialias?: boolean;
 }
 export type ExtractImageOptions = BaseExtractOptions & ImageOptions;
 export type ExtractDownloadOptions = BaseExtractOptions & {
@@ -150,17 +151,17 @@ export class ExtractSystem implements System
         const target = options.target;
 
         const renderer = this._renderer;
-        const texture = target instanceof Texture
-            ? target
-            : renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
+
+        if (target instanceof Texture)
+        {
+            return renderer.texture.generateCanvas(target);
+        }
+
+        const texture = renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
 
         const canvas = renderer.texture.generateCanvas(texture);
 
-        if (target instanceof Container)
-        {
-            // destroy generated texture
-            texture.destroy();
-        }
+        texture.destroy();
 
         return canvas;
     }

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -28,6 +28,8 @@ export type GenerateTextureOptions =
 
     clearColor?: ColorSource;
 
+    antialias?: boolean;
+
     /** The options passed to the texture source. */
     textureSourceOptions?: GenerateTextureSourceOptions,
 };
@@ -81,6 +83,7 @@ export class GenerateTextureSystem implements System
         }
 
         const resolution = options.resolution || this._renderer.resolution;
+        const antialias = options.antialias || this._renderer.view.antialias;
 
         const container = options.target;
 
@@ -108,6 +111,7 @@ export class GenerateTextureSystem implements System
             width: region.width,
             height: region.height,
             resolution,
+            antialias,
         });
 
         const transform = Matrix.shared.translate(-region.x, -region.y);

--- a/tests/visual/scenes/filters/anitalias-filter.scene.ts
+++ b/tests/visual/scenes/filters/anitalias-filter.scene.ts
@@ -8,7 +8,6 @@ import type { TestScene } from '../../types';
 
 export const scene: TestScene = {
     it: 'should render filters correctly with antialiasing',
-    only: true,
     create: async (scene: Container) =>
     {
         const g = new Graphics();


### PR DESCRIPTION
- allow user to pass antialias option when extracting
- will default to the render antialiasing if none is provided
