### PR TITLE
Fix: issue with local bounds cache not being invalidated when a child is removed

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -562,7 +562,9 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     /**
      * A value that increments each time the container is modified
      * the first 12 bits represent the container changes (eg transform, alpha, visible etc)
-     * the second 12 bits represent the view changes (eg texture swap, geometry change etc)
+     * the second 12 bits represent:
+     *      - for view changes (eg texture swap, geometry change etc)
+     *      - containers changes (eg children added, removed etc)
      *
      *  view          container
      * [000000000000][00000000000]
@@ -658,6 +660,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         this.emit('childAdded', child, this, this.children.length - 1);
         child.emit('added', this);
 
+        this._didChangeId += 1 << 12;
+
         if (child._zIndex !== 0)
         {
             child.depthOfChildModified();
@@ -691,6 +695,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         if (index > -1)
         {
+            this._didChangeId += 1 << 12;
+
             this.children.splice(index, 1);
 
             if (this.renderGroup)

--- a/tests/scene/getLocalBounds.tests.ts
+++ b/tests/scene/getLocalBounds.tests.ts
@@ -419,4 +419,54 @@ describe('getLocalBounds', () =>
 
         expect(child._localBoundsCacheData.didChange).toEqual(true);
     });
+
+    it('should measure correctly if a child has been added and removed', async () =>
+    {
+        const container = new Container({ label: 'container' });
+
+        const bounds1 = container.getLocalBounds();
+
+        expect(bounds1).toMatchObject({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+
+        const child = new DummyView({ label: 'child' });
+
+        container.addChild(child);
+
+        const bounds2 = container.getLocalBounds();
+
+        expect(bounds2).toMatchObject({ minX: 0, minY: 0, maxX: 100, maxY: 100 });
+
+        container.removeChild(child);
+
+        const bounds3 = container.getLocalBounds();
+
+        expect(bounds3).toMatchObject({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+    });
+
+    it('should measure correctly if a nested child has been added and removed', async () =>
+    {
+        const container = new Container({ label: 'container' });
+
+        const container2 = new Container({ label: 'container2' });
+
+        container.addChild(container2);
+
+        const bounds1 = container.getLocalBounds();
+
+        expect(bounds1).toMatchObject({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+
+        const child = new DummyView({ label: 'child' });
+
+        container2.addChild(child);
+
+        const bounds2 = container.getLocalBounds();
+
+        expect(bounds2).toMatchObject({ minX: 0, minY: 0, maxX: 100, maxY: 100 });
+
+        container2.removeChild(child);
+
+        const bounds3 = container.getLocalBounds();
+
+        expect(bounds3).toMatchObject({ minX: 0, minY: 0, maxX: 0, maxY: 0 });
+    });
 });


### PR DESCRIPTION

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
When removing a child - the local bounds cache we not always being invalidated. This has now been addressed so that when removing / adding a child we explicitly invalidate the cache of the local bounds. 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10451