### PR TITLE
Add: Spritesheet option cachePrefix

### DIFF
--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -23,9 +23,10 @@ function getCacheableAssets(keys: string[], asset: Spritesheet, ignoreMultiPack:
     const out: Record<string, Texture> = keys.reduce((acc, key: string) =>
         Object.assign(acc, { [key]: asset }), {});
 
-    Object.keys(asset.textures)
-        .map((key) => `${asset.cachePrefix}${key}`)
-        .reduce((acc, key) => Object.assign(acc, { [key]: asset.textures[key] }), out);
+    Object.keys(asset.textures).forEach((key) =>
+    {
+        out[`${asset.cachePrefix}${key}`] = asset.textures[key];
+    });
 
     if (!ignoreMultiPack)
     {

--- a/packages/spritesheet/src/spritesheetAsset.ts
+++ b/packages/spritesheet/src/spritesheetAsset.ts
@@ -20,8 +20,12 @@ const validImages = ['jpg', 'png', 'jpeg', 'avif', 'webp'];
 
 function getCacheableAssets(keys: string[], asset: Spritesheet, ignoreMultiPack: boolean)
 {
-    const out: Record<string, Texture> = keys.reduce((acc, key: string) =>
-        Object.assign(acc, { [key]: asset }), {});
+    const out: Record<string, Texture | Spritesheet> = {};
+
+    keys.forEach((key: string) =>
+    {
+        out[key] = asset;
+    });
 
     Object.keys(asset.textures).forEach((key) =>
     {

--- a/packages/spritesheet/test/Spritesheet.tests.ts
+++ b/packages/spritesheet/test/Spritesheet.tests.ts
@@ -94,6 +94,23 @@ describe('Spritesheet', () =>
         spritesheet.destroy(true);
     });
 
+    it('should create an instance with options', () =>
+    {
+        const baseTexture = new BaseTexture();
+        const data = {
+            frames: {},
+            meta: {},
+        } as unknown as ISpritesheetData;
+
+        const spritesheet = new Spritesheet({ texture: baseTexture, data });
+
+        expect(spritesheet.data).toEqual(data);
+        expect(spritesheet.baseTexture).toEqual(baseTexture);
+        expect(spritesheet.resolution).toEqual(1);
+
+        spritesheet.destroy(true);
+    });
+
     it('should create instance with scale resolution', (done) =>
     {
         jest.setTimeout(10000);

--- a/packages/spritesheet/test/spritesheetAsset.tests.ts
+++ b/packages/spritesheet/test/spritesheetAsset.tests.ts
@@ -161,6 +161,34 @@ describe('spritesheetAsset', () =>
         await loader.unload(src);
     });
 
+    it('should load a spritesheet with cachePrefix and cache parser', async () =>
+    {
+        const cacheParser = spritesheetAsset.cache as CacheParser;
+
+        Cache['_parsers'].push(cacheParser);
+
+        const src = `${serverPath}spritesheet.json`;
+        const cachePrefix = 'spritesheet.json/';
+        const data = { cachePrefix };
+        const spriteSheet = await loader.load<Spritesheet>({ src, data });
+
+        Cache.set('spritesheet.json', spriteSheet);
+
+        const bunnyTexture = spriteSheet.textures['bunny.png'];
+        const senseiTexture = spriteSheet.textures['pic-sensei.jpg'];
+        const cacheTexture1 = Cache.get(`${cachePrefix}bunny.png`);
+        const cacheTexture2 = Cache.get(`${cachePrefix}pic-sensei.jpg`);
+
+        expect(cacheTexture1).toBeDefined();
+        expect(cacheTexture2).toBeDefined();
+        expect(cacheTexture1).toBe(bunnyTexture);
+        expect(cacheTexture2).toBe(senseiTexture);
+
+        Cache['_parsers'].splice(Cache['_parsers'].indexOf(cacheParser), 1);
+
+        await loader.unload(src);
+    });
+
     it('should not create multipack resources when related_multi_packs field is missing or the wrong type', async () =>
     {
         const validLinked = `${serverPath}building1-1.json`;


### PR DESCRIPTION
This was a request that was made via Discord. 

The use-case is that we have a global `TextureCache` and a global `Assets` cache and collisions of textures can easily happen with an app that's a little more complex. Sometimes there's a need to be more specific when loading multiple atlases that might share the same texture name. This change allows users to optionally provide a cachePrefix that prepended to texture IDs whenever adding to TextureCache or Assets' Cache.

### Added

* Adds `cachePrefix` option to Spritesheet
* Adds options for Spritesheet constructor

### Chores

* General cleanup of Spritesheet tests to unload assets better


### Example

```ts
import { Assets } from 'pixi.js';

await Assets.load({
   src: './atlas.json', // contains "background" texture
   data: { cachePrefix: 'atlas.json/' }
});

await Assets.load({
   src: './atlas2.json', // also contains "background" texture
   data: { cachePrefix: 'atlas2.json/' }
});

const background = Assets.get('atlas.json/background');
const background2 = Assets.get('atlas2.json/background');
````