### PR TITLE
fix: Blur Dimensions Flipped

### DIFF
--- a/src/filters/defaults/blur/BlurFilter.ts
+++ b/src/filters/defaults/blur/BlurFilter.ts
@@ -102,8 +102,8 @@ export class BlurFilter extends Filter
             resources: {}
         });
 
-        this.blurXFilter = new BlurFilterPass({ horizontal: false, ...options });
-        this.blurYFilter = new BlurFilterPass({ horizontal: true, ...options });
+        this.blurXFilter = new BlurFilterPass({ horizontal: true, ...options });
+        this.blurYFilter = new BlurFilterPass({ horizontal: false, ...options });
 
         this.quality = quality;
         this.strengthX = strengthX ?? strength;


### PR DESCRIPTION
Follow-up to #10807

### Changed

* Fixes the `horizontal` property flipped on BlurFilterPass in BlurFilter

### ❌  Before Fix (dev)

https://jsfiddle.net/bigtimebuddy/8amzg2f9/

![Screenshot 2024-08-01 at 11 44 45 AM](https://github.com/user-attachments/assets/66b0d994-142e-4164-8040-b2e8edf31694)

### ✅  After Fix

https://jsfiddle.net/bigtimebuddy/gk4rxca0/

![Screenshot 2024-08-01 at 11 43 06 AM](https://github.com/user-attachments/assets/0a295fe1-4386-40f8-ace4-4cdd7bfd913b)
