### PR TITLE
Fix: apply defaultAnchor for sprite if present

### DIFF
--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -112,8 +112,17 @@ export class Sprite extends Container implements View
             },
         );
 
-        if (anchor) this.anchor = anchor;
+        if (anchor)
+        {
+            this.anchor = anchor;
+        }
+        else if (texture.defaultAnchor)
+        {
+            this.anchor = texture.defaultAnchor;
+        }
+
         this.texture = texture;
+
         this.allowChildren = false;
         this.roundPixels = roundPixels ?? false;
 

--- a/tests/renderering/sprite/Sprite.test.ts
+++ b/tests/renderering/sprite/Sprite.test.ts
@@ -284,4 +284,20 @@ describe('Sprite', () =>
             sprite.destroy();
         });
     });
+
+    describe('init', () =>
+    {
+        it('should use defaultAnchor from Texture if available on the constructor', () =>
+        {
+            const texture = new Texture({
+                source: new TextureSource({ width: 100, height: 100 }),
+                defaultAnchor: { x: 0.5, y: 0.5 },
+            });
+
+            const sprite = new Sprite(texture);
+
+            expect(sprite.anchor.x).toEqual(0.5);
+            expect(sprite.anchor.y).toEqual(0.5);
+        });
+    });
 });


### PR DESCRIPTION
Sprite will now use the defaultAnchor property on a Texture if it is present.

Test added!

fixes #10398 