### PR TITLE
fix: Ensure `depthStencilRenderBuffer` gets resized when render target has depth enabled

### DIFF
--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -256,7 +256,7 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
 
         this._resizeColor(renderTarget, glRenderTarget);
 
-        if (renderTarget.stencil)
+        if (renderTarget.stencil || renderTarget.depth)
         {
             this._resizeStencil(glRenderTarget);
         }


### PR DESCRIPTION
##### Description of change
Closes #10652 
Makes sure the `depthStencilRenderBuffer` gets resized when `renderTarget.depth` is enabled but not `renderTarget.stencil`.

##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
