### PR TITLE
chore: Revert "fix: avoid creating new view in WebGPU"

### DIFF
--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -141,7 +141,9 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
                 }
                 else
                 {
-                    view = this._renderer.texture.getTextureView(texture);
+                    view = this._renderer.texture.getGpuSource(texture).createView({
+                        mipLevelCount: 1,
+                    });
                 }
 
                 if (gpuRenderTarget.msaaTextures[i])


### PR DESCRIPTION
Reverts pixijs/pixijs#10875

Unsure why CI didn't catch this but the above PR breaks the `mipmap-render-texture` test for webgpu