### PR TITLE
chore: improve types for asset parsers

### DIFF
--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -1,8 +1,33 @@
 import type { ExtensionType } from '../extensions/Extensions';
 import type { CacheParser } from './cache/CacheParser';
 import type { FormatDetectionParser } from './detections/types';
-import type { LoaderParserVerbose } from './loader/parsers/LoaderParser';
+import type { LoaderParserAdvanced } from './loader/parsers/LoaderParser';
 import type { ResolveURLParser } from './resolver/types';
+
+/**
+ * A more verbose version of the AssetExtension,
+ * allowing you to set the cached, loaded, parsed, and unloaded asset separately
+ * @memberof assets
+ */
+interface AssetExtensionAdvanced<
+    ASSET = any,
+    PARSED_ASSET = ASSET,
+    UNLOAD_ASSET = ASSET,
+    CACHE_ASSET = ASSET,
+    META_DATA = any
+>
+{
+    /** The type of extension */
+    extension: ExtensionType.Asset,
+    /** the asset loader */
+    loader?: LoaderParserAdvanced<ASSET, PARSED_ASSET, UNLOAD_ASSET, META_DATA>,
+    /** the asset resolve parser */
+    resolver?: Partial<ResolveURLParser>,
+    /** the asset cache parser */
+    cache?: Partial<CacheParser<CACHE_ASSET>>,
+    /** the asset format detection parser */
+    detection?: Partial<FormatDetectionParser>,
+}
 
 /**
  * This developer convenience object allows developers to group
@@ -59,26 +84,6 @@ import type { ResolveURLParser } from './resolver/types';
  * }
  * @memberof assets
  */
-interface AssetExtensionVerbose<
-    ASSET = any,
-    PARSED_ASSET = ASSET,
-    UNLOAD_ASSET = ASSET,
-    CACHE_ASSET = ASSET,
-    META_DATA = any
->
-{
-    /** The type of extension */
-    extension: ExtensionType.Asset,
-    /** the asset loader */
-    loader?: LoaderParserVerbose<ASSET, PARSED_ASSET, UNLOAD_ASSET, META_DATA>,
-    /** the asset resolve parser */
-    resolver?: Partial<ResolveURLParser>,
-    /** the asset cache parser */
-    cache?: Partial<CacheParser<CACHE_ASSET>>,
-    /** the asset format detection parser */
-    detection?: Partial<FormatDetectionParser>,
-}
+interface AssetExtension<ASSET = any, META_DATA = any> extends AssetExtensionAdvanced<ASSET, META_DATA>{}
 
-interface AssetExtension<ASSET = any, META_DATA = any> extends AssetExtensionVerbose<ASSET, META_DATA>{}
-
-export type { AssetExtension, AssetExtensionVerbose };
+export type { AssetExtension, AssetExtensionAdvanced };

--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -1,7 +1,7 @@
 import type { ExtensionType } from '../extensions/Extensions';
 import type { CacheParser } from './cache/CacheParser';
 import type { FormatDetectionParser } from './detections/types';
-import type { LoaderParser } from './loader/parsers/LoaderParser';
+import type { LoaderParserVerbose } from './loader/parsers/LoaderParser';
 import type { ResolveURLParser } from './resolver/types';
 
 /**
@@ -59,18 +59,26 @@ import type { ResolveURLParser } from './resolver/types';
  * }
  * @memberof assets
  */
-interface AssetExtension<ASSET = any, META_DATA = any>
+interface AssetExtensionVerbose<
+    ASSET = any,
+    PARSED_ASSET = ASSET,
+    UNLOAD_ASSET = ASSET,
+    CACHE_ASSET = ASSET,
+    META_DATA = any
+>
 {
     /** The type of extension */
     extension: ExtensionType.Asset,
     /** the asset loader */
-    loader?: LoaderParser<ASSET, META_DATA>,
+    loader?: LoaderParserVerbose<ASSET, PARSED_ASSET, UNLOAD_ASSET, META_DATA>,
     /** the asset resolve parser */
     resolver?: Partial<ResolveURLParser>,
     /** the asset cache parser */
-    cache?: Partial<CacheParser<ASSET>>,
+    cache?: Partial<CacheParser<CACHE_ASSET>>,
     /** the asset format detection parser */
     detection?: Partial<FormatDetectionParser>,
 }
 
