### PR TITLE
feat: Add generics Texture for TextureSource type

### DIFF
--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -114,7 +114,7 @@ export type TextureSourceLike = TextureSource | TextureResourceOrOptions | strin
  * @memberof rendering
  * @class
  */
-export class Texture extends EventEmitter<{
+export class Texture<TextureSourceType extends TextureSource = TextureSource> extends EventEmitter<{
     update: Texture
     destroy: Texture
 }> implements BindableTexture
@@ -138,7 +138,7 @@ export class Texture extends EventEmitter<{
      */
     public destroyed: boolean;
 
-    public _source: TextureSource;
+    public _source: TextureSourceType;
 
     /**
      * Indicates whether the texture is rotated inside the atlas
@@ -219,7 +219,7 @@ export class Texture extends EventEmitter<{
         super();
 
         this.label = label;
-        this.source = source?.source ?? new TextureSource();
+        this.source = (source?.source ?? new TextureSource()) as TextureSourceType;
 
         this.noFrame = !frame;
 
@@ -248,7 +248,7 @@ export class Texture extends EventEmitter<{
         this.updateUvs();
     }
 
-    set source(value: TextureSource)
+    set source(value: TextureSourceType)
     {
         if (this._source)
         {
@@ -263,7 +263,7 @@ export class Texture extends EventEmitter<{
     }
 
     /** the underlying source of the texture (equivalent of baseTexture in v7) */
-    get source(): TextureSource
+    get source(): TextureSourceType
     {
         return this._source;
     }

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -45,10 +45,10 @@ export type UVs = {
  * The options that can be passed to a new Texture
  * @memberof rendering
  */
-export interface TextureOptions
+export interface TextureOptions<TextureSourceType extends TextureSource = TextureSource>
 {
     /** the underlying texture data that this texture will use  */
-    source?: TextureSource;
+    source?: TextureSourceType;
     /** optional label, for debugging */
     label?: string;
     /** The rectangle frame of the texture to show */
@@ -214,7 +214,7 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
         defaultBorders,
         rotate,
         dynamic
-    }: TextureOptions = {})
+    }: TextureOptions<TextureSourceType> = {})
     {
         super();
 
@@ -392,7 +392,7 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
     /** an Empty Texture used internally by the engine */
     public static EMPTY: Texture;
     /** a White texture used internally by the engine */
-    public static WHITE: Texture;
+    public static WHITE: Texture<BufferImageSource>;
 }
 
 Texture.EMPTY = new Texture({

--- a/src/rendering/renderers/shared/texture/utils/getCanvasTexture.ts
+++ b/src/rendering/renderers/shared/texture/utils/getCanvasTexture.ts
@@ -4,13 +4,13 @@ import { Texture } from '../Texture';
 import type { ICanvas } from '../../../../../environment/canvas/ICanvas';
 import type { CanvasSourceOptions } from '../sources/CanvasSource';
 
-const canvasCache: Map<ICanvas, Texture> = new Map();
+const canvasCache: Map<ICanvas, Texture<CanvasSource>> = new Map();
 
-export function getCanvasTexture(canvas: ICanvas, options?: CanvasSourceOptions): Texture
+export function getCanvasTexture(canvas: ICanvas, options?: CanvasSourceOptions): Texture<CanvasSource>
 {
     if (!canvasCache.has(canvas))
     {
-        const texture = new Texture({
+        const texture = new Texture<CanvasSource>({
             source: new CanvasSource({
                 resource: canvas,
                 ...options,

--- a/src/rendering/renderers/shared/texture/utils/getCanvasTexture.ts
+++ b/src/rendering/renderers/shared/texture/utils/getCanvasTexture.ts
@@ -10,7 +10,7 @@ export function getCanvasTexture(canvas: ICanvas, options?: CanvasSourceOptions)
 {
     if (!canvasCache.has(canvas))
     {
-        const texture = new Texture<CanvasSource>({
+        const texture = new Texture({
             source: new CanvasSource({
                 resource: canvas,
                 ...options,

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -134,11 +134,11 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
      */
     public get autoDensity(): boolean
     {
-        return (this.texture.source as CanvasSource).autoDensity;
+        return this.texture.source.autoDensity;
     }
     public set autoDensity(value: boolean)
     {
-        (this.texture.source as CanvasSource).autoDensity = value;
+        this.texture.source.autoDensity = value;
     }
 
     /** Whether to enable anti-aliasing. This may affect performance. */

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -8,7 +8,7 @@ import { getCanvasTexture } from '../texture/utils/getCanvasTexture';
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
 import type { TypeOrBool } from '../../../../scene/container/destroyTypes';
 import type { System } from '../system/System';
-import type { CanvasSource, CanvasSourceOptions } from '../texture/sources/CanvasSource';
+import type { CanvasSource } from '../texture/sources/CanvasSource';
 import type { Texture } from '../texture/Texture';
 
 /**
@@ -126,7 +126,7 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
     public canvas!: ICanvas;
 
     /** The texture that is used to draw the canvas to the screen. */
-    public texture: Texture;
+    public texture: Texture<CanvasSource>;
 
     /**
      * Whether CSS dimensions of canvas view should be resized to screen dimensions automatically.
@@ -191,14 +191,14 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
         this.screen = new Rectangle(0, 0, options.width, options.height);
         this.canvas = options.canvas || DOMAdapter.get().createCanvas();
         this.antialias = !!options.antialias;
-        this.texture = getCanvasTexture(this.canvas, options as CanvasSourceOptions);
+        this.texture = getCanvasTexture(this.canvas, options);
         this.renderTarget = new RenderTarget({
             colorTextures: [this.texture],
             depth: !!options.depth,
             isRoot: true,
         });
 
-        (this.texture.source as CanvasSource).transparent = options.backgroundAlpha < 1;
+        this.texture.source.transparent = options.backgroundAlpha < 1;
         this.resolution = options.resolution;
     }
 

--- a/tests/renderering/textures/VideoSource.test.ts
+++ b/tests/renderering/textures/VideoSource.test.ts
@@ -12,11 +12,11 @@ describe('VideoSource', () =>
 {
     const setup = async (options?: VideoSourceOptions, forceUrl?: string) =>
     {
-        const texture = await Assets.load<Texture>({
+        const texture = await Assets.load<Texture<VideoSource>>({
             src: forceUrl ?? url,
             data: options
         });
-        const source = texture.source as VideoSource;
+        const source = texture.source;
         const sourceElement = source.resource.firstElementChild as HTMLSourceElement;
 
         return { source, sourceElement };


### PR DESCRIPTION
### Overview

Adds a generic for Texture to specify the TextureSource type. This can help eliminate some type-casting.

#### Before

```ts
const texture = new Texture();
const source = texture.source as CanvasSource;
```

#### After 
```ts
const texture = new Texture({
  source: new CanvasSource({
    resource: canvas,
  })
});
const source = texture.source; // CanvasSource
```
