### PR TITLE
Fix: containsPoint on Mesh if no index buffer is set

### DIFF
--- a/src/maths/point/pointInTriangle.ts
+++ b/src/maths/point/pointInTriangle.ts
@@ -1,0 +1,42 @@
+/**
+ * Check if a point is inside a triangle.
+ * @param px - x coordinate of the point
+ * @param py - y coordinate of the point
+ * @param x1 - x coordinate of the first vertex of the triangle
+ * @param y1 - y coordinate of the first vertex of the triangle
+ * @param x2 - x coordinate of the second vertex of the triangle
+ * @param y2 - y coordinate of the second vertex of the triangle
+ * @param x3 - x coordinate of the third vertex of the triangle
+ * @param y3 - y coordinate of the third vertex of the triangle
+ * @returns `true` if the point is inside the triangle, `false` otherwise
+ */
+export function pointInTriangle(
+    px: number, py: number,
+    x1: number, y1: number,
+    x2: number, y2: number,
+    x3: number, y3: number
+)
+{
+    // Calculate vectors from point p to each vertex of the triangle
+    const v2x = x3 - x1;
+    const v2y = y3 - y1;
+    const v1x = x2 - x1;
+    const v1y = y2 - y1;
+    const v0x = px - x1;
+    const v0y = py - y1;
+
+    // Compute dot products
+    const dot00 = (v2x * v2x) + (v2y * v2y);
+    const dot01 = (v2x * v1x) + (v2y * v1y);
+    const dot02 = (v2x * v0x) + (v2y * v0y);
+    const dot11 = (v1x * v1x) + (v1y * v1y);
+    const dot12 = (v1x * v0x) + (v1y * v0y);
+
+    // Calculate barycentric coordinates
+    const invDenom = 1 / ((dot00 * dot11) - (dot01 * dot01));
+    const u = ((dot11 * dot02) - (dot01 * dot12)) * invDenom;
+    const v = ((dot00 * dot12) - (dot01 * dot02)) * invDenom;
+
+    // Check if point is in triangle
+    return (u >= 0) && (v >= 0) && (u + v < 1);
+}

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -1,4 +1,4 @@
-import { Polygon } from '../../../maths/shapes/Polygon';
+import { pointInTriangle } from '../../../maths/point/pointInTriangle';
 import { Geometry } from '../../../rendering/renderers/shared/geometry/Geometry';
 import { State } from '../../../rendering/renderers/shared/state/State';
 import { Texture } from '../../../rendering/renderers/shared/texture/Texture';
@@ -14,8 +14,6 @@ import type { View } from '../../../rendering/renderers/shared/view/View';
 import type { Bounds } from '../../container/bounds/Bounds';
 import type { ContainerOptions } from '../../container/Container';
 import type { DestroyOptions } from '../../container/destroyTypes';
-
-const tempPolygon = new Polygon();
 
 export interface TextureShader extends Shader
 {
@@ -280,27 +278,55 @@ export class Mesh<
 
         const vertices = this.geometry.getBuffer('aPosition').data;
 
-        const points = tempPolygon.points;
-        const indices = this.geometry.getIndex().data;
-        const len = indices.length;
         const step = this.geometry.topology === 'triangle-strip' ? 3 : 1;
 
-        for (let i = 0; i + 2 < len; i += step)
+        if (this.geometry.getIndex())
         {
-            const ind0 = indices[i] * 2;
-            const ind1 = indices[i + 1] * 2;
-            const ind2 = indices[i + 2] * 2;
+            const indices = this.geometry.getIndex().data;
+            const len = indices.length;
 
-            points[0] = vertices[ind0];
-            points[1] = vertices[ind0 + 1];
-            points[2] = vertices[ind1];
-            points[3] = vertices[ind1 + 1];
-            points[4] = vertices[ind2];
-            points[5] = vertices[ind2 + 1];
-
-            if (tempPolygon.contains(x, y))
+            for (let i = 0; i + 2 < len; i += step)
             {
-                return true;
+                const ind0 = indices[i] * 2;
+                const ind1 = indices[i + 1] * 2;
+                const ind2 = indices[i + 2] * 2;
+
+                if (pointInTriangle(
+                    x, y,
+                    vertices[ind0],
+                    vertices[ind0 + 1],
+                    vertices[ind1],
+                    vertices[ind1 + 1],
+                    vertices[ind2],
+                    vertices[ind2 + 1],
+                ))
+                {
+                    return true;
+                }
+            }
+        }
+        else
+        {
+            const len = vertices.length / 2; // Each vertex has 2 coordinates, x and y
+
+            for (let i = 0; i + 2 < len; i += step)
+            {
+                const ind0 = i * 2;
+                const ind1 = (i + 1) * 2;
+                const ind2 = (i + 2) * 2;
+
+                if (pointInTriangle(
+                    x, y,
+                    vertices[ind0],
+                    vertices[ind0 + 1],
+                    vertices[ind1],
+                    vertices[ind1 + 1],
+                    vertices[ind2],
+                    vertices[ind2 + 1],
+                ))
+                {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
I was not taking into account a mesh may not have an index buffer when running contains point. This has now been addressed. I also optimised the checks by using a pointInTriangle functions, which is faster than copying to a temp poly and testing that.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10485