### PR TITLE
Fix: tiling sprite transform not updating correctly

### DIFF
--- a/src/utils/misc/Transform.ts
+++ b/src/utils/misc/Transform.ts
@@ -178,7 +178,7 @@ export class Transform
         if (this._rotation !== value)
         {
             this._rotation = value;
-            this.updateSkew();
+            this._onUpdate(this.skew);
         }
     }
 }

--- a/tests/math/Transform.tests.ts
+++ b/tests/math/Transform.tests.ts
@@ -92,5 +92,21 @@ describe('Transform', () =>
             expect(skew.y).toBeCloseTo(0.175, eps);
             expect(otherTransform.rotation).toEqual(0);
         });
+
+        it('should update when rotation changes', () =>
+        {
+            const observer
+            = {
+                _onUpdate: jest.fn(),
+            };
+
+            const transform = new Transform({
+                observer
+            });
+
+            transform.rotation = Math.PI / 6;
+
+            expect(observer._onUpdate).toHaveBeenCalled();
+        });
     });
 });


### PR DESCRIPTION
Fixes issue where rotation was not updating the uvs correctly without calling `_onTilingSpriteUpdate`


fixed with test!

example: https://www.pixiplayground.com/#/edit/-FkV3enddtHBC00QIzYrv