### PR TITLE
fix: allow renderers to be created without autoDetectRenderer

### DIFF
--- a/src/rendering/renderers/autoDetectRenderer.ts
+++ b/src/rendering/renderers/autoDetectRenderer.ts
@@ -1,26 +1,19 @@
-import { autoDetectEnvironment } from '../../environment/autoDetectEnvironment';
 import { isWebGLSupported } from '../../utils/browser/isWebGLSupported';
 import { isWebGPUSupported } from '../../utils/browser/isWebGPUSupported';
 import { AbstractRenderer } from './shared/system/AbstractRenderer';
 
 import type { WebGLOptions } from './gl/WebGLRenderer';
 import type { WebGPUOptions } from './gpu/WebGPURenderer';
-import type { Renderer } from './types';
+import type { Renderer, RendererOptions } from './types';
 
 /**
  * Options for {@link rendering.autoDetectRenderer}.
  * @memberof rendering
  */
-export interface AutoDetectOptions extends WebGLOptions, WebGPUOptions
+export interface AutoDetectOptions extends RendererOptions
 {
     /** The preferred renderer type. WebGPU is recommended as its generally faster than WebGL. */
     preference?: 'webgl' | 'webgpu'// | 'canvas';
-    /**
-     * Whether to manage the dynamic imports of the renderer code. It is true by default, this means
-     * PixiJS will load all the default pixi systems and extensions. If you set this to false, then
-     * you as the dev will need to manually import the systems and extensions you need.
-     */
-    manageImports?: boolean;
     /** Optional WebGPUOptions to pass only to WebGPU renderer. */
     webgpu?: Partial<WebGPUOptions>;
     /** Optional WebGLOptions to pass only to the WebGL renderer */
@@ -89,11 +82,6 @@ export async function autoDetectRenderer(options: Partial<AutoDetectOptions>): P
     }
 
     let RendererClass: new () => Renderer;
-
-    await autoDetectEnvironment(
-        options.manageImports ?? true,
-    );
-
     let finalOptions: Partial<AutoDetectOptions> = {};
 
     for (let i = 0; i < preferredOrder.length; i++)

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -1,4 +1,5 @@
 import { Color } from '../../../../color/Color';
+import { autoDetectEnvironment } from '../../../../environment/autoDetectEnvironment';
 import { Container } from '../../../../scene/container/Container';
 import { unsafeEvalSupported } from '../../../../utils/browser/unsafeEvalSupported';
 import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
@@ -19,6 +20,7 @@ import type { PipeConstructor } from '../instructions/RenderPipe';
 import type { RenderSurface } from '../renderTarget/RenderTargetSystem';
 import type { Texture } from '../texture/Texture';
 import type { ViewSystem, ViewSystemDestroyOptions } from '../view/ViewSystem';
+import type { SharedRendererOptions } from './SharedSystems';
 import type { System, SystemConstructor } from './System';
 
 interface RendererConfig
@@ -129,7 +131,7 @@ type Runners = {[key in DefaultRunners]: SystemRunner} & {
  */
 /* eslint-enable max-len */
 export class AbstractRenderer<
-    PIPES, OPTIONS extends PixiMixins.RendererOptions, CANVAS extends ICanvas = HTMLCanvasElement
+    PIPES, OPTIONS extends SharedRendererOptions, CANVAS extends ICanvas = HTMLCanvasElement
 > extends EventEmitter<{resize: [number, number]}>
 {
     /** The default options for the renderer. */
@@ -185,6 +187,7 @@ export class AbstractRenderer<
     public textureGenerator: GenerateTextureSystem;
 
     protected _initOptions: OPTIONS = {} as OPTIONS;
+    protected config: RendererConfig;
 
     private _systemsHash: Record<string, System> = Object.create(null);
     private _lastObjectRendered: Container;
@@ -199,13 +202,11 @@ export class AbstractRenderer<
         super();
         this.type = config.type;
         this.name = config.name;
+        this.config = config;
 
-        const combinedRunners = [...defaultRunners, ...(config.runners ?? [])];
+        const combinedRunners = [...defaultRunners, ...(this.config.runners ?? [])];
 
         this._addRunners(...combinedRunners);
-        this._addSystems(config.systems);
-        this._addPipes(config.renderPipes, config.renderPipeAdaptors);
-
         // Validation check that this environment support `new Function`
         this._unsafeEvalCheck();
     }
@@ -216,6 +217,13 @@ export class AbstractRenderer<
      */
     public async init(options: Partial<OPTIONS> = {})
     {
+        await autoDetectEnvironment(
+            options.manageImports ?? true,
+        );
+
+        this._addSystems(this.config.systems);
+        this._addPipes(this.config.renderPipes, this.config.renderPipeAdaptors);
+
         // loop through all systems...
         for (const systemName in this._systemsHash)
         {

--- a/src/rendering/renderers/shared/system/SharedSystems.ts
+++ b/src/rendering/renderers/shared/system/SharedSystems.ts
@@ -43,4 +43,12 @@ export const SharedRenderPipes = [
  * Options for the shared systems of a renderer.
  * @memberof rendering
  */
-export interface SharedRendererOptions extends ExtractRendererOptions<typeof SharedSystems>, PixiMixins.RendererOptions{}
+export interface SharedRendererOptions extends ExtractRendererOptions<typeof SharedSystems>, PixiMixins.RendererOptions
+{
+    /**
+     * Whether to manage the dynamic imports of the renderer code. It is true by default, this means
+     * PixiJS will load all the default pixi systems and extensions. If you set this to false, then
+     * you as the dev will need to manually import the systems and extensions you need.
+     */
+    manageImports?: boolean;
+}


### PR DESCRIPTION
Fixes: #10366 and #10554

We now move the loading the environment into `AbstractRenderer`, which populates all of the render pipes, into the `init` call. Tis allows the renderer to be created correctly without using `autoDetectRenderer`

I also tidied up a few interfaces so now the types extend the correct things