### PR TITLE
fix: Check if transform is set on lastShape before dereferencing

### DIFF
--- a/src/scene/graphics/shared/path/ShapePath.ts
+++ b/src/scene/graphics/shared/path/ShapePath.ts
@@ -650,7 +650,7 @@ export class ShapePath
                 let lx = lastShape.shape.x;
                 let ly = lastShape.shape.y;
 
-                if (!lastShape.transform.isIdentity())
+                if (lastShape.transform && !lastShape.transform.isIdentity())
                 {
                     const t = lastShape.transform;
 


### PR DESCRIPTION
I found this while working on https://github.com/ShukantPal/pixi-essentials/pull/107

This fixes an issue where `_ensurePoly` called after closing a polygon without a transform matrix set. This can happen if `lineTo` is called after `fill`.

For a reproduction, please see:
https://jsfiddle.net/ShukantPal/25g6jrth/