-export type { AssetExtension };
+interface AssetExtension<ASSET = any, META_DATA = any> extends AssetExtensionVerbose<ASSET, META_DATA>{}
+
+export type { AssetExtension, AssetExtensionVerbose };

--- a/src/assets/loader/parsers/LoaderParser.ts
+++ b/src/assets/loader/parsers/LoaderParser.ts
@@ -37,7 +37,13 @@ export enum LoaderParserPriority
  * Some loaders may only be used for parsing, some only for loading, and some for both!
  * @memberof assets
  */
-export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<string, any>>
+export interface LoaderParserVerbose<
+    ASSET = any,
+    PARSED_ASSET = ASSET,
+    UNLOAD_ASSET = ASSET,
+    META_DATA = any,
+    CONFIG = Record<string, any>
+>
 {
     /** Should be ExtensionType.LoaderParser */
     extension?: ExtensionMetadata;
@@ -65,7 +71,7 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
      * @param resolvedAsset - Any custom additional information relevant to the asset being loaded
      * @param loader - The loader instance
      */
-    load?: <T>(url: string, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<T>;
+    load?: <T>(url: string, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<ASSET | T>;
 
     /**
      * This function is used to test if the parse function should be run on the asset
@@ -82,7 +88,7 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
      * @param resolvedAsset - Any custom additional information relevant to the asset being loaded
      * @param loader - The loader instance
      */
-    parse?: <T>(asset: ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<T>;
+    parse?: <T>(asset: ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<PARSED_ASSET | T>;
 
     /**
      * If an asset is parsed using this parser, the unload function will be called when the user requests an asset
@@ -91,5 +97,8 @@ export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<stri
      * @param resolvedAsset - Any custom additional information relevant to the asset being loaded
      * @param loader - The loader instance
      */
-    unload?: (asset: ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<void>;
+    unload?: (asset: UNLOAD_ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<void> | void;
 }
+
+export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<string, any>>
+    extends LoaderParserVerbose<ASSET, ASSET, ASSET, META_DATA, CONFIG> {}

--- a/src/assets/loader/parsers/LoaderParser.ts
+++ b/src/assets/loader/parsers/LoaderParser.ts
@@ -19,25 +19,8 @@ export enum LoaderParserPriority
     High = 2,
 }
 
-/**
- * The interface to define a loader parser *(all functions are optional)*.
- *
- * When you create a `parser` object, the flow for every asset loaded is:
- *
- * 1. `parser.test()` - Each URL to load will be tested here, if the test is passed the assets are
- * loaded using the load function below. Good place to test for things like file extensions!
- * 2. `parser.load()` - This is the promise that loads the URL provided resolves with a loaded asset
- * if returned by the parser.
- * 3. `parser.testParse()` - This function is used to test if the parse function should be run on the
- *  asset If this returns true then parse is called with the asset
- * 4. `parse.parse()` - Gets called on the asset it testParse passes. Useful to convert a raw asset
- *  into something more useful
- *
- * <br/>
- * Some loaders may only be used for parsing, some only for loading, and some for both!
- * @memberof assets
- */
-export interface LoaderParserVerbose<
+/** A more verbose version of the LoaderParser, allowing you to set the loaded, parsed, and unloaded asset separately */
+export interface LoaderParserAdvanced<
     ASSET = any,
     PARSED_ASSET = ASSET,
     UNLOAD_ASSET = ASSET,
@@ -100,5 +83,23 @@ export interface LoaderParserVerbose<
     unload?: (asset: UNLOAD_ASSET, resolvedAsset?: ResolvedAsset<META_DATA>, loader?: Loader) => Promise<void> | void;
 }
 
+/**
+ * The interface to define a loader parser *(all functions are optional)*.
+ *
+ * When you create a `parser` object, the flow for every asset loaded is:
+ *
+ * 1. `parser.test()` - Each URL to load will be tested here, if the test is passed the assets are
+ * loaded using the load function below. Good place to test for things like file extensions!
+ * 2. `parser.load()` - This is the promise that loads the URL provided resolves with a loaded asset
+ * if returned by the parser.
+ * 3. `parser.testParse()` - This function is used to test if the parse function should be run on the
+ *  asset If this returns true then parse is called with the asset
+ * 4. `parse.parse()` - Gets called on the asset it testParse passes. Useful to convert a raw asset
+ *  into something more useful
+ *
+ * <br/>
+ * Some loaders may only be used for parsing, some only for loading, and some for both!
+ * @memberof assets
+ */
 export interface LoaderParser<ASSET = any, META_DATA = any, CONFIG = Record<string, any>>
-    extends LoaderParserVerbose<ASSET, ASSET, ASSET, META_DATA, CONFIG> {}
+    extends LoaderParserAdvanced<ASSET, ASSET, ASSET, META_DATA, CONFIG> {}

--- a/src/assets/loader/parsers/loadJson.ts
+++ b/src/assets/loader/parsers/loadJson.ts
@@ -34,4 +34,4 @@ export const loadJson = {
 
         return json as T;
     },
-} as LoaderParser;
+} satisfies LoaderParser<string>;

--- a/src/assets/loader/parsers/loadTxt.ts
+++ b/src/assets/loader/parsers/loadTxt.ts
@@ -20,6 +20,7 @@ export const loadTxt = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.Low,
+        name: 'loadTxt',
     },
 
     test(url: string): boolean
@@ -35,4 +36,4 @@ export const loadTxt = {
 
         return txt;
     },
-} as LoaderParser;
+} satisfies LoaderParser<string>;

