### PR TITLE
fix: issue with empty mipmaps

### DIFF
--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -130,6 +130,8 @@ export class GenerateTextureSystem implements System
             clearColor,
         });
 
+        target.source.updateMipmaps();
+
         return target;
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes #10610 . Mipmaps were not being generated on creation when using generateTexture. This tweak fixes that!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
