### PR TITLE
Fix: Mesh.destroy throws error when not using batch mode

### DIFF
--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -165,9 +165,11 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<MeshInstructi
 
         const gpuMesh = this._gpuBatchableMeshHash[mesh.uid];
 
-        BigPool.return(gpuMesh as PoolItem);
-
-        this._gpuBatchableMeshHash[mesh.uid] = null;
+        if (gpuMesh)
+        {
+            BigPool.return(gpuMesh as PoolItem);
+            this._gpuBatchableMeshHash[mesh.uid] = null;
+        }
     }
 
     public execute({ mesh }: MeshInstruction)


### PR DESCRIPTION
##### Description of change
When destroying Mesh that can't be batched, `MeshPipe` fails to return `gpuMesh` to pool since it's undefined. Checking that `_gpuBatchableMeshHash` contains a mesh with given uid before trying to return it to pool fixes the issue.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
