### PR TITLE
fix: graphics clear not clearing mid path.

### DIFF
--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1048,6 +1048,7 @@ export class GraphicsContext extends EventEmitter<{
      */
     public clear(): this
     {
+        this._activePath.clear();
         this.instructions.length = 0;
         this.resetTransform();
 

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -245,6 +245,20 @@ describe('Graphics', () =>
             expect(graphicsData.geometry.indexBuffer.data.length).toEqual(3 * 6);
             expect(graphicsData.geometry.buffers[0].data.length).toEqual(3 * 4 * 6);
         });
+
+        it('should clear a graphics correctly', async () =>
+        {
+            const graphics = new Graphics()
+                .rect(0, 0, 1000, 1000)
+                .rect(1000, 1000, 1000, 1000)
+                .rect(2000, 2000, 1000, 1000);
+
+            graphics.clear();
+
+            expect(graphics.context['_activePath'].instructions.length).toEqual(0);
+            expect(graphics.context.instructions.length).toEqual(0);
+            expect(graphics.context['_transform'].toArray()).toEqual(Matrix.IDENTITY.toArray());
+        });
     });
 
     // todo: all these tests should be moved to GraphicsContext.test.ts, with equivalent changes for api


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes an issue where clearing the graphics object mid draw was not removing previous instructions.
All good now!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10550