### PR TITLE
feat: skip video load if is safari and dimension is provide

### DIFF
--- a/src/rendering/renderers/shared/texture/sources/VideoSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/VideoSource.ts
@@ -274,7 +274,7 @@ export class VideoSource extends TextureSource<VideoResource>
                     this._preloadTimeout = setTimeout(() =>
                     {
                         this._onError(new ErrorEvent(`Preload exceeded timeout of ${options.preloadTimeoutMs}ms`));
-                    }) as unknown as number;
+                    }, options.preloadTimeoutMs) as unknown as number;
                 }
                 source.load();
             }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fix #10633 

Skip forever waiting video `'canplay'` event if browser is **Safari** and dimension(width & height) is provide for texture creation.

Keep same behavior on Chrome as fallback.

Also add `loadTimeoutMs` to prevent forever waiting

```js
/**
 * Configuration for the [loadVideo]{@link assets.loadVideo} plugin.
 * @see assets.loadVideo
 * @memberof assets
 */
export interface LoadVideoConfig
{
    /**
     * The time in milliseconds to wait for the video 'canplay' event before timing out.
     * @default 30000
     */
    loadTimeoutMs?: number
}
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
