### PR TITLE
chore: optimize Mesh instructions

### DIFF
--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -52,7 +52,7 @@ export interface MeshOptions<
      * Represents the vertex and fragment shaders that processes the geometry and runs on the GPU.
      * Can be shared between multiple Mesh objects.
      */
-    shader?: SHADER;
+    shader?: SHADER | null;
     /** The state of WebGL required to render the mesh. */
     state?: State;
     /** The texture that the Mesh uses. Null for non-MeshMaterial shaders */

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -7,7 +7,6 @@ import { BigPool } from '../../../utils/pool/PoolGroup';
 import { color32BitToUniform } from '../../graphics/gpu/colorToUniform';
 import { BatchableMesh } from './BatchableMesh';
 
-import type { Instruction } from '../../../rendering/renderers/shared/instructions/Instruction';
 import type { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import type {
     InstructionPipe,
@@ -34,14 +33,8 @@ export interface MeshAdaptor
     destroy(): void;
 }
 
-export interface MeshInstruction extends Instruction
-{
-    renderPipeId: 'mesh';
-    mesh: Mesh;
-}
-
 // eslint-disable-next-line max-len
-export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<MeshInstruction>
+export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 {
     /** @ignore */
     public static extension = {
@@ -140,10 +133,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<MeshInstructi
         {
             batcher.break(instructionSet);
 
-            instructionSet.add({
-                renderPipeId: 'mesh',
-                mesh
-            } as MeshInstruction);
+            instructionSet.add(mesh);
         }
     }
 
@@ -173,7 +163,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<MeshInstructi
         }
     }
 
-    public execute({ mesh }: MeshInstruction)
+    public execute(mesh: Mesh)
     {
         if (!mesh.isRenderable) return;
 


### PR DESCRIPTION
##### Description of change

I understand correctly, we should be able to the use `Mesh` itself as the instruction.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
