### PR TITLE
Fix: `Polygon.__proto__.strokeContains` skips checking last line segment when `this.closePath` false

### DIFF
--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -130,8 +130,9 @@ export class Polygon implements ShapePrimitive
         const halfStrokeWidth = strokeWidth / 2;
         const halfStrokeWidthSqrd = halfStrokeWidth * halfStrokeWidth;
         const { points } = this;
+        const iterationLength = points.length - (this.closePath ? 0 : 2);
 
-        for (let i = 0; i < points.length; i += 2)
+        for (let i = 0; i < iterationLength; i += 2)
         {
             const x1 = points[i];
             const y1 = points[i + 1];

--- a/tests/math/Polygon.tests.ts
+++ b/tests/math/Polygon.tests.ts
@@ -130,6 +130,26 @@ describe('Polygon', () =>
             expect(polygon.strokeContains(0, 12, 3)).toBe(false);
         });
 
+        const polygonClosePathTrue: Polygon = new Polygon([0, 0, 10, 0, 10, 10, 0, 10]);
+
+        test('returns true for a point on the polygon closePath edge', () =>
+        {
+            expect(polygonClosePathTrue.strokeContains(0, 3, 1)).toBe(true);
+            expect(polygonClosePathTrue.strokeContains(0, 5, 1)).toBe(true);
+            expect(polygonClosePathTrue.strokeContains(0, 7, 1)).toBe(true);
+        });
+
+        const polygonClosePathFalse: Polygon = new Polygon([0, 0, 10, 0, 10, 10, 0, 10]);
+
+        polygonClosePathFalse.closePath = false;
+
+        test('returns false for a point on the polygon closePath edge', () =>
+        {
+            expect(polygonClosePathFalse.strokeContains(0, 3, 1)).toBe(false);
+            expect(polygonClosePathFalse.strokeContains(0, 5, 1)).toBe(false);
+            expect(polygonClosePathFalse.strokeContains(0, 7, 1)).toBe(false);
+        });
+
         // Add additional tests as necessary
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

- `strokeContains` method of `Polygon` checks `this.closePath` boolean value to skip last line segment or not skip
- Issue #10303 is related.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included (closePath related tests are added)
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
