### PR TITLE
Fix: auto assignment of gpu pixi groups

### DIFF
--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -115,6 +115,11 @@ export class GpuProgram
     public readonly name: string;
     private _attributeData: Record<string, ExtractedAttributeData>;
 
+    /** if true, the program will automatically assign global uniforms to group[0] */
+    public autoAssignGlobalUniforms: boolean;
+    /** if true, the program will automatically assign local uniforms to group[1] */
+    public autoAssignLocalUniforms: boolean;
+
     /**
      * Create a new GpuProgram
      * @param options - The options for the gpu program
@@ -149,6 +154,9 @@ export class GpuProgram
         // struct properties!
 
         this.gpuLayout = gpuLayout ?? generateGpuLayoutGroups(this.structsAndGroups);
+
+        this.autoAssignGlobalUniforms = !!this.layout[0]?.globalUniforms;
+        this.autoAssignLocalUniforms = !!this.layout[1]?.localUniforms;
 
         this._generateProgramKey();
     }

--- a/src/scene/mesh/gl/GlMeshAdaptor.ts
+++ b/src/scene/mesh/gl/GlMeshAdaptor.ts
@@ -68,8 +68,10 @@ export class GlMeshAdaptor implements MeshAdaptor
             return;
         }
 
-        shader.groups[0] = renderer.globalUniforms.bindGroup;
-        shader.groups[1] = meshPipe.localUniformsBindGroup;
+        // setting the groups to be high to be compatible and not
+        // overlap any other groups
+        shader.groups[100] = renderer.globalUniforms.bindGroup;
+        shader.groups[101] = meshPipe.localUniformsBindGroup;
 
         renderer.encoder.draw({
             geometry: mesh._geometry,

--- a/src/scene/mesh/gpu/GpuMeshAdapter.ts
+++ b/src/scene/mesh/gpu/GpuMeshAdapter.ts
@@ -68,13 +68,22 @@ export class GpuMeshAdapter implements MeshAdaptor
 
             return;
         }
+
+        const gpuProgram = shader.gpuProgram;
         // GPU..
-        shader.groups[0] = renderer.globalUniforms.bindGroup;
 
-        const localUniforms = meshPipe.localUniforms;
+        if (gpuProgram.autoAssignGlobalUniforms)
+        {
+            shader.groups[0] = renderer.globalUniforms.bindGroup;
+        }
 
-        shader.groups[1] = (renderer as WebGPURenderer)
-            .renderPipes.uniformBatch.getUniformBindGroup(localUniforms, true);
+        if (gpuProgram.autoAssignLocalUniforms)
+        {
+            const localUniforms = meshPipe.localUniforms;
+
+            shader.groups[1] = (renderer as WebGPURenderer)
+                .renderPipes.uniformBatch.getUniformBindGroup(localUniforms, true);
+        }
 
         renderer.encoder.draw({
             geometry: mesh._geometry,

--- a/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
@@ -1,0 +1,94 @@
+import { GlProgram } from '../../../../src/rendering/renderers/gl/shader/GlProgram';
+import { GpuProgram } from '../../../../src/rendering/renderers/gpu/shader/GpuProgram';
+import { Geometry } from '../../../../src/rendering/renderers/shared/geometry/Geometry';
+import { Shader } from '../../../../src/rendering/renderers/shared/shader/Shader';
+import { Mesh } from '../../../../src/scene/mesh/shared/Mesh';
+
+import type { Container } from '../../../../src/scene/container/Container';
+import type { TestScene } from '../../types';
+
+export const scene: TestScene = {
+    it: 'should render a fully custom mesh',
+    only: true,
+    create: async (scene: Container) =>
+    {
+        // Create our application instance
+        const shaderSrc = `
+            struct MyUniforms {
+                uTint: vec4<f32>,
+            }
+
+            @binding(0) @group(0) var<uniform> myUniforms : MyUniforms;
+
+            @vertex 
+            fn vsMain(
+                @location(0) aPosition : vec2<f32>,
+            ) -> @builtin(position) vec4f {
+            return vec4f(aPosition, 0, 1);
+            }
+
+            @fragment 
+            fn fsMain() -> @location(0) vec4<f32> {
+                return myUniforms.uTint;
+            }
+        `;
+
+        const geometry = new Geometry({
+            attributes: {
+                aPosition: [-1, -1, -1, 1, 1, 1],
+            },
+            indexBuffer: [0, 1, 2],
+        });
+
+        const gpuProgram = new GpuProgram({
+            name: 'my-shader',
+            vertex: {
+                source: shaderSrc,
+                entryPoint: 'vsMain'
+            },
+            fragment: {
+                source: shaderSrc,
+                entryPoint: 'fsMain'
+            }
+        });
+
+        const glProgram = new GlProgram({
+            name: 'my-shader',
+            vertex: `
+            attribute vec2 aPosition;
+
+            void main() {
+                gl_Position = vec4(aPosition, 0.0, 1.0);
+            }
+        `,
+            fragment: `
+
+            uniform vec4 uTint;
+
+            void main() {
+                gl_FragColor = uTint;
+            }
+        `
+        });
+
+        const shader = new Shader({
+            glProgram,
+            gpuProgram,
+            resources: {
+                myUniforms: {
+                    uTint: {
+                        value: [1, 1, 0, 1],
+                        type: 'vec4<f32>'
+                    }
+                }
+            }
+        });
+
+        const mesh = new Mesh({
+            geometry,
+            shader,
+        });
+
+        scene.addChild(mesh);
+    },
+};

--- a/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
@@ -7,9 +7,15 @@ import { Mesh } from '../../../../src/scene/mesh/shared/Mesh';
 import type { Container } from '../../../../src/scene/container/Container';
 import type { TestScene } from '../../types';
 
+/**
+ * NOTE on the result:
+ * The webGL triangles will be upside down in this test - this is actually correct as rendering to a
+ * texture in WebGL causes it to be inverted on the Y. This is not the case in WebGPU
+ * We usually handle this automatically with our transform uniforms, but as this example
+ * does not use them.. they come out flipped!
+ */
 export const scene: TestScene = {
     it: 'should render a fully custom mesh',
-    only: true,
     create: async (scene: Container) =>
     {
         // Create our application instance


### PR DESCRIPTION
- add visual test

the webGL ones will be upside down - this is actually correct as rendering to a texture in WebGL causes it to be inverted.

We handle this automatically with our transform uniforms, but as this example does not use them.. they come out flipped!