### PR TITLE
Fix: NineSliceSprite not rendering correctly when used with a spritesheet texture

### DIFF
--- a/src/rendering/renderers/shared/texture/TextureMatrix.ts
+++ b/src/rendering/renderers/shared/texture/TextureMatrix.ts
@@ -54,15 +54,16 @@ export class TextureMatrix
 
     /**
      * Tracks Texture frame changes.
-     * @protected
+     * @ignore
      */
-    protected _textureID: number;
+    public _updateID: number;
 
     /**
      * Tracks Texture frame changes.
      * @protected
      */
-    protected _updateID: number;
+    protected _textureID: number;
+
     protected _texture: Texture;
 
     /**

--- a/src/scene/sprite-nine-slice/NineSliceGeometry.ts
+++ b/src/scene/sprite-nine-slice/NineSliceGeometry.ts
@@ -129,8 +129,6 @@ export class NineSliceGeometry extends PlaneGeometry
     /** Updates the UVs of the vertices. */
     public updateUvs()
     {
-        const textureMatrix = this._textureMatrix;
-
         const uvs = this.uvs;
 
         uvs[0] = uvs[8] = uvs[16] = uvs[24] = 0;
@@ -148,31 +146,7 @@ export class NineSliceGeometry extends PlaneGeometry
         uvs[4] = uvs[12] = uvs[20] = uvs[28] = 1 - (_uvw * this._rightWidth);
         uvs[17] = uvs[19] = uvs[21] = uvs[23] = 1 - (_uvh * this._bottomHeight);
 
-        multiplyUvs(textureMatrix, uvs);
-
         this.getBuffer('aUV').update();
     }
 }
 
-function multiplyUvs(matrix: Matrix, uvs: Float32Array, out?: Float32Array)
-{
-    out ??= uvs;
-
-    const a = matrix.a;
-    const b = matrix.b;
-    const c = matrix.c;
-    const d = matrix.d;
-    const tx = matrix.tx;
-    const ty = matrix.ty;
-
-    for (let i = 0; i < uvs.length; i += 2)
-    {
-        const x = uvs[i];
-        const y = uvs[i + 1];
-
-        out[i] = (x * a) + (y * c) + tx;
-        out[i + 1] = (x * b) + (y * d) + ty;
-    }
-
-    return out;
-}

--- a/src/scene/sprite-nine-slice/NineSliceGeometry.ts
+++ b/src/scene/sprite-nine-slice/NineSliceGeometry.ts
@@ -1,4 +1,3 @@
-import { Matrix } from '../../maths/matrix/Matrix';
 import { PlaneGeometry } from '../mesh-plane/PlaneGeometry';
 
 /**
@@ -24,8 +23,6 @@ export interface NineSliceGeometryOptions
     rightWidth?: number
     /** The height of the bottom row. */
     bottomHeight?: number
-    /** The texture matrix of the NineSlicePlane. */
-    textureMatrix?: Matrix
 }
 
 /**
@@ -62,7 +59,6 @@ export class NineSliceGeometry extends PlaneGeometry
 
     private _originalWidth: number;
     private _originalHeight: number;
-    private readonly _textureMatrix: Matrix = new Matrix();
 
     constructor(options: NineSliceGeometryOptions = {})
     {
@@ -92,11 +88,6 @@ export class NineSliceGeometry extends PlaneGeometry
         this._rightWidth = options.rightWidth ?? this._rightWidth;
         this._topHeight = options.topHeight ?? this._topHeight;
         this._bottomHeight = options.bottomHeight ?? this._bottomHeight;
-
-        if (options.textureMatrix)
-        {
-            this._textureMatrix.copyFrom(options.textureMatrix);
-        }
 
         this.updateUvs();
         this.updatePositions();

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -252,12 +252,6 @@ export class NineSliceSprite extends Container implements View
         this._roundPixels = value ? 1 : 0;
     }
 
-    /** The texture matrix of the NineSliceSprite. */
-    get textureMatrix()
-    {
-        return this._texture.textureMatrix.mapCoord;
-    }
-
     /** The original width of the texture */
     get originalWidth()
     {


### PR DESCRIPTION
We had previously adjusted the mesh to take into account sprite sheets.
Nine Slice Sprite was also doing this work - so uvs were being multiplied twice.
easy fix at least!