### PR TITLE
chore: make uid members public

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -111,7 +111,8 @@ export class Batcher
         indexSize: 6,
     };
 
-    public uid = uid('batcher');
+    /** unique id for this batcher */
+    public readonly uid: number = uid('batcher');
     public attributeBuffer: ViewableBuffer;
     public indexBuffer: IndexBufferArray;
 

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -95,12 +95,8 @@ export class Buffer extends EventEmitter<{
      * @event destroy
      */
 
-    /**
-     * a unique id for this uniform group used through the renderer
-     * @internal
-     * @ignore
-     */
-    public readonly uid = uid('buffer');
+    /** a unique id for this uniform group used through the renderer */
+    public readonly uid: number = uid('buffer');
 
     /**
      * a resource type, used to identify how to handle it when its in a bind group / shader resource

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -34,12 +34,8 @@ export class BufferResource extends EventEmitter<{
      * @event change
      */
 
-    /**
-     * a unique id for this uniform group used through the renderer
-     * @internal
-     * @ignore
-     */
-    public readonly uid = uid('buffer');
+    /** a unique id for this uniform group used through the renderer */
+    public readonly uid: number = uid('buffer');
 
     /**
      * a resource type, used to identify how to handle it when its in a bind group / shader resource

--- a/src/rendering/renderers/shared/instructions/InstructionSet.ts
+++ b/src/rendering/renderers/shared/instructions/InstructionSet.ts
@@ -15,7 +15,7 @@ import type { Instruction } from './Instruction';
 export class InstructionSet
 {
     /** a unique id for this instruction set used through the renderer */
-    public readonly uid = uid('instructionSet');
+    public readonly uid: number = uid('instructionSet');
     /** the array of instructions */
     public readonly instructions: Instruction[] = [];
     /** the actual size of the array (any instructions passed this should be ignored) */

--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -63,7 +63,8 @@ export class RenderTarget
         isRoot: false
     };
 
-    public uid = uid('renderTarget');
+    /** unique id for this render target */
+    public readonly uid: number = uid('renderTarget');
 
     /**
      * An array of textures that can be written to by the GPU - mostly this has one texture in Pixi, but you could

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -96,7 +96,7 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
     public _touched = 0;
 
     /** a unique id for this uniform group used through the renderer */
-    public readonly uid = uid('uniform');
+    public readonly uid: number = uid('uniform');
     /** a resource type, used to identify how to handle it when its in a bind group / shader resource */
     public _resourceType = 'uniformGroup';
     /** the resource id used internally by the renderer to build bind group keys */

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -131,7 +131,7 @@ export class Texture extends EventEmitter<{
     /** label used for debugging */
     public label?: string;
     /** unique id for this texture */
-    public uid = uid('texture');
+    public readonly uid: number = uid('texture');
     /**
      * Has the texture been destroyed?
      * @readonly

--- a/src/rendering/renderers/shared/texture/sources/TextureSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/TextureSource.ts
@@ -95,7 +95,7 @@ export class TextureSource<T extends Record<string, any> = any> extends EventEmi
     };
 
     /** unique id for this Texture source */
-    public readonly uid = uid('textureSource');
+    public readonly uid: number = uid('textureSource');
     /** optional label, can be used for debugging */
     public label: string;
 

--- a/src/rendering/renderers/shared/view/View.ts
+++ b/src/rendering/renderers/shared/view/View.ts
@@ -13,7 +13,7 @@ export interface ViewObserver
 export interface View
 {
     /** a unique id for this view */
-    uid: number;
+    readonly uid: number;
 
     /** whether or not this view should be batched */
     batched: boolean;

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -356,8 +356,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         Object.defineProperties(Container.prototype, Object.getOwnPropertyDescriptors(source));
     }
 
-    /** @private */
-    public uid: number = uid('renderable');
+    /** unique id for this container */
+    public readonly uid: number = uid('renderable');
 
     /** @private */
     public _updateFlags = 0b1111;

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -106,7 +106,8 @@ export class GraphicsContext extends EventEmitter<{
         fill: null,
     };
 
-    public uid = uid('graphicsContext');
+    /** unique id for this graphics context */
+    public readonly uid: number = uid('graphicsContext');
     public dirty = true;
     public batchMode: BatchMode = 'auto';
     public instructions: GraphicsInstructions[] = [];

--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -28,7 +28,8 @@ export class FillGradient implements CanvasGradient
 {
     public static defaultTextureSize = 256;
 
-    public readonly uid = uid('fillGradient');
+    /** unique id for this fill gradient */
+    public readonly uid: number = uid('fillGradient');
     public readonly type: GradientType = 'linear';
 
     public x0: number;

--- a/src/scene/graphics/shared/fill/FillPattern.ts
+++ b/src/scene/graphics/shared/fill/FillPattern.ts
@@ -27,7 +27,8 @@ const repetitionMap = {
 
 export class FillPattern implements CanvasPattern
 {
-    public readonly uid = uid('fillPattern');
+    /** unique id for this fill pattern */
+    public readonly uid: number = uid('fillPattern');
     public texture: Texture;
     public transform = new Matrix();
 

--- a/src/scene/graphics/shared/path/GraphicsPath.ts
+++ b/src/scene/graphics/shared/path/GraphicsPath.ts
@@ -30,7 +30,8 @@ export class GraphicsPath
 {
     public instructions: PathInstruction[] = [];
 
-    public uid = uid('graphicsPath');
+    /** unique id for this graphics path */
+    public readonly uid: number = uid('graphicsPath');
 
     private _dirty = true;
     // needed for hit testing and bounds calculations


### PR DESCRIPTION
##### Description of change

If custom pipes are expected to be implemented the same way as PIXI pipes, we need `uid` to be part of the public API.

I made all `uid`s public and readonly.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
