### PR TITLE
Fix: WebGPU buffer update logic

### DIFF
--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -50,7 +50,7 @@ export class GpuBufferSystem implements System
             this._gpu.device.queue.writeBuffer(
                 gpuBuffer, 0, data.buffer, 0,
                 // round to the nearest 4 bytes
-                (buffer._updateSize + 3) & ~3
+                ((buffer._updateSize || data.byteLength) + 3) & ~3
             );
         }
 
@@ -98,11 +98,11 @@ export class GpuBufferSystem implements System
 
     protected onBufferChange(buffer: Buffer)
     {
-        let gpuBuffer = this._gpuBuffers[buffer.uid];
+        const gpuBuffer = this._gpuBuffers[buffer.uid];
 
         gpuBuffer.destroy();
-        gpuBuffer = this.createGPUBuffer(buffer);
         buffer._updateID = 0;
+        this._gpuBuffers[buffer.uid] = this.createGPUBuffer(buffer);
     }
 
     /**

--- a/src/unsafe-eval/init.ts
+++ b/src/unsafe-eval/init.ts
@@ -27,12 +27,12 @@ function selfInstall()
 
     Object.assign(GlUboSystem.prototype, {
         // use polyfill which avoids eval method
-        _generateUniformBufferSync: generateUboSyncPolyfillSTD40,
+        _generateUboSync: generateUboSyncPolyfillSTD40,
     });
 
     Object.assign(GpuUboSystem.prototype, {
         // use polyfill which avoids eval method
-        _generateUniformBufferSync: generateUboSyncPolyfillWGSL,
+        _generateUboSync: generateUboSyncPolyfillWGSL,
     });
 
     Object.assign(GlShaderSystem.prototype, {


### PR DESCRIPTION
- Fixed a small issue when updating buffers on WebGPU
- Fixed issue with UnsafeEval overriding incorrect functions 

tests are a bit of a pain here as WebGPU does not currently work in the CLI. Sorry about that!