### PR TITLE
feat: Support alpha colors with stroke and fill

### DIFF
--- a/src/scene/text/canvas/utils/getCanvasFillStyle.ts
+++ b/src/scene/text/canvas/utils/getCanvasFillStyle.ts
@@ -14,7 +14,9 @@ export function getCanvasFillStyle(
 {
     if (fillStyle.texture === Texture.WHITE && !fillStyle.fill)
     {
-        return Color.shared.setValue(fillStyle.color).toHex();
+        const fill = Color.shared.setValue(fillStyle.color);
+
+        return fill.alpha === 1 ? fill.toHex() : fill.toHexa();
     }
     else if (!fillStyle.fill)
     {

--- a/src/scene/text/canvas/utils/getCanvasFillStyle.ts
+++ b/src/scene/text/canvas/utils/getCanvasFillStyle.ts
@@ -14,9 +14,10 @@ export function getCanvasFillStyle(
 {
     if (fillStyle.texture === Texture.WHITE && !fillStyle.fill)
     {
-        const fill = Color.shared.setValue(fillStyle.color);
+        const alpha = fillStyle.alpha ?? 1;
+        const fill = Color.shared.setValue(fillStyle.color).setAlpha(alpha);
 
-        return fill.alpha === 1 ? fill.toHex() : fill.toHexa();
+        return alpha === 1 ? fill.toHex() : fill.toHexa();
     }
     else if (!fillStyle.fill)
     {


### PR DESCRIPTION
Fixes #10798 

This fixes support on stroke for both #RRGGBBAA colors and alpha property uses.

### Broken (v8.2.5)

https://jsfiddle.net/bigtimebuddy/gy7dw8mh/5/
```
{
  color: '#ff000080',
  width: 10,
}
```

https://jsfiddle.net/bigtimebuddy/gw2vbnc7/
```
{
  color: '#ff0000',
  alpha: 0.5,
  width: 10,
}
```

### Fixed (PR)

https://jsfiddle.net/bigtimebuddy/b6uztmjd/
```
{
  color: '#ff000080',
  width: 10,
}
```

https://jsfiddle.net/bigtimebuddy/t3h476x8/
```
{
  color: '#ff0000',
  alpha: 0.5,
  width: 10,
}
```