### PR TITLE
Feat: add ability to set width/height of Container together

### DIFF
--- a/tests/display/Container.Visual.tests.ts
+++ b/tests/display/Container.Visual.tests.ts
@@ -1,6 +1,7 @@
 import { DEG_TO_RAD, RAD_TO_DEG } from '../../src/maths/misc/const';
 import { Container } from '../../src/scene/container/Container';
 import { updateRenderGroupTransforms } from '../../src/scene/container/utils/updateRenderGroupTransforms';
+import { Sprite } from '../../src/scene/sprite/Sprite';
 
 describe('Container Visual', () =>
 {
@@ -159,6 +160,39 @@ describe('Container Visual', () =>
 
             expect(container.width).toEqual(0);
             expect(container.scale.x).toEqual(1);
+        });
+
+        it('should get/set size', () =>
+        {
+            const container = new Sprite();
+
+            container.setSize(5);
+
+            expect(container.getSize().width).toEqual(5);
+            expect(container.width).toEqual(5);
+            expect(container.getSize().height).toEqual(5);
+            expect(container.height).toEqual(5);
+
+            container.setSize(10, 15);
+
+            expect(container.getSize().width).toEqual(10);
+            expect(container.width).toEqual(10);
+            expect(container.getSize().height).toEqual(15);
+            expect(container.height).toEqual(15);
+
+            container.setSize({ width: 20, height: 25 });
+
+            expect(container.getSize().width).toEqual(20);
+            expect(container.width).toEqual(20);
+            expect(container.getSize().height).toEqual(25);
+            expect(container.height).toEqual(25);
+
+            container.setSize({ width: 30 });
+
+            expect(container.getSize().width).toEqual(30);
+            expect(container.width).toEqual(30);
+            expect(container.getSize().height).toEqual(30);
+            expect(container.height).toEqual(30);
         });
     });
 


### PR DESCRIPTION
This PR adds the ability to set the width/height of a container in one go which reduces the number of `getLocalBounds` calls that get made

```ts
new Container()
    .setSize(100) // 100, 100
    .setSize(100, 150) // 100, 150
    .setSize({width: 100}) // 100, 100
    .setSize({width: 100, height: 150}) // 100, 150
```

There is also a `getSize()` with an optional `out` property to get the width/height of a container without the additional calls as well