### PR TITLE
fix: avoid creating new view in WebGPU

### DIFF
--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -141,9 +141,7 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
                 }
                 else
                 {
-                    view = this._renderer.texture.getGpuSource(texture).createView({
-                        mipLevelCount: 1,
-                    });
+                    view = this._renderer.texture.getTextureView(texture);
                 }
 
                 if (gpuRenderTarget.msaaTextures[i])


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
After trying out the WebGPU debugger, it showed that we createView each time a render target is bound. Tweaked it to use the  `getTextureView` instead. This way we don't create a new view each time!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
