### PR TITLE
fix: Support alpha colors on FillGradient

### DIFF
--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -53,7 +53,7 @@ export class FillGradient implements CanvasGradient
 
     public addColorStop(offset: number, color: ColorSource): this
     {
-        this.gradientStops.push({ offset, color: Color.shared.setValue(color).toHex() });
+        this.gradientStops.push({ offset, color: Color.shared.setValue(color).toHexa() });
         this._styleKey = null;
 
         return this;

--- a/tests/renderering/text/TextStyle.tests.ts
+++ b/tests/renderering/text/TextStyle.tests.ts
@@ -238,9 +238,9 @@ describe('TextStyle', () =>
 
         expect(textStyle._fill.fill).toBeInstanceOf(FillGradient);
         expect((textStyle._fill.fill as FillGradient).gradientStops).toEqual([
-            { offset: 0, color: '#000000' },
-            { offset: 0.5, color: '#ff0000' },
-            { offset: 1, color: '#ffffff' },
+            { offset: 0, color: '#000000ff' },
+            { offset: 0.5, color: '#ff0000ff' },
+            { offset: 1, color: '#ffffffff' },
         ]);
     });
 });


### PR DESCRIPTION
FillGradient doesn't support alpha:

* https://jsfiddle.net/bigtimebuddy/yo6e04u3/ (v8.2.2)
* https://jsfiddle.net/bigtimebuddy/3zvjr5qt/ (patched)