### PR TITLE
fix: Sprite#bounds with trimmed texture

### DIFF
--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -73,7 +73,7 @@ export class SpritePipe implements RenderPipe<Sprite>
     private _updateBatchableSprite(sprite: Sprite, batchableSprite: BatchableSprite)
     {
         sprite._didSpriteUpdate = false;
-        batchableSprite.bounds = sprite.bounds;
+        batchableSprite.bounds = sprite._texture.trim ? sprite.trimmedBounds : sprite.bounds;
         batchableSprite.texture = sprite._texture;
     }
 
@@ -89,7 +89,7 @@ export class SpritePipe implements RenderPipe<Sprite>
         batchableSprite.renderable = sprite;
 
         batchableSprite.texture = sprite._texture;
-        batchableSprite.bounds = sprite.bounds;
+        batchableSprite.bounds = sprite._texture.trim ? sprite.trimmedBounds : sprite.bounds;
         batchableSprite.roundPixels = (this._renderer._roundPixels | sprite._roundPixels) as 0 | 1;
 
         this._gpuSpriteHash[sprite.uid] = batchableSprite;


### PR DESCRIPTION
##### Description of change

I don't think `Sprite#bounds` should be the trimmed bounds. Otherwise `getFastGlobalBounds` returns the wrong bounds. `getFastGlobalBounds` uses `bounds`, but `Sprite#addBounds` uses `sourceBounds`.

- Deprecated `sourceBounds`.
- Added `trimmedBounds`.
- `bounds` are now the untrimmed bounds.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
