### PR TITLE
fix: update view if roundPixels is changed and update batches

### DIFF
--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -143,7 +143,13 @@ export class Graphics extends Container implements View, Instruction
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     protected onViewUpdate()

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -154,7 +154,13 @@ export class Mesh<
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     /** Alias for {@link scene.Mesh#shader}. */

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -126,6 +126,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 
             gpuBatchableMesh.texture = mesh._texture;
             gpuBatchableMesh.geometry = mesh._geometry;
+            gpuBatchableMesh.roundPixels = (this.renderer._roundPixels | mesh._roundPixels) as 0 | 1;
 
             batcher.addToBatch(gpuBatchableMesh);
         }
@@ -145,6 +146,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 
             gpuBatchableMesh.texture = mesh._texture;
             gpuBatchableMesh.geometry = mesh._geometry;
+            gpuBatchableMesh.roundPixels = (this.renderer._roundPixels | mesh._roundPixels) as 0 | 1;
 
             gpuBatchableMesh.batcher.updateElement(gpuBatchableMesh);
         }
@@ -215,7 +217,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
         // TODO - make this batchable graphics??
         const gpuMesh: BatchableMesh = BigPool.get(BatchableMesh);
 
-        gpuMesh.mesh = mesh;
+        gpuMesh.geometry = mesh._geometry;
         gpuMesh.texture = mesh._texture;
         gpuMesh.roundPixels = (this.renderer._roundPixels | mesh._roundPixels) as 0 | 1;
 

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -251,7 +251,13 @@ export class NineSliceSprite extends Container implements View
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     /** The original width of the texture */

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -78,6 +78,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
         // = sprite.bounds;
         batchableSprite.texture = sprite._texture;
+        batchableSprite.roundPixels = (this._renderer._roundPixels | sprite._roundPixels) as 0 | 1;
     }
 
     private _getGpuSprite(sprite: NineSliceSprite): BatchableMesh

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -318,7 +318,13 @@ export class TilingSprite extends Container implements View, Instruction
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     /**

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -103,9 +103,8 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
                 batchableMesh.geometry = geometry;
                 batchableMesh.mesh = tilingSprite;
                 batchableMesh.texture = tilingSprite._texture;
+                batchableMesh.roundPixels = (this._renderer._roundPixels | tilingSprite._roundPixels) as 0 | 1;
             }
-
-            batchableMesh.roundPixels = (this._renderer._roundPixels | tilingSprite._roundPixels) as 0 | 1;
 
             batcher.addToBatch(batchableMesh);
         }

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -328,7 +328,13 @@ export class Sprite extends Container implements View
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     /** The width of the sprite, setting this will actually modify the scale to achieve the value set. */

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -75,6 +75,7 @@ export class SpritePipe implements RenderPipe<Sprite>
         sprite._didSpriteUpdate = false;
         batchableSprite.bounds = sprite.bounds;
         batchableSprite.texture = sprite._texture;
+        batchableSprite.roundPixels = (this._renderer._roundPixels | sprite._roundPixels) as 0 | 1;
     }
 
     private _getGpuSprite(sprite: Sprite): BatchableSprite

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -139,6 +139,8 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         const padding = htmlText._style.padding;
 
         updateQuadBounds(batchableSprite.bounds, htmlText._anchor, batchableSprite.texture, padding);
+
+        batchableSprite.roundPixels = (this._renderer._roundPixels | htmlText._roundPixels) as 0 | 1;
     }
 
     private async _updateGpuText(htmlText: HTMLText)

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -175,7 +175,13 @@ export abstract class AbstractText<
 
     set roundPixels(value: boolean)
     {
-        this._roundPixels = value ? 1 : 0;
+        const valueNumber = value ? 1 : 0;
+
+        if (this._roundPixels === valueNumber) return;
+
+        this._roundPixels = valueNumber;
+
+        this.onViewUpdate();
     }
 
     /** Set the copy for the text object. To split a line you can use '\n'. */

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -140,6 +140,8 @@ export class CanvasTextPipe implements RenderPipe<Text>
         const padding = text._style.padding;
 
         updateQuadBounds(batchableSprite.bounds, text._anchor, batchableSprite.texture, padding);
