### PR TITLE
Fix: handling of getRenderTarget when passing in a canvas

### DIFF
--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -481,7 +481,7 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
 
         if (CanvasSource.test(renderSurface))
         {
-            renderSurface = getCanvasTexture(renderSurface as ICanvas);
+            renderSurface = getCanvasTexture(renderSurface as ICanvas).source;
         }
 
         if (renderSurface instanceof RenderTarget)

--- a/tests/renderering/RenderTargetSystem.test.ts
+++ b/tests/renderering/RenderTargetSystem.test.ts
@@ -1,0 +1,17 @@
+import { RenderTarget } from '../../src/rendering/renderers/shared/renderTarget/RenderTarget';
+import { getWebGLRenderer } from '../utils/getRenderer';
+
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+describe('RenderTargetSystem', () =>
+{
+    it('should return a render target for canvas elements', async () =>
+    {
+        const renderer = await getWebGLRenderer({}) as WebGLRenderer;
+        const canvas = document.createElement('canvas');
+
+        const target = renderer.renderTarget.getRenderTarget(canvas);
+
+        expect(target).toBeInstanceOf(RenderTarget);
+    });
+});


### PR DESCRIPTION
##### Description of change

Right now, `getRenderTarget(canvas)` returns null because of how the canvas is converted into a `TextureSource`.

In the code, `getCanvasTexture` returns a texture, but the 2 if conditions in `getRenderTarget` only handle render targets and texture sources.

This change updates it so that a canvas is converted into a canvas source, not a texture.