### PR TITLE
fix: naming for gc system properties

### DIFF
--- a/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
@@ -21,13 +21,13 @@ export interface RenderableGCSystemOptions
      * @default true
      * @memberof rendering.SharedRendererOptions
      */
-    renderablesGCActive: boolean;
+    renderableGCActive: boolean;
     /**
      * The maximum idle frames before a texture is destroyed by garbage collection.
      * @default 60 * 60
      * @memberof rendering.SharedRendererOptions
      */
-    renderablesGCMaxUnusedTime: number;
+    renderableGCMaxUnusedTime: number;
     /**
      * Frames between two garbage collections.
      * @default 600
@@ -59,12 +59,12 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
          * If set to true, this will enable the garbage collector on the GPU.
          * @default true
          */
-        renderablesGCActive: true,
+        renderableGCActive: true,
         /**
          * The maximum idle frames before a texture is destroyed by garbage collection.
          * @default 60 * 60
          */
-        renderablesGCMaxUnusedTime: 60000,
+        renderableGCMaxUnusedTime: 60000,
         /**
          * Frames between two garbage collections.
          * @default 600
@@ -95,10 +95,10 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
     {
         options = { ...RenderableGCSystem.defaultOptions, ...options };
 
-        this.maxUnusedTime = options.renderablesGCMaxUnusedTime;
+        this.maxUnusedTime = options.renderableGCMaxUnusedTime;
         this._frequency = options.renderableGCFrequency;
 
-        this.enabled = options.renderablesGCActive;
+        this.enabled = options.renderableGCActive;
     }
 
     get enabled(): boolean

--- a/src/rendering/renderers/shared/texture/TextureGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/TextureGCSystem.ts
@@ -20,11 +20,17 @@ export interface TextureGCSystemOptions
      */
     textureGCActive: boolean;
     /**
+     * @deprecated since 8.3.0
+     * @see {@link TextureGCSystem.textureGCMaxIdle}
+     * @memberof rendering.SharedRendererOptions
+     */
+    textureGCAMaxIdle: number;
+    /**
      * The maximum idle frames before a texture is destroyed by garbage collection.
      * @default 60 * 60
      * @memberof rendering.SharedRendererOptions
      */
-    textureGCAMaxIdle: number;
+    textureGCMaxIdle: number;
     /**
      * Frames between two garbage collections.
      * @default 600
@@ -56,10 +62,15 @@ export class TextureGCSystem implements System<TextureGCSystemOptions>
          */
         textureGCActive: true,
         /**
+         * @deprecated since 8.3.0
+         * @see {@link TextureGCSystem.textureGCMaxIdle}
+         */
+        textureGCAMaxIdle: null,
+        /**
          * The maximum idle frames before a texture is destroyed by garbage collection.
          * @default 60 * 60
          */
-        textureGCAMaxIdle: 60 * 60,
+        textureGCMaxIdle: 60 * 60,
         /**
          * Frames between two garbage collections.
          * @default 600
@@ -112,7 +123,7 @@ export class TextureGCSystem implements System<TextureGCSystemOptions>
         options = { ...TextureGCSystem.defaultOptions, ...options };
 
         this.checkCountMax = options.textureGCCheckCountMax;
-        this.maxIdle = options.textureGCAMaxIdle;
+        this.maxIdle = options.textureGCAMaxIdle ?? options.textureGCMaxIdle;
         this.active = options.textureGCActive;
     }
 

--- a/tests/renderering/RenderablesGC.test.ts
+++ b/tests/renderering/RenderablesGC.test.ts
@@ -16,7 +16,7 @@ describe('RenderableGC', () =>
     it('should gc correctly', async () =>
     {
         const renderer = await getWebGLRenderer({
-            renderablesGCMaxUnusedTime: 5,
+            renderableGCMaxUnusedTime: 5,
             renderableGCFrequency: 10,
         });
 
@@ -60,7 +60,7 @@ describe('RenderableGC', () =>
     it('should call destroy on all renderables that are gc', async () =>
     {
         const renderer = await getWebGLRenderer({
-            renderablesGCMaxUnusedTime: 5,
+            renderableGCMaxUnusedTime: 5,
             renderableGCFrequency: 10,
         });
 


### PR DESCRIPTION
this pr fixes a couple of typos 

- deprecates `textureGCAMaxIdle` for `textureGCMaxIdle`
- renames `renderablesGCMaxUnusedTime` to `renderableGCMaxUnusedTime`
- renames `renderablesGCActive` to `renderableGCActive`

only the texture var needs to be deprecated as the other two have only been merged into dev