### PR TITLE
Fix: Respect the user-input for filters and don't freeze

### DIFF
--- a/src/scene/container/container-mixins/effectsMixin.ts
+++ b/src/scene/container/container-mixins/effectsMixin.ts
@@ -138,19 +138,26 @@ export const effectsMixin: Partial<Container> = {
     {
         if (!Array.isArray(value) && value) value = [value];
 
+        // Ignore the Filter type
+        value = value as Filter[] | null | undefined;
+
         // by reusing the same effect.. rather than adding and removing from the pool!
         this._filters ||= { filters: null, effect: null, filterArea: null };
 
-        const hasFilters = value && (value as Filter[]).length > 0;
+        const hasFilters = value?.length > 0;
         const didChange = (this._filters.effect && !hasFilters) || (!this._filters.effect && hasFilters);
 
-        this._filters.filters = Object.freeze(value as Filter[]);
+        // Clone the filters array so we don't freeze the user-input
+        value = Array.isArray(value) ? value.slice(0) : value;
+
+        // Ensure filters are immutable via filters getter
+        this._filters.filters = Object.freeze(value);
 
         if (didChange)
         {
             if (hasFilters)
             {
-                const effect = getFilterEffect(value as Filter[], this.filterArea);
+                const effect = getFilterEffect(value, this.filterArea);
 
                 this._filters.effect = effect;
                 this.addEffect(effect);

--- a/tests/scene/filter-effect.tests.ts
+++ b/tests/scene/filter-effect.tests.ts
@@ -96,4 +96,25 @@ describe('Filter effect', () =>
         expect(spyAdd).toHaveBeenCalledTimes(2);
         expect(spyRemove).toHaveBeenCalledTimes(1);
     });
+
+    it('should copy the filters user input', () =>
+    {
+        const container = new Container();
+        const noiseFilter = new NoiseFilter();
+        const alphaFilter = new AlphaFilter();
+        const origFilters: (NoiseFilter | AlphaFilter)[] = [noiseFilter];
+
+        container.filters = origFilters;
+
+        expect(container.filters).toEqual([noiseFilter]);
+
+        origFilters.push(alphaFilter);
+
+        expect(container.filters).toEqual([noiseFilter]);
+        expect(origFilters).toEqual([noiseFilter, alphaFilter]);
+
+        container.filters = origFilters;
+
+        expect(container.filters).toEqual([noiseFilter, alphaFilter]);
+    });
 });


### PR DESCRIPTION
Follow up to #10238

I think this was an over-sight. Any input to `filters` shouldn't get frozen. For example:

```ts
import { Container, NoiseFilter, AlphaFilter } from 'pixi.js';

const container = new Container();
const myFilters = [new NoiseFilter()];

container.filters = myFilters;

myFilters.push(new AlphaFilter()); // in v8.0.0 this didn't work because `myFilters` was frozen
container.filters.push(new AlphaFilter()); // Still throws an error!

container.filters = myFilters; // Promote re-assignment
```