### PR TITLE
Fix: padding issue on text

### DIFF
--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -161,7 +161,9 @@ export class CanvasTextSystem implements System
 
         context.scale(resolution, resolution);
 
-        context.clearRect(0, 0, measured.width + 4, measured.height + 4);
+        const padding = style.padding * 2;
+
+        context.clearRect(0, 0, measured.width + 4 + padding, measured.height + 4 + padding);
 
         // set stroke styles..
 


### PR DESCRIPTION


##### Description of change
Fixes #10493 . When clearing the texture for reuse, I was not inclding the padding as part of the area that needed clearing. Easy fix at least!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
