### PR TITLE
Tweaks to visual tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,4 +29,5 @@ module.exports = {
         '<rootDir>/src/**/*.ts',
     ],
     coverageDirectory: '<rootDir>/dist/coverage',
+    testTimeout: 10000
 };

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -157,6 +157,8 @@ export class FilterSystem implements System
         // if a filterArea is provided, we save our selves some measuring and just use that area supplied
         else if (instruction.filterEffect.filterArea)
         {
+            bounds.clear();
+
             // transform the filterArea into global space..
             bounds.addRect(instruction.filterEffect.filterArea);
 

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -277,13 +277,13 @@ export class GlTextureSystem implements System, CanvasGenerator
 
         if (source.autoGenerateMipmaps && source.mipLevelCount > 1)
         {
-            this.onUpdateMipmaps(source);
+            this.onUpdateMipmaps(source, false);
         }
     }
 
-    protected onUpdateMipmaps(source: TextureSource): void
+    protected onUpdateMipmaps(source: TextureSource, bind = true): void
     {
-        this.bindSource(source, 0);
+        if (bind) this.bindSource(source, 0);
 
         const glTexture = this.getGlSource(source);
 

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -45,6 +45,13 @@ const renderTypeSettings: Record<RenderType, Partial<RendererOptions>> = {
     } as Partial<RendererOptions>,
 };
 
