### PR TITLE
fix: tiling sprite crash

### DIFF
--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -62,9 +62,10 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
             const { batchableMesh } = tilingSpriteData;
 
             // we are batching.. check a texture change!
-            if (batchableMesh.texture._source !== renderable.texture._source)
-
-            { return !batchableMesh.batcher.checkAndUpdateTexture(batchableMesh, renderable.texture); }
+            if (batchableMesh && batchableMesh.texture._source !== renderable.texture._source)
+            {
+                return !batchableMesh.batcher.checkAndUpdateTexture(batchableMesh, renderable.texture);
+            }
         }
 
         return (couldBatch !== canBatch);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Fixes #10603 . When validating a tiling sprite - it was assuming the batchable element exists. Which would not be the case if it had not been rendered yet

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
