### PR TITLE
fix: Bleed on blur filter 

### DIFF
--- a/src/filters/defaults/blur/BlurFilterPass.ts
+++ b/src/filters/defaults/blur/BlurFilterPass.ts
@@ -110,9 +110,11 @@ export class BlurFilterPass extends Filter
 
             this._state.blend = false;
 
+            const shouldClear = filterManager.renderer.type === RendererType.WEBGPU;
+
             for (let i = 0; i < this.passes - 1; i++)
             {
-                filterManager.applyFilter(this, flip, flop, filterManager.renderer.type === RendererType.WEBGPU);
+                filterManager.applyFilter(this, flip, flop, i === 0 ? true : shouldClear);
 
                 const temp = flop;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This PR clears the texture fully the first time we render using a blur filter. This will stop the previous usage from bleeding into the new one

Fixes #10808

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
