### PR TITLE
fix: fills/strokes not being set correctly

### DIFF
--- a/src/scene/graphics/shared/FillTypes.ts
+++ b/src/scene/graphics/shared/FillTypes.ts
@@ -101,6 +101,9 @@ export type ConvertedFillStyle = Omit<Required<FillStyle>, 'color'> & { color: n
 // used internally and is a complete stroke style
 export type ConvertedStrokeStyle = ConvertedFillStyle & Required<StrokeAttributes>;
 
-/** @deprecated */
+/**
+ * @deprecated since v8.2.0
+ * @see scene.FillInput
+ */
 // eslint-disable-next-line max-len
 export type FillStyleInputs = ColorSource | FillGradient | FillPattern | FillStyle | ConvertedFillStyle | StrokeStyle | ConvertedStrokeStyle;

--- a/src/scene/graphics/shared/FillTypes.ts
+++ b/src/scene/graphics/shared/FillTypes.ts
@@ -102,7 +102,7 @@ export type ConvertedFillStyle = Omit<Required<FillStyle>, 'color'> & { color: n
 export type ConvertedStrokeStyle = ConvertedFillStyle & Required<StrokeAttributes>;
 
 /**
- * @deprecated since v8.2.0
+ * @deprecated since v8.1.6
  * @see scene.FillInput
  */
 // eslint-disable-next-line max-len

--- a/src/scene/graphics/shared/FillTypes.ts
+++ b/src/scene/graphics/shared/FillTypes.ts
@@ -1,0 +1,106 @@
+import type { ColorSource } from '../../../color/Color';
+import type { Matrix } from '../../../maths/matrix/Matrix';
+import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
+import type { LineCap, LineJoin } from './const';
+import type { FillGradient } from './fill/FillGradient';
+import type { FillPattern } from './fill/FillPattern';
+
+/**
+ * A fill style object.
+ * @memberof scene
+ */
+export interface FillStyle
+{
+    /** The color to use for the fill. */
+    color?: ColorSource;
+    /** The alpha value to use for the fill. */
+    alpha?: number;
+    /** The texture to use for the fill. */
+    texture?: Texture | null;
+    /** The matrix to apply. */
+    matrix?: Matrix | null;
+    /** The fill pattern to use. */
+    fill?: FillPattern | FillGradient | null;
+}
+
+/**
+ * A stroke attribute object, used to define properties for a stroke.
+ * @memberof scene
+ */
+export interface StrokeAttributes
+{
+    /** The width of the stroke. */
+    width?: number;
+    /** The alignment of the stroke. */
+    alignment?: number;
+    /** The line cap style to use. */
+    cap?: LineCap;
+    /** The line join style to use. */
+    join?: LineJoin;
+    /** The miter limit to use. */
+    miterLimit?: number;
+}
+
+/**
+ * A stroke style object.
+ * @memberof scene
+ */
+export interface StrokeStyle extends FillStyle, StrokeAttributes {}
+
+/**
+ * These can be directly used as a fill or a stroke
+ * ```ts
+ * graphics.fill(0xff0000);
+ * graphics.fill(new FillPattern(texture));
+ * graphics.fill(new FillGradient(0, 0, 200, 0));
+ * graphics.fill({
+ *   color: 0xff0000,
+ *   alpha: 0.5,
+ *   texture?: null,
+ *   matrix?: null,
+ * });
+ * graphics.fill({
+ *   fill: new FillPattern(texture),
+ * });
+ * graphics.fill({
+ *   fill: new FillGradient(0, 0, 200, 0),
+ * });
+ * ```
+ * @memberof scene
+ */
+export type FillInput = ColorSource | FillGradient | FillPattern | FillStyle;
+
+/**
+ * These can be directly used as a stroke
+ * ```ts
+ * graphics.stroke(0xff0000);
+ * graphics.stroke(new FillPattern(texture));
+ * graphics.stroke(new FillGradient(0, 0, 200, 0));
+ * graphics.stroke({
+ *   color: 0xff0000,
+ *   width?: 1,
+ *   alignment?: 0.5,
+ * });
+ * graphics.stroke({
+ *   fill: new FillPattern(texture),
+ *   width: 1,
+ *   alignment: 0.5,
+ * });
+ * graphics.stroke({
+ *   fill: new FillGradient(0, 0, 200, 0),
+ *   width: 1,
+ *   alignment: 0.5,
+ * });
+ * ```
+ * @memberof scene
+ */
+export type StrokeInput = ColorSource | FillGradient | FillPattern | StrokeStyle;
+
+// used internally and is a complete fill style
+export type ConvertedFillStyle = Omit<Required<FillStyle>, 'color'> & { color: number };
+// used internally and is a complete stroke style
+export type ConvertedStrokeStyle = ConvertedFillStyle & Required<StrokeAttributes>;
+
+/** @deprecated */
+// eslint-disable-next-line max-len
+export type FillStyleInputs = ColorSource | FillGradient | FillPattern | FillStyle | ConvertedFillStyle | StrokeStyle | ConvertedStrokeStyle;

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -11,7 +11,7 @@ import type { View } from '../../../rendering/renderers/shared/view/View';
 import type { Bounds } from '../../container/bounds/Bounds';
 import type { ContainerOptions } from '../../container/Container';
 import type { ContextDestroyOptions, DestroyOptions } from '../../container/destroyTypes';
-import type { FillStyle, FillStyleInputs, StrokeStyle } from './GraphicsContext';
+import type { FillInput, FillStyle, StrokeStyle } from './FillTypes';
 import type { GraphicsPath } from './path/GraphicsPath';
 import type { RoundedPoint } from './path/roundShape';
 
@@ -206,7 +206,7 @@ export class Graphics extends Container implements View, Instruction
     /**
      * Sets the current fill style of the graphics context. The fill style can be a color, gradient,
      * pattern, or a more complex style defined by a FillStyle object.
-     * @param {FillStyleInputs} args - The fill style to apply. This can be a simple color, a gradient or
+     * @param {FillInput} args - The fill style to apply. This can be a simple color, a gradient or
      * pattern object, or a FillStyle or ConvertedFillStyle object.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
@@ -218,7 +218,7 @@ export class Graphics extends Container implements View, Instruction
     /**
      * Sets the current stroke style of the graphics context. Similar to fill styles, stroke styles can
      * encompass colors, gradients, patterns, or more detailed configurations via a StrokeStyle object.
-     * @param {FillStyleInputs} args - The stroke style to apply. Can be defined as a color, a gradient or pattern,
+     * @param {StrokeInput} args - The stroke style to apply. Can be defined as a color, a gradient or pattern,
      * or a StrokeStyle or ConvertedStrokeStyle object.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
@@ -229,22 +229,22 @@ export class Graphics extends Container implements View, Instruction
 
     /**
      * Fills the current or given path with the current fill style. This method can optionally take
-     * a color and alpha for a simple fill, or a more complex FillStyleInputs object for advanced fills.
-     * @param {FillStyleInputs} style - (Optional) The style to fill the path with. Can be a color, gradient, pattern, or a
+     * a color and alpha for a simple fill, or a more complex FillStyle object for advanced fills.
+     * @param {FillStyle} style - (Optional) The style to fill the path with. Can be a color, gradient, pattern, or a
      * complex style object. If omitted, uses the current fill style.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
-    public fill(style?: FillStyleInputs): this;
+    public fill(style?: FillStyle): this;
     /** @deprecated 8.0.0 */
-    public fill(color: ColorSource, alpha: number): this;
-    public fill(...args: [FillStyleInputs, ColorSource?]): this
+    public fill(color: ColorSource, alpha?: number): this;
+    public fill(...args: [FillStyle | ColorSource, number?]): this
     {
         return this._callContextMethod('fill', args);
     }
     /**
      * Strokes the current path with the current stroke style. This method can take an optional
-     * FillStyleInputs parameter to define the stroke's appearance, including its color, width, and other properties.
-     * @param {FillStyleInputs} args - (Optional) The stroke style to apply. Can be defined as a simple color or a more
+     * FillStyle parameter to define the stroke's appearance, including its color, width, and other properties.
+     * @param {FillStyle} args - (Optional) The stroke style to apply. Can be defined as a simple color or a more
      * complex style object. If omitted, uses the current stroke style.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
@@ -714,7 +714,7 @@ export class Graphics extends Container implements View, Instruction
     {
         return this._context.fillStyle;
     }
-    set fillStyle(value: FillStyleInputs)
+    set fillStyle(value: FillInput)
     {
         this._context.fillStyle = value;
     }
@@ -726,7 +726,7 @@ export class Graphics extends Container implements View, Instruction
     {
         return this._context.strokeStyle;
     }
-    set strokeStyle(value: FillStyleInputs)
+    set strokeStyle(value: StrokeStyle)
     {
         this._context.strokeStyle = value;
     }

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -9,7 +9,7 @@ import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 import { Bounds } from '../../container/bounds/Bounds';
 import { GraphicsPath } from './path/GraphicsPath';
 import { SVGParser } from './svg/SVGParser';
-import { convertFillInputToFillStyle, convertStrokeInputToStrokeStyle } from './utils/convertFillInputToFillStyle';
+import { toFillStyle, toStrokeStyle } from './utils/convertFillInputToFillStyle';
 
 import type { PointData } from '../../../maths/point/PointData';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
@@ -156,7 +156,7 @@ export class GraphicsContext extends EventEmitter<{
 
     set fillStyle(value: FillInput)
     {
-        this._fillStyle = convertFillInputToFillStyle(value, GraphicsContext.defaultFillStyle);
+        this._fillStyle = toFillStyle(value, GraphicsContext.defaultFillStyle);
     }
 
     /**
@@ -169,7 +169,7 @@ export class GraphicsContext extends EventEmitter<{
 
     set strokeStyle(value: FillInput)
     {
-        this._strokeStyle = convertStrokeInputToStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
+        this._strokeStyle = toStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
     }
 
     /**
@@ -181,7 +181,7 @@ export class GraphicsContext extends EventEmitter<{
      */
     public setFillStyle(style: FillInput): this
     {
-        this._fillStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultFillStyle);
+        this._fillStyle = toFillStyle(style, GraphicsContext.defaultFillStyle);
 
         return this;
     }
@@ -195,7 +195,7 @@ export class GraphicsContext extends EventEmitter<{
      */
     public setStrokeStyle(style: StrokeInput): this
     {
-        this._strokeStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
+        this._strokeStyle = toFillStyle(style, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
 
         return this;
     }
@@ -289,7 +289,7 @@ export class GraphicsContext extends EventEmitter<{
 
                 style = { color: style, alpha };
             }
-            this._fillStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultFillStyle);
+            this._fillStyle = toFillStyle(style, GraphicsContext.defaultFillStyle);
         }
 
         // TODO not a fan of the clone!!
@@ -342,7 +342,7 @@ export class GraphicsContext extends EventEmitter<{
         // eslint-disable-next-line no-eq-null, eqeqeq
         if (style != null)
         {
-            this._strokeStyle = convertStrokeInputToStrokeStyle(style, GraphicsContext.defaultStrokeStyle);
+            this._strokeStyle = toStrokeStyle(style, GraphicsContext.defaultStrokeStyle);
         }
 
         // TODO not a fan of the clone!!

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -9,69 +9,17 @@ import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 import { Bounds } from '../../container/bounds/Bounds';
 import { GraphicsPath } from './path/GraphicsPath';
 import { SVGParser } from './svg/SVGParser';
-import { convertFillInputToFillStyle } from './utils/convertFillInputToFillStyle';
+import { convertFillInputToFillStyle, convertStrokeInputToStrokeStyle } from './utils/convertFillInputToFillStyle';
 
 import type { PointData } from '../../../maths/point/PointData';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
 import type { TextureDestroyOptions, TypeOrBool } from '../../container/destroyTypes';
-import type { LineCap, LineJoin } from './const';
-import type { FillGradient } from './fill/FillGradient';
-import type { FillPattern } from './fill/FillPattern';
+import type { ConvertedFillStyle, ConvertedStrokeStyle, FillInput, StrokeInput } from './FillTypes';
 import type { RoundedPoint } from './path/roundShape';
-
-/**
- * A fill style object.
- * @memberof scene
- */
-export interface FillStyle
-{
-    /** The color to use for the fill. */
-    color?: ColorSource;
-    /** The alpha value to use for the fill. */
-    alpha?: number;
-    /** The texture to use for the fill. */
-    texture?: Texture | null;
-    /** The matrix to apply. */
-    matrix?: Matrix | null;
-    /** The fill pattern to use. */
-    fill?: FillPattern | FillGradient | null;
-}
-
-export type ConvertedFillStyle = Omit<Required<FillStyle>, 'color'> & { color: number };
-
-export interface PatternFillStyle
-{
-    fill?: FillPattern | FillGradient;
-    color?: number;
-    alpha?: number;
-}
-
-/**
- * A stroke style object.
- * @memberof scene
- */
-export interface StrokeStyle extends FillStyle
-{
-    /** The width of the stroke. */
-    width?: number;
-    /** The alignment of the stroke. */
-    alignment?: number;
-    // native?: boolean;
-    /** The line cap style to use. */
-    cap?: LineCap;
-    /** The line join style to use. */
-    join?: LineJoin;
-    /** The miter limit to use. */
-    miterLimit?: number;
-}
-
-export type ConvertedStrokeStyle = Omit<StrokeStyle, 'color'> & ConvertedFillStyle;
 
 const tmpPoint = new Point();
 
 export type BatchMode = 'auto' | 'batch' | 'no-batch';
-
-export type FillStyleInputs = ColorSource | FillGradient | CanvasPattern | PatternFillStyle | FillStyle | ConvertedFillStyle | StrokeStyle | ConvertedStrokeStyle;
 
 export interface FillInstruction
 {
@@ -206,7 +154,7 @@ export class GraphicsContext extends EventEmitter<{
         return this._fillStyle;
     }
 
-    set fillStyle(value: FillStyleInputs)
+    set fillStyle(value: FillInput)
     {
         this._fillStyle = convertFillInputToFillStyle(value, GraphicsContext.defaultFillStyle);
     }
@@ -219,9 +167,9 @@ export class GraphicsContext extends EventEmitter<{
         return this._strokeStyle;
     }
 
-    set strokeStyle(value: FillStyleInputs)
+    set strokeStyle(value: FillInput)
     {
-        this._strokeStyle = convertFillInputToFillStyle(value, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
+        this._strokeStyle = convertStrokeInputToStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
     }
 
     /**
@@ -231,7 +179,7 @@ export class GraphicsContext extends EventEmitter<{
      *                or a FillStyle or ConvertedFillStyle object.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
-    public setFillStyle(style: FillStyleInputs): this
+    public setFillStyle(style: FillInput): this
     {
         this._fillStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultFillStyle);
 
@@ -245,7 +193,7 @@ export class GraphicsContext extends EventEmitter<{
      *                or a StrokeStyle or ConvertedStrokeStyle object.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
-    public setStrokeStyle(style: FillStyleInputs): this
+    public setStrokeStyle(style: StrokeInput): this
     {
         this._strokeStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultStrokeStyle) as ConvertedStrokeStyle;
 
@@ -306,14 +254,14 @@ export class GraphicsContext extends EventEmitter<{
 
     /**
      * Fills the current or given path with the current fill style. This method can optionally take
-     * a color and alpha for a simple fill, or a more complex FillStyleInputs object for advanced fills.
+     * a color and alpha for a simple fill, or a more complex FillInput object for advanced fills.
      * @param style - (Optional) The style to fill the path with. Can be a color, gradient, pattern, or a complex style object. If omitted, uses the current fill style.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
-    public fill(style?: FillStyleInputs): this;
+    public fill(style?: FillInput): this;
     /** @deprecated 8.0.0 */
     public fill(color: ColorSource, alpha: number): this;
-    public fill(style?: FillStyleInputs, alpha?: number): this
+    public fill(style?: FillInput, alpha?: number): this
     {
         let path: GraphicsPath;
 
@@ -370,11 +318,11 @@ export class GraphicsContext extends EventEmitter<{
 
     /**
      * Strokes the current path with the current stroke style. This method can take an optional
-     * FillStyleInputs parameter to define the stroke's appearance, including its color, width, and other properties.
+     * FillInput parameter to define the stroke's appearance, including its color, width, and other properties.
      * @param style - (Optional) The stroke style to apply. Can be defined as a simple color or a more complex style object. If omitted, uses the current stroke style.
      * @returns The instance of the current GraphicsContext for method chaining.
      */
-    public stroke(style?: FillStyleInputs): this
+    public stroke(style?: StrokeInput): this
     {
         let path: GraphicsPath;
 
@@ -394,7 +342,7 @@ export class GraphicsContext extends EventEmitter<{
         // eslint-disable-next-line no-eq-null, eqeqeq
         if (style != null)
         {
-            this._strokeStyle = convertFillInputToFillStyle(style, GraphicsContext.defaultStrokeStyle);
+            this._strokeStyle = convertStrokeInputToStrokeStyle(style, GraphicsContext.defaultStrokeStyle);
         }
 
         // TODO not a fan of the clone!!

--- a/src/scene/graphics/shared/buildCommands/buildLine.ts
+++ b/src/scene/graphics/shared/buildCommands/buildLine.ts
@@ -2,7 +2,7 @@ import { Point } from '../../../../maths/point/Point';
 import { closePointEps, curveEps } from '../const';
 import { getOrientationOfPoints } from '../utils/getOrientationOfPoints';
 
-import type { StrokeStyle } from '../GraphicsContext';
+import type { StrokeAttributes } from '../FillTypes';
 
 /**
  * Buffers vertices to draw a square cap.
@@ -164,7 +164,7 @@ function round(
  */
 export function buildLine(
     points: number[],
-    lineStyle: StrokeStyle,
+    lineStyle: StrokeAttributes,
     flipAlignment: boolean,
     closed: boolean,
     // alignment:number,

--- a/src/scene/graphics/shared/svg/SVGParser.ts
+++ b/src/scene/graphics/shared/svg/SVGParser.ts
@@ -1,12 +1,9 @@
 import { Color } from '../../../../color/Color';
 import { GraphicsPath } from '../path/GraphicsPath';
 
+import type { ConvertedFillStyle, ConvertedStrokeStyle, FillStyle, StrokeStyle } from '../FillTypes';
 import type {
-    ConvertedFillStyle,
-    ConvertedStrokeStyle,
-    FillStyle,
     GraphicsContext,
-    StrokeStyle,
 } from '../GraphicsContext';
 
 interface Session

--- a/src/scene/graphics/shared/utils/buildContextBatches.ts
+++ b/src/scene/graphics/shared/utils/buildContextBatches.ts
@@ -13,7 +13,8 @@ import { triangulateWithHoles } from './triangulateWithHoles';
 
 import type { Polygon } from '../../../../maths/shapes/Polygon';
 import type { ShapeBuildCommand } from '../buildCommands/ShapeBuildCommand';
-import type { ConvertedFillStyle, GraphicsContext, TextureInstruction } from '../GraphicsContext';
+import type { ConvertedFillStyle, ConvertedStrokeStyle } from '../FillTypes';
+import type { GraphicsContext, TextureInstruction } from '../GraphicsContext';
 import type { GpuGraphicsContext } from '../GraphicsContextSystem';
 import type { GraphicsPath } from '../path/GraphicsPath';
 import type { ShapePath } from '../path/ShapePath';
@@ -137,7 +138,7 @@ function addTextureToGeometryData(
 
 function addShapePathToGeometryData(
     shapePath: ShapePath,
-    style: ConvertedFillStyle,
+    style: ConvertedFillStyle | ConvertedStrokeStyle,
     hole: GraphicsPath,
     isStroke: boolean,
     batches: BatchableGraphics[],
@@ -202,7 +203,7 @@ function addShapePathToGeometryData(
         else
         {
             const close = (shape as Polygon).closePath ?? true;
-            const lineStyle = style;
+            const lineStyle = style as ConvertedStrokeStyle;
 
             buildLine(points, lineStyle, false, close, vertices, 2, vertOffset, indices, indexOffset);
         }

--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -7,76 +7,113 @@ import { FillPattern } from '../fill/FillPattern';
 import type { ColorSource } from '../../../../color/Color';
 import type {
     ConvertedFillStyle,
+    ConvertedStrokeStyle,
+    FillInput,
     FillStyle,
-    FillStyleInputs,
-    PatternFillStyle,
-} from '../GraphicsContext';
+    StrokeInput,
+} from '../FillTypes';
 
-export function convertFillInputToFillStyle(
-    value: FillStyleInputs,
+function isColorLike(value: unknown): value is ColorSource
+{
+    return Color.isColorLike(value as ColorSource);
+}
+
+function isFillPattern(value: unknown): value is FillPattern
+{
+    return value instanceof FillPattern;
+}
+
+function isFillGradient(value: unknown): value is FillGradient
+{
+    return value instanceof FillGradient;
+}
+
+/**
+ * Handles the case where the value is a ColorLike
+ * @param fill
+ * @param value
+ * @param defaultStyle
+ * @example
+ * graphics.fill(0xff0000)
+ * graphics.fill(new Color(0xff0000))
+ * graphics.fill({ r: 255, g: 0, b: 0 })
+ */
+function handleColorLike(
+    fill: FillStyle,
+    value: ColorSource,
     defaultStyle: ConvertedFillStyle
 ): ConvertedFillStyle
 {
-    if (value === undefined || value === null)
-    {
-        return null;
-    }
+    const temp = Color.shared.setValue(value ?? 0);
 
-    let fillStyleToParse: ConvertedFillStyle;
-    let styleToMerge: FillStyleInputs;
+    fill.color = temp.toNumber();
+    fill.alpha = temp.alpha === 1 ? defaultStyle.alpha : temp.alpha;
+    fill.texture = Texture.WHITE;
 
-    if ((value as PatternFillStyle)?.fill)
-    {
-        styleToMerge = (value as PatternFillStyle).fill;
-        fillStyleToParse = { ...defaultStyle, ...(value as PatternFillStyle) };
-    }
-    else
-    {
-        styleToMerge = value;
-        fillStyleToParse = defaultStyle;
-    }
+    return { ...defaultStyle, ...fill } as ConvertedFillStyle;
+}
 
-    if (Color.isColorLike(styleToMerge as ColorSource))
-    {
-        const temp = Color.shared.setValue(styleToMerge as ColorSource ?? 0);
-        const opts: ConvertedFillStyle = {
-            ...fillStyleToParse,
-            color: temp.toNumber(),
-            alpha: temp.alpha === 1 ? fillStyleToParse.alpha : temp.alpha,
-            texture: Texture.WHITE,
-        };
+/**
+ * Handles the case where the value is a FillPattern
+ * @param fill
+ * @param value
+ * @param defaultStyle
+ * @example
+ * graphics.fill(new FillPattern(0xff0000))
+ */
+function handleFillPattern(
+    fill: FillStyle,
+    value: FillPattern,
+    defaultStyle: ConvertedFillStyle
+): ConvertedFillStyle
+{
+    fill.fill = value;
+    fill.color = 0xffffff;
+    fill.texture = value.texture;
+    fill.matrix = value.transform;
 
-        return opts;
-    }
-    else if (styleToMerge instanceof FillPattern)
-    {
-        const pattern = styleToMerge as FillPattern;
+    return { ...defaultStyle, ...fill } as ConvertedFillStyle;
+}
 
-        return {
-            ...fillStyleToParse,
-            color: 0xffffff,
-            texture: pattern.texture,
-            matrix: pattern.transform,
-            fill: fillStyleToParse.fill ?? null,
-        };
-    }
+/**
+ * Handles the case where the value is a FillGradient
+ * @param fill
+ * @param value
+ * @param defaultStyle
+ * @example
+ * graphics.fill(new FillGradient(0, 0, 200, 0))
+ */
+function handleFillGradient(
+    fill: FillStyle,
+    value: FillGradient,
+    defaultStyle: ConvertedFillStyle
+): ConvertedFillStyle
+{
+    value.buildLinearGradient();
+    fill.fill = value;
+    fill.color = 0xffffff;
+    fill.texture = value.texture;
+    fill.matrix = value.transform;
 
-    // // TODO Texture
-    else if (styleToMerge instanceof FillGradient)
-    {
-        const gradient = styleToMerge as FillGradient;
+    return { ...defaultStyle, ...fill } as ConvertedFillStyle;
+}
 
-        gradient.buildLinearGradient();
-
-        return {
-            ...fillStyleToParse,
-            color: 0xffffff,
-            texture: gradient.texture,
-            matrix: gradient.transform,
-        };
-    }
-
-    const style: FillStyle = { ...defaultStyle, ...(value as FillStyle) };
+/**
+ * Handles the case where the value is not a direct Pixi Color, PatternFill, or GradientFill but instead
+ * an object with potentially `color`
+ * @example
+ * {
+ *   color: new Color(0xff0000)
+ *   alpha: 0.5,
+ *   texture?: null,
+ *   matrix?: null,
+ * }
+ * @param value
+ * @param defaultStyle
+ */
+function handleFillObject(value: FillStyle, defaultStyle: ConvertedFillStyle): ConvertedFillStyle
+{
+    const style = { ...defaultStyle, ...(value as FillStyle) };
 
     if (style.texture)
     {
@@ -84,10 +121,7 @@ export function convertFillInputToFillStyle(
         {
             const m = style.matrix?.invert() || new Matrix();
 
-            m.scale(
-                1 / style.texture.frame.width,
-                1 / style.texture.frame.height
-            );
+            m.scale(1 / style.texture.frame.width, 1 / style.texture.frame.height);
 
             style.matrix = m;
         }
@@ -106,6 +140,62 @@ export function convertFillInputToFillStyle(
     style.color = color.toNumber();
     style.matrix = style.matrix ? style.matrix.clone() : null; // todo: lets optimise this!
 
-    // its a regular fill style!
     return style as ConvertedFillStyle;
+}
+
+export function convertFillInputToFillStyle<T extends FillInput>(
+    value: T,
+    defaultStyle: ConvertedFillStyle
+): ConvertedFillStyle
+{
+    if (value === undefined || value === null)
+    {
+        return null;
+    }
+
+    const fill: ConvertedFillStyle = {} as ConvertedFillStyle;
+    const objectStyle = value as FillStyle;
+
+    if (isColorLike(value))
+    {
+        return handleColorLike(fill, value, defaultStyle);
+    }
+    else if (isFillPattern(value))
+    {
+        return handleFillPattern(fill, value, defaultStyle);
+    }
+    else if (isFillGradient(value))
+    {
+        return handleFillGradient(fill, value, defaultStyle);
+    }
+    else if (objectStyle.fill && isFillPattern(objectStyle.fill))
+    {
+        return handleFillPattern(objectStyle, objectStyle.fill, defaultStyle);
+    }
+    else if (objectStyle.fill && isFillGradient(objectStyle.fill))
+    {
+        return handleFillGradient(objectStyle, objectStyle.fill, defaultStyle);
+    }
+
+    return handleFillObject(objectStyle, defaultStyle);
+}
+
+export function convertStrokeInputToStrokeStyle(value: StrokeInput, defaultStyle: ConvertedStrokeStyle): ConvertedStrokeStyle
+{
+    const { width, alignment, miterLimit, cap, join, ...rest } = defaultStyle;
+    const fill = convertFillInputToFillStyle(value, rest);
+
+    if (!fill)
+    {
+        return null;
+    }
+
+    return {
+        width,
+        alignment,
+        miterLimit,
+        cap,
+        join,
+        ...fill,
+    };
 }

--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -143,7 +143,16 @@ function handleFillObject(value: FillStyle, defaultStyle: ConvertedFillStyle): C
     return style as ConvertedFillStyle;
 }
 
-export function convertFillInputToFillStyle<T extends FillInput>(
+/**
+ * Converts a value to a fill style, we do this as PixiJS has a number of ways to define a fill style
+ * They can be a direct color, a texture, a gradient, or an object with these values in them
+ * This function will take any of these input types and convert them into a single object
+ * that PixiJS can understand and use internally.
+ * @param value - The value to convert to a fill style
+ * @param defaultStyle - The default fill style to use
+ * @private
+ */
+export function toFillStyle<T extends FillInput>(
     value: T,
     defaultStyle: ConvertedFillStyle
 ): ConvertedFillStyle
@@ -180,10 +189,16 @@ export function convertFillInputToFillStyle<T extends FillInput>(
     return handleFillObject(objectStyle, defaultStyle);
 }
 
-export function convertStrokeInputToStrokeStyle(value: StrokeInput, defaultStyle: ConvertedStrokeStyle): ConvertedStrokeStyle
+/**
+ * Converts a value to a stroke style, similar to `toFillStyle` but for strokes
+ * @param value - The value to convert to a stroke style
+ * @param defaultStyle - The default stroke style to use
+ * @private
+ */
+export function toStrokeStyle(value: StrokeInput, defaultStyle: ConvertedStrokeStyle): ConvertedStrokeStyle
 {
     const { width, alignment, miterLimit, cap, join, ...rest } = defaultStyle;
-    const fill = convertFillInputToFillStyle(value, rest);
+    const fill = toFillStyle(value, rest);
 
     if (!fill)
     {

--- a/src/scene/text-html/HtmlTextStyle.ts
+++ b/src/scene/text-html/HtmlTextStyle.ts
@@ -4,7 +4,7 @@ import { TextStyle } from '../text/TextStyle';
 import { generateTextStyleKey } from '../text/utils/generateTextStyleKey';
 import { textStyleToCSS } from './utils/textStyleToCSS';
 
-import type { FillStyleInputs } from '../graphics/shared/GraphicsContext';
+import type { FillInput, StrokeInput } from '../graphics/shared/FillTypes';
 import type { TextStyleOptions } from '../text/TextStyle';
 
 /**
@@ -160,7 +160,7 @@ export class HTMLTextStyle extends TextStyle
         }
     }
 
-    override set fill(value: FillStyleInputs)
+    override set fill(value: FillInput)
     {
         // if its not a string or a number, then its a texture!
         if (typeof value !== 'string' && typeof value !== 'number')
@@ -173,7 +173,7 @@ export class HTMLTextStyle extends TextStyle
         super.fill = value;
     }
 
-    override set stroke(value: FillStyleInputs)
+    override set stroke(value: StrokeInput)
     {
         // if its not a string or a number, then its a texture!
         if (value && typeof value !== 'string' && typeof value !== 'number')

--- a/src/scene/text-html/utils/textStyleToCSS.ts
+++ b/src/scene/text-html/utils/textStyleToCSS.ts
@@ -1,6 +1,6 @@
 import { Color } from '../../../color/Color';
 
-import type { StrokeStyle } from '../../graphics/shared/GraphicsContext';
+import type { ConvertedStrokeStyle } from '../../graphics/shared/FillTypes';
 import type { TextStyle } from '../../text/TextStyle';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../HtmlTextStyle';
 
@@ -58,7 +58,7 @@ function dropShadowToCSS(dropShadowStyle: TextStyle['dropShadow']): string
     return `text-shadow: ${position} ${color}`;
 }
 
-function strokeToCSS(stroke: StrokeStyle): string
+function strokeToCSS(stroke: ConvertedStrokeStyle): string
 {
     return [
         `-webkit-text-stroke-width: ${stroke.width}px`,

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -4,16 +4,20 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { FillGradient } from '../graphics/shared/fill/FillGradient';
 import { FillPattern } from '../graphics/shared/fill/FillPattern';
 import { GraphicsContext } from '../graphics/shared/GraphicsContext';
-import { convertFillInputToFillStyle } from '../graphics/shared/utils/convertFillInputToFillStyle';
+import {
+    convertFillInputToFillStyle,
+    convertStrokeInputToStrokeStyle
+} from '../graphics/shared/utils/convertFillInputToFillStyle';
 import { generateTextStyleKey } from './utils/generateTextStyleKey';
 
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 import type {
     ConvertedFillStyle,
     ConvertedStrokeStyle,
+    FillInput,
     FillStyle,
-    FillStyleInputs
-} from '../graphics/shared/GraphicsContext';
+    StrokeInput
+} from '../graphics/shared/FillTypes';
 
 export type TextStyleAlign = 'left' | 'center' | 'right' | 'justify';
 export type TextStyleFill = string | string[] | number | number[] | CanvasGradient | CanvasPattern;
@@ -75,7 +79,7 @@ export interface TextStyleOptions
      * {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle|MDN}
      * @type {string|string[]|number|number[]|CanvasGradient|CanvasPattern}
      */
-    fill?: FillStyleInputs;
+    fill?: FillInput;
     /** The font family, can be a single font name, or a list of names where the first is the preferred font. */
     fontFamily?: string | string[];
     /** The font size (as a number it converts to px, but as a string, equivalents are '26px','20pt','160%' or '1.6em') */
@@ -107,7 +111,7 @@ export interface TextStyleOptions
      */
     padding?: number;
     /** A canvas fillstyle that will be used on the text stroke, e.g., 'blue', '#FCFF00' */
-    stroke?: FillStyleInputs;
+    stroke?: StrokeInput;
     /**
      * The baseline of the text that is rendered.
      * @type {'alphabetic'|'top'|'hanging'|'middle'|'ideographic'|'bottom'}
@@ -231,10 +235,10 @@ export class TextStyle extends EventEmitter<{
 
     // colors!!
     public _fill: ConvertedFillStyle;
-    private _originalFill: FillStyleInputs;
+    private _originalFill: FillInput;
 
     public _stroke: ConvertedStrokeStyle;
-    private _originalStroke: FillStyleInputs;
+    private _originalStroke: StrokeInput;
 
     private _dropShadow: TextDropShadow;
 
@@ -384,12 +388,12 @@ export class TextStyle extends EventEmitter<{
     set wordWrapWidth(value: number) { this._wordWrapWidth = value; this.update(); }
 
     /** A fillstyle that will be used on the text e.g., 'red', '#00FF00'. */
-    get fill(): FillStyleInputs
+    get fill(): FillInput
     {
         return this._originalFill;
     }
 
-    set fill(value: FillStyleInputs)
+    set fill(value: FillInput)
     {
         if (value === this._originalFill) return;
 
@@ -402,17 +406,17 @@ export class TextStyle extends EventEmitter<{
     }
 
     /** A fillstyle that will be used on the text stroke, e.g., 'blue', '#FCFF00'. */
-    get stroke(): FillStyleInputs
+    get stroke(): StrokeInput
     {
         return this._originalStroke;
     }
 
-    set stroke(value: FillStyleInputs)
+    set stroke(value: StrokeInput)
     {
         if (value === this._originalStroke) return;
 
         this._originalStroke = value;
-        this._stroke = convertFillInputToFillStyle(value, GraphicsContext.defaultStrokeStyle);
+        this._stroke = convertStrokeInputToStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
         this.update();
     }
 

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -5,8 +5,8 @@ import { FillGradient } from '../graphics/shared/fill/FillGradient';
 import { FillPattern } from '../graphics/shared/fill/FillPattern';
 import { GraphicsContext } from '../graphics/shared/GraphicsContext';
 import {
-    convertFillInputToFillStyle,
-    convertStrokeInputToStrokeStyle
+    toFillStyle,
+    toStrokeStyle
 } from '../graphics/shared/utils/convertFillInputToFillStyle';
 import { generateTextStyleKey } from './utils/generateTextStyleKey';
 
@@ -398,7 +398,7 @@ export class TextStyle extends EventEmitter<{
         if (value === this._originalFill) return;
 
         this._originalFill = value;
-        this._fill = convertFillInputToFillStyle(
+        this._fill = toFillStyle(
             value === 0x0 ? 'black' : value,
             GraphicsContext.defaultFillStyle
         );
@@ -416,7 +416,7 @@ export class TextStyle extends EventEmitter<{
         if (value === this._originalStroke) return;
 
         this._originalStroke = value;
-        this._stroke = convertStrokeInputToStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
+        this._stroke = toStrokeStyle(value, GraphicsContext.defaultStrokeStyle);
         this.update();
     }
 

--- a/src/scene/text/canvas/utils/getCanvasFillStyle.ts
+++ b/src/scene/text/canvas/utils/getCanvasFillStyle.ts
@@ -6,7 +6,7 @@ import { FillGradient } from '../../../graphics/shared/fill/FillGradient';
 import { FillPattern } from '../../../graphics/shared/fill/FillPattern';
 
 import type { ICanvasRenderingContext2D } from '../../../../environment/canvas/ICanvasRenderingContext2D';
-import type { ConvertedFillStyle } from '../../../graphics/shared/GraphicsContext';
+import type { ConvertedFillStyle } from '../../../graphics/shared/FillTypes';
 
 export function getCanvasFillStyle(
     fillStyle: ConvertedFillStyle,
@@ -32,7 +32,7 @@ export function getCanvasFillStyle(
     }
     else if (fillStyle.fill instanceof FillPattern)
     {
-        const fillPattern = fillStyle.fill as FillPattern;
+        const fillPattern = fillStyle.fill;
 
         const pattern = context.createPattern(fillPattern.texture.source.resource, 'repeat');
 
@@ -49,7 +49,7 @@ export function getCanvasFillStyle(
     }
     else if (fillStyle.fill instanceof FillGradient)
     {
-        const fillGradient = fillStyle.fill as FillGradient;
+        const fillGradient = fillStyle.fill;
 
         if (fillGradient.type === 'linear')
         {

--- a/src/scene/text/utils/generateTextStyleKey.ts
+++ b/src/scene/text/utils/generateTextStyleKey.ts
@@ -1,7 +1,7 @@
 import { Color } from '../../../color/Color';
 
 import type { FillGradient } from '../../graphics/shared/fill/FillGradient';
-import type { ConvertedFillStyle, ConvertedStrokeStyle } from '../../graphics/shared/GraphicsContext';
+import type { ConvertedFillStyle, ConvertedStrokeStyle } from '../../graphics/shared/FillTypes';
 import type { HTMLTextStyle } from '../../text-html/HtmlTextStyle';
 import type { TextStyle } from '../TextStyle';
 

--- a/tests/graphics/GraphicsFill.tests.ts
+++ b/tests/graphics/GraphicsFill.tests.ts
@@ -2,7 +2,7 @@ import { Color } from '../../src/color/Color';
 import { Texture } from '../../src/rendering/renderers/shared/texture/Texture';
 import { FillGradient } from '../../src/scene/graphics/shared/fill/FillGradient';
 import { FillPattern } from '../../src/scene/graphics/shared/fill/FillPattern';
-import { convertStrokeInputToStrokeStyle } from '../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
+import { toStrokeStyle } from '../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
 
 import type { ConvertedStrokeStyle } from '../../src/scene/graphics/shared/FillTypes';
 
@@ -23,14 +23,14 @@ describe('convertStrokeInputToStrokeStyle', () =>
 
     it('should return null when value is undefined', () =>
     {
-        const result = convertStrokeInputToStrokeStyle(undefined, getDefaultValue());
+        const result = toStrokeStyle(undefined, getDefaultValue());
 
         expect(result).toBeNull();
     });
 
     it('should return null when value is null', () =>
     {
-        const result = convertStrokeInputToStrokeStyle(null, getDefaultValue());
+        const result = toStrokeStyle(null, getDefaultValue());
 
         expect(result).toBeNull();
     });
@@ -41,7 +41,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
         const color = new Color(0xff0000);
 
         color.setAlpha(0.5);
-        const result = convertStrokeInputToStrokeStyle(color, defaultStyle);
+        const result = toStrokeStyle(color, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -53,7 +53,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     it('should convert color object to stroke style', () =>
     {
         const defaultStyle = getDefaultValue();
-        const result = convertStrokeInputToStrokeStyle({ r: 255, g: 0, b: 0 }, defaultStyle);
+        const result = toStrokeStyle({ r: 255, g: 0, b: 0 }, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -65,7 +65,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     {
         const defaultStyle = getDefaultValue();
         const pattern = new FillPattern(Texture.WHITE);
-        const result = convertStrokeInputToStrokeStyle(pattern, defaultStyle);
+        const result = toStrokeStyle(pattern, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -81,7 +81,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     {
         const defaultStyle = getDefaultValue();
         const gradient = new FillGradient(0, 0, 200, 0);
-        const result = convertStrokeInputToStrokeStyle(gradient, defaultStyle);
+        const result = toStrokeStyle(gradient, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -96,7 +96,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     it('should convert stroke object to stroke style', () =>
     {
         const defaultStyle = getDefaultValue();
-        const result = convertStrokeInputToStrokeStyle({ color: 0xff0000, alpha: 0.5, width: 4 }, defaultStyle);
+        const result = toStrokeStyle({ color: 0xff0000, alpha: 0.5, width: 4 }, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -112,7 +112,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
         const color = new Color(0xff0000);
 
         color.setAlpha(0.5);
-        const result = convertStrokeInputToStrokeStyle({ color, alpha: 0.5 }, defaultStyle);
+        const result = toStrokeStyle({ color, alpha: 0.5 }, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -125,7 +125,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     {
         const defaultStyle = getDefaultValue();
         const pattern = new FillPattern(Texture.WHITE);
-        const result = convertStrokeInputToStrokeStyle({ fill: pattern, alpha: 0.5 }, defaultStyle);
+        const result = toStrokeStyle({ fill: pattern, alpha: 0.5 }, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,
@@ -141,7 +141,7 @@ describe('convertStrokeInputToStrokeStyle', () =>
     {
         const defaultStyle = getDefaultValue();
         const gradient = new FillGradient(0, 0, 200, 0);
-        const result = convertStrokeInputToStrokeStyle({ fill: gradient, alpha: 0.5 }, defaultStyle);
+        const result = toStrokeStyle({ fill: gradient, alpha: 0.5 }, defaultStyle);
 
         expect(result).toEqual({
             ...defaultStyle,

--- a/tests/graphics/GraphicsFill.tests.ts
+++ b/tests/graphics/GraphicsFill.tests.ts
@@ -1,0 +1,155 @@
+import { Color } from '../../src/color/Color';
+import { Texture } from '../../src/rendering/renderers/shared/texture/Texture';
+import { FillGradient } from '../../src/scene/graphics/shared/fill/FillGradient';
+import { FillPattern } from '../../src/scene/graphics/shared/fill/FillPattern';
+import { convertStrokeInputToStrokeStyle } from '../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
+
+import type { ConvertedStrokeStyle } from '../../src/scene/graphics/shared/FillTypes';
+
+describe('convertStrokeInputToStrokeStyle', () =>
+{
+    const getDefaultValue = (): ConvertedStrokeStyle => ({
+        width: 5,
+        color: 0xffffff,
+        alpha: 1,
+        alignment: 0.5,
+        miterLimit: 10,
+        cap: 'butt',
+        join: 'miter',
+        texture: Texture.WHITE,
+        matrix: null,
+        fill: null,
+    });
+
+    it('should return null when value is undefined', () =>
+    {
+        const result = convertStrokeInputToStrokeStyle(undefined, getDefaultValue());
+
+        expect(result).toBeNull();
+    });
+
+    it('should return null when value is null', () =>
+    {
+        const result = convertStrokeInputToStrokeStyle(null, getDefaultValue());
+
+        expect(result).toBeNull();
+    });
+
+    it('should convert Color to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const color = new Color(0xff0000);
+
+        color.setAlpha(0.5);
+        const result = convertStrokeInputToStrokeStyle(color, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            color: color.toNumber(),
+            alpha: color.alpha,
+        });
+    });
+
+    it('should convert color object to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const result = convertStrokeInputToStrokeStyle({ r: 255, g: 0, b: 0 }, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            color: 0xff0000,
+        });
+    });
+
+    it('should convert FillPattern to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const pattern = new FillPattern(Texture.WHITE);
+        const result = convertStrokeInputToStrokeStyle(pattern, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            fill: pattern,
+            color: 0xffffff,
+            alpha: 1,
+            texture: pattern.texture,
+            matrix: pattern.transform,
+        });
+    });
+
+    it('should convert FillGradient to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const gradient = new FillGradient(0, 0, 200, 0);
+        const result = convertStrokeInputToStrokeStyle(gradient, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            fill: gradient,
+            color: 0xffffff,
+            alpha: 1,
+            texture: gradient.texture,
+            matrix: gradient.transform,
+        });
+    });
+
+    it('should convert stroke object to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const result = convertStrokeInputToStrokeStyle({ color: 0xff0000, alpha: 0.5, width: 4 }, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            color: 0xff0000,
+            width: 4,
+            alpha: 0.5,
+        });
+    });
+
+    it('should convert stroke object with Color to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const color = new Color(0xff0000);
+
+        color.setAlpha(0.5);
+        const result = convertStrokeInputToStrokeStyle({ color, alpha: 0.5 }, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            color: 0xff0000,
+            alpha: 0.5 * 0.5, // alpha is multiplied
+        });
+    });
+
+    it('should convert stroke object with fill to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const pattern = new FillPattern(Texture.WHITE);
+        const result = convertStrokeInputToStrokeStyle({ fill: pattern, alpha: 0.5 }, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            fill: pattern,
+            color: 0xffffff,
+            alpha: 0.5,
+            texture: pattern.texture,
+            matrix: pattern.transform
+        });
+    });
+
+    it('should convert stroke object with gradient to stroke style', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const gradient = new FillGradient(0, 0, 200, 0);
+        const result = convertStrokeInputToStrokeStyle({ fill: gradient, alpha: 0.5 }, defaultStyle);
+
+        expect(result).toEqual({
+            ...defaultStyle,
+            fill: gradient,
+            alpha: 0.5,
+            color: 0xffffff,
+            texture: gradient.texture,
+            matrix: gradient.transform
+        });
+    });
+});

--- a/tests/renderering/graphics/Graphics.test.ts
+++ b/tests/renderering/graphics/Graphics.test.ts
@@ -3,7 +3,7 @@ import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture
 import { Graphics } from '../../../src/scene/graphics/shared/Graphics';
 import { GraphicsContext } from '../../../src/scene/graphics/shared/GraphicsContext';
 import { GraphicsPath } from '../../../src/scene/graphics/shared/path/GraphicsPath';
-import { convertFillInputToFillStyle } from '../../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
+import { toFillStyle } from '../../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
 import { getWebGLRenderer } from '../../utils/getRenderer';
 
 describe('Graphics', () =>
@@ -27,14 +27,14 @@ describe('Graphics', () =>
     {
         it('should parse the alpha component from a color string value', () =>
         {
-            const style = convertFillInputToFillStyle({ color: '#ff000080' }, GraphicsContext.defaultFillStyle);
+            const style = toFillStyle({ color: '#ff000080' }, GraphicsContext.defaultFillStyle);
 
             expect(style.alpha).toBe(0.5);
         });
 
         it('should multiply alpha component from a color string value with a passed alpha value', () =>
         {
-            const style = convertFillInputToFillStyle(
+            const style = toFillStyle(
                 { color: '#ff000080', alpha: 0.5 },
                 GraphicsContext.defaultFillStyle
             );
@@ -122,7 +122,7 @@ describe('Graphics', () =>
 
             matrix.scale(2, 3);
 
-            const style = convertFillInputToFillStyle({ texture, matrix }, GraphicsContext.defaultFillStyle);
+            const style = toFillStyle({ texture, matrix }, GraphicsContext.defaultFillStyle);
 
             expect(style.matrix.a).toBe(1 / 2);
             expect(style.matrix.d).toBe(1 / 3);


### PR DESCRIPTION

- fixes the issue where setting a `FillPattern` or a `FillGraident` directly did not work e.g
```ts
const gradient = new FillGradient(0, 0, 200, 0);
new TextStyle({
  stroke: gradient,
})
```
- split the types up to clearly separate fill and stroke styles
- moved the types for strokes/fills into a separate file as `GraphicsContext` is already pretty large
- deprecated `FillStyleInputs` in favor of splitting into `FillInput` and `StrokeInput` for better types. Also `FillStyleInputs` contained stroke styles, which meant you got the wrong typings when using `.fill()`