### PR TITLE
Improve the @pixi/runner developer experience

### DIFF
--- a/packages/core/src/framebuffer/Framebuffer.ts
+++ b/packages/core/src/framebuffer/Framebuffer.ts
@@ -44,7 +44,7 @@ export class Framebuffer
     depthTexture: BaseTexture;
     colorTextures: Array<BaseTexture>;
     glFramebuffers: {[key: string]: GLFramebuffer};
-    disposeRunner: Runner;
+    disposeRunner: Runner<'disposeFramebuffer', [framebuffer: Framebuffer, contextLost?: boolean]>;
 
     /**
      * @param width - Width of the frame buffer

--- a/packages/core/src/geometry/Buffer.ts
+++ b/packages/core/src/geometry/Buffer.ts
@@ -53,7 +53,7 @@ export class Buffer
 
     public static: boolean;
     public id: number;
-    disposeRunner: Runner;
+    disposeRunner: Runner<'disposeBuffer', [buffer: Buffer, contextLost?: boolean]>;
 
     /**
      * A map of renderer IDs to webgl buffer

--- a/packages/core/src/geometry/BufferSystem.ts
+++ b/packages/core/src/geometry/BufferSystem.ts
@@ -170,7 +170,7 @@ export class BufferSystem implements ISystem
      * @param {PIXI.Buffer} buffer - buffer with data
      * @param {boolean} [contextLost=false] - If context was lost, we suppress deleteVertexArray
      */
-    dispose(buffer: Buffer, contextLost?: boolean): void
+    disposeBuffer(buffer: Buffer, contextLost?: boolean): void
     {
         if (!this.managedBuffers[buffer.id])
         {
@@ -207,7 +207,7 @@ export class BufferSystem implements ISystem
 
         for (let i = 0; i < all.length; i++)
         {
-            this.dispose(this.managedBuffers[all[i]], contextLost);
+            this.disposeBuffer(this.managedBuffers[all[i]], contextLost);
         }
     }
 

--- a/packages/core/src/geometry/Geometry.ts
+++ b/packages/core/src/geometry/Geometry.ts
@@ -61,7 +61,7 @@ export class Geometry
      * @type {object}
      */
     glVertexArrayObjects: {[key: number]: {[key: string]: WebGLVertexArrayObject}};
-    disposeRunner: Runner;
+    disposeRunner: Runner<'disposeGeometry', [geometry: Geometry, contextLost?: boolean]>;
 
     /** Count of existing (not destroyed) meshes that reference this geometry. */
     refCount: number;

--- a/packages/core/src/geometry/GeometrySystem.ts
+++ b/packages/core/src/geometry/GeometrySystem.ts
@@ -416,7 +416,7 @@ export class GeometrySystem implements ISystem
                     buf.refCount--;
                     if (buf.refCount === 0 && !contextLost)
                     {
-                        bufferSystem.dispose(buffers[i], contextLost);
+                        bufferSystem.disposeBuffer(buffers[i], contextLost);
                     }
                 }
             }

--- a/packages/core/src/shader/Shader.ts
+++ b/packages/core/src/shader/Shader.ts
@@ -20,7 +20,7 @@ export class Shader
      */
     uniformBindCount = 0;
 
-    disposeRunner: Runner;
+    disposeRunner: Runner<'disposeShader', [shader: Shader]>;
 
     /**
      * @param program - The program the shader will use.

--- a/packages/core/src/system/SystemManager.ts
+++ b/packages/core/src/system/SystemManager.ts
@@ -19,7 +19,7 @@ interface ISystemConfig<R>
 export class SystemManager<R=IRenderer> extends EventEmitter
 {
     /** a collection of runners defined by the user */
-    readonly runners: {[key: string]: Runner} = {};
+    readonly runners: {[key: string]: Runner<string, any[]>} = {};
 
     private _systemsHash: Record<string, ISystem> = {};
 
@@ -123,7 +123,7 @@ export class SystemManager<R=IRenderer> extends EventEmitter
      * @param runner - the runner to target
      * @param options - key value options for each system
      */
