### PR TITLE
fix: destroy renderGroups

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1320,7 +1320,6 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         // remove children is faster than removeChild..
         const oldChildren = this.removeChildren(0, this.children.length);
 
-        this.removeFromParent();
         this.parent = null;
         this._maskEffect = null;
         this._filterEffect = null;
@@ -1342,6 +1341,12 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             {
                 oldChildren[i].destroy(options);
             }
+        }
+
+        if (this.renderGroup)
+        {
+            this.renderGroup.destroy();
+            this.renderGroup = null;
         }
     }
 }

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1343,11 +1343,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             }
         }
 
-        if (this.renderGroup)
-        {
-            this.renderGroup.destroy();
-            this.renderGroup = null;
-        }
+        this.renderGroup?.destroy();
+        this.renderGroup = null;
     }
 }
 

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1320,6 +1320,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         // remove children is faster than removeChild..
         const oldChildren = this.removeChildren(0, this.children.length);
 
+        this.removeFromParent();
         this.parent = null;
         this._maskEffect = null;
         this._filterEffect = null;

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -220,6 +220,17 @@ export class RenderGroup implements Instruction
         }
     }
 
+    public destroy()
+    {
+        this.renderGroupParent = null;
+        this.root = null;
+        (this.childrenRenderablesToUpdate as any) = null;
+        (this.childrenToUpdate as any) = null;
+        (this.renderGroupChildren as any) = null;
+        (this._onRenderContainers as any) = null;
+        this.instructionSet = null;
+    }
+
     public getChildren(out: Container[] = []): Container[]
     {
         const children = this.root.children;

--- a/tests/renderering/scene/Container.test.ts
+++ b/tests/renderering/scene/Container.test.ts
@@ -365,6 +365,45 @@ describe('Container', () =>
             expect(container.position).toBeNull();
             expect(child.position).toBeNull();
         });
+
+        it('should destroy render groups', () =>
+        {
+            const container = new Container({ isRenderGroup: true });
+
+            const child = new Container({
+                isRenderGroup: true,
+                children: [new Container()],
+            });
+
+            const renderGroup = container.renderGroup;
+            const renderGroup2 = child.renderGroup;
+
+            const spy = jest.spyOn(renderGroup, 'destroy');
+            const spy2 = jest.spyOn(renderGroup2, 'destroy');
+
+            container.addChild(child);
+            container.destroy({
+                children: true,
+            });
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy2).toHaveBeenCalled();
+
+            expect(container.renderGroup).toBeNull();
+            expect(child.renderGroup).toBeNull();
+
+            expect(renderGroup.renderGroupParent).toBeNull();
+            expect(renderGroup.childrenRenderablesToUpdate).toBeNull();
+            expect(renderGroup.instructionSet).toBeNull();
+            expect(renderGroup.renderGroupChildren).toBeNull();
+            expect(renderGroup['_onRenderContainers']).toBeNull();
+
+            expect(renderGroup2.renderGroupParent).toBeNull();
+            expect(renderGroup2.childrenRenderablesToUpdate).toBeNull();
+            expect(renderGroup2.instructionSet).toBeNull();
+            expect(renderGroup2.renderGroupChildren).toBeNull();
+            expect(renderGroup2['_onRenderContainers']).toBeNull();
+        });
     });
 
     function assertRemovedFromParent(parent: Container, container: Container, child: Container, functionToAssert: () => void)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Added a destroy function to renderGroup and also made sure it is called when the container that owns it is destroyed.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

fixes #10533