### PR TITLE
chore: clean hashes 

### DIFF
--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { BufferUsage } from '../../shared/buffer/const';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 import { BUFFER_TYPE } from './const';
 import { GlBuffer } from './GlBuffer';
 
@@ -49,6 +50,8 @@ export class GlBufferSystem implements System
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuBuffers');
     }
 
     /**

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { getAttributeInfoFromFormat } from '../../shared/geometry/utils/getAttributeInfoFromFormat';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 import { ensureAttributes } from '../shader/program/ensureAttributes';
 import { getGlTypeFromFormat } from './utils/getGlTypeFromFormat';
 
@@ -62,6 +63,8 @@ export class GlGeometrySystem implements System
 
         this.hasVao = true;
         this.hasInstance = true;
+
+        scheduleCleanHash(renderer, this, '_geometryVaoHash');
     }
 
     /** Sets up the renderer context and necessary buffers. */

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { getMaxTexturesPerBatch } from '../../../batcher/gl/utils/maxRecommendedTextures';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 import { generateShaderSyncCode } from './GenerateShaderSyncCode';
 import { generateProgram } from './program/generateProgram';
 
@@ -60,6 +61,8 @@ export class GlShaderSystem implements ShaderSystem
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_programDataHash');
     }
 
     protected contextChange(gl: GlRenderingContext): void

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -1,6 +1,7 @@
 import { DOMAdapter } from '../../../../environment/adapter';
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { Texture } from '../../shared/texture/Texture';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 import { GlTexture } from './GlTexture';
 import { glUploadBufferImageResource } from './uploaders/glUploadBufferImageResource';
 import { glUploadCompressedTextureResource } from './uploaders/glUploadCompressedTextureResource';
@@ -68,6 +69,9 @@ export class GlTextureSystem implements System, CanvasGenerator
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_glTextures');
+        scheduleCleanHash(renderer, this, '_glSamplers');
     }
 
     protected contextChange(gl: GlRenderingContext): void

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { scheduleCleanHash } from '../shared/utils/cleanHash';
 
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { BufferResource } from '../shared/buffer/BufferResource';
@@ -34,6 +35,7 @@ export class BindGroupSystem implements System
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+        scheduleCleanHash(renderer, this, '_hash');
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { scheduleCleanHash } from '../..';
 import { Buffer } from '../shared/buffer/Buffer';
 import { BufferResource } from '../shared/buffer/BufferResource';
 import { BufferUsage } from '../shared/buffer/const';
@@ -52,6 +53,8 @@ export class GpuUniformBatchPipe
                 usage
             }));
         }
+
+        scheduleCleanHash(renderer, this, '_bindGroupHash');
     }
 
     public renderEnd()

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -1,8 +1,8 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { scheduleCleanHash } from '../..';
 import { Buffer } from '../shared/buffer/Buffer';
 import { BufferResource } from '../shared/buffer/BufferResource';
 import { BufferUsage } from '../shared/buffer/const';
+import { scheduleCleanHash } from '../shared/utils/cleanHash';
 import { UboBatch } from './buffer/UboBatch';
 import { BindGroup } from './shader/BindGroup';
 

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -1,9 +1,11 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
+import { scheduleCleanHash } from '../../..';
 import { fastCopy } from '../../shared/buffer/utils/fastCopy';
 
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
+import type { WebGPURenderer } from '../WebGPURenderer';
 
 /**
  * System plugin to the renderer to manage buffers.
@@ -24,6 +26,11 @@ export class GpuBufferSystem implements System
     private readonly _managedBuffers: Buffer[] = [];
 
     private _gpu: GPU;
+
+    constructor(renderer: WebGPURenderer)
+    {
+        scheduleCleanHash(renderer, this, '_gpuBuffers');
+    }
 
     protected contextChange(gpu: GPU): void
     {

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -1,6 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
-import { scheduleCleanHash } from '../../..';
 import { fastCopy } from '../../shared/buffer/utils/fastCopy';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -1,7 +1,7 @@
 import { DOMAdapter } from '../../../../environment/adapter';
 import { ExtensionType } from '../../../../extensions/Extensions';
-import { scheduleCleanHash } from '../../..';
 import { CanvasPool } from '../../shared/texture/CanvasPool';
+import { scheduleCleanHash } from '../../shared/utils/cleanHash';
 import { BindGroup } from '../shader/BindGroup';
 import { gpuUploadBufferImageResource } from './uploaders/gpuUploadBufferImageResource';
 import { blockDataMap, gpuUploadCompressedTextureResource } from './uploaders/gpuUploadCompressedTextureResource';

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -1,5 +1,6 @@
 import { DOMAdapter } from '../../../../environment/adapter';
 import { ExtensionType } from '../../../../extensions/Extensions';
+import { scheduleCleanHash } from '../../..';
 import { CanvasPool } from '../../shared/texture/CanvasPool';
 import { BindGroup } from '../shader/BindGroup';
 import { gpuUploadBufferImageResource } from './uploaders/gpuUploadBufferImageResource';
@@ -55,6 +56,11 @@ export class GpuTextureSystem implements System, CanvasGenerator
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuSources');
+        scheduleCleanHash(renderer, this, '_gpuSamplers');
+        scheduleCleanHash(renderer, this, '_bindGroupHash');
+        scheduleCleanHash(renderer, this, '_textureViewHash');
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1,6 +1,5 @@
 import { Matrix } from '../../../../maths/matrix/Matrix';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
-import { scheduleCleanHash } from '../../..';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';
 import { SystemRunner } from '../system/SystemRunner';
@@ -8,6 +7,7 @@ import { CanvasSource } from '../texture/sources/CanvasSource';
 import { TextureSource } from '../texture/sources/TextureSource';
 import { Texture } from '../texture/Texture';
 import { getCanvasTexture } from '../texture/utils/getCanvasTexture';
+import { scheduleCleanHash } from '../utils/cleanHash';
 import { isRenderingToScreen } from './isRenderingToScreen';
 import { RenderTarget } from './RenderTarget';
 

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1,5 +1,6 @@
 import { Matrix } from '../../../../maths/matrix/Matrix';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
+import { scheduleCleanHash } from '../../..';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';
 import { SystemRunner } from '../system/SystemRunner';
@@ -187,6 +188,7 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        scheduleCleanHash(renderer, this, '_gpuRenderTargetHash');
     }
 
     /** called when dev wants to finish a render pass */

