### PR TITLE
Fix: issues with TextStyle getter/setters and BitmapText default fill

### DIFF
--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -178,9 +178,9 @@ export class Text extends Container implements View
 
         this.style = style;
 
-        if (this._renderMode === 'bitmap')
+        if (this._renderMode === 'bitmap' && !style?.fill)
         {
-            this.style.fill ??= 0xffffff;
+            this.style.fill = 0xffffff;
         }
 
         this.renderPipeId = map[this._renderMode];

--- a/tests/renderering/text/BitmapText.tests.ts
+++ b/tests/renderering/text/BitmapText.tests.ts
@@ -48,6 +48,90 @@ describe('BitmapText', () =>
         expect(Cache.get('arial-bitmap').pages).toHaveLength(1);
     });
 
+    it('should default to white fill', async () =>
+    {
+        let text = new Text({
+            text: 'ABCDEFG',
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.fill).toEqual(0xffffff);
+
+        text = new Text({
+            text: 'ABCDEFG',
+            style: {
+                fill: 0xff0000,
+            },
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.fill).toEqual(0xff0000);
+
+        text = new Text({
+            text: 'ABCDEFG',
+            style: {
+                dropShadow: true,
+            },
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.fill).toEqual(0xffffff);
+    });
+
+    it('should apply dropShadow defaults correctly', async () =>
+    {
+        let text = new Text({
+            text: 'ABCDEFG',
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.dropShadow).toEqual(null);
+
+        text = new Text({
+            text: 'ABCDEFG',
+            style: {
+                dropShadow: {
+                    color: 'blue',
+                }
+            },
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.dropShadow).toMatchObject({
+            alpha: 1,
+            angle: Math.PI / 6,
+            blur: 0,
+            color: 'blue',
+            distance: 5,
+        });
+
+        text = new Text({
+            text: 'ABCDEFG',
+            style: {
+                dropShadow: true
+            },
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.dropShadow).toMatchObject({
+            alpha: 1,
+            angle: Math.PI / 6,
+            blur: 0,
+            color: 'black',
+            distance: 5,
+        });
+
+        text = new Text({
+            text: 'ABCDEFG',
+            style: {
+                dropShadow: false
+            },
+            renderMode: 'bitmap',
+        });
+
+        expect(text.style.dropShadow).toEqual(null);
+    });
+
     it.each([
         'bitmap',
         'html',

--- a/tests/visual/scenes/text/bitmap-text.scene.ts
+++ b/tests/visual/scenes/text/bitmap-text.scene.ts
@@ -28,7 +28,6 @@ export const scene: TestScene = {
             style: {
                 fontFamily: 'Outfit',
                 fontSize: 16,
-                fill: 'white',
                 letterSpacing: 5,
                 // lineHeight: 20, // todo: https://github.com/orgs/pixijs/projects/2/views/4?pane=issue&itemId=46297431
             },


### PR DESCRIPTION
This PR fixes a couple of issues with TextStyle

- the setters did not have the logic that was in the constructor
- dropShadow is now fully supported as either a bool or an object and will apply defaults if a partial style is provided
- stroke now checks for `_originalStroke` instead of `_originalFill`
- when converting from v7 drop shadow options the default settings are now applied 

This PR also fixes the issue where bitmap texts fill was always being set to white