### PR TITLE
fix: event mixin types

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -12,8 +12,6 @@ import type { EmitterListeners, TrackingData } from './EventBoundaryTypes';
 import type { FederatedEvent } from './FederatedEvent';
 import type {
     Cursor, EventMode, FederatedEventHandler,
-    FederatedEventTarget,
-    IFederatedContainer
 } from './FederatedEventTarget';
 
 // The maximum iterations used in propagation. This prevent infinite loops.
@@ -139,9 +137,9 @@ export class EventBoundary
     protected eventPool: Map<typeof FederatedEvent, FederatedEvent[]> = new Map();
 
     /** Every interactive element gathered from the scene. Only used in `pointermove` */
-    private readonly _allInteractiveElements: FederatedEventTarget[] = [];
+    private readonly _allInteractiveElements: Container[] = [];
     /** Every element that passed the hit test. Only used in `pointermove` */
-    private _hitElements: FederatedEventTarget[] = [];
+    private _hitElements: Container[] = [];
     /** Whether or not to collect all the interactive elements from the scene. Enabled in `pointermove` */
     private _isPointerMoveEvent = false;
 
@@ -350,7 +348,7 @@ export class EventBoundary
      * {@code target}. The last element in the path is {@code target}.
      * @param target - The target to find the propagation path to.
      */
