### PR TITLE
Fix/graphics batcher

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -30,7 +30,7 @@ export class Batch implements Instruction
     // for drawing..
     public start = 0;
     public size = 0;
-    public textures: BatchTextureArray;
+    public textures: BatchTextureArray = new BatchTextureArray();
 
     public blendMode: BLEND_MODES = 'normal';
 
@@ -60,6 +60,19 @@ export class Batch implements Instruction
     }
 }
 
+// inlined pool for SPEEEEEEEEEED :D
+const batchPool: Batch[] = [];
+let batchPoolIndex = 0;
+
+function getBatchFromPool()
+{
+    return batchPoolIndex > 0 ? batchPool[--batchPoolIndex] : new Batch();
+}
+
+function returnBatchToPool(batch: Batch)
+{
+    batchPool[batchPoolIndex++] = batch;
+}
 export interface BatchableObject
 {
     indexStart: number;
@@ -130,10 +143,6 @@ export class Batcher
 
     private _elements: BatchableObject[] = [];
 
-    private readonly _batchPool: Batch[] = [];
-    private _batchPoolIndex = 0;
-    private readonly _textureBatchPool: BatchTextureArray[] = [];
-    private _textureBatchPoolIndex = 0;
     private _batchIndexStart: number;
     private _batchIndexSize: number;
     private readonly _maxTextures: number;
@@ -153,13 +162,17 @@ export class Batcher
 
     public begin()
     {
-        this.batchIndex = 0;
         this.elementSize = 0;
         this.elementStart = 0;
         this.indexSize = 0;
         this.attributeSize = 0;
-        this._batchPoolIndex = 0;
-        this._textureBatchPoolIndex = 0;
+
+        for (let i = 0; i < this.batchIndex; i++)
+        {
+            returnBatchToPool(this.batches[i]);
+        }
+
+        this.batchIndex = 0;
         this._batchIndexStart = 0;
         this._batchIndexSize = 0;
 
@@ -212,12 +225,13 @@ export class Batcher
         // ++BATCH_TICK;
         const elements = this._elements;
 
-        let textureBatch = this._textureBatchPool[this._textureBatchPoolIndex++] ||= new BatchTextureArray();
-
-        textureBatch.clear();
-
         // length 0??!! (we broke without adding anything)
         if (!elements[this.elementStart]) return;
+
+        let batch = getBatchFromPool();
+        let textureBatch = batch.textures;
+
+        textureBatch.clear();
 
         const firstElement = elements[this.elementStart];
         let blendMode = getAdjustedBlendModeBlend(firstElement.blendMode, firstElement.texture._source);
@@ -240,7 +254,6 @@ export class Batcher
         let start = this._batchIndexStart;
 
         let action: BatchAction = 'startBatch';
-        let batch = this._batchPool[this._batchPoolIndex++] ||= new Batch();
 
         const maxTextures = this._maxTextures;
 
@@ -289,10 +302,10 @@ export class Batcher
                 // create a batch...
                 blendMode = adjustedBlendMode;
 
-                textureBatch = this._textureBatchPool[this._textureBatchPoolIndex++] ||= new BatchTextureArray();
+                batch = getBatchFromPool();
+                textureBatch = batch.textures;
                 textureBatch.clear();
 
-                batch = this._batchPool[this._batchPoolIndex++] ||= new Batch();
                 ++BATCH_TICK;
             }
 
@@ -350,6 +363,8 @@ export class Batcher
 
         ++BATCH_TICK;
 
+        // track for returning later!
+        this.batches[this.batchIndex++] = batch;
         instructionSet.add(batch);
     }
 

--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -440,7 +440,7 @@ export class Batcher
     {
         for (let i = 0; i < this.batches.length; i++)
         {
-            this.batches[i].destroy();
+            returnBatchToPool(this.batches[i]);
         }
 
         this.batches = null;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes the critical bug @ivanpopelyshev found. Alternative to #10731.
Essentially a GraphicsContext will hold on to its Batcher once ti becomes large enough to require one. In side the batcher, they all now use a shared pool.  

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
