### PR TITLE
Update LinearLightBlend.ts

### DIFF
--- a/src/advanced-blend-modes/LinearLightBlend.ts
+++ b/src/advanced-blend-modes/LinearLightBlend.ts
@@ -38,7 +38,7 @@ export class LinearLightBlend extends BlendModeFilter
                 }
 
                 float linearLight(float base, float blend) {
-                    return (blend <= 0.5) ? linearBurn(base,2.0*blend) : linearBurn(base,2.0*(blend-0.5));
+                    return base+2.0*blend-1.0;
                 }
 
                 vec3 blendLinearLight(vec3 base, vec3 blend, float opacity) {


### PR DESCRIPTION
fix linearlight blend mode to consistent with Photoshop
The linear light mode is base+2*top-1. After modification, the display is consistent with that of Photoshop.