### PR TITLE
fix: culling issues

### DIFF
--- a/src/culling/Culler.ts
+++ b/src/culling/Culler.ts
@@ -46,10 +46,14 @@ export class Culler
             const bounds = container.cullArea ?? getGlobalBounds(container, skipUpdateTransform, tempBounds);
 
             // check view intersection..
-            container.culled = !(bounds.x >= view.x + view.width
+            container.culled = bounds.x >= view.x + view.width
                 || bounds.y >= view.y + view.height
                 || bounds.x + bounds.width <= view.x
-                || bounds.y + bounds.height <= view.y);
+                || bounds.y + bounds.height <= view.y;
+        }
+        else
+        {
+            container.culled = false;
         }
 
         // dont process children if not needed

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -141,8 +141,6 @@ export interface ContainerOptions<C extends ContainerChild = ContainerChild> ext
     skew?: PointData;
     /** @see scene.Container#visible */
     visible?: boolean;
-    /** @see scene.Container#culled */
-    culled?: boolean;
     /** @see scene.Container#x */
     x?: number;
     /** @see scene.Container#y */
@@ -539,7 +537,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * This property holds three bits: culled, visible, renderable
      * the third bit represents culling (0 = culled, 1 = not culled) 0b100
      * the second bit represents visibility (0 = not visible, 1 = visible) 0b010
-     * the first bit represents renderable (0 = renderable, 1 = not renderable) 0b001
+     * the first bit represents renderable (0 = not renderable, 1 = renderable) 0b001
      * @internal
      * @ignore
      */
@@ -1249,9 +1247,9 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
     set visible(value: boolean)
     {
-        const valueNumber = value ? 1 : 0;
+        const valueNumber = value ? 0b010 : 0;
 
-        if ((this.localDisplayStatus & 0b010) >> 1 === valueNumber) return;
+        if ((this.localDisplayStatus & 0b010) === valueNumber) return;
 
         if (this.parentRenderGroup)
         {
@@ -1274,9 +1272,9 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     /** @ignore */
     set culled(value: boolean)
     {
-        const valueNumber = value ? 1 : 0;
+        const valueNumber = value ? 0 : 0b100;
 
-        if ((this.localDisplayStatus & 0b100) >> 2 === valueNumber) return;
+        if ((this.localDisplayStatus & 0b100) === valueNumber) return;
 
         if (this.parentRenderGroup)
         {
@@ -1297,7 +1295,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
     set renderable(value: boolean)
     {
-        const valueNumber = value ? 1 : 0;
+        const valueNumber = value ? 0b001 : 0;
 
         if ((this.localDisplayStatus & 0b001) === valueNumber) return;
 

--- a/tests/scene/culler.test.ts
+++ b/tests/scene/culler.test.ts
@@ -62,6 +62,30 @@ describe('Culler', () =>
         expect(child.culled).toBe(false);
     });
 
+    it('should set culled to false if object becomes non-cullable', () =>
+    {
+        const child = new Sprite(texture);
+
+        child.x = 100;
+        child.y = 100;
+        child.width = 10;
+        child.height = 10;
+        child.cullable = true;
+        container.addChild(child);
+
+        Culler.shared.cull(container, view, false);
+
+        expect(child.culled).toBe(true);
+
+        child.x = 0;
+        child.y = 0;
+        child.cullable = false;
+
+        Culler.shared.cull(container, view, false);
+
+        expect(child.culled).toBe(false);
+    });
+
     it('noncullable container should always be rendered even if bounds do not intersect the frame', () =>
     {
         const graphics = container.addChild(new Graphics().rect(0, 0, 10, 10).fill());

--- a/tests/scene/transform-visibility.tests.ts
+++ b/tests/scene/transform-visibility.tests.ts
@@ -109,7 +109,7 @@ describe('Transform Visibility', () =>
 
         container.visible = false;
         container.renderable = false;
-        container.culled = false;
+        container.culled = true;
 
         updateRenderGroupTransforms(root.renderGroup, true);
 
@@ -117,7 +117,7 @@ describe('Transform Visibility', () =>
 
         container.visible = true;
         container.renderable = true;
-        container.culled = true;
+        container.culled = false;
 
         updateRenderGroupTransforms(root.renderGroup, true);
 


### PR DESCRIPTION
##### Description of change

- Fixed: Assigning `culled` to false made `culled` true and vice versa.
- Fixed: If a previously `cullable` object was made non-`cullable`, the `culled` state would not be reset by `Culler`.
- Removed `culled` as one of the `ContainerOptions`, because `culled` is not part of the public API (it is tagged `@ignore`).

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