--- a/src/rendering/renderers/shared/utils/cleanHash.ts
+++ b/src/rendering/renderers/shared/utils/cleanHash.ts
@@ -1,4 +1,4 @@
-import type { Renderer } from '../../..';
+import type { Renderer } from '../../types';
 
 /**
  * Takes a hash and removes all the falsy values from it.

--- a/src/rendering/renderers/shared/utils/cleanHash.ts
+++ b/src/rendering/renderers/shared/utils/cleanHash.ts
@@ -1,0 +1,55 @@
+import type { Renderer } from '../../..';
+
+/**
+ * Takes a hash and removes all the falsy values from it.
+ * In PixiJS, we tend to null properties instead of using 'delete' for performance reasons.
+ * However, in some cases, this could be a problem if the hash grows too large over time,
+ * this function can be used to clean a hash.
+ * @param hash - The hash to clean.
+ * @returns A new hash with all the falsy values removed.
+ */
+export function cleanHash<T>(hash: Record<string, T>): Record<string, T>
+{
+    let clean = false;
+
+    for (const i in hash)
+    {
+        if (!hash[i])
+        {
+            clean = true;
+            break;
+        }
+    }
+
+    if (!clean) return hash;
+
+    const cleanHash = Object.create(null);
+
+    for (const i in hash)
+    {
+        const value = hash[i];
+
+        if (value)
+        {
+            cleanHash[i] = value;
+        }
+    }
+
+    return cleanHash;
+}
+
+/**
+ * A helper function that schedules the cleaning of a hash on an object.
+ * @param renderer - The renderer this System works for.
+ * @param owner - The owner of the hash.
+ * @param hashName - the name of the hash on the owner
+ * @param frequency - The frequency to clean the hash (defaults to 2 mins)
+ */
+export function scheduleCleanHash(renderer: Renderer, owner: any, hashName: string, frequency = 120000): void
+{
+    renderer.scheduler.repeat(() =>
+    {
+        owner[hashName] = cleanHash(owner[hashName]);
+    }, frequency);
+}
+

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { scheduleCleanHash } from '../../../rendering';
 import { getTextureBatchBindGroup } from '../../../rendering/batcher/gpu/getTextureBatchBindGroup';
 import { Batcher } from '../../../rendering/batcher/shared/Batcher';
 import { BatchGeometry } from '../../../rendering/batcher/shared/BatchGeometry';
@@ -6,6 +7,7 @@ import { InstructionSet } from '../../../rendering/renderers/shared/instructions
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { buildContextBatches } from './utils/buildContextBatches';
 
+import type { Renderer } from '../../../rendering';
 import type { System } from '../../../rendering/renderers/shared/system/System';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
@@ -93,6 +95,12 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
     private _gpuContextHash: Record<number, GpuGraphicsContext> = {};
     // used for non-batchable graphics
     private _graphicsDataContextHash: Record<number, GraphicsContextRenderData> = Object.create(null);
