### PR TITLE
fix: events firing twice when using dynamic mode

### DIFF
--- a/src/events/EventTicker.ts
+++ b/src/events/EventTicker.ts
@@ -110,6 +110,8 @@ class EventsTickerClass
         globalThis.document.dispatchEvent(new PointerEvent('pointermove', {
             clientX: rootPointerEvent.clientX,
             clientY: rootPointerEvent.clientY,
+            pointerType: rootPointerEvent.pointerType,
+            pointerId: rootPointerEvent.pointerId,
         }));
     }
 


### PR DESCRIPTION
fixes: https://github.com/pixijs/pixijs/issues/10441
fixes: https://github.com/pixijs/pixijs/issues/10131

before: https://www.pixiplayground.com/#/edit/exDzbrsXsLvgdbWm0iZFG
after: https://www.pixiplayground.com/#/edit/cbfMQ_YRzBPNtwevahYkW

I can't find a good way of adding a test for this fix as the way we emulate pointer events in our tests is not the exact same as how a browser does it, due to `pointerId` being different, but the demo above does show the over event only firing once