+/**
+ * returns an instance of a renderer to test with. If no options are passed, we always return the same renderer
+ * instance for each type. If options are passed, we create a new renderer instance for each call.
+ * @param type - the type of renderer to create
+ * @param options - any custom options to pass to the renderer
+ * @returns
+ */
 async function getRenderer(type: RenderType, options?: Partial<RendererOptions>): Promise<Renderer>
 {
     if (!options)

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -50,7 +50,6 @@ const renderTypeSettings: Record<RenderType, Partial<RendererOptions>> = {
  * instance for each type. If options are passed, we create a new renderer instance for each call.
  * @param type - the type of renderer to create
  * @param options - any custom options to pass to the renderer
- * @returns
  */
 async function getRenderer(type: RenderType, options?: Partial<RendererOptions>): Promise<Renderer>
 {

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -2,8 +2,8 @@ import { ensureDirSync, existsSync, readFileSync, writeFile } from 'fs-extra';
 import { dirname } from 'path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
+import { Rectangle } from '../../src/maths/shapes/Rectangle';
 import { autoDetectRenderer } from '../../src/rendering/renderers/autoDetectRenderer';
-import { RenderTexture } from '../../src/rendering/renderers/shared/texture/RenderTexture';
 import { Container } from '../../src/scene/container/Container';
 import { Graphics } from '../../src/scene/graphics/shared/Graphics';
 
@@ -23,14 +23,45 @@ function toArrayBuffer(buf: Buffer): ArrayBuffer
     return ab;
 }
 
-function toRenderType(renderType: RenderType): 'webgl' | 'webgpu'
+const cachedPromise: Record<string, Promise<Renderer>> = {};
+
+const rendererOptions = {
+    width: 128,
+    height: 128,
+    backgroundColor: 0x1099bb,
+};
+
+const renderTypeSettings: Record<RenderType, Partial<RendererOptions>> = {
+    webgpu: {
+        preference: 'webgpu',
+    } as Partial<RendererOptions>,
+    webgl2: {
+        preference: 'webgl',
+        preferWebGLVersion: 2,
+    } as Partial<RendererOptions>,
+    webgl1: {
+        preference: 'webgl',
+        preferWebGLVersion: 1,
+    } as Partial<RendererOptions>,
+};
+
+async function getRenderer(type: RenderType, options?: Partial<RendererOptions>): Promise<Renderer>
 {
-    if (renderType === 'webgl1' || renderType === 'webgl2')
+    if (!options)
     {
-        return 'webgl';
+        cachedPromise[type] ??= autoDetectRenderer({
+            ...rendererOptions,
+            ...renderTypeSettings[type],
+        });
+
+        return cachedPromise[type];
     }
 
-    return 'webgpu';
+    return autoDetectRenderer({
+        ...rendererOptions,
+        ...options,
+        ...renderTypeSettings[type],
+    });
 }
 
 /**
@@ -50,47 +81,36 @@ export async function renderTest(
     options?: Partial<RendererOptions>,
 ): Promise<number>
 {
-    const sceneOpts = {
-        width: 128,
-        height: 128,
-        backgroundColor: 0x1099bb,
-        ...options
-    };
+    const renderer = await getRenderer(rendererType, options);
 
-    const renderer = await autoDetectRenderer({
-        preference: toRenderType(rendererType),
-        preferWebGLVersion: rendererType === 'webgl2' ? 2 : 1,
-        ...sceneOpts,
-    });
     const stage = new Container();
     const scene = new Container();
 
-    stage.addChild(new Graphics().rect(0, 0, sceneOpts.width, sceneOpts.height)).fill(renderer.background.color);
+    const { width, height } = rendererOptions;
+
+    stage.addChild(new Graphics().rect(0, 0, width, height)).fill(renderer.background.color);
     stage.addChild(scene);
 
     await createFunction(scene, renderer);
 
-    renderer.render({
-        container: stage,
-    });
+    const canvas = renderer.extract.canvas({
+        target: stage,
+        frame: new Rectangle(0, 0, width, height)
+    }) as HTMLCanvasElement;
 
     const imageLocation = `./tests/visual/snapshots/${id}-${rendererType}.png`;
 
     if (!existsSync(imageLocation))
     {
-        await saveSnapShot(imageLocation, stage, renderer);
+        await saveSnapShot(imageLocation, canvas);
     }
 
     const prevSnapShot = loadSnapShot(imageLocation);
-    const newSnapShot = createSnapShot(stage, renderer);
-    const diff = new PNG({ width: sceneOpts.width, height: sceneOpts.height });
-
-    // generate an image...
+    const newSnapShot = createSnapShot(canvas);
+    const diff = new PNG({ width, height });
 
     if (process.env.DEBUG_MODE)
     {
-        const canvas = createCanvas(stage, renderer);
-
         document.body.appendChild(canvas);
     }
 
@@ -98,8 +118,8 @@ export async function renderTest(
         prevSnapShot,
         newSnapShot,
         diff.data,
-        sceneOpts.width,
-        sceneOpts.height,
+        width,
+        height,
         { threshold: 0.2 }
     );
 
@@ -107,40 +127,36 @@ export async function renderTest(
     ensureDirSync('.pr_uploads/visual');
     await writeFile(`.pr_uploads/visual/${id}-${rendererType}-diff.png`, PNG.sync.write(diff));
     // save output image
-    await saveSnapShot(`.pr_uploads/visual/${id}-${rendererType}.png`, stage, renderer);
+    await saveSnapShot(`.pr_uploads/visual/${id}-${rendererType}.png`, canvas);
 
-    renderer.destroy();
+    // this means we created a custom renderer.. so lts clean up after ourselves!
+    if (options)
+    {
+        renderer.destroy();
+    }
 
     return match;
 }
 
 /**
  * returns an array of pixels of the current scene.
- * @param stage - pixi container that contains the scene view
- * @param renderer - the pixi renderer that we will extract the snapshot from
+ * @param canvas - then canvas to create the snapshot from
  */
-function createSnapShot(stage: Container, renderer: Renderer)
+function createSnapShot(canvas: HTMLCanvasElement)
 {
-    const rt = RenderTexture.create({ width: renderer.width, height: renderer.height });
+    // write to a  new canvas to be same!
+    const readableCanvas = document.createElement('canvas');
 
-    renderer.render({
-        target: rt,
-        container: stage,
-    });
+    readableCanvas.width = canvas.width;
+    readableCanvas.height = canvas.height;
 
-    return renderer.extract.pixels(rt).pixels;
-}
+    const context = readableCanvas.getContext('2d');
 
-function createCanvas(stage: Container, renderer: Renderer): HTMLCanvasElement
-{
-    const rt = RenderTexture.create({ width: renderer.width, height: renderer.height });
+    context.drawImage(canvas, 0, 0);
 
-    renderer.render({
-        target: rt,
-        container: stage,
-    });
+    const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
 
-    return renderer.extract.canvas(rt) as HTMLCanvasElement;
+    return new Uint8ClampedArray(imageData.data.buffer);
 }
 
 /**
@@ -155,25 +171,13 @@ function loadSnapShot(input: string): Uint8Array
 /**
  * writes a PNG file of the passed in scene.
  * @param output - the location where to save the image
- * @param stage - pixi container that contains the scene view
- * @param renderer - the pixi renderer that we will extract the snapshot from
+ * @param canvas - the canvas to save
  */
-async function saveSnapShot(output: string, stage: Container, renderer: Renderer): Promise<void>
+async function saveSnapShot(output: string, canvas: HTMLCanvasElement): Promise<void>
 {
     ensureDirSync(dirname(output));
 
-    const rt = RenderTexture.create({ width: renderer.width, height: renderer.height });
-
-    renderer.render({
-        target: rt,
-        container: stage,
-    });
-
-    const base64Image = await renderer.extract.base64({
-        target: rt,
-        format: 'png',
-        resolution: 1,
-    });
+    const base64Image = await canvas.toDataURL('png', 1);
 
     const base64Data = base64Image.replace(/^data:image\/png;base64,/, '');
 

--- a/tests/visual/visuals.test.ts
+++ b/tests/visual/visuals.test.ts
@@ -90,7 +90,7 @@ describe('Visual Tests', () =>
                     id,
                     scene.data.create,
                     renderer as RenderType,
-                    scene.data.options ?? {}
+                    scene.data.options
                 );
 
                 expect(res).toBeLessThanOrEqual(scene.data.pixelMatch || 100);


### PR DESCRIPTION
- we now just extract a canvas directly and then use that same canvas to save / compare pixels etc.
- renderers are now reused, so one of each is created as required. However if a test requires custom init options, then a new instance of a renderer with the specific options is created (and subsiquently destroyed).
- this new set up Highlighted a couple of bugs that have also been fixed
- this should run through the tests a a lot quicker now.
 