### PR TITLE
Fix: performance for setting textures in WebGL

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -223,12 +223,17 @@ export class GlTextureSystem implements System, CanvasGenerator
         }
 
         this.onSourceUpdate(source);
-        this.onStyleChange(source);
+        this.updateStyle(source, false);
 
         return glTexture;
     }
 
     protected onStyleChange(source: TextureSource): void
+    {
+        this.updateStyle(source, false);
+    }
+
+    protected updateStyle(source: TextureSource, firstCreation: boolean): void
     {
         const gl = this._gl;
 
@@ -246,7 +251,8 @@ export class GlTextureSystem implements System, CanvasGenerator
             'texParameteri',
             gl.TEXTURE_2D,
             // will force a clamp to edge if the texture is not a power of two
-            !this._renderer.context.supports.nonPowOf2wrapping && !source.isPowerOfTwo
+            !this._renderer.context.supports.nonPowOf2wrapping && !source.isPowerOfTwo,
+            firstCreation,
         );
     }
 
@@ -326,7 +332,8 @@ export class GlTextureSystem implements System, CanvasGenerator
             this._renderer.context.extensions.anisotropicFiltering,
             'samplerParameteri',
             glSampler,
-            false
+            false,
+            true,
         );
 
         return this._glSamplers[style._resourceId];

--- a/src/rendering/renderers/gl/texture/utils/applyStyleParams.ts
+++ b/src/rendering/renderers/gl/texture/utils/applyStyleParams.ts
@@ -15,32 +15,47 @@ export function applyStyleParams(
     anisotropicExt: EXT_texture_filter_anisotropic,
     glFunctionName: 'samplerParameteri' | 'texParameteri',
     firstParam: 3553 | WebGLSampler,
-    forceClamp: boolean
+    forceClamp: boolean,
+    /** if true we can skip setting certain values if the values is the same as the default gl values */
+    firstCreation: boolean
 )
 {
     const castParam = firstParam as 3553;
 
-    // 1. set the wrapping mode
-    const wrapModeS = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeU];
-    const wrapModeT = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeV];
-    const wrapModeR = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeW];
+    if (!firstCreation
+        || style.addressModeU !== 'repeat'
+        || style.addressModeV !== 'repeat'
+        || style.addressModeW !== 'repeat'
+    )
+    {
+        // 1. set the wrapping mode
+        const wrapModeS = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeU];
+        const wrapModeT = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeV];
+        const wrapModeR = wrapModeToGlAddress[forceClamp ? 'clamp-to-edge' : style.addressModeW];
 
-    gl[glFunctionName](castParam, gl.TEXTURE_WRAP_S, wrapModeS);
-    gl[glFunctionName](castParam, gl.TEXTURE_WRAP_T, wrapModeT);
+        gl[glFunctionName](castParam, gl.TEXTURE_WRAP_S, wrapModeS);
+        gl[glFunctionName](castParam, gl.TEXTURE_WRAP_T, wrapModeT);
 
-    // does not exist in webGL1
-    if (gl.TEXTURE_WRAP_R) gl[glFunctionName](castParam, gl.TEXTURE_WRAP_R, wrapModeR);
+        // does not exist in webGL1
+        if (gl.TEXTURE_WRAP_R) gl[glFunctionName](castParam, gl.TEXTURE_WRAP_R, wrapModeR);
+    }
 
-    // 2. set the filtering mode
-    gl[glFunctionName](castParam, gl.TEXTURE_MAG_FILTER, scaleModeToGlFilter[style.magFilter]);
+    if (!firstCreation || style.magFilter !== 'linear')
+    {
+        // 2. set the filtering mode
+        gl[glFunctionName](castParam, gl.TEXTURE_MAG_FILTER, scaleModeToGlFilter[style.magFilter]);
+    }
 
     // assuming the currently bound texture is the one we want to set the filter for
     // the only smelly part of this code, WebGPU is much better here :P
     if (mipmaps)
     {
-        const glFilterMode = mipmapScaleModeToGlFilter[style.minFilter][style.mipmapFilter];
+        if (!firstCreation || style.mipmapFilter !== 'linear')
+        {
+            const glFilterMode = mipmapScaleModeToGlFilter[style.minFilter][style.mipmapFilter];
 
-        gl[glFunctionName](castParam, gl.TEXTURE_MIN_FILTER, glFilterMode);
+            gl[glFunctionName](castParam, gl.TEXTURE_MIN_FILTER, glFilterMode);
+        }
     }
 
     else

--- a/src/rendering/renderers/shared/texture/TextureStyle.ts
+++ b/src/rendering/renderers/shared/texture/TextureStyle.ts
@@ -84,7 +84,7 @@ export class TextureStyle extends EventEmitter<{
 
     /** default options for the style */
     public static readonly defaultOptions: TextureStyleOptions = {
-        addressMode: 'clamp-to-edge',
+        addressMode: 'repeat',
         scaleMode: 'linear'
     };
 


### PR DESCRIPTION
GlTextureSystem optimisation:

When first creating a texture and applying its samples - we can skip setting the params that are the same as the defaults. 

this speeds up texture creation. from the cpu side by reducing the need to change the default.

I also set the default to texture style to `repeat`. Which makes more sense now that its supported by WebGL2 and WebGPU for all textures (we also have a catch for this edge case in WebGL 1 already, so its safe!)

It will alls mean textures will just tile by default when being used in shaders - which is more in line with standard expectations. 

This change won't affect anything like sprites etc 