### PR TITLE
fix: Text deprecation not converting correctly

### DIFF
--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'eventemitter3';
 import { Color, type ColorSource } from '../../color/Color';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { FillGradient } from '../graphics/shared/fill/FillGradient';
+import { FillPattern } from '../graphics/shared/fill/FillPattern';
 import { GraphicsContext } from '../graphics/shared/GraphicsContext';
 import { convertFillInputToFillStyle } from '../graphics/shared/utils/convertFillInputToFillStyle';
 import { generateTextStyleKey } from './utils/generateTextStyleKey';
@@ -525,7 +526,15 @@ export class TextStyle extends EventEmitter<{
 
 function convertV7Tov8Style(style: TextStyleOptions)
 {
-    const oldStyle = style as any;
+    const oldStyle = style as TextStyleOptions & {
+        dropShadowAlpha?: number;
+        dropShadowAngle?: number;
+        dropShadowBlur?: number;
+        dropShadowColor?: number;
+        dropShadowDistance?: number;
+        fillGradientStops?: number[];
+        strokeThickness?: number;
+    };
 
     if (typeof oldStyle.dropShadow === 'boolean' && oldStyle.dropShadow)
     {
@@ -547,26 +556,65 @@ function convertV7Tov8Style(style: TextStyleOptions)
         // #endif
 
         const color = oldStyle.stroke;
+        let obj: FillStyle = {};
+
+        // handles stroke: 0x0, stroke: { r: 0, g: 0, b: 0, a: 0 } stroke: new Color(0x0)
+        if (Color.isColorLike(color as ColorSource))
+        {
+            obj.color = color as ColorSource;
+        }
+        // handles stroke: new FillGradient()
+        else if (color instanceof FillGradient || color instanceof FillPattern)
+        {
+            obj.fill = color as FillGradient | FillPattern;
+        }
+        // handles stroke: { color: 0x0 } or stroke: { fill: new FillGradient() }
+        else if (Object.hasOwnProperty.call(color, 'color') || Object.hasOwnProperty.call(color, 'fill'))
+        {
+            obj = color as FillStyle;
+        }
+        else
+        {
+            throw new Error('Invalid stroke value.');
+        }
 
         style.stroke = {
-            color,
+            ...obj,
             width: oldStyle.strokeThickness
         };
     }
 
-    if (Array.isArray(oldStyle.fill))
+    if (Array.isArray(oldStyle.fillGradientStops))
     {
         // #if _DEBUG
         deprecation(v8_0_0, 'gradient fill is now a fill pattern: `new FillGradient(...)`');
         // #endif
 
-        const gradientFill = new FillGradient(0, 0, 0, (style.fontSize as number) * 1.7);
+        let fontSize: number;
 
-        const fills: number[] = oldStyle.fill.map((color: ColorSource) => Color.shared.setValue(color).toNumber());
+        // eslint-disable-next-line no-eq-null, eqeqeq
+        if (style.fontSize == null)
+        {
+            style.fontSize = TextStyle.defaultTextStyle.fontSize;
+        }
+        else if (typeof style.fontSize === 'string')
+        {
+            // eg '34px' to number
+            fontSize = parseInt(style.fontSize as string, 10);
+        }
+        else
+        {
+            fontSize = style.fontSize as number;
+        }
+
+        const gradientFill = new FillGradient(0, 0, 0, fontSize * 1.7);
+
+        const fills: number[] = oldStyle.fillGradientStops
+            .map((color: ColorSource) => Color.shared.setValue(color).toNumber());
 
         fills.forEach((number, index) =>
         {
-            const ratio = oldStyle.fillGradientStops[index] ?? index / fills.length;
+            const ratio = index / (fills.length - 1);
 
             gradientFill.addColorStop(ratio, number);
         });
@@ -576,3 +624,4 @@ function convertV7Tov8Style(style: TextStyleOptions)
         };
     }
 }
+

--- a/tests/renderering/text/TextStyle.tests.ts
+++ b/tests/renderering/text/TextStyle.tests.ts
@@ -1,6 +1,13 @@
 /* eslint-disable jest/no-commented-out-tests */