--- a/src/assets/loader/parsers/loadWebFont.ts
+++ b/src/assets/loader/parsers/loadWebFont.ts
@@ -184,7 +184,7 @@ export const loadWebFont = {
         return null;
     },
 
-    unload(font: FontFace | FontFace[]): void
+    unload(font: FontFace | FontFace[])
     {
         (Array.isArray(font) ? font : [font])
             .forEach((t) =>
@@ -193,4 +193,4 @@ export const loadWebFont = {
                 DOMAdapter.get().getFontFaceSet().delete(t);
             });
     }
-} as LoaderParser<FontFace | FontFace[]>;
+} satisfies LoaderParser<FontFace | FontFace[]>;

--- a/src/assets/loader/parsers/loadWebFont.ts
+++ b/src/assets/loader/parsers/loadWebFont.ts
@@ -184,7 +184,7 @@ export const loadWebFont = {
         return null;
     },
 
-    unload(font: FontFace | FontFace[])
+    unload(font: FontFace | FontFace[]): void
     {
         (Array.isArray(font) ? font : [font])
             .forEach((t) =>

--- a/src/assets/loader/parsers/textures/loadSVG.ts
+++ b/src/assets/loader/parsers/textures/loadSVG.ts
@@ -48,6 +48,7 @@ export const loadSvg = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.Low,
+        name: 'loadSVG',
     },
 
     name: 'loadSVG',
@@ -81,7 +82,7 @@ export const loadSvg = {
         asset.destroy(true);
     }
 
-} as LoaderParser<Texture | GraphicsContext, TextureSourceOptions, LoadSVGConfig>;
+} satisfies LoaderParser<Texture | GraphicsContext, TextureSourceOptions & LoadSVGConfig>;
 
 async function loadAsTexture(
     url: string,

--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -103,6 +103,7 @@ export const loadTextures = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.High,
+        name: 'loadTextures',
     },
 
     config: {
@@ -167,4 +168,4 @@ export const loadTextures = {
     {
         texture.destroy(true);
     }
-} as LoaderParser<Texture, TextureSourceOptions, LoadTextureConfig>;
+} satisfies LoaderParser<Texture, TextureSourceOptions, LoadTextureConfig>;

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -123,9 +123,8 @@ export const loadVideoTextures = {
 
     extension: {
         type: ExtensionType.LoadParser,
+        name: 'loadVideo',
     },
-
-    config: null,
 
     test(url: string): boolean
     {
@@ -223,4 +222,4 @@ export const loadVideoTextures = {
     {
         texture.destroy(true);
     }
-} as LoaderParser<Texture, VideoSourceOptions, null>;
+} satisfies LoaderParser<Texture, VideoSourceOptions>;

--- a/src/assets/resolver/parsers/resolveJsonUrl.ts
+++ b/src/assets/resolver/parsers/resolveJsonUrl.ts
@@ -10,8 +10,11 @@ import type { ResolveURLParser } from '../types';
  * @memberof assets
  */
 export const resolveJsonUrl = {
-    extension: ExtensionType.ResolveParser,
+    extension: {
+        type: ExtensionType.ResolveParser,
+        name: 'resolve-json',
+    },
     test: (value: string): boolean =>
         Resolver.RETINA_PREFIX.test(value) && value.endsWith('.json'),
     parse: resolveTextureUrl.parse,
-} as ResolveURLParser;
+} satisfies ResolveURLParser;

