### PR TITLE
fixed: RenderTexture.create return RenderTexture

### DIFF
--- a/src/rendering/renderers/shared/texture/RenderTexture.ts
+++ b/src/rendering/renderers/shared/texture/RenderTexture.ts
@@ -10,9 +10,9 @@ import type { TextureSourceOptions } from './sources/TextureSource';
  */
 export class RenderTexture extends Texture
 {
-    public static create(options: TextureSourceOptions): Texture
+    public static create(options: TextureSourceOptions): RenderTexture
     {
-        return new Texture({
+        return new RenderTexture({
             source: new TextureSource(options)
         });
     }


### PR DESCRIPTION
##### Description of change
RenderTexture.create should return RenderTexture, otherwise the resize function is no way to use.
