### PR TITLE
chore: add better error checking for unsupported shader uniform types

### DIFF
--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -1,10 +1,10 @@
 import { uid } from '../../../../utils/data/uid';
 import { createIdFromString } from '../utils/createIdFromString';
+import { UNIFORM_TYPES_MAP, UNIFORM_TYPES_VALUES, type UniformData } from './types';
 import { getDefaultUniformValue } from './utils/getDefaultUniformValue';
 
 import type { BindResource } from '../../gpu/shader/BindResource';
 import type { Buffer } from '../buffer/Buffer';
-import type { UniformData } from './types';
 
 type FLOPS<T = UniformData> = T extends { value: infer V } ? V : never;
 
@@ -151,6 +151,13 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
 
             uniformData.name = i;
             uniformData.size = uniformData.size ?? 1;
+
+            if (!UNIFORM_TYPES_MAP[uniformData.type])
+            {
+                // eslint-disable-next-line max-len
+                throw new Error(`Uniform type ${uniformData.type} is not supported. Supported uniform types are: ${UNIFORM_TYPES_VALUES.join(', ')}`);
+            }
+
             uniformData.value ??= getDefaultUniformValue(uniformData.type, uniformData.size);
 
             uniforms[i] = uniformData.value as ExtractUniformObject<UNIFORMS>[keyof UNIFORMS];

--- a/src/rendering/renderers/shared/shader/types.ts
+++ b/src/rendering/renderers/shared/shader/types.ts
@@ -24,8 +24,6 @@ export const UNIFORM_TYPES_MAP = UNIFORM_TYPES_VALUES.reduce((acc, type) =>
     return acc;
 }, {} as Record<UNIFORM_TYPES, boolean>);
 
-/* eslint-disable quote-props */
-
 export type UNIFORM_TYPES_SINGLE = typeof UNIFORM_TYPES_VALUES[number];
 
 type OPTIONAL_SPACE = ' ' | '';

--- a/src/rendering/renderers/shared/shader/types.ts
+++ b/src/rendering/renderers/shared/shader/types.ts
@@ -1,26 +1,34 @@
+// TODO add more types as required
+export const UNIFORM_TYPES_VALUES = [
+    'f32',
+    'i32',
+    'vec2<f32>',
+    'vec3<f32>',
+    'vec4<f32>',
+    'mat2x2<f32>',
+    'mat3x3<f32>',
+    'mat4x4<f32>',
+    'mat3x2<f32>',
+    'mat4x2<f32>',
+    'mat2x3<f32>',
+    'mat4x3<f32>',
+    'mat2x4<f32>',
+    'mat3x4<f32>'
+] as const;
+
+/** useful for checking if a type is supported - a map of supported types with a true value. */
+export const UNIFORM_TYPES_MAP = UNIFORM_TYPES_VALUES.reduce((acc, type) =>
+{
+    acc[type] = true;
+
+    return acc;
+}, {} as Record<UNIFORM_TYPES, boolean>);
+
 /* eslint-disable quote-props */
-export type UNIFORM_TYPES_SINGLE =
-    'f32' |
-    'i32' |
-    'vec2<f32>' |
-    'vec3<f32>' |
-    'vec4<f32>' |
 
-    'mat2x2<f32>' |
-    'mat3x3<f32>' |
-    'mat4x4<f32>' |
+export type UNIFORM_TYPES_SINGLE = typeof UNIFORM_TYPES_VALUES[number];
 
-    'mat3x2<f32>' |
-    'mat4x2<f32>' |
-
-    'mat2x3<f32>' |
-    'mat4x3<f32>' |
-
-    'mat2x4<f32>' |
-    'mat3x4<f32>';
-    // TODO add more types as required
-
-    type OPTIONAL_SPACE = ' ' | '';
+type OPTIONAL_SPACE = ' ' | '';
 
 export type UNIFORM_TYPES_ARRAY = `array<${UNIFORM_TYPES_SINGLE},${OPTIONAL_SPACE}${number}>`;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Added a check to `UniformGroup` that ensures only valid uniform types are used:

`Error: Uniform type doopboopMatrix100x100 is not supported. Supported uniform types are: f32, i32, vec2<f32>, vec3<f32>, vec4<f32>, mat2x2<f32>, mat3x3<f32>, mat4x4<f32>, mat3x2<f32>, mat4x2<f32>, mat2x3<f32>, mat4x3<f32>, mat2x4<f32>, mat3x4<f32>`
