### PR TITLE
Fix: Text bounds calculation with padding

### DIFF
--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -64,8 +64,8 @@ export class Text
         const { width, height } = canvasMeasurement;
 
         bounds.minX = (-anchor._x * width) - padding;
-        bounds.maxX = bounds.minX + width;
+        bounds.maxX = bounds.minX + width + (padding * 2);
         bounds.minY = (-anchor._y * height) - padding;
-        bounds.maxY = bounds.minY + height;
+        bounds.maxY = bounds.minY + height + (padding * 2);
     }
 }

--- a/tests/renderering/text/Text.tests.ts
+++ b/tests/renderering/text/Text.tests.ts
@@ -251,4 +251,16 @@ describe('Text', () =>
             expect(text.height).toEqual(100);
         });
     });
+
+    it('should measure bounds of text correctly when padding is set', () =>
+    {
+        const textNoPadding = new Text({ text: 'HI', style: { padding: 0 } });
+        const text = new Text({ text: 'HI', style: { padding: 10 } });
+
+        const boundsNoPadding = textNoPadding.getBounds();
+        const bounds = text.getBounds();
+
+        expect(boundsNoPadding.width).toBeLessThan(bounds.width + 20);
+        expect(boundsNoPadding.height).toBeLessThan(bounds.height + 20);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
When getting the bounds of text or using width / height. the padding was not being taken into account on the bottom and right sides. Easy fix, with test! 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10500
