### PR TITLE
fix: issue where when a context is lost, the textures are not bound to…

### DIFF
--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -67,6 +67,7 @@ export class GlShaderSystem
         this._programDataHash = Object.create(null);
         this._boundUniformsIdsToIndexHash = Object.create(null);
         this._boundIndexToUniformsHash = Object.create(null);
+        this._shaderSyncFunctions = Object.create(null);
         this._activeProgram = null;
     }
 

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -67,6 +67,10 @@ export class GlShaderSystem
         this._programDataHash = Object.create(null);
         this._boundUniformsIdsToIndexHash = Object.create(null);
         this._boundIndexToUniformsHash = Object.create(null);
+        /**
+         * these need to also be cleared as internally some uniforms are set as an optimisation as the sync
+         * function is generated. Specifically the texture ints.
+         */
         this._shaderSyncFunctions = Object.create(null);
         this._activeProgram = null;
     }


### PR DESCRIPTION
… their correct slots

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

When experiencing a context loss, the uniform index of the texture was not set correctly as this happens during the generation of the shader upload code. The simplest solution is to regenerate the shder upload code by wiping the cache on context loss. 

There are more complex solutions available, but i think this solution is fine for now as context loss should be relatively rare! and it taking an extra beat to restore is not too bad!

No test added as context loss is kind of tricky to test for! 

fixes #10620

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
