### PR TITLE
Fix: pixi.js/unsafe-eval broken in 8.0.0-rc.9

### DIFF
--- a/src/unsafe-eval/init.ts
+++ b/src/unsafe-eval/init.ts
@@ -2,6 +2,7 @@ import { GlUboSystem } from '../rendering/renderers/gl/GlUboSystem';
 import { GlShaderSystem } from '../rendering/renderers/gl/shader/GlShaderSystem';
 import { GlUniformGroupSystem } from '../rendering/renderers/gl/shader/GlUniformGroupSystem';
 import { GpuUboSystem } from '../rendering/renderers/gpu/GpuUboSystem';
+import { UboSystem } from '../rendering/renderers/shared/shader/UboSystem';
 import { AbstractRenderer } from '../rendering/renderers/shared/system/AbstractRenderer';
 import { generateShaderSyncPolyfill } from './shader/generateShaderSyncPolyfill';
 import {
@@ -15,6 +16,14 @@ function selfInstall()
     Object.assign(AbstractRenderer.prototype, {
         // override unsafeEval check, as we don't need to use it
         _unsafeEvalCheck()
+        {
+            // Do nothing, don't throw error
+        },
+    });
+
+    Object.assign(UboSystem.prototype, {
+        // override unsafeEval check, as we don't need to use it
+        _systemCheck()
         {
             // Do nothing, don't throw error
         },


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

It seems that the `pixi.js/unsafe-eval` in v8 has been broken since 8.0.0-rc.6 (by 32cc5583f2023aefd0f0ebbc45c8c4fe8915ed9c):

```
Uncaught (in promise) Error: Current environment does not allow unsafe-eval, please use pixi.js/unsafe-eval module to enable support.
    at GlUboSystem._systemCheck
    ...
```

It turns out that the `UboSystem._systemCheck` is not overrided by an empty function, so the unsafe check is still performed. This PR fixes this issue.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
