### PR TITLE
fix: unicode support for BitmapFontManager

### DIFF
--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -155,7 +155,7 @@ class BitmapFontManagerClass
     {
         const bitmapFont = this.getFont(text, style);
 
-        return getBitmapTextLayout(text.split(''), style, bitmapFont);
+        return getBitmapTextLayout([...text], style, bitmapFont);
     }
 
     /**

--- a/tests/renderering/text/BitmapFontManager.test.ts
+++ b/tests/renderering/text/BitmapFontManager.test.ts
@@ -1,6 +1,6 @@
 import { Cache } from '../../../src/assets/cache/Cache';
-import { BitmapFontManager } from '../../../src/scene/text-bitmap/BitmapFontManager';
 import { TextStyle } from '../../../src/scene/text/TextStyle';
+import { BitmapFontManager } from '../../../src/scene/text-bitmap/BitmapFontManager';
 
 import type { BitmapFont } from '../../../src/scene/text-bitmap/BitmapFont';
 
@@ -26,7 +26,8 @@ describe('BitmapFontManager', () =>
         expect(Cache.get<BitmapFont>('foo-bitmap')).toBeUndefined();
     });
 
-    it('should return layout for text containing emoji', () => {
+    it('should return layout for text containing emoji', () =>
+    {
         const layout = BitmapFontManager.getLayout('foo👍', new TextStyle());
 
         expect(layout).toBeDefined();

--- a/tests/renderering/text/BitmapFontManager.test.ts
+++ b/tests/renderering/text/BitmapFontManager.test.ts
@@ -1,5 +1,6 @@
 import { Cache } from '../../../src/assets/cache/Cache';
 import { BitmapFontManager } from '../../../src/scene/text-bitmap/BitmapFontManager';
+import { TextStyle } from '../../../src/scene/text/TextStyle';
 
 import type { BitmapFont } from '../../../src/scene/text-bitmap/BitmapFont';
 
@@ -23,5 +24,11 @@ describe('BitmapFontManager', () =>
 
         BitmapFontManager.uninstall('foo');
         expect(Cache.get<BitmapFont>('foo-bitmap')).toBeUndefined();
+    });
+
+    it('should return layout for text containing emoji', () => {
+        const layout = BitmapFontManager.getLayout('foo👍', new TextStyle());
+
+        expect(layout).toBeDefined();
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
`BitmapFontManager.getLayout` fails when called with text containing unicode characters due to `String.split('')` splitting multichar unicode characters, e.g. `'👍'.split('') === ['\uD83D', '\uDC4D']`. The spread operator on the other hand respects unicode.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