-    emitWithCustomOptions(runner: Runner, options: Record<string, unknown>): void
+    emitWithCustomOptions(runner: Runner<string, any[]>, options: Record<string, unknown>): void
     {
         const systemHashKeys = Object.keys(this._systemsHash);
 

--- a/packages/core/src/textures/resources/Resource.ts
+++ b/packages/core/src/textures/resources/Resource.ts
@@ -42,14 +42,15 @@ export abstract class Resource
      * @member {Runner}
      * @private
      */
-    protected onResize: Runner; // TODO: Should this be private? It doesn't seem to be used anywhere else.
+    // TODO: Should this be private? It doesn't seem to be used anywhere else.
+    protected onResize: Runner<'setRealSize', [width: number, height: number]>;
 
     /**
      * Mini-runner for handling update events
      * @member {Runner}
      * @private
      */
-    protected onUpdate: Runner;
+    protected onUpdate: Runner<'update', []>;
 
     /**
      * Handle internal errors, such as loading errors
@@ -57,7 +58,7 @@ export abstract class Resource
      * @member {Runner}
      * @private
      */
-    protected onError: Runner;
+    protected onError: Runner<'onError', [error: any]>;
 
     /**
      * @param width - Width of the resource

--- a/packages/core/src/transformFeedback/TransformFeedback.ts
+++ b/packages/core/src/transformFeedback/TransformFeedback.ts
@@ -14,7 +14,7 @@ export class TransformFeedback
 
     buffers: Buffer[];
 
-    disposeRunner: Runner;
+    disposeRunner: Runner<'disposeTransformFeedback', [tf: TransformFeedback, contextLost?: boolean]>;
 
     constructor()
     {

--- a/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
+++ b/packages/core/src/transformFeedback/TransformFeedbackSystem.ts
@@ -159,7 +159,7 @@ export class TransformFeedbackSystem implements ISystem
                     buf.refCount--;
                     if (buf.refCount === 0 && !contextLost)
                     {
-                        bufferSystem.dispose(buffer, contextLost);
+                        bufferSystem.disposeBuffer(buffer, contextLost);
                     }
                 }
             }

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,16 +1,14 @@
-export type RunnerListenerCallback<ARG extends unknown[] = any[]> = (...args: ARG) => unknown;
+export type RunnerListenerCallback<ARG extends any[]> = (...args: ARG) => any;
 
-type RunnerItemValid<T extends string, ARG extends unknown[] = any[]> =
-    { [K in T]: RunnerListenerCallback<ARG> | unknown };
+type RunnerItemValid<T extends string, ARG extends any[]> = {
+    [K in T]: RunnerListenerCallback<ARG>;
+};
 
-type RunnerItemAny = Record<string, unknown>;
+type RunnerItemAny = Record<string, any>;
 
-type RunnerItemEmpty = Record<string, never>;
-
-export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
-    T extends string ?
-        RunnerItemValid<T, ARG> & RunnerItemAny | RunnerItemEmpty :
-        unknown;
+export type RunnerItem<T extends string, ARG extends any[]> =
+    | RunnerItemValid<T, ARG>
+    | RunnerItemAny;
 
 /**
  * A Runner is a highly performant and simple alternative to signals. Best used in situations
@@ -98,7 +96,7 @@ export type RunnerItem<T = string, ARG extends unknown[] = any[]> =
  * @template ARG - The argument types for the event handler functions.
  * @memberof PIXI
  */
-export class Runner<T = any, ARG extends unknown[] = any[]>
+export class Runner<T extends string, ARG extends any[]>
 {
     public items: any[];
     private _name: T;


### PR DESCRIPTION
### Description of change
<!-- Provide a description of the change below this comment. -->

The current implementation of the `runner' package is not always usable with classes and can cause bugs due to overly complicated generics.

I removed default values of `Runner` generics, fixed improper use of `unknown` type and made types smaller to make errors more readable.

Also i found a [bug(?) in BufferSystem](https://github.com/pixijs/pixijs/commit/688ab2647d99b6a38702c760f9334aeeee1f9eab) caused by lack of strict checks that the object contains a callback function. I didn't add these checks myself so as not to change the APIs of this class too much, but this change may help us avoid similar problems in the future. 
Let me know if it's OK to add them, I'll include them in this PR.

### Instances problem

#### before
![old1](https://github.com/pixijs/pixijs/assets/65600719/f5bf1518-ee74-4063-8d74-b5fe8509c0b3)

#### now
![new1](https://github.com/pixijs/pixijs/assets/65600719/46e06a02-4df0-4638-ba43-6829e09efe5d)

### Explicit generics

#### before

![old2](https://github.com/pixijs/pixijs/assets/65600719/6c267738-6009-4aa4-a57e-b3584c92349b)

#### now

![new2](https://github.com/pixijs/pixijs/assets/65600719/e68feb5b-011f-4533-9176-6f75bdba676d)

### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
