### PR TITLE
Fix: shader preprocessor to support older chrome versions

### DIFF
--- a/src/rendering/renderers/gl/shader/program/preprocessors/addProgramDefines.ts
+++ b/src/rendering/renderers/gl/shader/program/preprocessors/addProgramDefines.ts
@@ -8,7 +8,7 @@ export function addProgramDefines(src: string, isES300: boolean, isFragment?: bo
 
         return `
         
-        #ifdef GL_ES // This checks if it's WebGL1
+        #ifdef GL_ES // This checks if it is WebGL1
         #define in varying
         #define finalColor gl_FragColor
         #define texture texture2D
@@ -19,7 +19,7 @@ export function addProgramDefines(src: string, isES300: boolean, isFragment?: bo
 
     return `
         
-        #ifdef GL_ES // This checks if it's WebGL1
+        #ifdef GL_ES // This checks if it is WebGL1
         #define in attribute
         #define out varying
         #endif


### PR DESCRIPTION
Chrome 78 and older do not parse shader source correct when single quote is present inside the comment and produce and error message: shaderSource: string not ASCII

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
