### PR TITLE
fix: Remove TextureSource from internal map when destroyed

### DIFF
--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -504,6 +504,8 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
             {
                 renderTarget.destroy();
 
+                this._renderSurfaceToRenderTargetHash.delete(renderSurface);
+
                 const gpuRenderTarget = this._gpuRenderTargetHash[renderTarget.uid];
 
                 if (gpuRenderTarget)


### PR DESCRIPTION
##### Description of change
Fix issue where TextureSource is not removed from internal map when destroyed

Resolves https://github.com/pixijs/pixijs/issues/10578

##### Pre-Merge Checklist
- [X] Tests passed (`npm run test`)
