### PR TITLE
Fix: ICanvasRenderingContext2D extending letterSpacing

### DIFF
--- a/src/environment/canvas/ICanvasRenderingContext2D.ts
+++ b/src/environment/canvas/ICanvasRenderingContext2D.ts
@@ -18,7 +18,7 @@ export interface ICanvasRenderingContext2D extends
     CanvasDrawImage,
     CanvasImageData,
     CanvasPathDrawingStyles,
-    CanvasTextDrawingStyles,
+    Omit<CanvasTextDrawingStyles, 'letterSpacing'>,
     CanvasPath
 {
     /** creates a pattern using the specified image and repetition. */


### PR DESCRIPTION
Fixes #9765 

By excluding `letterSpacing` from `CanvasTextDrawingStyles`, this will now cleanly inherit. 

