### PR TITLE
Fix: stencil mask not resetting correctly on context loss

### DIFF
--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -89,6 +89,11 @@ export class GlStencilSystem implements System
             'increment-wrap': gl.INCR_WRAP,
             'decrement-wrap': gl.DECR_WRAP,
         };
+
+        // reset stencil cache
+        this._stencilCache.enabled = false;
+        this._stencilCache.stencilMode = STENCIL_MODES.NONE;
+        this._stencilCache.stencilReference = 0;
     }
 
     protected onRenderTargetChange(renderTarget: RenderTarget)


### PR DESCRIPTION
when a context loss happens all WebGL state is reset.
I was not reseting our stencil cache on context loss, so it was not updating accordingly.

it does now!