### PR TITLE
Fix: removeChild bug

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -695,11 +695,11 @@ export class Container extends EventEmitter<ContainerEvents & AnyEvent>
             {
                 this.renderGroup.removeChild(child);
             }
-        }
 
-        child.parent = null;
-        this.emit('childRemoved', child, this, index);
-        child.emit('removed', this);
+            child.parent = null;
+            this.emit('childRemoved', child, this, index);
+            child.emit('removed', this);
+        }
 
         return child;
     }

--- a/tests/scene/scene.tests.ts
+++ b/tests/scene/scene.tests.ts
@@ -27,6 +27,23 @@ describe('Scene', () =>
         expect(container.children).toHaveLength(0);
     });
 
+    it('should not remove a child if it does not belong to the parent container', async () =>
+    {
+        const container = new Container();
+        const actualContainer = new Container();
+
+        const child = new Container();
+
+        actualContainer.addChild(child);
+
+        container.removeChild(child);
+
+        expect(container.children).toHaveLength(0);
+        expect(actualContainer.children).toHaveLength(1);
+
+        expect(child.parent).toEqual(actualContainer);
+    });
+
     it('should re-parent a child', async () =>
     {
         const container = new Container();


### PR DESCRIPTION
fixes an issue where removeChild() an item that did not belong to that object would null the parent in v8