### PR TITLE
fix: change renderPipeId types to string

### DIFF
--- a/src/rendering/renderers/shared/view/View.ts
+++ b/src/rendering/renderers/shared/view/View.ts
@@ -22,7 +22,7 @@ export interface View
      * an identifier that is used to identify the type of system that will be used to render this renderable
      * eg, 'sprite' will use the sprite system (based on the systems name
      */
-    renderPipeId: string;
+    readonly renderPipeId: string;
 
     /** this is an int because it is packed directly into an attribute in the shader */
     _roundPixels: 0 | 1;

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -548,7 +548,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      */
     public globalDisplayStatus = 0b111; // 0b11 | 0b10 | 0b01 | 0b00
 
-    public renderPipeId: string;
+    public readonly renderPipeId: string;
 
     /**
      * An optional bounds area for this container. Setting this rectangle will stop the renderer

--- a/src/scene/container/RenderContainer.ts
+++ b/src/scene/container/RenderContainer.ts
@@ -83,7 +83,7 @@ export class RenderContainer extends Container implements View, Instruction
     public addBounds: (bounds: Bounds) => void;
 
     public canBundle = false;
-    public renderPipeId = 'customRender';
+    public readonly renderPipeId: string = 'customRender';
 
     /**
      * @param options - The options for the container.

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -44,7 +44,7 @@ export interface GraphicsOptions extends ContainerOptions
 export class Graphics extends Container implements View, Instruction
 {
     public readonly canBundle = true;
-    public readonly renderPipeId = 'graphics';
+    public readonly renderPipeId: string = 'graphics';
     public batched: boolean;
 
     public _roundPixels: 0 | 1 = 0;

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -80,7 +80,7 @@ export class Mesh<
     SHADER extends Shader = TextureShader
 > extends Container implements View, Instruction
 {
-    public readonly renderPipeId = 'mesh';
+    public readonly renderPipeId: string = 'mesh';
     public readonly canBundle = true;
     public state: State;
 

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -79,7 +79,7 @@ export class NineSliceSprite extends Container implements View
     };
 
     public _roundPixels: 0 | 1 = 0;
-    public readonly renderPipeId = 'nineSliceSprite';
+    public readonly renderPipeId: string = 'nineSliceSprite';
     public _texture: Texture;
 
     public batched = true;

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -130,7 +130,7 @@ export class TilingSprite extends Container implements View, Instruction
         applyAnchorToTexture: false,
     };
 
-    public readonly renderPipeId = 'tilingSprite';
+    public readonly renderPipeId: string = 'tilingSprite';
     public readonly canBundle = true;
     public readonly batched = true;
 

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -71,7 +71,7 @@ export class Sprite extends Container implements View
         return new Sprite(Texture.from(source, skipCache));
     }
 
-    public readonly renderPipeId = 'sprite';
+    public readonly renderPipeId: string = 'sprite';
 
     public batched = true;
     public readonly _anchor: ObservablePoint;


### PR DESCRIPTION
##### Description of change

Allows subclasses of `Mesh` etc. to change `renderPipeId` without typescript complaining:

```ts
class MyMesh extends Mesh {
    public readonly renderPipeId: string = 'myMesh';
}
```

Also changed `renderPipeId` of `Container` and `View` to readonly. I don't think switching pipes is supported (at the moment).

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
