### PR TITLE
fix mask issue when setting to null and back

### DIFF
--- a/src/scene/container/container-mixins/effectsMixin.ts
+++ b/src/scene/container/container-mixins/effectsMixin.ts
@@ -98,6 +98,8 @@ export const effectsMixin: Partial<Container> = {
             this.removeEffect(effect);
 
             MaskEffectManager.returnMaskEffect(effect);
+
+            this._maskEffect = null;
         }
 
         if (value === null || value === undefined) return;

--- a/tests/scene/mask.test.ts
+++ b/tests/scene/mask.test.ts
@@ -1,0 +1,27 @@
+import { Container } from '../../src/scene/container/Container';
+import { Graphics } from '../../src/scene/graphics/shared/Graphics';
+
+describe('Mask Tests', () =>
+{
+    it('should correctly set a mask to null and back', async () =>
+    {
+        const container = new Container({
+            label: 'container',
+        });
+
+        const mask = new Graphics({
+            label: 'mask',
+        })
+            .rect(0, 0, 100, 100)
+            .fill('red');
+
+        expect(() =>
+        {
+            container.mask = mask;
+            container.mask = null;
+            container.mask = mask;
+        }).not.toThrow();
+    });
+});
+
+// Test to cover

--- a/tests/scene/mask.test.ts
+++ b/tests/scene/mask.test.ts
@@ -24,4 +24,3 @@ describe('Mask Tests', () =>
     });
 });
 
-// Test to cover


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes a little regression bug when doing the following:

```
 thing.mask = mask;
 thing.mask = null;
 thing.mask = mask; // would throw as mask effect refference was not removed.
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
