### PR TITLE
chore: rename Container#_onUpdate

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -445,7 +445,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @internal
      * @ignore
      */
-    public _position: ObservablePoint = new ObservablePoint(this, 0, 0);
+    public _position: ObservablePoint = new ObservablePoint(
+        { _onUpdate: (point: ObservablePoint) => this.#onUpdate(point) }, 0, 0);
 
     /**
      * The scale factor of the object.
@@ -721,7 +722,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     }
 
     /** @ignore */
-    public _onUpdate(point?: ObservablePoint)
+    #onUpdate(point?: ObservablePoint)
     {
         if (point)
         {
@@ -894,7 +895,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         if (this._rotation !== value)
         {
             this._rotation = value;
-            this._onUpdate(this._skew);
+            this.#onUpdate(this._skew);
         }
     }
 
@@ -923,7 +924,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._pivot === defaultPivot)
         {
-            this._pivot = new ObservablePoint(this, 0, 0);
+            this._pivot = new ObservablePoint((this._position as any)._observer, 0, 0);
         }
 
         return this._pivot;
@@ -933,7 +934,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._pivot === defaultPivot)
         {
-            this._pivot = new ObservablePoint(this, 0, 0);
+            this._pivot = new ObservablePoint((this._position as any)._observer, 0, 0);
         }
 
         typeof value === 'number' ? this._pivot.set(value) : this._pivot.copyFrom(value);
@@ -947,7 +948,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._skew === defaultSkew)
         {
-            this._skew = new ObservablePoint(this, 0, 0);
+            this._skew = new ObservablePoint((this._position as any)._observer, 0, 0);
         }
 
         return this._skew;
@@ -957,7 +958,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._skew === defaultSkew)
         {
-            this._skew = new ObservablePoint(this, 0, 0);
+            this._skew = new ObservablePoint((this._position as any)._observer, 0, 0);
         }
 
         this._skew.copyFrom(value);
@@ -973,7 +974,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._scale === defaultScale)
         {
-            this._scale = new ObservablePoint(this, 1, 1);
+            this._scale = new ObservablePoint((this._position as any)._observer, 1, 1);
         }
 
         return this._scale;
@@ -983,7 +984,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     {
         if (this._scale === defaultScale)
         {
-            this._scale = new ObservablePoint(this, 0, 0);
+            this._scale = new ObservablePoint((this._position as any)._observer, 0, 0);
         }
 
         typeof value === 'number' ? this._scale.set(value) : this._scale.copyFrom(value);
@@ -1174,7 +1175,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         this._updateFlags |= UPDATE_COLOR;
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /** The opacity of the object. */
@@ -1194,7 +1195,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         this._updateFlags |= UPDATE_COLOR;
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /**
@@ -1225,7 +1226,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         this.localBlendMode = value;
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /**
@@ -1260,7 +1261,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         this.localDisplayStatus ^= 0b010;
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /** @ignore */
@@ -1284,7 +1285,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         this._updateFlags |= UPDATE_VISIBLE;
         this.localDisplayStatus ^= 0b100;
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /** Can this object be rendered, if false the object will not be drawn but the transform will still be updated. */
@@ -1307,7 +1308,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             this.parentRenderGroup.structureDidChange = true;
         }
 
-        this._onUpdate();
+        this.#onUpdate();
     }
 
     /** Whether or not the object should be rendered. */

--- a/tests/scene/transform-tint.tests.ts
+++ b/tests/scene/transform-tint.tests.ts
@@ -33,7 +33,7 @@ describe('Transform Tints', () =>
     {
         const root = new Container();
 
-        root._onUpdate = jest.fn();
+        (root._position as any)._onUpdate = jest.fn();
 
         root.alpha = 0.5;
 
@@ -41,28 +41,28 @@ describe('Transform Tints', () =>
 
         root.alpha = 0.5;
 
-        expect(root._onUpdate).toHaveBeenCalledTimes(1);
+        expect((root._position as any)._onUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('should set and return tints correctly', async () =>
     {
         const root = new Container();
 
-        root._onUpdate = jest.fn();
+        (root._position as any)._onUpdate = jest.fn();
 
         root.tint = 0xFF0000;
 
         expect((root.tint)).toEqual(0xFF0000);
         root.tint = 0xFF0000;
 
-        expect(root._onUpdate).toHaveBeenCalledTimes(1);
+        expect((root._position as any)._onUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('should set and return both alpha and tint correctly', async () =>
     {
         const root = new Container();
 
-        root._onUpdate = jest.fn();
+        (root._position as any)._onUpdate = jest.fn();
 
         root.tint = 0xFF00FF;
         root.alpha = 0.5;
@@ -72,7 +72,7 @@ describe('Transform Tints', () =>
         expect((root.alpha)).toEqual(0.5);
         expect((root.localColor)).toEqual(0xFF00FF);
 
-        expect(root._onUpdate).toHaveBeenCalledTimes(2);
+        expect((root._position as any)._onUpdate).toHaveBeenCalledTimes(2);
     });
 
     it('should update global alpha correctly', async () =>


### PR DESCRIPTION
##### Description of change

The name `_onUpdate` is causing problems for our public API (Foundry VTT), where we already have a method `_onUpdate` in a class that extends `PIXI.Container`. Since the function isn't part of the public PIXI API (`@ignore` tag), making it `#`-private (or renaming it) should be not a problem hopefully.

I haven't seen anything `#`-private in the PIXI code base so I'm not sure if there isn't a reason why we cannot do it.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
