### PR TITLE
fix: Filter jittering using fractional resolutions

### DIFF
--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -251,7 +251,6 @@ export class FilterSystem implements System
         // need to factor in resolutions also..
         bounds.scale(resolution)
             .fitBounds(0, viewPort.width, 0, viewPort.height)
-            .ceil()
             .scale(1 / resolution)
             .pad(padding);
 
@@ -277,8 +276,8 @@ export class FilterSystem implements System
         // bind...
         // get a P02 texture from our pool...
         filterData.inputTexture = TexturePool.getOptimalTexture(
-            bounds.width,
-            bounds.height,
+            Math.ceil(bounds.width),
+            Math.ceil(bounds.height),
             resolution,
             antialias,
         );

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -249,10 +249,12 @@ export class FilterSystem implements System
         // this should not take into account the x, y offset of the viewport - as this is
         // handled by the viewport on the gpu.
         // need to factor in resolutions also..
-        bounds.scale(resolution)
+        bounds
+            .scale(resolution)
             .fitBounds(0, viewPort.width, 0, viewPort.height)
+            .ceil()
             .scale(1 / resolution)
-            .pad(padding);
+            .pad(padding | 0);
 
         // skip if the bounds are negative or zero as this means they are
         // not visible on the screen
@@ -276,8 +278,8 @@ export class FilterSystem implements System
         // bind...
         // get a P02 texture from our pool...
         filterData.inputTexture = TexturePool.getOptimalTexture(
-            Math.ceil(bounds.width),
-            Math.ceil(bounds.height),
+            bounds.width,
+            bounds.height,
             resolution,
             antialias,
         );

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -251,9 +251,9 @@ export class FilterSystem implements System
         // need to factor in resolutions also..
         bounds.scale(resolution)
             .fitBounds(0, viewPort.width, 0, viewPort.height)
+            .ceil()
             .scale(1 / resolution)
-            .pad(padding)
-            .ceil();
+            .pad(padding);
 
         // skip if the bounds are negative or zero as this means they are
         // not visible on the screen


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Much smoother now! the issue was that the padding was not rounded - which meant that for resolutions that where not whole numbers, a small precision was introduced that scaled with each render pass of a filter. Adjusted the order so that padding is added at the end and rounded.

fixes #10809


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
