### PR TITLE
fix: passing 0 width/height to AbstractText/Sprite constructor

### DIFF
--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -129,8 +129,8 @@ export class Sprite extends Container implements View
         this.roundPixels = roundPixels ?? false;
 
         // needs to be set after the container has initiated
-        if (width) this.width = width;
-        if (height) this.height = height;
+        if (width !== undefined) this.width = width;
+        if (height !== undefined) this.height = height;
     }
 
     set texture(value: Texture)

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -135,8 +135,8 @@ export abstract class AbstractText<
         this.roundPixels = roundPixels ?? false;
 
         // needs to be set after the container has initiated
-        if (width) this.width = width;
-        if (height) this.height = height;
+        if (width !== undefined) this.width = width;
+        if (height !== undefined) this.height = height;
     }
 
     /**


### PR DESCRIPTION
##### Description of change

Fixes passing 0 `width`/`height` not change the width/height to 0.

```js
new PIXI.Sprite({ width: 0 }).width // should be 0
new PIXI.Text({ height: 0 }).height // should be 0
```

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
