### PR TITLE
chore: make validateRenderable nonoptional

### DIFF
--- a/src/rendering/renderers/shared/instructions/RenderPipe.ts
+++ b/src/rendering/renderers/shared/instructions/RenderPipe.ts
@@ -86,7 +86,6 @@ export interface RenderPipe<RENDERABLE = Renderable>
      * Called whenever a renderable is destroyed, often the pipes keep a webGL / webGPU specific representation
      * of the renderable that needs to be tidied up when the renderable is destroyed.
      * @param renderable - the renderable that needs to be rendered
-     * @returns
      */
     destroyRenderable: (renderable: RENDERABLE) => void;
     /**
@@ -94,9 +93,9 @@ export interface RenderPipe<RENDERABLE = Renderable>
      * improve performance. If this function returns false, the renderer will rebuild the whole instruction set
      * for the scene. This is only called if the scene has not its changed its structure .
      * @param renderable
-     * @returns
+     * @returns {boolean}
      */
-    validateRenderable?: (renderable: RENDERABLE) => boolean;
+    validateRenderable: (renderable: RENDERABLE) => boolean;
 }
 
 /**


### PR DESCRIPTION
##### Description of change

It doesn't look like `validateRenderable ` can actually be optional:
https://github.com/pixijs/pixijs/blob/ece3e0068a9c969deb24456559f033f0f4b466ee/src/scene/container/utils/validateRenderables.ts#L18

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