+
+        batchableSprite.roundPixels = (this._renderer._roundPixels | text._roundPixels) as 0 | 1;
     }
 
     private _updateGpuText(text: Text)

--- a/tests/renderering/RoundPixels.test.ts
+++ b/tests/renderering/RoundPixels.test.ts
@@ -134,6 +134,101 @@ describe('Round Pixels', () =>
         expect(batchableTilingSprite.roundPixels).toBe(1);
     });
 
+    it('batches should have round pixels if the object has round pixels', async () =>
+    {
+        const renderer = new WebGLRenderer();
+
+        await renderer.init({
+            roundPixels: false,
+        });
+
+        const sprite = new Sprite();
+        const tilingSprite = new TilingSprite();
+        const graphics = new Graphics().rect(0, 0, 100, 100).fill('red');
+
+        const mesh = new Mesh({
+            geometry: new QuadGeometry(),
+        });
+
+        sprite.roundPixels = true;
+        tilingSprite.roundPixels = true;
+        graphics.roundPixels = true;
+        mesh.roundPixels = true;
+
+        const container = new Container();
+
+        container.addChild(tilingSprite, graphics, mesh, sprite);
+
+        renderer.render(container);
+
+        const batchableSprite = renderer.renderPipes.sprite['_getGpuSprite'](sprite);
+
+        expect(batchableSprite.roundPixels).toBe(1);
+
+        const batchableGraphics = renderer.renderPipes.graphics['_getBatchesForRenderable'](graphics);
+
+        expect(batchableGraphics[0].roundPixels).toBe(1);
+
+        const batchableMesh = renderer.renderPipes.mesh['_getBatchableMesh'](mesh);
+
+        expect(batchableMesh.roundPixels).toBe(1);
+
+        const batchableTilingSprite = renderer.renderPipes.tilingSprite['_getTilingSpriteData'](tilingSprite).batchableMesh;
+
+        expect(batchableTilingSprite.roundPixels).toBe(1);
+    });
+
+    it('round pixels of batches should update if round pixels of the object is changed', async () =>
+    {
+        const renderer = new WebGLRenderer();
+
+        await renderer.init({
+            roundPixels: false,
+        });
+
+        const sprite = new Sprite();
+        const tilingSprite = new TilingSprite();
+        const graphics = new Graphics().rect(0, 0, 100, 100).fill('red');
+
+        const mesh = new Mesh({
+            geometry: new QuadGeometry(),
+        });
+
+        sprite.roundPixels = true;
+        tilingSprite.roundPixels = true;
+        graphics.roundPixels = true;
+        mesh.roundPixels = true;
+
+        const container = new Container();
+
+        container.addChild(tilingSprite, graphics, mesh, sprite);
+
+        renderer.render(container);
+
+        sprite.roundPixels = false;
+        tilingSprite.roundPixels = false;
+        graphics.roundPixels = false;
+        mesh.roundPixels = false;
+
+        renderer.render(container);
+
+        const batchableSprite = renderer.renderPipes.sprite['_getGpuSprite'](sprite);
+
+        expect(batchableSprite.roundPixels).toBe(0);
+
+        const batchableGraphics = renderer.renderPipes.graphics['_getBatchesForRenderable'](graphics);
+
+        expect(batchableGraphics[0].roundPixels).toBe(0);
+
+        const batchableMesh = renderer.renderPipes.mesh['_getBatchableMesh'](mesh);
+
+        expect(batchableMesh.roundPixels).toBe(0);
+
+        const batchableTilingSprite = renderer.renderPipes.tilingSprite['_getTilingSpriteData'](tilingSprite).batchableMesh;
+
+        expect(batchableTilingSprite.roundPixels).toBe(0);
+    });
+
     it('renderer round pixels should override text items round pixels if false', async () =>
     {
         const renderer = new WebGLRenderer();


### PR DESCRIPTION
##### Description of change

If `Container#roundPixels` is changed, we need to update the view and update the batches.

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
