### PR TITLE
fix: don't batch Mesh with incompatible state

### DIFF
--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -218,6 +218,10 @@ export class Mesh<
     {
         if (this._shader) return false;
 
+        // The state must be compatible with the batcher pipe.
+        // It isn't compatible if depth test or culling is enabled.
+        if ((this.state.data & 0b001100) !== 0) return false;
+
         if (this._geometry instanceof MeshGeometry)
         {
             if (this._geometry.batchMode === 'auto')


### PR DESCRIPTION
##### Description of change

We can't batch the mesh if the state is not compatible (i.e. depth testing or culling is enabled) with the state of the batch adaptor.

Test: https://pixiplayground.com/#/edit/I-ClpYRQc0VGfi6NiEY5Z

Or perhaps we should make `Mesh#state` private/internal? Not sure if we even want to allow all possible states with Mesh?

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