--- a/src/assets/resolver/parsers/resolveJsonUrl.ts
+++ b/src/assets/resolver/parsers/resolveJsonUrl.ts
@@ -13,7 +13,7 @@ export const resolveJsonUrl = {
     extension: {
         type: ExtensionType.ResolveParser,
         priority: -2,
-        name: 'resolve-json',
+        name: 'resolveJson',
     },
     test: (value: string): boolean =>
         Resolver.RETINA_PREFIX.test(value) && value.endsWith('.json'),

--- a/src/assets/resolver/parsers/resolveTextureUrl.ts
+++ b/src/assets/resolver/parsers/resolveTextureUrl.ts
@@ -2,7 +2,6 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import { loadTextures } from '../../loader/parsers/textures/loadTextures';
 import { Resolver } from '../Resolver';
 
-import type { UnresolvedAsset } from '../../types';
 import type { ResolveURLParser } from '../types';
 
 /**
@@ -10,12 +9,15 @@ import type { ResolveURLParser } from '../types';
  * @memberof assets
  */
 export const resolveTextureUrl = {
-    extension: ExtensionType.ResolveParser,
+    extension: {
+        type: ExtensionType.ResolveParser,
+        name: 'resolve-texture',
+    },
     test: loadTextures.test,
-    parse: (value: string): UnresolvedAsset =>
+    parse: (value: string) =>
         ({
             resolution: parseFloat(Resolver.RETINA_PREFIX.exec(value)?.[1] ?? '1'),
             format: value.split('.').pop(),
             src: value,
         }),
-} as ResolveURLParser;
+} satisfies ResolveURLParser;

--- a/src/assets/resolver/parsers/resolveTextureUrl.ts
+++ b/src/assets/resolver/parsers/resolveTextureUrl.ts
@@ -11,7 +11,7 @@ import type { ResolveURLParser } from '../types';
 export const resolveTextureUrl = {
     extension: {
         type: ExtensionType.ResolveParser,
-        name: 'resolve-texture',
+        name: 'resolveTexture',
     },
     test: loadTextures.test,
     parse: (value: string) =>

--- a/src/assets/resolver/types.ts
+++ b/src/assets/resolver/types.ts
@@ -26,5 +26,5 @@ export interface ResolveURLParser
     /** the test to perform on the url to determine if it should be parsed */
     test: (url: string) => boolean;
     /** the function that will convert the url into an object */
-    parse: (value: string) => ResolvedAsset;
+    parse: (value: string) => ResolvedAsset & {[key: string]: any};
 }

--- a/src/compressed-textures/basis/loadBasis.ts
+++ b/src/compressed-textures/basis/loadBasis.ts
@@ -17,6 +17,7 @@ export const loadBasis = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.High,
+        name: 'loadBasis',
     },
 
     name: 'loadBasis',
@@ -49,5 +50,4 @@ export const loadBasis = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], TextureSourceOptions>;
-
+} satisfies LoaderParser<Texture | Texture[], TextureSourceOptions>;

--- a/src/compressed-textures/dds/loadDDS.ts
+++ b/src/compressed-textures/dds/loadDDS.ts
@@ -17,6 +17,7 @@ export const loadDDS = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.High,
+        name: 'loadDDS',
     },
 
     name: 'loadDDS',
@@ -53,5 +54,5 @@ export const loadDDS = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], TextureSourceOptions>;
+} satisfies LoaderParser<Texture | Texture[], TextureSourceOptions>;
 

--- a/src/compressed-textures/ktx/loadKTX.ts
+++ b/src/compressed-textures/ktx/loadKTX.ts
@@ -17,6 +17,7 @@ export const loadKTX = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.High,
+        name: 'loadKTX',
     },
 
     name: 'loadKTX',
@@ -53,5 +54,5 @@ export const loadKTX = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], TextureSourceOptions>;
+} satisfies LoaderParser<Texture | Texture[], TextureSourceOptions>;
 

--- a/src/compressed-textures/ktx2/loadKTX2.ts
+++ b/src/compressed-textures/ktx2/loadKTX2.ts
@@ -17,6 +17,7 @@ export const loadKTX2 = {
     extension: {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.High,
+        name: 'loadKTX2',
     },
 
     name: 'loadKTX2',
@@ -37,7 +38,7 @@ export const loadKTX2 = {
         return createTexture(compressedTextureSource, loader, url);
     },
 
-    unload(texture: Texture | Texture[]): void
+    async unload(texture: Texture | Texture[]): Promise<void>
     {
         if (Array.isArray(texture))
         {
@@ -49,5 +50,5 @@ export const loadKTX2 = {
         }
     }
 
-} as LoaderParser<Texture | Texture[], TextureSourceOptions>;
+} satisfies LoaderParser<Texture | Texture[], TextureSourceOptions>;
 

