### PR TITLE
Fix: Change WebGL to default renderer

### DIFF
--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -27,7 +27,7 @@ export interface AutoDetectOptions extends WebGLOptions, WebGPUOptions
     webgl?: Partial<WebGLOptions>;
 }
 
-const renderPriority = ['webgpu', 'webgl', 'canvas'];
+const renderPriority = ['webgl', 'webgpu', 'canvas'];
 
 /**
  * Automatically determines the most appropriate renderer for the current environment.

--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -32,8 +32,10 @@ const renderPriority = ['webgl', 'webgpu', 'canvas'];
 /**
  * Automatically determines the most appropriate renderer for the current environment.
  *
- * The function will prioritize the WebGPU renderer, falling back to WebGL2 if WebGPU
- * is not supported. The selected renderer's code is then dynamically imported to optimize
+ * The function will prioritize the WebGL renderer as it is the most tested safe renderer to use.
+ * In the near future as WebGPU becomes more stable and ubiquitous, it will be prioritized over WebGL.
+ *
+ * The selected renderer's code is then dynamically imported to optimize
  * performance and minimize the initial bundle size.
  *
  * To maximize the benefits of dynamic imports, it's recommended to use a modern bundler

--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -32,7 +32,7 @@ const renderPriority = ['webgl', 'webgpu', 'canvas'];
 /**
  * Automatically determines the most appropriate renderer for the current environment.
  *
- * The function will prioritize the WebGL renderer as it is the most tested safe renderer to use.
+ * The function will prioritize the WebGL renderer as it is the most tested safe API to use.
  * In the near future as WebGPU becomes more stable and ubiquitous, it will be prioritized over WebGL.
  *
  * The selected renderer's code is then dynamically imported to optimize


### PR DESCRIPTION
After seeing the feedback from the commmunity (and seeing some of this first hand) I think it would be best in the short term to make the WebGL renderer the default.

There are two main reasons:

- WebGL is generally more performant at the fundamental level for most of PixiJS's use cases right now. (this makes sense as Browser have had a lot more time to be optimise WebGL than they have WebGPU). An example of this is uploading a texture, WebGL is just that little bit quicker!

- WebGL is more stable. Whilst the chrome implementation seems ok, browsers like FF are a lot more unstable. With quirks and issues at the WebGPU layer.

Not worried about both of these being resolved in time, but for now I think most users would prefer stable over bleeding edge (especially if there is no current perf gains)

Technically a breaking change, but perhaps we are early enough to get away with a minor bump :D

Thought welcome!