### PR TITLE
Bump @pixi/webworker-plugins to 0.3.0

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -3,8 +3,10 @@
 
 declare module '*.worker.ts'
 {
-    class WorkerInstance extends Worker
+    class WorkerInstance
     {
+        public worker: Worker;
+
         constructor();
 
         static revokeObjectURL(): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@pixi/eslint-config": "^5.1.0",
         "@pixi/webdoc-template": "^1.5.5",
-        "@pixi/webworker-plugins": "^0.2.0",
+        "@pixi/webworker-plugins": "^0.3.0",
         "@rollup/plugin-alias": "^5.0.0",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
@@ -2874,9 +2874,9 @@
       "link": true
     },
     "node_modules/@pixi/webworker-plugins": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pixi/webworker-plugins/-/webworker-plugins-0.2.0.tgz",
-      "integrity": "sha512-/rUSoO5p2JGY3faFyWq+zvMP/G1TnNuDKFUkKdhmx3Vp+qhkNxtCedgt+bOFXthDCs5QZWXzYxnn0MUKuHv5ng==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/webworker-plugins/-/webworker-plugins-0.3.0.tgz",
+      "integrity": "sha512-1Nz04Vcw/Zos0redoyBaPLjUAkBfdv6Ikl9evRMw7vDcd0k1eNycNIOyqheLOxm2v6mN6FOGSPM18OdIrMQj3g==",
       "dev": true,
       "peerDependencies": {
         "@jest/transform": ">=26 <27",
@@ -21238,9 +21238,9 @@
       }
     },
     "@pixi/webworker-plugins": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@pixi/webworker-plugins/-/webworker-plugins-0.2.0.tgz",
-      "integrity": "sha512-/rUSoO5p2JGY3faFyWq+zvMP/G1TnNuDKFUkKdhmx3Vp+qhkNxtCedgt+bOFXthDCs5QZWXzYxnn0MUKuHv5ng==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@pixi/webworker-plugins/-/webworker-plugins-0.3.0.tgz",
+      "integrity": "sha512-1Nz04Vcw/Zos0redoyBaPLjUAkBfdv6Ikl9evRMw7vDcd0k1eNycNIOyqheLOxm2v6mN6FOGSPM18OdIrMQj3g==",
       "dev": true
     },
     "@rollup/plugin-alias": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@pixi/eslint-config": "^5.1.0",
     "@pixi/webdoc-template": "^1.5.5",
-    "@pixi/webworker-plugins": "^0.2.0",
+    "@pixi/webworker-plugins": "^0.3.0",
     "@rollup/plugin-alias": "^5.0.0",
     "@rollup/plugin-commonjs": "^25.0.0",
     "@rollup/plugin-json": "^6.0.0",

--- a/packages/assets/src/loader/parsers/WorkerManager.ts
+++ b/packages/assets/src/loader/parsers/WorkerManager.ts
@@ -45,7 +45,7 @@ class WorkerManagerClass
 
         this._isImageBitmapSupported = new Promise((resolve) =>
         {
-            const worker = (new CheckImageBitmapWorker()).worker;
+            const { worker } = new CheckImageBitmapWorker();
 
             worker.addEventListener('message', (event: MessageEvent<boolean>) =>
             {

--- a/packages/assets/src/loader/parsers/WorkerManager.ts
+++ b/packages/assets/src/loader/parsers/WorkerManager.ts
@@ -45,7 +45,7 @@ class WorkerManagerClass
 
         this._isImageBitmapSupported = new Promise((resolve) =>
         {
-            const worker = new CheckImageBitmapWorker();
+            const worker = (new CheckImageBitmapWorker()).worker;
 
             worker.addEventListener('message', (event: MessageEvent<boolean>) =>
             {
@@ -82,7 +82,7 @@ class WorkerManagerClass
         {
             // only create as many as MAX_WORKERS allows..
             this._createdWorkers++;
-            worker = new LoadImageBitmapWorker();
+            worker = (new LoadImageBitmapWorker()).worker;
 
             worker.addEventListener('message', (event: MessageEvent) =>
             {


### PR DESCRIPTION
Bump **@pixi/webworker-plugins** to [0.3.0](https://github.com/pixijs/webworker-plugins/releases/tag/v0.3.0), this prevent `ReferenceError` when using **@pixi/node**.

Fixes #10170, fixes pixijs/node#15.