### PR TITLE
chore: make Mesh#shader nullable

### DIFF
--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -89,7 +89,7 @@ export class Mesh<
     /** @ignore */
     public _geometry: GEOMETRY;
     /** @ignore */
-    public _shader?: SHADER;
+    public _shader: SHADER | null = null;
 
     public _roundPixels: 0 | 1 = 0;
 
@@ -133,7 +133,7 @@ export class Mesh<
 
         this.allowChildren = false;
 
-        this.shader = shader;
+        this.shader = shader ?? null;
         this.texture = texture ?? (shader as unknown as TextureShader)?.texture ?? Texture.WHITE;
         this.state = state ?? State.for2d();
 
@@ -171,7 +171,7 @@ export class Mesh<
      * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
      * Can be shared between multiple Mesh objects.
      */
-    set shader(value: SHADER)
+    set shader(value: SHADER | null)
     {
         if (this._shader === value) return;
 
@@ -179,7 +179,7 @@ export class Mesh<
         this.onViewUpdate();
     }
 
-    get shader()
+    get shader(): SHADER | null
     {
         return this._shader;
     }


### PR DESCRIPTION
##### Description of change


Not sure if the `| null` is really required, but I think we want `shader` to be `null` if not assigned in the constructor instead of `undefined`. At least we probably shouldn't allow both `undefined` and `null` to represent "no shader", I think.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
