### PR TITLE
Fix: bind to default framebuffer only when copying from main canvas

### DIFF
--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -1,6 +1,5 @@
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { warn } from '../../../../utils/logging/warn';
-import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 import { CLEAR } from '../const';
 import { GlRenderTarget } from '../GlRenderTarget';
 
@@ -162,8 +161,8 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
 
         const glRenderTarget = new GlRenderTarget();
 
-        // we are rendering to a canvas..
-        if (CanvasSource.test(renderTarget.colorTexture.resource))
+        // we are rendering to the main canvas..
+        if (renderTarget.colorTexture.resource === renderer.gl.canvas)
         {
             glRenderTarget.framebuffer = null;
 


### PR DESCRIPTION
The render target system's copyToTexture assumes that if the source render surface is a canvas, then it must be the main framebuffer. But this is false if someone is trying to copy from a secondary or offscreen canvas.

This change uses a direct comparison with the main canvas to check whether to use the default framebuffer instead.

For a bug repro, see this JSFiddle
https://jsfiddle.net/ShukantPal/vwrh51qs/27/

I've verified locally that this fix causes the gradient to paint correctly. @bigtimebuddy Do we still deploy a public build URL for GitHub branches? (so that I can create a fiddle that works correctly using this branch's build)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
