### PR TITLE
fix: getMaxTexturesPerBatch being called before adaptor is ready

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -124,7 +124,7 @@ export class Batcher
     public static defaultOptions: BatcherOptions = {
         vertexSize: 4,
         indexSize: 6,
-        maxTextures: getMaxTexturesPerBatch(),
+        maxTextures: null,
     };
 
     /** unique id for this batcher */
@@ -155,6 +155,7 @@ export class Batcher
 
     constructor(options: BatcherOptions = {})
     {
+        Batcher.defaultOptions.maxTextures = Batcher.defaultOptions.maxTextures ?? getMaxTexturesPerBatch();
         options = { ...Batcher.defaultOptions, ...options };
 
         const { vertexSize, indexSize, maxTextures } = options;


### PR DESCRIPTION
fixes #10815

just moving the call to the constructor should be enough