### PR TITLE
Fix: Fixing multi touch interactions in @pixi/interaction package

### DIFF
--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1642,7 +1642,7 @@ export class InteractionManager extends EventEmitter
         }
         else
         {
-            interactionData = new InteractionData();
+            interactionData = this.interactionDataPool.pop() || new InteractionData();
             interactionData.identifier = pointerId;
             this.activeInteractionData[pointerId] = interactionData;
         }
@@ -1665,6 +1665,8 @@ export class InteractionManager extends EventEmitter
         {
             delete this.activeInteractionData[pointerId];
             interactionData.reset();
+            if(interactionData == this.mouse) return
+            this.interactionDataPool.push(interactionData);
         }
     }
 

--- a/packages/interaction/src/InteractionManager.ts
+++ b/packages/interaction/src/InteractionManager.ts
@@ -1642,7 +1642,7 @@ export class InteractionManager extends EventEmitter
         }
         else
         {
-            interactionData = this.interactionDataPool.pop() || new InteractionData();
+            interactionData = new InteractionData();
             interactionData.identifier = pointerId;
             this.activeInteractionData[pointerId] = interactionData;
         }
@@ -1665,7 +1665,6 @@ export class InteractionManager extends EventEmitter
         {
             delete this.activeInteractionData[pointerId];
             interactionData.reset();
-            this.interactionDataPool.push(interactionData);
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Problem:
When a user creates a pinch zoom (multi touch interaction), it works for the first time and then stops working subsequently. There were a couple of open issues in pixi-viewport that discuss this problem 
1. https://github.com/davidfig/pixi-viewport/issues/200
2. https://github.com/davidfig/pixi-viewport/issues/364 

Demo:


Solution:
In @pixi/interaction package, we have interactionDataPool. When a tap occurs, we create an InteractionData object. And when it is released, we push this object to the array for future use in function `getInteractionDataForPointerId`

Now, if the `pointerId == MOUSE_POINTER_ID`,the interactionData is `this.mouse`. This gets pushed to the interaction pool on release. In future touches, this data gets manipulated and identifier gets to 0 because of the following code:

```typescript
 private getInteractionDataForPointerId(event: PointerEvent): InteractionData
   ...
        else
        {
            interactionData = this.interactionDataPool.pop() || new InteractionData();
            interactionData.identifier = pointerId; // HERE this.mouse.identifier can be set to 0
            this.activeInteractionData[pointerId] = interactionData;
        }
        // copy properties from the event, so that we can make sure that touch/pointer specific
        // data is available
        interactionData.copyEvent(event);

        return interactionData;
    }
``` 
 
Solution:
If the interaction data is this.mouse, we do not push it to interactionDataPool


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