--- a/src/compressed-textures/shared/resolveCompressedTextureUrl.ts
+++ b/src/compressed-textures/shared/resolveCompressedTextureUrl.ts
@@ -3,7 +3,6 @@ import { checkExtension } from '../../assets/utils/checkExtension';
 import { ExtensionType } from '../../extensions/Extensions';
 
 import type { ResolveURLParser } from '../../assets/resolver/types';
-import type { UnresolvedAsset } from '../../assets/types';
 
 export const validFormats = ['basis', 'bc7', 'bc6h', 'astc', 'etc2', 'bc5', 'bc4', 'bc3', 'bc2', 'bc1', 'eac'];
 
@@ -11,7 +10,7 @@ export const resolveCompressedTextureUrl = {
     extension: ExtensionType.ResolveParser,
     test: (value: string) =>
         checkExtension(value, ['.ktx', '.ktx2', '.dds']),
-    parse: (value: string): UnresolvedAsset =>
+    parse: (value: string) =>
     {
         let format;
 
@@ -37,4 +36,4 @@ export const resolveCompressedTextureUrl = {
             src: value,
         };
     }
-} as ResolveURLParser;
+} satisfies ResolveURLParser;

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -8,7 +8,7 @@ import { bitmapFontTextParser } from './bitmapFontTextParser';
 import { bitmapFontXMLStringParser } from './bitmapFontXMLStringParser';
 
 import type { Loader } from '../../../assets/loader/Loader';
-import type { LoaderParserVerbose } from '../../../assets/loader/parsers/LoaderParser';
+import type { LoaderParserAdvanced } from '../../../assets/loader/parsers/LoaderParser';
 import type { ResolvedAsset } from '../../../assets/types';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 
@@ -95,4 +95,4 @@ export const loadBitmapFont = {
 
         bitmapFont.destroy();
     }
-} satisfies LoaderParserVerbose<string, BitmapFont, BitmapFont>;
+} satisfies LoaderParserAdvanced<string, BitmapFont, BitmapFont>;

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -8,7 +8,7 @@ import { bitmapFontTextParser } from './bitmapFontTextParser';
 import { bitmapFontXMLStringParser } from './bitmapFontXMLStringParser';
 
 import type { Loader } from '../../../assets/loader/Loader';
-import type { LoaderParser } from '../../../assets/loader/parsers/LoaderParser';
+import type { LoaderParserVerbose } from '../../../assets/loader/parsers/LoaderParser';
 import type { ResolvedAsset } from '../../../assets/types';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 
@@ -38,6 +38,8 @@ export const loadBitmapFont = {
         type: ExtensionType.LoadParser,
         priority: LoaderParserPriority.Normal,
     },
+
+    name: 'loadBitmapFont',
 
     test(url: string): boolean
     {
@@ -93,4 +95,4 @@ export const loadBitmapFont = {
 
         bitmapFont.destroy();
     }
-} as LoaderParser;
+} satisfies LoaderParserVerbose<string, BitmapFont, BitmapFont>;

--- a/src/spritesheet/spritesheetAsset.ts
+++ b/src/spritesheet/spritesheetAsset.ts
@@ -6,7 +6,7 @@ import { Texture } from '../rendering/renderers/shared/texture/Texture';
 import { path } from '../utils/path';
 import { Spritesheet } from './Spritesheet';
 
-import type { AssetExtensionVerbose } from '../assets/AssetExtension';
+import type { AssetExtensionAdvanced } from '../assets/AssetExtension';
 import type { Loader } from '../assets/loader/Loader';
 import type { ResolvedAsset } from '../assets/types';
 import type { SpritesheetData } from './Spritesheet';
@@ -79,8 +79,7 @@ export const spritesheetAsset = {
     resolver: {
         extension: {
             type: ExtensionType.ResolveParser,
-            priority: LoaderParserPriority.Normal,
-            name: 'resolve-spritesheet',
+            name: 'resolveSpritesheet',
         },
         test: (value: string): boolean =>
         {
@@ -215,4 +214,4 @@ export const spritesheetAsset = {
             spritesheet.destroy(false);
         },
     }
-} satisfies AssetExtensionVerbose<SpriteSheetJson, Spritesheet, Spritesheet, Spritesheet>;
+} satisfies AssetExtensionAdvanced<SpriteSheetJson, Spritesheet, Spritesheet, Spritesheet>;

