### PR TITLE
Fix: incorrect cache warning check

### DIFF
--- a/packages/assets/src/cache/Cache.ts
+++ b/packages/assets/src/cache/Cache.ts
@@ -111,7 +111,9 @@ class CacheClass
 
         cacheKeys.forEach((key) =>
         {
-            if (this._cache.has(key) && this._cache.get(key) !== value)
+            const val = cacheableAssets ? cacheableAssets[key] : value;
+
+            if (this._cache.has(key) && this._cache.get(key) !== val)
             {
                 if (process.env.DEBUG)
                 {

--- a/packages/assets/test/assets.tests.ts
+++ b/packages/assets/test/assets.tests.ts
@@ -493,6 +493,44 @@ describe('Assets', () =>
         spy.mockRestore();
     });
 
+    it('should not show a cache warning if the same spritesheet asset is loaded twice', async () =>
+    {
+        jest.setTimeout(10000);
+        await Assets.init({
+            basePath,
+        });
+
+        const spy = jest.spyOn(console, 'warn');
+
+        await Promise.all([
+            Assets.load('spritesheet/spritesheet.json'),
+            Assets.load('spritesheet/spritesheet.json'),
+        ]);
+
+        expect(spy).not.toHaveBeenCalled();
+
+        spy.mockRestore();
+    });
+
+    it('should show a cache warning if asset is different', async () =>
+    {
+        jest.setTimeout(10000);
+        await Assets.init({
+            basePath,
+        });
+
+        const spy = jest.spyOn(console, 'warn');
+
+        await Promise.all([
+            Assets.load({ alias: 'test', src: 'textures/bunny.png' }),
+            Assets.load({ alias: 'test', src: 'textures/bunny.1.png' }),
+        ]);
+
+        expect(spy).toHaveBeenCalled();
+
+        spy.mockRestore();
+    });
+
     it('should load font assets with space in URL', async () =>
     {
         await Assets.init({


### PR DESCRIPTION
We were checking the wrong value when testing if an asset is different, resulting in a bunch of warnings for things like spritesheets
