### PR TITLE
fix: Mesh shader sharing

### DIFF
--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -15,11 +15,6 @@ import type { Bounds } from '../../container/bounds/Bounds';
 import type { ContainerOptions } from '../../container/Container';
 import type { DestroyOptions } from '../../container/destroyTypes';
 
-export interface TextureShader extends Shader
-{
-    texture: Texture;
-}
-
 /**
  * Constructor options used for `Mesh` instances. Extends {@link scene.MeshViewOptions}
  * ```js
@@ -39,7 +34,7 @@ export interface TextureShader extends Shader
  */
 export interface MeshOptions<
     GEOMETRY extends Geometry = MeshGeometry,
-    SHADER extends Shader = TextureShader
+    SHADER extends Shader = Shader
 > extends ContainerOptions
 {
     /**
@@ -77,7 +72,7 @@ export interface MeshOptions<
  */
 export class Mesh<
     GEOMETRY extends Geometry = MeshGeometry,
-    SHADER extends Shader = TextureShader
+    SHADER extends Shader = Shader
 > extends Container implements View, Instruction
 {
     public readonly renderPipeId = 'mesh';
@@ -134,7 +129,7 @@ export class Mesh<
         this.allowChildren = false;
 
         this.shader = shader;
-        this.texture = texture ?? (shader as unknown as TextureShader)?.texture ?? Texture.WHITE;
+        this.texture = texture ?? Texture.WHITE;
         this.state = state ?? State.for2d();
 
         this._geometry = geometry;
@@ -216,11 +211,6 @@ export class Mesh<
 
         if (currentTexture && currentTexture.dynamic) currentTexture.off('update', this.onViewUpdate, this);
         if (value.dynamic) value.on('update', this.onViewUpdate, this);
-
-        if (this.shader)
-        {
-            (this.shader as unknown as TextureShader).texture = value;
-        }
 
         this._texture = value;
         this.onViewUpdate();

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -3,6 +3,7 @@ import { Matrix } from '../../../maths/matrix/Matrix';
 import { BindGroup } from '../../../rendering/renderers/gpu/shader/BindGroup';
 import { UniformGroup } from '../../../rendering/renderers/shared/shader/UniformGroup';
 import { getAdjustedBlendModeBlend } from '../../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
+import { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { color32BitToUniform } from '../../graphics/gpu/colorToUniform';
 import { BatchableMesh } from './BatchableMesh';
@@ -62,6 +63,20 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<MeshInstructi
     public localUniformsBindGroup = new BindGroup({
         0: this.localUniforms,
     });
+
+    public textureUniforms = new UniformGroup({
+        uTextureMatrix: { value: new Matrix(), type: 'mat3x3<f32>' },
+        uClampFrame: { value: new Float32Array([0, 0, 1, 1]), type: 'vec4<f32>' },
+        uClampOffset: { value: new Float32Array([0, 0]), type: 'vec2<f32>' },
+    });
+
+    public textureUniformsBindGroup = new BindGroup({
+        0: Texture.EMPTY._source,
+        1: Texture.EMPTY._source.style,
+        2: this.textureUniforms,
+    });
+
+    public textureUniformsBindMap = { 0: 'uTexture', 1: 'uSampler' };
 
     public renderer: Renderer;
 


### PR DESCRIPTION
##### Description of change

`Mesh#shader` claims:
> Can be shared between multiple Mesh objects.

While this is true, it doesn't really work if the meshes different textures, because the setter of `Mesh#texture` sets `TextureShader#texture`. So if a shader is shared, `mesh.texture` may not be equal to `mesh.shader.texture`. In PIXI v7 mesh shader sharing was even less possible, because the `tint` was also owned by the shader. But this has changed now with introduction of the `localUniforms`.

With this PR the mesh pipe adapter binds the texture uniforms as `textureUniforms` like `localUniforms`/`globalUniforms` would be. So mesh shader no longer needs to define the `texture` setter, and the shader can be shared among meshes with different textures.

These changes (seem to) work, but I'm not sure they are the optimal implementation. I'm still learning the new API.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
