### PR TITLE
Fix: onRender being called twice when converted to a renderGroup

### DIFF
--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -103,11 +103,6 @@ export class RenderGroup implements Instruction
             {
                 child.relativeRenderGroupDepth = child.parent.relativeRenderGroupDepth + 1;
             }
-
-            if (child._onRender)
-            {
-                this.addOnRender(child);
-            }
         }
 
         if (child.renderGroup)
@@ -124,6 +119,22 @@ export class RenderGroup implements Instruction
         {
             child.renderGroup = this;
             child.didChange = true;
+        }
+
+        if (child._onRender)
+        {
+            // Add the child to the onRender list under the following conditions:
+            // 1. If the child is not a render group.
+            // 2. If the child is a render group root of this render group
+
+            if (!child.isRenderGroupRoot)
+            {
+                this.addOnRender(child);
+            }
+            else if (child.renderGroup.root === child)
+            {
+                this.addOnRender(child);
+            }
         }
 
         const children = child.children;
@@ -146,7 +157,18 @@ export class RenderGroup implements Instruction
 
         if (child._onRender)
         {
-            this.removeOnRender(child);
+            // Remove the child to the onRender list under the following conditions:
+            // 1. If the child is not a render group.
+            // 2. If the child is a render group root of this render group
+
+            if (!child.isRenderGroupRoot)
+            {
+                this.removeOnRender(child);
+            }
+            else if (child.renderGroup.root === child)
+            {
+                this.removeOnRender(child);
+            }
         }
 
         if (child.renderGroup.root !== child)

--- a/tests/renderering/scene/RenderGroupSystem.test.ts
+++ b/tests/renderering/scene/RenderGroupSystem.test.ts
@@ -25,4 +25,38 @@ describe('RenderGroupSystem', () =>
 
         expect(container.renderGroup.childrenRenderablesToUpdate.index).toEqual(0);
     });
+
+    it('should only call on render once for a render group after conversion', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        const container = new Container({ isRenderGroup: false, label: 'root' });
+
+        const child = new Container({ isRenderGroup: true, label: 'child' });
+
+        container.addChild(child);
+
+        child.onRender = jest.fn();
+
+        renderer.render(container);
+
+        expect(child.onRender).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only call on render once for a render group before conversion', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        const container = new Container({ isRenderGroup: true, label: 'root' });
+
+        const child = new Container({ isRenderGroup: true, label: 'child' });
+
+        container.addChild(child);
+
+        child.onRender = jest.fn();
+
+        renderer.render(container);
+
+        expect(child.onRender).toHaveBeenCalledTimes(1);
+    });
 });


### PR DESCRIPTION

##### Description of change
When converting an item to a render group - its onRender function was being called in both its own render group (correct!) 
and its parent render group (incorrect!). This resulted in onRender being called twice for render groups in some scenarios.

This PR address the issue.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Fixes #10432 
