### PR TITLE
fix: filters not being applied correctly

### DIFF
--- a/src/scene/view/View.ts
+++ b/src/scene/view/View.ts
@@ -27,7 +27,7 @@ export abstract class ViewContainer extends Container implements View
     /** @private */
     public _lastInstructionTick = -1;
 
-    protected _bounds: Bounds = new Bounds();
+    protected _bounds: Bounds = new Bounds(0, 1, 0, 0);
     protected _boundsDirty = true;
 
     /**


### PR DESCRIPTION
In #10812 we moved the `bounds` object into a shared class but we didn't set the default bounds, which means it defaulted to `infinity`. This has resulted in filters not being applied correctly as the result of `getFastGlobalBounds` is now incorrect

I have not been able to boil this down into a visual test as the error comes from one of our games and it seems to be some combination of nested things that is causing the issue but here is the before/after 

before: 
![image](https://github.com/user-attachments/assets/93f5ed96-574b-45a8-a0c6-76e517e0e38c)

after: 
![image](https://github.com/user-attachments/assets/58b88792-faac-43cb-bd0f-d0aa29d00338)

and here is the bounds values before the above PR:
https://github.com/pixijs/pixijs/blob/24d857ef7cfed25d49c83806b7186a1f04aa2c06/src/scene/sprite-nine-slice/NineSliceSprite.ts#L99
https://github.com/pixijs/pixijs/blob/24d857ef7cfed25d49c83806b7186a1f04aa2c06/src/scene/sprite/Sprite.ts#L83