### PR TITLE
fix: inconsistencies in docs (10663)

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -111,7 +111,7 @@ export class Application<R extends Renderer = Renderer>
 
     /**
      * WebGL renderer if available, otherwise CanvasRenderer.
-     * @member {Renderer}
+     * @member {rendering.Renderer}
      */
     public renderer: R;
 

--- a/src/app/TickerPlugin.ts
+++ b/src/app/TickerPlugin.ts
@@ -5,7 +5,7 @@ import { Ticker } from '../ticker/Ticker';
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
 /**
- * Application options for the {@link app.TickerPluginOptions}.
+ * Application options for the {@link app.TickerPlugin}.
  * @memberof app
  * @property {boolean} [autoStart=true] - Automatically starts the rendering after the construction.
  * **Note**: Setting this parameter to `false` does NOT stop the shared ticker even if you set

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -37,7 +37,7 @@ export abstract class PrepareBase
     protected timeout?: number;
 
     /**
-     * @param {Renderer} renderer - A reference to the current renderer
+     * @param {rendering.Renderer} renderer - A reference to the current renderer
      */
     constructor(renderer: Renderer)
     {

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -37,8 +37,7 @@ export abstract class PrepareBase
     protected timeout?: number;
 
     /**
-     * * @param {Renderer} renderer - A reference to the current renderer
-     * @param renderer
+     * @param {Renderer} renderer - A reference to the current renderer
      */
     constructor(renderer: Renderer)
     {

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -202,7 +202,7 @@ export class Texture extends EventEmitter<{
     public readonly isTexture = true;
 
     /**
-     * @param {TextureOptions} param0 - Options for the texture
+     * @param {rendering.TextureOptions} options - Options for the texture
      */
     constructor({
         source,

--- a/src/rendering/renderers/types.ts
+++ b/src/rendering/renderers/types.ts
@@ -3,6 +3,11 @@ import type { WebGLOptions, WebGLPipes, WebGLRenderer } from './gl/WebGLRenderer
 import type { WebGPUOptions, WebGPUPipes, WebGPURenderer } from './gpu/WebGPURenderer';
 
 /** A generic renderer. */
+/**
+ * @memberof rendering
+ * @extends rendering.WebGLRenderer
+ * @extends rendering.WebGPURenderer
+ */
 export type Renderer<T extends ICanvas = HTMLCanvasElement> = WebGLRenderer<T> | WebGPURenderer<T>;
 export type RenderPipes = WebGLPipes | WebGPUPipes;
 /**

--- a/src/rendering/renderers/types.ts
+++ b/src/rendering/renderers/types.ts
@@ -5,6 +5,10 @@ import type { WebGPUOptions, WebGPUPipes, WebGPURenderer } from './gpu/WebGPURen
 /** A generic renderer. */
 export type Renderer<T extends ICanvas = HTMLCanvasElement> = WebGLRenderer<T> | WebGPURenderer<T>;
 export type RenderPipes = WebGLPipes | WebGPUPipes;
+/**
+ * @extends rendering.WebGLOptions
+ * @extends rendering.WebGPUOptions
+ */
 export interface RendererOptions extends WebGLOptions, WebGPUOptions {}
 
 /* eslint-disable @typescript-eslint/indent */


### PR DESCRIPTION

##### Description of change
PR is dedicated to fixing issues mentioned in [issues/10663](https://github.com/pixijs/pixijs/issues/10663) and a few other small mistakes in docs that I've noticed along the way

1 commit
[https://github.com/pixijs/pixijs/commit/104c18bce4a1c44c59e4dc7337a95205d97b0511](https://github.com/pixijs/pixijs/commit/104c18bce4a1c44c59e4dc7337a95205d97b0511)
fixes [rendering.PrepareBase.html#constructor](https://pixijs.download/release/docs/rendering.PrepareBase.html#constructor) - renderer param in constructor is in text instead of in table

2 commit
[https://github.com/pixijs/pixijs/commit/0972c0b8b1a046f493f6a900c776f4103c11a592](https://github.com/pixijs/pixijs/commit/0972c0b8b1a046f493f6a900c776f4103c11a592)
fixes [rendering.Texture.html#constructor](https://pixijs.download/release/docs/rendering.Texture.html#constructor) - change param name in constructor from param0 to options and fix link of its type to TextureOptions (3rd point in [issue/10663](https://github.com/pixijs/pixijs/issues/10663))

3 commit
[https://github.com/pixijs/pixijs/commit/f268dab993b18b6510fe8f21f624e27091599f8b](https://github.com/pixijs/pixijs/commit/f268dab993b18b6510fe8f21f624e27091599f8b)
fixes [app.TickerPluginOptions.html](https://pixijs.download/release/docs/app.TickerPluginOptions.html) - change "Application options for the TickerPluginOptions" to "Application options for the TickerPlugin" and link to TickerPlugin instead of back to the same page

4 commit
[https://github.com/pixijs/pixijs/commit/111ee2c180dd751095124e7a8717a0c8169afd1d](https://github.com/pixijs/pixijs/commit/111ee2c180dd751095124e7a8717a0c8169afd1d)
partially fixes 2nd problem in [issue/10663](https://github.com/pixijs/pixijs/issues/10663) - as the "background" prop in type of object passed to .init is comming from deeply connected (extended) interface and not from the ApplicationOptions, I've decided that it should not be artifically added in documentation of ApplicationOptions. Instead I've just fixed Extensions chain back to this poperty:
[ApplicationOptions](https://pixijs.download/release/docs/app.ApplicationOptions.html) -> [AutoDetectOptions](https://pixijs.download/release/docs/rendering.AutoDetectOptions.html) -> [RendererOptions](https://pixijs.download/release/docs/RendererOptions.html) -> [WebGLOptions](https://pixijs.download/release/docs/rendering.WebGLOptions.html) -> [SharedRendererOptions](https://pixijs.download/release/docs/rendering.SharedRendererOptions.html)

Before my changes RendererOptions do not exist therefore they break the Extends-chain making it harder to find where this "background" prop is comming from. 
I am unsure if this AutoDetectOptions should be a member of rendering - If so, I am willing to add this change to this PR


5 commit
[https://github.com/pixijs/pixijs/commit/0736520f7f7803446ffa9c73191d43040d62ffc5](https://github.com/pixijs/pixijs/commit/0736520f7f7803446ffa9c73191d43040d62ffc5)
is intended to fix 3rd problem in [issue/10663](https://github.com/pixijs/pixijs/issues/10663) - It adds Renderer typedef to [rendering.html#Renderer](https://pixijs.download/release/docs/rendering.html#Renderer), and changes link in [app.Application.html#renderer](https://pixijs.download/release/docs/app.Application.html#renderer) to point to this typedef



##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