--- a/src/spritesheet/spritesheetAsset.ts
+++ b/src/spritesheet/spritesheetAsset.ts
@@ -6,9 +6,9 @@ import { Texture } from '../rendering/renderers/shared/texture/Texture';
 import { path } from '../utils/path';
 import { Spritesheet } from './Spritesheet';
 
-import type { AssetExtension } from '../assets/AssetExtension';
+import type { AssetExtensionVerbose } from '../assets/AssetExtension';
 import type { Loader } from '../assets/loader/Loader';
-import type { ResolvedAsset, UnresolvedAsset } from '../assets/types';
+import type { ResolvedAsset } from '../assets/types';
 import type { SpritesheetData } from './Spritesheet';
 
 export interface SpriteSheetJson extends SpritesheetData
@@ -77,6 +77,11 @@ export const spritesheetAsset = {
     },
     /** Resolve the resolution of the asset. */
     resolver: {
+        extension: {
+            type: ExtensionType.ResolveParser,
+            priority: LoaderParserPriority.Normal,
+            name: 'resolve-spritesheet',
+        },
         test: (value: string): boolean =>
         {
             const tempURL = value.split('?')[0];
@@ -86,7 +91,7 @@ export const spritesheetAsset = {
 
             return extension === 'json' && validImages.includes(format);
         },
-        parse: (value: string): UnresolvedAsset =>
+        parse: (value: string) =>
         {
             const split = value.split('.');
 
@@ -109,6 +114,7 @@ export const spritesheetAsset = {
         extension: {
             type: ExtensionType.LoadParser,
             priority: LoaderParserPriority.Normal,
+            name: 'spritesheetLoader',
         },
 
         async testParse(asset: SpriteSheetJson, options: ResolvedAsset): Promise<boolean>
@@ -118,8 +124,8 @@ export const spritesheetAsset = {
 
         async parse(
             asset: SpriteSheetJson,
-            options: ResolvedAsset<{texture: Texture, imageFilename: string, ignoreMultiPack: boolean}>,
-            loader: Loader
+            options: ResolvedAsset<{texture?: Texture, imageFilename?: string, ignoreMultiPack?: boolean}>,
+            loader?: Loader
         ): Promise<Spritesheet>
         {
             const {
@@ -208,5 +214,5 @@ export const spritesheetAsset = {
 
             spritesheet.destroy(false);
         },
-    },
-} as AssetExtension<Spritesheet | SpriteSheetJson>;
+    }
+} satisfies AssetExtensionVerbose<SpriteSheetJson, Spritesheet, Spritesheet, Spritesheet>;

--- a/tests/renderering/sprite/spritesheetAsset.tests.ts
+++ b/tests/renderering/sprite/spritesheetAsset.tests.ts
@@ -162,7 +162,7 @@ describe('spritesheetAsset', () =>
         const spritesheetJsonUrl = `${basePath}spritesheet/spritesheet.json`;
         const preloadedTexture = new Texture();
         const json = await loadJson.load<SpriteSheetJson>(spritesheetJsonUrl);
-        const spritesheet = await spritesheetAsset.loader.parse<Spritesheet>(
+        const spritesheet = await spritesheetAsset.loader.parse(
             json,
             {
                 src: spritesheetJsonUrl,
@@ -177,7 +177,7 @@ describe('spritesheetAsset', () =>
         const spritesheetJsonUrl = `${basePath}spritesheet/spritesheet.json`;
         const customImageFilename = 'multi-pack-1.png';
         const json = await loadJson.load<SpriteSheetJson>(spritesheetJsonUrl);
-        const spritesheet = await spritesheetAsset.loader.parse<Spritesheet>(
+        const spritesheet = await spritesheetAsset.loader.parse(
             json,
             {
                 src: spritesheetJsonUrl,


### PR DESCRIPTION
This PR improves the types for the asset parsers and keeps the types backwards compatible

- all parsers now use `satisfies` 
- added `AssetExtensionAdvanced` and `LoaderParserAdvanced`, which allow you to have better control over what asset is parsed to each function
- all parsers now have an extension name, making debugging these things so much easier 