+
+    constructor(renderer: Renderer)
+    {
+        scheduleCleanHash(renderer, this, '_gpuContextHash');
+        scheduleCleanHash(renderer, this, '_graphicsDataContextHash');
+    }
 
     /**
      * Runner init called, update the default options

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -1,14 +1,14 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { scheduleCleanHash } from '../../../rendering';
 import { getTextureBatchBindGroup } from '../../../rendering/batcher/gpu/getTextureBatchBindGroup';
 import { Batcher } from '../../../rendering/batcher/shared/Batcher';
 import { BatchGeometry } from '../../../rendering/batcher/shared/BatchGeometry';
 import { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
+import { scheduleCleanHash } from '../../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { buildContextBatches } from './utils/buildContextBatches';
 
-import type { Renderer } from '../../../rendering';
 import type { System } from '../../../rendering/renderers/shared/system/System';
+import type { Renderer } from '../../../rendering/renderers/types';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
 import type { GraphicsContext } from './GraphicsContext';

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -1,9 +1,11 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { scheduleCleanHash } from '../../../rendering';
 import { State } from '../../../rendering/renderers/shared/state/State';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { color32BitToUniform } from '../gpu/colorToUniform';
 import { BatchableGraphics } from './BatchableGraphics';
 
+import type { Renderer } from '../../../rendering';
 import type { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import type { BatchPipe, RenderPipe } from '../../../rendering/renderers/shared/instructions/RenderPipe';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
@@ -40,7 +42,7 @@ export class GraphicsPipe implements RenderPipe<Graphics>
         name: 'graphics',
     } as const;
 
-    public renderer: GraphicsSystem;
+    public renderer: Renderer;
     public state: State = State.for2d();
 
     // batchable graphics list, used to render batches
@@ -48,9 +50,11 @@ export class GraphicsPipe implements RenderPipe<Graphics>
     private _adaptor: GraphicsAdaptor;
     private readonly _destroyRenderableBound = this.destroyRenderable.bind(this) as (renderable: Container) => void;
 
-    constructor(renderer: GraphicsSystem, adaptor: GraphicsAdaptor)
+    constructor(renderer: Renderer, adaptor: GraphicsAdaptor)
     {
         this.renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_graphicsBatchesHash');
 
         this._adaptor = adaptor;
         this._adaptor.init();

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -1,14 +1,14 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { scheduleCleanHash } from '../../../rendering';
 import { State } from '../../../rendering/renderers/shared/state/State';
+import { scheduleCleanHash } from '../../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { color32BitToUniform } from '../gpu/colorToUniform';
 import { BatchableGraphics } from './BatchableGraphics';
 
-import type { Renderer } from '../../../rendering';
 import type { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import type { BatchPipe, RenderPipe } from '../../../rendering/renderers/shared/instructions/RenderPipe';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
+import type { Renderer } from '../../../rendering/renderers/types';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { Container } from '../../container/Container';
 import type { Graphics } from './Graphics';

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -1,5 +1,6 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { Matrix } from '../../../maths/matrix/Matrix';
+import { scheduleCleanHash } from '../../../rendering';
 import { BindGroup } from '../../../rendering/renderers/gpu/shader/BindGroup';
 import { UniformGroup } from '../../../rendering/renderers/shared/shader/UniformGroup';
 import { getAdjustedBlendModeBlend } from '../../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
@@ -67,6 +68,10 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
     constructor(renderer: Renderer, adaptor: MeshAdaptor)
     {
         this.renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuBatchableMeshHash');
+        scheduleCleanHash(renderer, this, '_meshDataHash');
+
         this._adaptor = adaptor;
 
         this._adaptor.init();

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -1,9 +1,9 @@
 import { ExtensionType } from '../../../extensions/Extensions';
 import { Matrix } from '../../../maths/matrix/Matrix';
-import { scheduleCleanHash } from '../../../rendering';
 import { BindGroup } from '../../../rendering/renderers/gpu/shader/BindGroup';
 import { UniformGroup } from '../../../rendering/renderers/shared/shader/UniformGroup';
 import { getAdjustedBlendModeBlend } from '../../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
+import { scheduleCleanHash } from '../../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { color32BitToUniform } from '../../graphics/gpu/colorToUniform';
 import { BatchableMesh } from './BatchableMesh';

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
+import { scheduleCleanHash } from '../../rendering';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableMesh } from '../mesh/shared/BatchableMesh';
 import { NineSliceGeometry } from './NineSliceGeometry';
@@ -29,6 +30,8 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuSpriteHash');
     }
 
     public addRenderable(sprite: NineSliceSprite, _instructionSet: InstructionSet)

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -1,5 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
-import { scheduleCleanHash } from '../../rendering';
+import { scheduleCleanHash } from '../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableMesh } from '../mesh/shared/BatchableMesh';
 import { NineSliceGeometry } from './NineSliceGeometry';

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { ExtensionType } from '../../extensions/Extensions';
-import { scheduleCleanHash } from '../../rendering';
 import { getAdjustedBlendModeBlend } from '../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
 import { State } from '../../rendering/renderers/shared/state/State';
+import { scheduleCleanHash } from '../../rendering/renderers/shared/utils/cleanHash';
 import { type Renderer, RendererType } from '../../rendering/renderers/types';
 import { color32BitToUniform } from '../graphics/gpu/colorToUniform';
 import { BatchableMesh } from '../mesh/shared/BatchableMesh';

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { ExtensionType } from '../../extensions/Extensions';
+import { scheduleCleanHash } from '../../rendering';
 import { getAdjustedBlendModeBlend } from '../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
 import { State } from '../../rendering/renderers/shared/state/State';
 import { type Renderer, RendererType } from '../../rendering/renderers/types';
@@ -48,6 +49,8 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_tilingSpriteDataHash');
     }
 
     public validateRenderable(renderable: TilingSprite): boolean

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
+import { scheduleCleanHash } from '../../rendering';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableSprite } from './BatchableSprite';
 
@@ -28,13 +29,13 @@ export class SpritePipe implements RenderPipe<Sprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuSpriteHash');
     }
 
     public addRenderable(sprite: Sprite, _instructionSet: InstructionSet)
     {
         const gpuSprite = this._getGpuSprite(sprite);
-
-        // console.log(sprite.didViewUpdate);
 
         if (sprite.didViewUpdate) this._updateBatchableSprite(sprite, gpuSprite);
 

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -1,5 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
-import { scheduleCleanHash } from '../../rendering';
+import { scheduleCleanHash } from '../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableSprite } from './BatchableSprite';
 

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -1,5 +1,6 @@
 import { Cache } from '../../assets/cache/Cache';
 import { ExtensionType } from '../../extensions/Extensions';
+import { scheduleCleanHash } from '../../rendering';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { Graphics } from '../graphics/shared/Graphics';
 import { SdfShader } from '../text/sdfShader/SdfShader';
@@ -33,6 +34,8 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+
+        scheduleCleanHash(renderer, this, '_gpuBitmapText');
     }
 
     public validateRenderable(bitmapText: BitmapText): boolean

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -1,6 +1,6 @@
 import { Cache } from '../../assets/cache/Cache';
 import { ExtensionType } from '../../extensions/Extensions';
-import { scheduleCleanHash } from '../../rendering';
+import { scheduleCleanHash } from '../../rendering/renderers/shared/utils/cleanHash';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { Graphics } from '../graphics/shared/Graphics';
 import { SdfShader } from '../text/sdfShader/SdfShader';

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
+import { scheduleCleanHash } from '../../rendering';
 import { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import { updateQuadBounds } from '../../utils/data/updateQuadBounds';
 import { BigPool } from '../../utils/pool/PoolGroup';
@@ -39,6 +40,8 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         this._renderer.runners.resolutionChange.add(this);
+
+        scheduleCleanHash(renderer, this, '_gpuText');
     }
 
     public resolutionChange()

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -1,6 +1,6 @@
 import { ExtensionType } from '../../extensions/Extensions';
-import { scheduleCleanHash } from '../../rendering';
 import { Texture } from '../../rendering/renderers/shared/texture/Texture';
+import { scheduleCleanHash } from '../../rendering/renderers/shared/utils/cleanHash';
 import { updateQuadBounds } from '../../utils/data/updateQuadBounds';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableSprite } from '../sprite/BatchableSprite';

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -1,5 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { scheduleCleanHash } from '../../../rendering';
+import { scheduleCleanHash } from '../../../rendering/renderers/shared/utils/cleanHash';
 import { updateQuadBounds } from '../../../utils/data/updateQuadBounds';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { BatchableSprite } from '../../sprite/BatchableSprite';

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { scheduleCleanHash } from '../../../rendering';
 import { updateQuadBounds } from '../../../utils/data/updateQuadBounds';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { BatchableSprite } from '../../sprite/BatchableSprite';
@@ -36,6 +37,8 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         this._renderer.runners.resolutionChange.add(this);
+
+        scheduleCleanHash(renderer, this, '_gpuText');
     }
 
     public resolutionChange()


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
In PixiJS we make use of hashes to map data to things like renderables within pipes. To keep things efficinat we do not use 'delete' when an item needs to be removed, instead we simply set the property to null. Over time (with lots of destroy / create) the hashes _could_ grow to be pretty large.

To prevent hashes from growing to large this PR checks the hashes every couple of mins and then removes all the null / falsy values in the hash. 

After discussing with @dev7355608 , i think this is the best route. This way we keep things fast by not using delete, but also ensure the hashes can't ever get too large.

Alternative to #10770 .   

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
