### PR TITLE
[v6.x]Fix: parameter type

### DIFF
--- a/packages/sprite-tiling/src/sprite-tiling-fallback.frag
+++ b/packages/sprite-tiling/src/sprite-tiling-fallback.frag
@@ -23,8 +23,8 @@ void main(void)
 
     #ifdef GL_EXT_shader_texture_lod
         vec4 texSample = unclamped == coord
-            ? texture2D(uSampler, coord) 
-            : texture2DLodEXT(uSampler, coord, 0);
+            ? texture2D(uSampler, coord)
+            : texture2DLodEXT(uSampler, coord, 0.0);
     #else
         vec4 texSample = texture2D(uSampler, coord);
     #endif


### PR DESCRIPTION
related: #10078

https://github.com/pixijs/pixijs/blob/42da22080016dbbfcca7b0ddbb7fe471d17cdd0d/packages/sprite-tiling/src/sprite-tiling-fallback.frag#L27

```glsl
vec4 texture2DLodEXT(sampler2D sampler, vec2 coord, float lod)
```

The third parameter should be of type `float`, otherwise it may cause errors on some devices, such as **WeChat**.

![1713001735048](https://github.com/pixijs/pixijs/assets/6738986/c010474e-b56b-4912-b6da-6d6d8f7ffa31)


