### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/pull-unit.yml
+++ b/.github/workflows/pull-unit.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ '**' ]
 
+concurrency:
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-visuals.yml
+++ b/.github/workflows/pull-visuals.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ '**' ]
 
+concurrency:
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ '**' ]
 
+concurrency:
+  group: ${{github.workflow}} - ${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     # Append assets to releases
     - name: Upload Assets to Release
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
           ./dist/**/*


### PR DESCRIPTION
Updates the pull/push workflows to using concurrency and updates the release workflow to use the latest action version to avoid node 16 warnings