### PR TITLE
chore: add pr name checker

### DIFF
--- a/.github/workflows/pull-name.yml
+++ b/.github/workflows/pull-name.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Check PR Title
         uses: clowdhaus/actions/pr-title@v0.1.0
         with:
-          on-fail-message: "Your PR title doesn't match the required format. The title should be in this format: \n\n```\nchore: add pr title workflow\n```"
+          on-fail-message: "Your PR title doesn't match the required format. The title should be in this format: \n\n```\nchore: update Text docs\nfix: text not rendering\nfeat: add new feature to Text\nbreaking: remove Text#resolution \n```"
           title-regex: '^(chore|feat|fix|breaking)?(!)?\:\s.*$'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-name.yml
+++ b/.github/workflows/pull-name.yml
@@ -1,0 +1,25 @@
+name: Pull Request Title Format
+
+on:
+  pull_request:
+    branches:
+      - '*'
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  prTitle:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check PR Title
+        uses: clowdhaus/actions/pr-title@v0.1.0
+        with:
+          on-fail-message: "Your PR title doesn't match the required format. The title should be in this format: \n\n```\nchore: add pr title workflow\n```"
+          title-regex: '^(chore|feat|fix|breaking)?(!)?\:\s.*$'
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-name.yml
+++ b/.github/workflows/pull-name.yml
@@ -3,7 +3,7 @@ name: Pull Request Title Format
 on:
   pull_request:
     branches:
-      - '*'
+      - '**'
     types:
       - opened
       - reopened


### PR DESCRIPTION
I've been consistently renaming pr's to follow the `chore/fix/feat/breaking` convention to make generating the release notes easier

This PR just adds a workflow to block a merge if the title isn't correct