### PR TITLE
Fix: attribute locations not being set automatically

### DIFF
--- a/src/rendering/batcher/gpu/BatchGeometry.ts
+++ b/src/rendering/batcher/gpu/BatchGeometry.ts
@@ -31,28 +31,24 @@ export class BatchGeometry extends Geometry
             attributes: {
                 aPosition: {
                     buffer: attributeBuffer,
-                    location: 0,
                     format: 'float32x2',
                     stride,
                     offset: 0,
                 },
                 aUV: {
                     buffer: attributeBuffer,
-                    location: 1,
                     format: 'float32x2',
                     stride,
                     offset: 2 * 4,
                 },
                 aColor: {
                     buffer: attributeBuffer,
-                    location: 2,
                     format: 'unorm8x4',
                     stride,
                     offset: 4 * 4,
                 },
                 aTextureIdAndRound: {
                     buffer: attributeBuffer,
-                    location: 3,
                     format: 'uint16x2',
                     stride,
                     offset: 5 * 4,

--- a/src/rendering/renderers/gl/shader/program/generateProgram.ts
+++ b/src/rendering/renderers/gl/shader/program/generateProgram.ts
@@ -56,7 +56,15 @@ export function generateProgram(gl: GlRenderingContext, program: GlProgram): GlP
         logProgramError(gl, webGLProgram, glVertShader, glFragShader);
     }
 
-    program._attributeData = extractAttributesFromGlProgram(webGLProgram, gl);
+    // GLSL 1.00: bind attributes sorted by name in ascending order
+    // GLSL 3.00: don't change the attribute locations that where chosen by the compiler
+    //            or assigned by the layout specifier in the shader source code
+    program._attributeData = extractAttributesFromGlProgram(
+        webGLProgram,
+        gl,
+        !(/^[ \t]*#[ \t]*version[ \t]+300[ \t]+es[ \t]*$/m).test(program.vertex)
+    );
+
     program._uniformData = getUniformData(webGLProgram, gl);
     program._uniformBlockData = getUboData(webGLProgram, gl);
 

--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -79,14 +79,12 @@ export class MeshGeometry extends Geometry
             attributes: {
                 aPosition: {
                     buffer: positionBuffer,
-                    location: 0,
                     format: 'float32x2',
                     stride: 2 * 4,
                     offset: 0,
                 },
                 aUV: {
                     buffer: uvBuffer,
-                    location: 1,
                     format: 'float32x2',
                     stride: 2 * 4,
                     offset: 0,


### PR DESCRIPTION
Upgrade to the Geometry meant that shader locations are now being allocated automatically. Actual shader locations differ across browsers.

This PR should now not force the locations in the geometry.