### PR TITLE
chore: remove dead code from Batcher

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -122,9 +122,6 @@ export class Batcher
 
     public dirty = true;
 
-    public batchIndex = 0;
-    public batches: Batch[] = [];
-
     // specifics.
     private readonly _vertexSize: number = 6;
 
@@ -153,7 +150,6 @@ export class Batcher
 
     public begin()
     {
-        this.batchIndex = 0;
         this.elementSize = 0;
         this.elementStart = 0;
         this.indexSize = 0;
@@ -423,13 +419,6 @@ export class Batcher
 
     public destroy()
     {
-        for (let i = 0; i < this.batches.length; i++)
-        {
-            this.batches[i].destroy();
-        }
-
-        this.batches = null;
-
         for (let i = 0; i < this._elements.length; i++)
         {
             this._elements[i].batch = null;

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -6,6 +6,7 @@ import { InstructionSet } from '../../../rendering/renderers/shared/instructions
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { buildContextBatches } from './utils/buildContextBatches';
 
+import type { Batch } from '../../../rendering/batcher/shared/Batcher';
 import type { System } from '../../../rendering/renderers/shared/system/System';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
@@ -206,9 +207,9 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
         geometry.indexBuffer.setDataWithSize(batcher.indexBuffer, batcher.indexSize, true);
         geometry.buffers[0].setDataWithSize(batcher.attributeBuffer.float32View, batcher.attributeSize, true);
 
-        const drawBatches = batcher.batches;
+        const drawBatches = graphicsData.instructions.instructions as Batch[];
 
-        for (let i = 0; i < drawBatches.length; i++)
+        for (let i = 0; i < graphicsData.instructions.instructionSize; i++)
         {
             const batch = drawBatches[i];
 


### PR DESCRIPTION
##### Description of change

`batchIndex` is always 0 and `batches` always empty.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
