### PR TITLE
chore: add Container#onViewUpdate

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -744,6 +744,21 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         }
     }
 
+    public onViewUpdate()
+    {
+        this._didChangeId += 1 << 12;
+
+        if (this.didViewUpdate) return;
+        this.didViewUpdate = true;
+
+        const renderGroup = this.renderGroup || this.parentRenderGroup;
+
+        if (renderGroup)
+        {
+            renderGroup.onChildViewUpdate(this);
+        }
+    }
+
     set isRenderGroup(value: boolean)
     {
         if (!!this.renderGroup === value) return;

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -146,21 +146,11 @@ export class Graphics extends Container implements View, Instruction
         this._roundPixels = value ? 1 : 0;
     }
 
-    protected onViewUpdate()
+    public onViewUpdate()
     {
-        // increment from the 12th bit!
-        this._didChangeId += 1 << 12;
         this._didGraphicsUpdate = true;
 
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
+        super.onViewUpdate();
     }
 
     /**

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -333,23 +333,6 @@ export class Mesh<
         return false;
     }
 
-    /** @ignore */
-    public onViewUpdate()
-    {
-        // increment from the 12th bit!
-        this._didChangeId += 1 << 12;
-
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
-    }
-
     /**
      * Destroys this sprite renderable and optionally its texture.
      * @param options - Options parameter. A boolean will act as if all options

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -268,19 +268,9 @@ export class NineSliceSprite extends Container implements View
 
     public onViewUpdate()
     {
-        // increment from the 12th bit!
-        this._didChangeId += 1 << 12;
         this._didSpriteUpdate = true;
 
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
+        super.onViewUpdate();
     }
 
     /**

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -440,17 +440,7 @@ export class TilingSprite extends Container implements View, Instruction
         this._boundsDirty = true;
         this._didTilingSpriteUpdate = true;
 
-        this._didChangeId += 1 << 12;
-
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
+        super.onViewUpdate();
     }
 
     /**

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -227,20 +227,10 @@ export class Sprite extends Container implements View
 
     public onViewUpdate()
     {
-        // increment from the 12th bit!
-        this._didChangeId += 1 << 12;
         this._didSpriteUpdate = true;
         this._sourceBoundsDirty = this._boundsDirty = true;
 
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
+        super.onViewUpdate();
     }
 
     private _updateBounds()

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -379,20 +379,10 @@ export abstract class AbstractText<
 
     public onViewUpdate()
     {
-        this._didChangeId += 1 << 12;
         this._boundsDirty = true;
-
-        if (this.didViewUpdate) return;
-        this.didViewUpdate = true;
-
         this._didTextUpdate = true;
 
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
-        if (renderGroup)
-        {
-            renderGroup.onChildViewUpdate(this);
-        }
+        super.onViewUpdate();
     }
 
     public _getKey(): string


### PR DESCRIPTION
##### Description of change

`_didChangeId` (tagged `@ignore`), `didViewUpdate` (tagged `@private`), `renderGroup` (tagged `@private`), `parentRenderGroup` (tagged `@private`) are all not part of the public API. But I assume every custom subclass of `Container` would need to implement a `onViewUpdate` function, but without access to these private/internal members that is not possible. So I added the `onViewUpdate` to `Container`, which does executes the code that all of the `onViewUpdate` implementations have in common.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
