### PR TITLE
fix: allow bitmap fonts to be loaded before renderer init

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import { extensions, ExtensionType } from '../extensions/Extensions';
+import { bitmapFontCachePlugin, loadBitmapFont } from '../scene/text-bitmap/asset/loadBitmapFont';
 import { warn } from '../utils/logging/warn';
 import { BackgroundLoader } from './BackgroundLoader';
 import { Cache } from './cache/Cache';
@@ -969,6 +970,9 @@ extensions.add(
     loadSvg,
     loadTextures,
     loadVideoTextures,
+    loadBitmapFont,
+
+    bitmapFontCachePlugin,
 
     resolveTextureUrl,
     resolveJsonUrl

--- a/src/scene/text-bitmap/init.ts
+++ b/src/scene/text-bitmap/init.ts
@@ -1,5 +1,4 @@
 import { extensions } from '../../extensions/Extensions';
-import { bitmapFontCachePlugin, loadBitmapFont } from './asset/loadBitmapFont';
 import { BitmapTextPipe } from './BitmapTextPipe';
 
-extensions.add(BitmapTextPipe, loadBitmapFont, bitmapFontCachePlugin);
+extensions.add(BitmapTextPipe);


### PR DESCRIPTION
fixes: #10397

moving the asset parsers into Assets allows us to load bitmap fonts before calling `await renderer.init()`

this only adds a few kb to the bundle size, so not a major impact in doing this