-    public propagationPath(target: FederatedEventTarget): FederatedEventTarget[]
+    public propagationPath(target: Container): Container[]
     {
         const propagationPath = [target];
 
@@ -650,7 +648,7 @@ export class EventBoundary
         type = type ?? e.type;
 
         // call the `on${type}` for the current target if it exists
-        const handlerKey = `on${type}` as keyof IFederatedContainer;
+        const handlerKey = `on${type}` as keyof Container;
 
         (e.currentTarget[handlerKey] as FederatedEventHandler<FederatedEvent>)?.(e);
 
@@ -1157,7 +1155,7 @@ export class EventBoundary
      * @param propagationPath - The propagation path was valid in the past.
      * @returns - The most specific event-target still mounted at the same location in the scene graph.
      */
-    protected findMountedTarget(propagationPath: FederatedEventTarget[]): FederatedEventTarget
+    protected findMountedTarget(propagationPath: Container[]): Container
     {
         if (!propagationPath)
         {
@@ -1194,7 +1192,7 @@ export class EventBoundary
     protected createPointerEvent(
         from: FederatedPointerEvent,
         type?: string,
-        target?: FederatedEventTarget
+        target?: Container
     ): FederatedPointerEvent
     {
         const event = this.allocateEvent(FederatedPointerEvent);
@@ -1206,7 +1204,7 @@ export class EventBoundary
         event.nativeEvent = from.nativeEvent;
         event.originalEvent = from;
         event.target = target
-            ?? this.hitTest(event.global.x, event.global.y) as FederatedEventTarget
+            ?? this.hitTest(event.global.x, event.global.y) as Container
             ?? this._hitElements[0];
 
         if (typeof type === 'string')

--- a/src/events/EventBoundaryTypes.ts
+++ b/src/events/EventBoundaryTypes.ts
@@ -1,23 +1,23 @@
-import type { FederatedEventTarget } from './FederatedEventTarget';
+import type { Container } from '../scene/container/Container';
 
 /**
  * The tracking data for each pointer held in the state of an {@link EventBoundary}.
  *
  * ```ts
  * pressTargetsByButton: {
- *     [id: number]: FederatedEventTarget[];
+ *     [id: number]: Container[];
  * };
  * clicksByButton: {
  *     [id: number]: {
  *         clickCount: number;
- *         target: FederatedEventTarget;
+ *         target: Container;
  *         timeStamp: number;
  *     };
  * };
- * overTargets: FederatedEventTarget[];
+ * overTargets: Container[];
  * ```
  * @typedef {object} TrackingData
- * @property {Record.<number, FederatedEventTarget>} pressTargetsByButton - The pressed containers'
+ * @property {Record.<number, Container>} pressTargetsByButton - The pressed containers'
  *  propagation paths by each button of the pointer.
  * @property {Record.<number, object>} clicksByButton - Holds clicking data for each button of the pointer.
  * @property {Container[]} overTargets - The Container propagation path over which the pointer is hovering.
@@ -25,16 +25,16 @@ import type { FederatedEventTarget } from './FederatedEventTarget';
  */
 export type TrackingData = {
     pressTargetsByButton: {
-        [id: number]: FederatedEventTarget[];
+        [id: number]: Container[];
     };
     clicksByButton: {
         [id: number]: {
             clickCount: number;
-            target: FederatedEventTarget;
+            target: Container;
             timeStamp: number;
         }
     };
-    overTargets: FederatedEventTarget[];
+    overTargets: Container[];
 };
 
 /**

--- a/src/events/EventsMixins.d.ts
+++ b/src/events/EventsMixins.d.ts
@@ -1,12 +1,12 @@
 import type { FederatedEventEmitterTypes } from './FederatedEventMap';
-import type { FederatedEventTarget, FederatedOptions, IFederatedContainer } from './FederatedEventTarget';
+import type { FederatedOptions, IFederatedContainer } from './FederatedEventTarget';
 
 declare global
 {
     namespace PixiMixins
     {
         // eslint-disable-next-line @typescript-eslint/no-empty-interface
-        interface Container extends Omit<FederatedEventTarget, keyof IFederatedContainer>, IFederatedContainer {}
+        interface Container extends IFederatedContainer {}
         // eslint-disable-next-line @typescript-eslint/no-empty-interface
         interface ContainerOptions extends FederatedOptions {}
 
@@ -15,10 +15,10 @@ declare global
 
         interface RendererOptions
         {
-        /**
-         * The default event mode for all display objects.
-         * @since 7.2.0
-         */
+            /**
+             * The default event mode for all display objects.
+             * @since 7.2.0
+             */
             eventMode?: import('./FederatedEventTarget').EventMode;
             /**
              * The event features that are enabled by the EventSystem.

--- a/src/events/FederatedEvent.ts
+++ b/src/events/FederatedEvent.ts
@@ -1,7 +1,7 @@
 import { Point } from '../maths/point/Point';
 
+import type { Container } from '../scene/container/Container';
 import type { EventBoundary } from './EventBoundary';
-import type { FederatedEventTarget } from './FederatedEventTarget';
 
 /**
  * A PixiJS compatible {@code Touch} event.
@@ -57,7 +57,7 @@ export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch>
     public readonly composed = false;
 
     /** The listeners of the event target that are being notified. */
-    public currentTarget: FederatedEventTarget;
+    public currentTarget: Container;
 
     /** Flags whether the default response of the user agent was prevent through this event. */
     public defaultPrevented = false;
@@ -78,7 +78,7 @@ export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch>
     public srcElement: EventTarget;
 
     /** The event target that this will be dispatched to. */
-    public target: FederatedEventTarget;
+    public target: Container;
 
     /** The timestamp of when the event was created. */
     public timeStamp: number;
@@ -99,7 +99,7 @@ export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch>
     public propagationImmediatelyStopped = false;
 
     /** The composed path of the event's propagation. The {@code target} is at the end. */
-    public path: FederatedEventTarget[];
+    public path: Container[];
 
     /** The {@link EventBoundary} that manages this event. Null for root events. */
     public readonly manager: EventBoundary;
@@ -153,7 +153,7 @@ export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch>
     }
 
     /** The propagation path for this event. Alias for {@link EventBoundary.propagationPath}. */
-    public composedPath(): FederatedEventTarget[]
+    public composedPath(): Container[]
     {
         // Find the propagation path if it isn't cached or if the target has changed since since
         // the last evaluation.

--- a/src/events/deprecatedTypes.ts
+++ b/src/events/deprecatedTypes.ts
@@ -1,0 +1,30 @@
+import type EventEmitter from 'eventemitter3';
+import type { EventMode, FederatedOptions } from './FederatedEventTarget';
+
+/**
+ * A simplified shape of an interactive object for the `eventTarget` property of a {@link FederatedEvent}
+ * @memberof events
+ * @deprecated since 8.1.4
+ */
+export interface FederatedEventTarget extends EventEmitter, EventTarget, Required<FederatedOptions>
+{
+    /** The parent of this event target. */
+    readonly parent?: FederatedEventTarget;
+
+    /** The children of this event target. */
+    readonly children?: ReadonlyArray<FederatedEventTarget>;
+
+    _internalEventMode: EventMode;
+
+    /** Returns true if the Container has interactive 'static' or 'dynamic' */
+    isInteractive: () => boolean;
+
+    // In Angular projects, zone.js is monkey patching the `EventTarget`
+    // by adding its own `removeAllListeners(event?: string): void;` method,
+    // so we have to override this signature when extending both `EventTarget` and `utils.EventEmitter`
+    // to make it compatible with Angular projects
+    // @see https://github.com/pixijs/pixijs/issues/8794
+
+    /** Remove all listeners, or those of the specified event. */
+    removeAllListeners(event?: string | symbol): this;
+}

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -151,8 +151,7 @@ export interface ContainerOptions<C extends ContainerChild = ContainerChild> ext
 }
 
 export interface Container<C extends ContainerChild>
-    extends Omit<PixiMixins.Container<C>, keyof EventEmitter<ContainerEvents<C> & AnyEvent>>,
-    EventEmitter<ContainerEvents<C> & AnyEvent> { }
+    extends PixiMixins.Container<C>, EventEmitter<ContainerEvents<C> & AnyEvent> {}
 
 /**
  * Container is a general-purpose display object that holds children. It also adds built-in support for advanced


### PR DESCRIPTION
Ok so this PR was a fun rabbit hole 😄 

# Overview

The main overview of what this PR is actually changing is that i have removed the abstraction of `IFederatedEventTarget` in favour of just using `Container`. `IFederatedContainer` is still mixed into the `Container`, which means that all types should work as before. 

I believe this change reflects a more accurate description of what object is stored in an `FederatedEvent`.

The benefits of this is that we don't need to do any typescript magic that decouples the two different implementations of `EventEmitter` e.g

This
```ts
export interface Container<C extends ContainerChild>
    extends Omit<PixiMixins.Container<C>, keyof EventEmitter<ContainerEvents<C> & AnyEvent>>,
    EventEmitter<ContainerEvents<C> & AnyEvent> { }
```

Becomes this
```ts
export interface Container<C extends ContainerChild>
    extends PixiMixins.Container<C>, EventEmitter<ContainerEvents<C> & AnyEvent> {}
```

## What Is This Fixing

The current implementation revealed a nasty bug with using our `PixiMixins` that is hidden in v7 due to `Container` extending `DisplayObject` and everyone will be attaching there custom properties to `Container`, not `DisplayObject`, because of this we have never seen the issue.

Hopefully i can try and explain it here...

If you try to add your own properties to `Container` in v8 currently like this:

```ts
declare namespace PixiMixins {
    interface Container {
        overrideMethod(): void
		returnThis(): this
    }
}
```
Then you try to override and use these methods like:
```ts
class NewContainer extends Container {
    testProperty: number;
    override overrideMethod(layout: ComputedLayout) {}
}

const container = new NewContainer();
const container2 = container.returnThis();
container.testProperty // type error: does not exist
```

We get two TS errors:

- `Class 'Container` defines instance member property `overrideMethod`, but extended class `NewContainer` defines it as instance member function.
- Property 'testProperty' does not exist on type `Container`

The first issue is that typescript believe the `overrideMethod` is a property on `Container` and not a method. So it wants you to declare it like this
```ts
override overrideMethod = (layout: ComputedLayout) => {}
```
However this isn't accurate as if we wanted to declare it as a property it should be defined like this
```ts
declare namespace PixiMixins {
    interface Container {
        overrideMethod: ()=> void
    }
}
```

The second issue is that `this` is not being respected correctly. It should be returning `NewContainer`, however it always returns `Container`

Now I have zero idea what sort of typescript magic is going on that messes up these types so badly but the change here is minimal and seems to work.
