### PR TITLE
Fix: allow for optional destruction of textStyle

### DIFF
--- a/src/scene/container/destroyTypes.ts
+++ b/src/scene/container/destroyTypes.ts
@@ -34,6 +34,10 @@ export interface ContextDestroyOptions
 
 export type TypeOrBool<T> = T | boolean;
 
+export type AllDestroyOptions = BaseDestroyOptions &
+ContextDestroyOptions &
+TextureDestroyOptions;
+
 /**
  * Options for destroying a container.
  * @property {boolean} [children=false] - Destroy the children of the container as well.
@@ -42,8 +46,4 @@ export type TypeOrBool<T> = T | boolean;
  * @property {boolean} [context=false] - Destroy the context of the container's children.
  * @memberof scene
  */
-export type DestroyOptions = TypeOrBool<
-BaseDestroyOptions &
-ContextDestroyOptions &
-TextureDestroyOptions
->;
+export type DestroyOptions<EXTRA_OPTIONS = object> = TypeOrBool<AllDestroyOptions & EXTRA_OPTIONS>;

--- a/src/scene/container/destroyTypes.ts
+++ b/src/scene/container/destroyTypes.ts
@@ -27,16 +27,35 @@ export interface TextureDestroyOptions
     textureSource?: boolean;
 }
 
+/**
+ * Options when destroying a graphics context.
+ * ```js
+ * // destroy the graphics context and its texture
+ * graphicsContext.destroy({ context: true, texture: true });
+ * ```
+ * @memberof scene
+ */
 export interface ContextDestroyOptions
 {
+    /** Destroy the graphics context as well. */
     context?: boolean;
 }
 
-export type TypeOrBool<T> = T | boolean;
+/**
+ * Options when destroying a text.
+ * ```js
+ * // destroy the text and its style
+ * text.destroy({ style: true });
+ * ```
+ * @memberof scene
+ */
+export interface TextDestroyOptions
+{
+    /** Destroy the text style as well. */
+    style?: boolean
+}
 
-export type AllDestroyOptions = BaseDestroyOptions &
-ContextDestroyOptions &
-TextureDestroyOptions;
+export type TypeOrBool<T> = T | boolean;
 
 /**
  * Options for destroying a container.
@@ -44,6 +63,12 @@ TextureDestroyOptions;
  * @property {boolean} [texture=false] - Destroy the texture of the container's children.
  * @property {boolean} [textureSource=false] - Destroy the texture source of the container's children.
  * @property {boolean} [context=false] - Destroy the context of the container's children.
+ * @property {boolean} [style=false] - Destroy the style of the container's children.
  * @memberof scene
  */
-export type DestroyOptions<EXTRA_OPTIONS = object> = TypeOrBool<AllDestroyOptions & EXTRA_OPTIONS>;
+export type DestroyOptions = TypeOrBool<
+BaseDestroyOptions &
+ContextDestroyOptions &
+TextureDestroyOptions &
+TextDestroyOptions
+>;

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -12,6 +12,8 @@ import type { DestroyOptions } from '../container/destroyTypes';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../text-html/HtmlTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
 
+export type TextDestroyOptions = DestroyOptions<{destroyStyle?: boolean}>;
+
 /**
  * A string or number that can be used as text.
  * @memberof text
@@ -394,15 +396,19 @@ export abstract class AbstractText<
      * @param {boolean} [options.texture=false] - Should it destroy the texture of the text style
      * @param {boolean} [options.textureSource=false] - Should it destroy the textureSource of the text style
      */
-    public destroy(options: DestroyOptions = false): void
+    public destroy(options: TextDestroyOptions = false): void
     {
-        super.destroy(options);
+        super.destroy(options as DestroyOptions);
 
         (this as any).owner = null;
         this._bounds = null;
         this._anchor = null;
 
-        this._style.destroy(options);
+        if (typeof options === 'boolean' ? options : options?.destroyStyle)
+        {
+            this._style.destroy(options);
+        }
+
         this._style = null;
         this._text = null;
     }

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -12,8 +12,6 @@ import type { DestroyOptions } from '../container/destroyTypes';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../text-html/HtmlTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
 
-export type TextDestroyOptions = DestroyOptions<{destroyStyle?: boolean}>;
-
 /**
  * A string or number that can be used as text.
  * @memberof text
@@ -395,16 +393,17 @@ export abstract class AbstractText<
      *  have been set to that value
      * @param {boolean} [options.texture=false] - Should it destroy the texture of the text style
      * @param {boolean} [options.textureSource=false] - Should it destroy the textureSource of the text style
+     * @param {boolean} [options.style=false] - Should it destroy the style of the text
      */
-    public destroy(options: TextDestroyOptions = false): void
+    public destroy(options: DestroyOptions = false): void
     {
-        super.destroy(options as DestroyOptions);
+        super.destroy(options);
 
         (this as any).owner = null;
         this._bounds = null;
         this._anchor = null;
 
-        if (typeof options === 'boolean' ? options : options?.destroyStyle)
+        if (typeof options === 'boolean' ? options : options?.style)
         {
             this._style.destroy(options);
         }

--- a/tests/renderering/text/Text.tests.ts
+++ b/tests/renderering/text/Text.tests.ts
@@ -2,6 +2,7 @@
 import { Container } from '../../../src/scene/container/Container';
 import { Sprite } from '../../../src/scene/sprite/Sprite';
 import { Text } from '../../../src/scene/text/Text';
+import { TextStyle } from '../../../src/scene/text/TextStyle';
 import { BitmapText } from '../../../src/scene/text-bitmap/BitmapText';
 import { getWebGLRenderer } from '../../utils/getRenderer';
 import '../../../src/scene/graphics/init';
@@ -169,6 +170,27 @@ describe('Text', () =>
             text.destroy();
 
             expect(renderer.renderPipes.bitmapText['_gpuBitmapText'][text.uid]).toBeNull();
+        });
+
+        it('should destroy textStyle correctly', () =>
+        {
+            const style = new TextStyle({ fill: 'red' });
+
+            const text = new Text({ text: 'foo', style });
+
+            expect(text.style.fill).toBe('red');
+
+            text.destroy();
+
+            expect(style.fill).toBe('red');
+
+            const text2 = new Text({ text: 'foo', style });
+
+            expect(text2.style.fill).toBe('red');
+
+            text2.destroy(true);
+
+            expect(style.fill).toBe(null);
         });
     });
 


### PR DESCRIPTION
Text style is not destroyed by default now - which make more sense (a bit like texture and texture sources)

to destroy the style you can now do:

```

fixes #10328
myText.destroy(true);

// or more granuler

myText.destroy({style:true});
```

fixes #10328