### PR TITLE
Do not use texSubImage2D if not necessary to improve performance

### DIFF
--- a/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
+++ b/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
@@ -69,11 +69,10 @@ export const glUploadImageResource = {
         }
         else if (glWidth === textureWidth || glHeight === textureHeight)
         {
-            gl.texSubImage2D(
-                gl.TEXTURE_2D,
+            gl.texImage2D(
+                glTexture.target,
                 0,
-                0,
-                0,
+                glTexture.internalFormat,
                 glTexture.format,
                 glTexture.type,
                 source.resource as TexImageSource


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This PR updates the image uploader to use texImage2D instead of texSubImage2D when possible. In testing on my phone I see a significant performance improvement with this patch.

As per this discussion at least some time in the past it was acknowledged this was a problem: https://issues.chromium.org/issues/40469618#comment85

It's unclear if the fast path has been updated appropriately for texSubImage2D after that comment but in any case the performance improvement on my test device is noticable. (CPU utilization of my app went from 120-150% to 100-120%)

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included (needed?)
- [ ] Documentation is changed or added (needed?)
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
