### PR TITLE
Fix: masks not working correctly when sub rendering a container

### DIFF
--- a/src/rendering/mask/stencil/StencilMaskPipe.ts
+++ b/src/rendering/mask/stencil/StencilMaskPipe.ts
@@ -141,7 +141,7 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
         const renderer = this._renderer;
         const renderTargetUid = renderer.renderTarget.renderTarget.uid;
 
-        let maskStackIndex = this._maskStackHash[renderTargetUid];
+        let maskStackIndex = this._maskStackHash[renderTargetUid] ??= 0;
 
         if (instruction.action === 'pushMaskBegin')
         {

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -66,6 +66,7 @@ export class GenerateTextureSystem implements System
      * @param {GenerateTextureOptions | Container} options - Generate texture options.
      * @param {Container} [options.container] - If not given, the renderer's resolution is used.
      * @param {Rectangle} options.region - The region of the container, that shall be rendered,
+     * @param {number} [options.resolution] - The resolution of the texture being generated.
      *        if no region is specified, defaults to the local bounds of the container.
      * @param {GenerateTextureSourceOptions} [options.textureSourceOptions] - Texture options for GPU.
      * @returns a shiny new texture of the container passed in


### PR DESCRIPTION
- fixes little mask issue when sub rendering a container
- added adoc for resolution in `generateTexture`