### PR TITLE
Do a more accurate Max Texture check

### DIFF
--- a/src/rendering/batcher/shared/const.ts
+++ b/src/rendering/batcher/shared/const.ts
@@ -1,1 +1,3 @@
-export const MAX_TEXTURES = 16;
+import { maxRecommendedTextures } from '../../renderers/shared/texture/utils/maxRecommendedTextures';
+
+export const MAX_TEXTURES = maxRecommendedTextures();

--- a/src/rendering/high-shader/shader-bits/generateTextureBatchBit.ts
+++ b/src/rendering/high-shader/shader-bits/generateTextureBatchBit.ts
@@ -1,3 +1,5 @@
+import { MAX_TEXTURES } from '../../batcher/shared/const';
+
 import type { HighShaderBit } from '../compiler/types';
 
 const textureBatchBitGpuCache: Record<number, HighShaderBit> = {};
@@ -87,13 +89,13 @@ export function generateTextureBatchBit(maxTextures: number): HighShaderBit
                 header: `
                 @in @interpolate(flat) vTextureId: u32;
     
-                ${generateBindingSrc(16)}
+                ${generateBindingSrc(MAX_TEXTURES)}
             `,
                 main: `
                 var uvDx = dpdx(vUV);
                 var uvDy = dpdy(vUV);
     
-                ${generateSampleSrc(16)}
+                ${generateSampleSrc(MAX_TEXTURES)}
             `
             }
         };
@@ -164,7 +166,7 @@ export function generateTextureBatchBitGl(maxTextures: number): HighShaderBit
             `,
                 main: `
     
-                ${generateSampleGlSrc(16)}
+                ${generateSampleGlSrc(MAX_TEXTURES)}
             `
             }
         };

--- a/src/rendering/renderers/shared/texture/utils/maxRecommendedTextures.ts
+++ b/src/rendering/renderers/shared/texture/utils/maxRecommendedTextures.ts
@@ -1,0 +1,21 @@
+import { getTestContext } from '../../../gl/shader/program/getTestContext';
+
+let maxTextureUnits = 0;
+
+/**
+ * Returns the maximum recommended texture units to use. This uses WebGL1's `MAX_TEXTURE_IMAGE_UNITS`.
+ * The response for this is that to get this info via WebGPU, we would need to make a context, which
+ * would make this function async, and we want to avoid that.
+ * @private
+ * @returns {number} The maximum recommended texture units to use.
+ */
+export function maxRecommendedTextures(): number
+{
+    if (maxTextureUnits) return maxTextureUnits;
+
+    const gl = getTestContext();
+
+    maxTextureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+
+    return maxTextureUnits;
+}


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
MAX_TEXTURES is now set by the GPU. WE do. alittle WebGL check to see how many textures it can support. This also happens for WebGPU. The reason we do a WebGL check is so that we don't need to create a promise and await the result. This keeps the code a lot simpler :D

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
