### PR TITLE
fix: event leak in graphics pipe

### DIFF
--- a/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
+++ b/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
@@ -57,7 +57,7 @@ export const glUploadImageResource = {
             else
             {
                 gl.texSubImage2D(
-                    glTexture.target,
+                    gl.TEXTURE_2D,
                     0,
                     0,
                     0,
@@ -67,15 +67,27 @@ export const glUploadImageResource = {
                 );
             }
         }
-        else if (glWidth === textureWidth && glHeight === textureHeight)
+        else if (glWidth === textureWidth || glHeight === textureHeight)
         {
             gl.texSubImage2D(
                 gl.TEXTURE_2D,
                 0,
                 0,
                 0,
-                source.width,
-                source.height,
+                glTexture.format,
+                glTexture.type,
+                source.resource as TexImageSource
+            );
+        }
+        else if (webGLVersion === 2)
+        {
+            gl.texImage2D(
+                glTexture.target,
+                0,
+                glTexture.internalFormat,
+                textureWidth,
+                textureHeight,
+                0,
                 glTexture.format,
                 glTexture.type,
                 source.resource as TexImageSource
@@ -83,32 +95,14 @@ export const glUploadImageResource = {
         }
         else
         {
-            // eslint-disable-next-line no-lonely-if
-            if (webGLVersion === 2)
-            {
-                gl.texImage2D(
-                    glTexture.target,
-                    0,
-                    glTexture.internalFormat,
-                    textureWidth,
-                    textureHeight,
-                    0,
-                    glTexture.format,
-                    glTexture.type,
-                    source.resource as TexImageSource
-                );
-            }
-            else
-            {
-                gl.texImage2D(
-                    glTexture.target,
-                    0,
-                    glTexture.internalFormat,
-                    glTexture.format,
-                    glTexture.type,
-                    source.resource as TexImageSource
-                );
-            }
+            gl.texImage2D(
+                glTexture.target,
+                0,
+                glTexture.internalFormat,
+                glTexture.format,
+                glTexture.type,
+                source.resource as TexImageSource
+            );
         }
 
         glTexture.width = textureWidth;

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1048,6 +1048,7 @@ export class GraphicsContext extends EventEmitter<{
      */
     public clear(): this
     {
+        this._activePath.clear();
         this.instructions.length = 0;
         this.resetTransform();
 

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -272,7 +272,10 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
 
         for (const i in this._gpuContextHash)
         {
-            this.onGraphicsContextDestroy(this._gpuContextHash[i].context);
+            if (this._gpuContextHash[i])
+            {
+                this.onGraphicsContextDestroy(this._gpuContextHash[i].context);
+            }
         }
     }
 }

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -26,6 +26,7 @@ interface GeometryData
 export class GpuGraphicsContext
 {
     public isBatchable: boolean;
+    public context: GraphicsContext;
     public batches: BatchableGraphics[] = [];
     public geometryData: GeometryData = {
         vertices: [],
@@ -92,7 +93,6 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
     private _gpuContextHash: Record<number, GpuGraphicsContext> = {};
     // used for non-batchable graphics
     private _graphicsDataContextHash: Record<number, GraphicsContextRenderData> = Object.create(null);
-    private readonly _needsContextNeedsRebuild: GraphicsContext[] = [];
 
     /**
      * Runner init called, update the default options
@@ -224,24 +224,19 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
     {
         const gpuContext = new GpuGraphicsContext();
 
+        gpuContext.context = context;
+
         this._gpuContextHash[context.uid] = gpuContext;
 
-        context.on('update', this.onGraphicsContextUpdate, this);
         context.on('destroy', this.onGraphicsContextDestroy, this);
 
         return this._gpuContextHash[context.uid];
-    }
-
-    protected onGraphicsContextUpdate(context: GraphicsContext)
-    {
-        this._needsContextNeedsRebuild.push(context);
     }
 
     protected onGraphicsContextDestroy(context: GraphicsContext)
     {
         this._cleanGraphicsContextData(context);
 
-        context.off('update', this.onGraphicsContextUpdate, this);
         context.off('destroy', this.onGraphicsContextDestroy, this);
 
         this._gpuContextHash[context.uid] = null;
@@ -274,15 +269,10 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
     public destroy()
     {
         // Clean up all graphics contexts
-        for (const context of this._needsContextNeedsRebuild)
-        {
-            // only clean if it exists
-            if (this._gpuContextHash[context.uid])
-            {
-                this.onGraphicsContextDestroy(context);
-            }
-        }
 
-        this._needsContextNeedsRebuild.length = 0;
+        for (const i in this._gpuContextHash)
+        {
+            this.onGraphicsContextDestroy(this._gpuContextHash[i].context);
+        }
     }
 }

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -213,13 +213,16 @@ export class GraphicsPipe implements RenderPipe<Graphics>
             return batchClone;
         });
 
-        this._graphicsBatchesHash[graphics.uid] = batches;
-
-        // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
-        graphics.on('destroyed', () =>
+        if (this._graphicsBatchesHash[graphics.uid] === undefined)
         {
-            this.destroyRenderable(graphics);
-        });
+            // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
+            graphics.on('destroyed', () =>
+            {
+                this.destroyRenderable(graphics);
+            });
+        }
+
+        this._graphicsBatchesHash[graphics.uid] = batches;
 
         return batches;
     }

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -245,6 +245,20 @@ describe('Graphics', () =>
             expect(graphicsData.geometry.indexBuffer.data.length).toEqual(3 * 6);
             expect(graphicsData.geometry.buffers[0].data.length).toEqual(3 * 4 * 6);
         });
+
+        it('should clear a graphics correctly', async () =>
+        {
+            const graphics = new Graphics()
+                .rect(0, 0, 1000, 1000)
+                .rect(1000, 1000, 1000, 1000)
+                .rect(2000, 2000, 1000, 1000);
+
+            graphics.clear();
+
+            expect(graphics.context['_activePath'].instructions.length).toEqual(0);
+            expect(graphics.context.instructions.length).toEqual(0);
+            expect(graphics.context['_transform'].toArray()).toEqual(Matrix.IDENTITY.toArray());
+        });
     });
 
     // todo: all these tests should be moved to GraphicsContext.test.ts, with equivalent changes for api


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes a graphics leak, where we were re-adding the graphcis object onDestroy event on each rebuild - rather than just the once on init. This PR fixes it.

There was also a second update list that was not being cleared (or used!) so i removed it.



##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10549