+import { Color } from '../../../src/color/Color';
+import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+import { FillGradient } from '../../../src/scene/graphics/shared/fill/FillGradient';
+import { FillPattern } from '../../../src/scene/graphics/shared/fill/FillPattern';
+import { GraphicsContext } from '../../../src/scene/graphics/shared/GraphicsContext';
 import { TextStyle } from '../../../src/scene/text/TextStyle';
 import { HTMLTextStyle } from '../../../src/scene/text-html/HtmlTextStyle';
+
+import type { TextStyleOptions } from '../../../src/scene/text/TextStyle';
 
 describe('TextStyle', () =>
 {
@@ -93,5 +100,147 @@ describe('TextStyle', () =>
 
             expect(result).toBeNull();
         }
+    });
+
+    it('should convert dropShadow properties', () =>
+    {
+        const style = {
+            dropShadow: true,
+            dropShadowAlpha: 0.5,
+            dropShadowAngle: 45,
+            dropShadowBlur: 10,
+            dropShadowColor: 0x000000,
+            dropShadowDistance: 5,
+        };
+
+        const textstyle = new TextStyle(style);
+
+        expect(textstyle.dropShadow).toEqual({
+            alpha: 0.5,
+            angle: 45,
+            blur: 10,
+            color: 0x000000,
+            distance: 5,
+        });
+
+        const style2 = {
+            dropShadow: false,
+            dropShadowAlpha: 0.5,
+        };
+
+        const textstyle2 = new TextStyle(style2);
+
+        expect(textstyle2.dropShadow).toBeNull();
+    });
+
+    it('should convert strokeThickness property for colors', () =>
+    {
+        const style = {
+            stroke: 0xff0000,
+            strokeThickness: 5,
+        };
+
+        expect(new TextStyle(style)._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            color: 0xff0000,
+            width: 5,
+        });
+
+        const style2 = {
+            stroke: new Color(0xff0000),
+            strokeThickness: 5,
+        };
+
+        expect(new TextStyle(style2)._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            color: 0xff0000,
+            width: 5,
+        });
+
+        const style3 = {
+            stroke: {
+                color: 0xff0000,
+            },
+            strokeThickness: 5,
+        };
+
+        expect(new TextStyle(style3)._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            color: 0xff0000,
+            width: 5,
+        });
+
+        const style4 = {
+            stroke: {
+                color: new Color(0xff0000),
+            },
+            strokeThickness: 5,
+        };
+
+        expect(new TextStyle(style4)._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            color: 0xff0000,
+            width: 5,
+        });
+    });
+
+    it('should keep other stroke properties', () =>
+    {
+        const style: TextStyleOptions & {strokeThickness: number} = {
+            stroke: {
+                color: 0xff0000,
+                alignment: 0.5,
+                cap: 'round',
+                join: 'round',
+                miterLimit: 15,
+            },
+            strokeThickness: 5,
+        };
+
+        expect(new TextStyle(style)._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            color: 0xff0000,
+            width: 5,
+            alignment: 0.5,
+            cap: 'round',
+            join: 'round',
+            miterLimit: 15,
+        });
+    });
+
+    it('should convert fill object to FillPattern', () =>
+    {
+        const pattern = new FillPattern(Texture.WHITE);
+        const style = {
+            stroke: pattern,
+            strokeThickness: 5,
+        };
+
+        const textStyle = new TextStyle(style);
+
+        expect(textStyle._stroke.fill).toBeInstanceOf(FillPattern);
+        expect(textStyle._stroke).toEqual({
+            ...GraphicsContext.defaultStrokeStyle,
+            fill: pattern,
+            width: 5,
+            texture: pattern.texture,
+            matrix: pattern.transform,
+        });
+    });
+
+    it('should convert fillGradientStops array to FillGradient', () =>
+    {
+        const style = {
+            fillGradientStops: [0x000000, 0xff0000, 0xFFFFFF],
+        };
+
+        const textStyle = new TextStyle(style as TextStyleOptions);
+
+        expect(textStyle._fill.fill).toBeInstanceOf(FillGradient);
+        expect((textStyle._fill.fill as FillGradient).gradientStops).toEqual([
+            { offset: 0, color: '#000000' },
+            { offset: 0.5, color: '#ff0000' },
+            { offset: 1, color: '#ffffff' },
+        ]);
     });
 });


### PR DESCRIPTION
fixes issues with `strokeThickness` and `fillGradientStops` not being converted correctly for deprecation