### PR TITLE
fix: masks interfering with interaction

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -548,7 +548,7 @@ export class EventBoundary
     private _interactivePrune(container: Container): boolean
     {
         // If container is a mask, invisible, or not renderable then it cannot be hit directly.
-        if (!container || !container.visible || !container.renderable)
+        if (!container || !container.visible || !container.renderable || !container.includeInBuild || !container.measurable)
         {
             return true;
         }


### PR DESCRIPTION
Interaction wasn't checking if the container is measurable or in the build which meant that some masks where being included in the interaction checks