### PR TITLE
fix: delete hash entries instead of assigning null

### DIFF
--- a/src/assets/loader/workers/WorkerManager.ts
+++ b/src/assets/loader/workers/WorkerManager.ts
@@ -112,7 +112,7 @@ class WorkerManagerClass
             this._resolveHash[data.uuid].resolve(data.data);
         }
 
-        this._resolveHash[data.uuid] = null;
+        delete this._resolveHash[data.uuid];
     }
 
     private async _run(id: string, args: any[]): Promise<any>

--- a/src/rendering/batcher/shared/BatchTextureArray.ts
+++ b/src/rendering/batcher/shared/BatchTextureArray.ts
@@ -29,7 +29,7 @@ export class BatchTextureArray
             const t = this.textures[i];
 
             this.textures[i] = null;
-            this.ids[t.uid] = null;
+            delete this.ids[t.uid];
         }
 
         this.count = 0;

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -195,7 +195,7 @@ export class GlBufferSystem implements System
             gl.deleteBuffer(glBuffer.buffer);
         }
 
-        this._gpuBuffers[buffer.uid] = null;
+        delete this._gpuBuffers[buffer.uid];
     }
 
     /**

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -332,7 +332,7 @@ export class GlGeometrySystem implements System
                 }
             }
 
-            this._geometryVaoHash[i] = null;
+            delete this._geometryVaoHash[i];
         }
     }
 

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -303,7 +303,7 @@ export class GlGeometrySystem implements System
                 }
             }
 
-            this._geometryVaoHash[geometry.uid] = null;
+            delete this._geometryVaoHash[geometry.uid];
         }
     }
 

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -210,7 +210,7 @@ export class GlShaderSystem implements ShaderSystem
             const programData = this._programDataHash[key];
 
             programData.destroy();
-            this._programDataHash[key] = null;
+            delete this._programDataHash[key];
         }
 
         this._programDataHash = null;

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -263,7 +263,7 @@ export class GlTextureSystem implements System, CanvasGenerator
         if (!glTexture) return;
 
         this.unbind(source);
-        this._glTextures[source.uid] = null;
+        delete this._glTextures[source.uid];
 
         this._gl.deleteTexture(glTexture.texture);
     }

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -134,7 +134,7 @@ export class BindGroupSystem implements System
     {
         for (const key of Object.keys(this._hash))
         {
-            this._hash[key] = null;
+            delete this._hash[key];
         }
 
         this._hash = null;

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -64,7 +64,7 @@ export class GpuUniformBatchPipe
     {
         for (const i in this._bindGroupHash)
         {
-            this._bindGroupHash[i] = null;
+            delete this._bindGroupHash[i];
         }
 
         this._batchBuffer.clear();

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -135,7 +135,7 @@ export class GpuBufferSystem implements System
         buffer.off('change', this.onBufferChange, this);
         buffer.off('destroy', this.onBufferDestroy, this);
 
-        this._gpuBuffers[buffer.uid] = null;
+        delete this._gpuBuffers[buffer.uid];
     }
 }
 

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -138,7 +138,7 @@ export class GpuTextureSystem implements System, CanvasGenerator
 
         if (gpuTexture)
         {
-            this._gpuSources[source.uid] = null;
+            delete this._gpuSources[source.uid];
 
             gpuTexture.destroy();
         }
@@ -179,8 +179,8 @@ export class GpuTextureSystem implements System, CanvasGenerator
         }
         else if (gpuTexture.width !== source.pixelWidth || gpuTexture.height !== source.pixelHeight)
         {
-            this._textureViewHash[source.uid] = null;
-            this._bindGroupHash[source.uid] = null;
+            delete this._textureViewHash[source.uid];
+            delete this._bindGroupHash[source.uid];
 
             this.onSourceUnload(source);
             this.initSource(source);

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -314,7 +314,7 @@ export class GpuTextureSystem implements System, CanvasGenerator
             const bindGroup = this._bindGroupHash[key];
 
             bindGroup?.destroy();
-            this._bindGroupHash[key] = null;
+            delete this._bindGroupHash[key];
         }
 
         this._gpu = null;

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -508,7 +508,7 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
 
                 if (gpuRenderTarget)
                 {
-                    this._gpuRenderTargetHash[renderTarget.uid] = null;
+                    delete this._gpuRenderTargetHash[renderTarget.uid];
                     this.adaptor.destroyGpuRenderTarget(gpuRenderTarget);
                 }
             });

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -221,7 +221,7 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
 
         context.off('destroy', this.onGraphicsContextDestroy, this);
 
-        this._gpuContextHash[context.uid] = null;
+        delete this._gpuContextHash[context.uid];
     }
 
     private _cleanGraphicsContextData(context: GraphicsContext)
@@ -235,7 +235,7 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
                 BigPool.return(this.getContextRenderData(context) as PoolItem);
 
                 // we will rebuild this...
-                this._graphicsDataContextHash[context.uid] = null;
+                delete this._graphicsDataContextHash[context.uid];
             }
         }
 

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -235,7 +235,7 @@ export class GraphicsPipe implements RenderPipe<Graphics>
             BigPool.return(batch as PoolItem);
         });
 
-        this._graphicsBatchesHash[graphicsUid] = null;
+        delete this._graphicsBatchesHash[graphicsUid];
     }
 
     public destroy()

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -154,14 +154,14 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 
     public destroyRenderable(mesh: Mesh)
     {
-        this._meshDataHash[mesh.uid] = null;
+        delete this._meshDataHash[mesh.uid];
 
         const gpuMesh = this._gpuBatchableMeshHash[mesh.uid];
 
         if (gpuMesh)
         {
             BigPool.return(gpuMesh as PoolItem);
-            this._gpuBatchableMeshHash[mesh.uid] = null;
+            delete this._gpuBatchableMeshHash[mesh.uid];
         }
 
         mesh.off('destroyed', this._destroyRenderableBound);

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -70,7 +70,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
         BigPool.return(batchableMesh.geometry as PoolItem);
         BigPool.return(batchableMesh as PoolItem);
 
-        this._gpuSpriteHash[sprite.uid] = null;
+        delete this._gpuSpriteHash[sprite.uid];
 
         sprite.off('destroyed', this._destroyRenderableBound);
     }

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -190,7 +190,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
 
         tilingSpriteData.shader?.destroy();
 
-        this._tilingSpriteDataHash[tilingSprite.uid] = null;
+        delete this._tilingSpriteDataHash[tilingSprite.uid];
 
         tilingSprite.off('destroyed', this._destroyRenderableBound);
     }

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -69,7 +69,7 @@ export class SpritePipe implements RenderPipe<Sprite>
         // this will call reset!
         BigPool.return(batchableSprite as PoolItem);
 
-        this._gpuSpriteHash[sprite.uid] = null;
+        delete this._gpuSpriteHash[sprite.uid];
 
         sprite.off('destroyed', this._destroyRenderableBound);
     }

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -94,7 +94,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
         }
 
         BigPool.return(this._gpuBitmapText[renderableUid] as PoolItem);
-        this._gpuBitmapText[renderableUid] = null;
+        delete this._gpuBitmapText[renderableUid];
     }
 
     public updateRenderable(bitmapText: BitmapText)

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -121,7 +121,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
         BigPool.return(gpuText.batchableSprite);
 
-        this._gpuText[htmlTextUid] = null;
+        delete this._gpuText[htmlTextUid];
     }
 
     private _updateText(htmlText: HTMLText)

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -195,7 +195,7 @@ export class HTMLTextSystem implements System
                 });
             }
 
-            this._activeTextures[textKey] = null;
+            delete this._activeTextures[textKey];
         }
     }
 

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -126,7 +126,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
 
         BigPool.return(gpuText.batchableSprite);
 
-        this._gpuText[textUid] = null;
+        delete this._gpuText[textUid];
     }
 
     private _updateText(text: Text)

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -188,7 +188,7 @@ export class CanvasTextSystem implements System
             source.uploadMethodId = 'unknown';
             source.alphaMode = 'no-premultiply-alpha';
 
-            this._activeTextures[textKey] = null;
+            delete this._activeTextures[textKey];
         }
     }
 

--- a/tests/renderering/Buffer.test.ts
+++ b/tests/renderering/Buffer.test.ts
@@ -32,7 +32,7 @@ describe('Buffer', () =>
 
         buffer.destroy();
 
-        expect((renderer).buffer['_gpuBuffers'][buffer.uid]).toBeNull();
+        expect(buffer.uid in renderer.buffer['_gpuBuffers']).toBeFalse();
     });
 
     it('should set a cast data correctly', () =>

--- a/tests/renderering/Geometry.test.ts
+++ b/tests/renderering/Geometry.test.ts
@@ -41,7 +41,7 @@ describe('Geometry', () =>
 
         geometry.destroy();
 
-        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(geometry.uid in renderer.geometry['_geometryVaoHash']).toBeFalse();
         expect(buffer.data).not.toBeNull();
     });
 
@@ -59,7 +59,7 @@ describe('Geometry', () =>
 
         geometry.destroy(true);
 
-        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(geometry.uid in renderer.geometry['_geometryVaoHash']).toBeFalse();
         expect(buffer.data).toBeNull();
     });
 
@@ -85,7 +85,7 @@ describe('Geometry', () =>
 
         renderer.geometry.destroyAll();
 
-        expect(renderer.geometry['_geometryVaoHash'][geometry.uid]).toBeNull();
+        expect(geometry.uid in renderer.geometry['_geometryVaoHash']).toBeFalse();
     });
 
     it('should return bounds of a geometry correctly', () =>

--- a/tests/renderering/graphics/Graphics.Destroy.test.ts
+++ b/tests/renderering/graphics/Graphics.Destroy.test.ts
@@ -41,15 +41,13 @@ describe('Graphics Destroy', () =>
 
         expect(graphics.context).toBeNull();
 
-        expect(renderer.renderPipes.graphics['_graphicsBatchesHash'][graphics.uid]).toBeNull();
+        expect(graphics.uid in renderer.renderPipes.graphics['_graphicsBatchesHash']).toBeFalse();
 
-        expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).not.toBeNull();
-        expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).not.toBeNull();
+        expect(context.uid in renderer.graphicsContext['_gpuContextHash']).toBeTrue();
 
         context.destroy(true);
 
-        expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).toBeNull();
-        expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).toBeNull();
+        expect(context.uid in renderer.graphicsContext['_gpuContextHash']).toBeFalse();
 
         expect(context.instructions).toBeNull();
     });

--- a/tests/renderering/mesh/Mesh.test.ts
+++ b/tests/renderering/mesh/Mesh.test.ts
@@ -53,8 +53,8 @@ describe('Mesh', () =>
         expect(mesh.geometry).toBeNull();
         expect(mesh.texture).toBeNull();
 
-        expect(renderer.renderPipes.mesh['_meshDataHash'][mesh.uid]).toBeNull();
-        expect(renderer.renderPipes.mesh['_gpuBatchableMeshHash'][mesh.uid]).toBeNull();
+        expect(mesh.uid in renderer.renderPipes.mesh['_meshDataHash']).toBeFalse();
+        expect(mesh.uid in renderer.renderPipes.mesh['_gpuBatchableMeshHash']).toBeFalse();
 
         expect(gpuMesh.mesh).toBeNull();
     });
@@ -80,8 +80,8 @@ describe('Mesh', () =>
         expect(mesh.geometry).toBeNull();
         expect(mesh.texture).toBeNull();
 
-        expect(renderer.renderPipes.mesh['_meshDataHash'][mesh.uid]).toBeNull();
-        expect(renderer.renderPipes.mesh['_gpuBatchableMeshHash'][mesh.uid]).toBeUndefined();
+        expect(mesh.uid in renderer.renderPipes.mesh['_meshDataHash']).toBeFalse();
+        expect(mesh.uid in renderer.renderPipes.mesh['_gpuBatchableMeshHash']).toBeFalse();
     });
 
     it('should support color tinting', () =>

--- a/tests/renderering/sprite/Sprite.test.ts
+++ b/tests/renderering/sprite/Sprite.test.ts
@@ -63,7 +63,7 @@ describe('Sprite', () =>
 
             sprite.destroy();
 
-            expect(renderer.renderPipes.sprite['_gpuSpriteHash'][sprite.uid]).toBeNull();
+            expect(sprite.uid in renderer.renderPipes.sprite['_gpuSpriteHash']).toBeFalse();
         });
     });
 

--- a/tests/renderering/sprite/TilingSprite.test.ts
+++ b/tests/renderering/sprite/TilingSprite.test.ts
@@ -100,7 +100,7 @@ describe('TilingSprite', () =>
 
             sprite.destroy();
 
-            expect(renderer.renderPipes.tilingSprite['_tilingSpriteDataHash'][sprite.uid]).toBeNull();
+            expect(sprite.uid in renderer.renderPipes.tilingSprite['_tilingSpriteDataHash']).toBeFalse();
 
             expect(sprite.texture).toBeNull();
         });

--- a/tests/renderering/text/Text.tests.ts
+++ b/tests/renderering/text/Text.tests.ts
@@ -150,7 +150,7 @@ describe('Text', () =>
             text.destroy();
 
             expect(text.uid in renderer.renderPipes.text['_gpuText']).toBeFalse();
-            expect(renderer.canvasText['_activeTextures'][key]).toBeNull();
+            expect(key in renderer.canvasText['_activeTextures']).toBeFalse();
         });
 
         it('should destroy bitmap text correctly on the pipes and systems', async () =>

--- a/tests/renderering/text/Text.tests.ts
+++ b/tests/renderering/text/Text.tests.ts
@@ -149,7 +149,7 @@ describe('Text', () =>
 
             text.destroy();
 
-            expect(renderer.renderPipes.text['_gpuText'][text.uid]).toBeNull();
+            expect(text.uid in renderer.renderPipes.text['_gpuText']).toBeFalse();
             expect(renderer.canvasText['_activeTextures'][key]).toBeNull();
         });
 
@@ -165,11 +165,11 @@ describe('Text', () =>
 
             renderer.render({ container });
 
-            expect(renderer.renderPipes.bitmapText['_gpuBitmapText'][text.uid]).not.toBeNull();
+            expect(text.uid in renderer.renderPipes.bitmapText['_gpuBitmapText']).toBeTrue();
 
             text.destroy();
 
-            expect(renderer.renderPipes.bitmapText['_gpuBitmapText'][text.uid]).toBeNull();
+            expect(text.uid in renderer.renderPipes.bitmapText['_gpuBitmapText']).toBeFalse();
         });
 
         it('should destroy textStyle correctly', () =>


### PR DESCRIPTION
##### Description of change

If we don't delete, we'll have `null` entries for destroyed objects forever since the uids are not recycled, I think.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
