### PR TITLE
Fix: webgl-1 support

### DIFF
--- a/src/environment-browser/BrowserAdapter.ts
+++ b/src/environment-browser/BrowserAdapter.ts
@@ -26,8 +26,7 @@ export const BrowserAdapter = {
         return canvas;
     },
     getCanvasRenderingContext2D: () => CanvasRenderingContext2D,
-    getWebGLRenderingContext: () => WebGLRenderingContext,
-    getWebGL2RenderingContext: () => WebGL2RenderingContext,
+    getWebGL1RenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI ?? window.location.href),
     getFontFaceSet: () => document.fonts,

--- a/src/environment-browser/BrowserAdapter.ts
+++ b/src/environment-browser/BrowserAdapter.ts
@@ -26,7 +26,7 @@ export const BrowserAdapter = {
         return canvas;
     },
     getCanvasRenderingContext2D: () => CanvasRenderingContext2D,
-    getWebGL1RenderingContext: () => WebGLRenderingContext,
+    getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => (document.baseURI ?? window.location.href),
     getFontFaceSet: () => document.fonts,

--- a/src/environment-webworker/WebWorkerAdapter.ts
+++ b/src/environment-webworker/WebWorkerAdapter.ts
@@ -18,7 +18,7 @@ import { DOMParser } from '@xmldom/xmldom';
 export const WebWorkerAdapter = {
     createCanvas: (width?: number, height?: number) => new OffscreenCanvas(width ?? 0, height ?? 0),
     getCanvasRenderingContext2D: () => OffscreenCanvasRenderingContext2D,
-    getWebGL1RenderingContext: () => WebGLRenderingContext,
+    getWebGLRenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => globalThis.location.href,
     getFontFaceSet: () => (globalThis as unknown as WorkerGlobalScope).fonts,

--- a/src/environment-webworker/WebWorkerAdapter.ts
+++ b/src/environment-webworker/WebWorkerAdapter.ts
@@ -18,8 +18,7 @@ import { DOMParser } from '@xmldom/xmldom';
 export const WebWorkerAdapter = {
     createCanvas: (width?: number, height?: number) => new OffscreenCanvas(width ?? 0, height ?? 0),
     getCanvasRenderingContext2D: () => OffscreenCanvasRenderingContext2D,
-    getWebGLRenderingContext: () => WebGLRenderingContext,
-    getWebGL2RenderingContext: () => WebGL2RenderingContext,
+    getWebGL1RenderingContext: () => WebGLRenderingContext,
     getNavigator: () => navigator,
     getBaseUrl: () => globalThis.location.href,
     getFontFaceSet: () => (globalThis as unknown as WorkerGlobalScope).fonts,

--- a/src/environment/adapter.ts
+++ b/src/environment/adapter.ts
@@ -37,9 +37,7 @@ export interface Adapter
     /** Returns a 2D rendering context. */
     getCanvasRenderingContext2D: () => { prototype: ICanvasRenderingContext2D; };
     /** Returns a WebGL rendering context. */
-    getWebGLRenderingContext: () => typeof WebGLRenderingContext;
-    /** Returns a WebGL2 rendering context. */
-    getWebGL2RenderingContext: () => typeof WebGL2RenderingContext;
+    getWebGL1RenderingContext: () => typeof WebGLRenderingContext;
     /** Returns a partial implementation of the browsers window.navigator */
     getNavigator: () => { userAgent: string, gpu: GPU | null };
     /** Returns the current base URL For browser environments this is either the document.baseURI or window.location.href */

--- a/src/environment/adapter.ts
+++ b/src/environment/adapter.ts
@@ -37,7 +37,7 @@ export interface Adapter
     /** Returns a 2D rendering context. */
     getCanvasRenderingContext2D: () => { prototype: ICanvasRenderingContext2D; };
     /** Returns a WebGL rendering context. */
-    getWebGL1RenderingContext: () => typeof WebGLRenderingContext;
+    getWebGLRenderingContext: () => typeof WebGLRenderingContext;
     /** Returns a partial implementation of the browsers window.navigator */
     getNavigator: () => { userAgent: string, gpu: GPU | null };
     /** Returns the current base URL For browser environments this is either the document.baseURI or window.location.href */

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -219,7 +219,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
     {
         this.gl = gl;
 
-        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGL1RenderingContext() ? 1 : 2;
+        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGLRenderingContext() ? 1 : 2;
 
         this.getExtensions();
 

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -219,7 +219,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
     {
         this.gl = gl;
 
-        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGL2RenderingContext() ? 2 : 1;
+        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGLRenderingContext() ? 1 : 2;
 
         this.getExtensions();
 

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -219,7 +219,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
     {
         this.gl = gl;
 
-        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGLRenderingContext() ? 1 : 2;
+        this.webGLVersion = gl instanceof DOMAdapter.get().getWebGL1RenderingContext() ? 1 : 2;
 
         this.getExtensions();
 

--- a/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
+++ b/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
@@ -19,7 +19,7 @@ export function mapFormatToGlInternalFormat(
     let srgb = {};
     let bgra8unorm: number = gl.RGBA;
 
-    if (gl instanceof DOMAdapter.get().getWebGL2RenderingContext())
+    if (!(gl instanceof DOMAdapter.get().getWebGLRenderingContext()))
     {
         srgb = {
             'rgba8unorm-srgb': gl.SRGB8_ALPHA8,

--- a/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
+++ b/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
@@ -19,7 +19,7 @@ export function mapFormatToGlInternalFormat(
     let srgb = {};
     let bgra8unorm: number = gl.RGBA;
 
-    if (!(gl instanceof DOMAdapter.get().getWebGL1RenderingContext()))
+    if (!(gl instanceof DOMAdapter.get().getWebGLRenderingContext()))
     {
         srgb = {
             'rgba8unorm-srgb': gl.SRGB8_ALPHA8,

--- a/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
+++ b/src/rendering/renderers/gl/texture/utils/mapFormatToGlInternalFormat.ts
@@ -19,7 +19,7 @@ export function mapFormatToGlInternalFormat(
     let srgb = {};
     let bgra8unorm: number = gl.RGBA;
 
-    if (!(gl instanceof DOMAdapter.get().getWebGLRenderingContext()))
+    if (!(gl instanceof DOMAdapter.get().getWebGL1RenderingContext()))
     {
         srgb = {
             'rgba8unorm-srgb': gl.SRGB8_ALPHA8,

--- a/src/utils/browser/isWebGLSupported.ts
+++ b/src/utils/browser/isWebGLSupported.ts
@@ -27,7 +27,7 @@ export function isWebGLSupported(
 
         try
         {
-            if (!DOMAdapter.get().getWebGL1RenderingContext())
+            if (!DOMAdapter.get().getWebGLRenderingContext())
             {
                 return false;
             }

--- a/src/utils/browser/isWebGLSupported.ts
+++ b/src/utils/browser/isWebGLSupported.ts
@@ -27,7 +27,7 @@ export function isWebGLSupported(
 
         try
         {
-            if (!DOMAdapter.get().getWebGLRenderingContext())
+            if (!DOMAdapter.get().getWebGL1RenderingContext())
             {
                 return false;
             }


### PR DESCRIPTION
fixes an issue where we were looking for a WebGL2Context even if it does not exist.

This PR removes the `getWebGL2RenderingContext`. It then renames `getWebGLRenderingContext` -> `getWebGL1RenderingContext` 
With that instead of checking if somthign is WebGL2, we can check if is not WebGL1.