### PR TITLE
Fix: overlay blend mode to be consistent with photoshop

### DIFF
--- a/src/advanced-blend-modes/OverlayBlend.ts
+++ b/src/advanced-blend-modes/OverlayBlend.ts
@@ -27,7 +27,7 @@ export class OverlayBlend extends BlendModeFilter
                 functions: `
                 float overlay(float base, float blend)
                 {
-                    return (blend < 0.5) ? (2.0*base*blend) : (1.0-2.0*(1.0-base)*(1.0-blend));
+                    return (base < 0.5) ? (2.0*base*blend) : (1.0-2.0*(1.0-base)*(1.0-blend));
                 }
 
                 vec3 blendOverlay(vec3 base, vec3 blend, float opacity)


### PR DESCRIPTION
fix the overlay blend mode

The overlay mode uses base as the judgment condition. After modification, the display is consistent with Photoshop.
