### PR TITLE
Fix: typo in the vertex shader of the bigTriangleProgram

### DIFF
--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -110,7 +110,7 @@ export class GlBackBufferSystem implements System<GlBackBufferOptions>
                 out vec2 vUv;
 
                 void main() {
-                    gl_Position = gl_Position = vec4(aPosition, 0.0, 1.0);
+                    gl_Position = vec4(aPosition, 0.0, 1.0);
 
                     vUv = (aPosition + 1.0) / 2.0;
 


### PR DESCRIPTION
GlBackBufferSystem

##### Description of change

Just a typo in the vertex shader that did not prevent the program to work correctly.


##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
