### PR TITLE
fix: setSize not overridden for all objects

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1069,29 +1069,19 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
     public setSize(value: number | Optional<Size, 'height'>, height?: number)
     {
         const size = this.getLocalBounds();
-        let convertedWidth: number;
-        let convertedHeight: number;
 
-        if (typeof value !== 'object')
+        if (typeof value === 'object')
         {
-            convertedWidth = value;
-            convertedHeight = height ?? value;
+            height = value.height ?? value.width;
+            value = value.width;
         }
         else
         {
-            convertedWidth = value.width;
-            convertedHeight = value.height ?? value.width;
+            height ??= value;
         }
 
-        if (convertedWidth !== undefined)
-        {
-            this._setWidth(convertedWidth, size.width);
-        }
-
-        if (convertedHeight !== undefined)
-        {
-            this._setHeight(convertedHeight, size.height);
-        }
+        value !== undefined && this._setWidth(value, size.width);
+        height !== undefined && this._setHeight(height, size.height);
     }
 
     /** Called when the skew or the rotation changes. */

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -3,9 +3,11 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { ViewContainer } from '../view/View';
 import { NineSliceGeometry } from './NineSliceGeometry';
 
+import type { Size } from '../../maths/misc/Size';
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { Bounds, BoundsData } from '../container/bounds/Bounds';
 import type { ContainerOptions } from '../container/Container';
+import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 
 /**
@@ -169,6 +171,41 @@ export class NineSliceSprite extends ViewContainer implements View
     {
         this.bounds.maxY = this._height = value;
         this.onViewUpdate();
+    }
+
+    /**
+     * Sets the size of the NiceSliceSprite to the specified width and height.
+     * setting this will actually modify the vertices and UV's of this plane
+     * This is faster than setting the width and height separately.
+     * @param value - This can be either a number or a [Size]{@link Size} object.
+     * @param height - The height to set. Defaults to the value of `width` if not provided.
+     */
+    public override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (typeof value === 'object')
+        {
+            height = value.height ?? value.width;
+            value = value.width;
+        }
+
+        this.bounds.maxX = this._width = value;
+        this.bounds.maxY = this._height = height ?? value;
+        this.onViewUpdate();
+    }
+
+    /**
+     * Retrieves the size of the NineSliceSprite as a [Size]{@link Size} object.
+     * This is faster than get the width and height separately.
+     * @param out - Optional object to store the size in.
+     * @returns - The size of the NineSliceSprite.
+     */
+    public override getSize(out?: Size): Size
+    {
+        out ||= {} as Size;
+        out.width = this._width;
+        out.height = this._height;
+
+        return out;
     }
 
     /** The width of the left column (a) of the NineSliceSprite. */

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -5,11 +5,13 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { Transform } from '../../utils/misc/Transform';
 import { ViewContainer } from '../view/View';
 
+import type { Size } from '../../maths/misc/Size';
 import type { PointData } from '../../maths/point/PointData';
 import type { Instruction } from '../../rendering/renderers/shared/instructions/Instruction';
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { Bounds } from '../container/bounds/Bounds';
 import type { ContainerOptions } from '../container/Container';
+import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 
 /**
@@ -361,6 +363,41 @@ export class TilingSprite extends ViewContainer implements View, Instruction
     override get height()
     {
         return this._height;
+    }
+
+    /**
+     * Sets the size of the TilingSprite to the specified width and height.
+     * This is faster than setting the width and height separately.
+     * @param value - This can be either a number or a [Size]{@link Size} object.
+     * @param height - The height to set. Defaults to the value of `width` if not provided.
+     */
+    public override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (typeof value === 'object')
+        {
+            height = value.height ?? value.width;
+            value = value.width;
+        }
+
+        this._width = value;
+        this._height = height ?? value;
+
+        this.onViewUpdate();
+    }
+
+    /**
+     * Retrieves the size of the TilingSprite as a [Size]{@link Size} object.
+     * This is faster than get the width and height separately.
+     * @param out - Optional object to store the size in.
+     * @returns - The size of the TilingSprite.
+     */
+    public override getSize(out?: Size): Size
+    {
+        out ||= {} as Size;
+        out.width = this._width;
+        out.height = this._height;
+
+        return out;
     }
 
     protected override _updateBounds()

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -364,28 +364,17 @@ export class Sprite extends ViewContainer
      */
     public override setSize(value: number | Optional<Size, 'height'>, height?: number)
     {
-        let convertedWidth: number;
-        let convertedHeight: number;
-
-        if (typeof value !== 'object')
+        if (typeof value === 'object')
         {
-            convertedWidth = value;
-            convertedHeight = height ?? value;
+            height = value.height ?? value.width;
+            value = value.width;
         }
         else
         {
-            convertedWidth = value.width;
-            convertedHeight = value.height ?? value.width;
+            height ??= value;
         }
 
-        if (convertedWidth !== undefined)
-        {
-            this._setWidth(convertedWidth, this._texture.orig.width);
-        }
-
-        if (convertedHeight !== undefined)
-        {
-            this._setHeight(convertedHeight, this._texture.orig.height);
-        }
+        value !== undefined && this._setWidth(value, this._texture.orig.width);
+        height !== undefined && this._setHeight(height, this._texture.orig.height);
     }
 }

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -345,11 +345,7 @@ export class Sprite extends ViewContainer
      */
     public override getSize(out?: Size): Size
     {
-        if (!out)
-        {
-            out = {} as Size;
-        }
-
+        out ||= {} as Size;
         out.width = Math.abs(this.scale.x) * this._texture.orig.width;
         out.height = Math.abs(this.scale.y) * this._texture.orig.height;
 

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -277,11 +277,7 @@ export abstract class AbstractText<
      */
     public override getSize(out?: Size): Size
     {
-        if (!out)
-        {
-            out = {} as Size;
-        }
-
+        out ||= {} as Size;
         out.width = Math.abs(this.scale.x) * this.bounds.width;
         out.height = Math.abs(this.scale.y) * this.bounds.height;
 

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -296,29 +296,18 @@ export abstract class AbstractText<
      */
     public override setSize(value: number | Optional<Size, 'height'>, height?: number)
     {
-        let convertedWidth: number;
-        let convertedHeight: number;
-
-        if (typeof value !== 'object')
+        if (typeof value === 'object')
         {
-            convertedWidth = value;
-            convertedHeight = height ?? value;
+            height = value.height ?? value.width;
+            value = value.width;
         }
         else
         {
-            convertedWidth = value.width;
-            convertedHeight = value.height ?? value.width;
+            height ??= value;
         }
 
-        if (convertedWidth !== undefined)
-        {
-            this._setWidth(convertedWidth, this.bounds.width);
-        }
-
-        if (convertedHeight !== undefined)
-        {
-            this._setHeight(convertedHeight, this.bounds.height);
-        }
+        value !== undefined && this._setWidth(value, this.bounds.width);
+        height !== undefined && this._setHeight(height, this.bounds.height);
     }
 
     /**


### PR DESCRIPTION
previously we didn't override get/set size for `TilingSprite` or `NineSliceSprite` when we should have been
I also just tidied up the implementation of get/setSize in `Container`/`Sprite`/`Text`