### PR TITLE
fix: Color value setter normalizes cloned value

### DIFF
--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -229,8 +229,8 @@ export class Color
         }
         else if (this._value === null || !this._isSourceEqual(this._value, value))
         {
-            this._normalize(value);
             this._value = this._cloneSource(value);
+            this._normalize(this._value);
         }
     }
     get value(): Exclude<ColorSource, Color> | null

--- a/tests/color/Color.test.ts
+++ b/tests/color/Color.test.ts
@@ -28,7 +28,7 @@ describe('Color', () =>
         });
     });
 
-    it.concurrent('should not throw error for invalid color values', async () =>
+    it.concurrent('should not throw error for invalid color values and not alter the original one', async () =>
     {
         const invalidColorValues: any[] = [
             [1, 1, -1, 1],
@@ -36,9 +36,13 @@ describe('Color', () =>
             { r: 1, g: 1, b: 1, a: 1.1 },
         ];
 
-        invalidColorValues.forEach((value) =>
+        invalidColorValues.forEach((originalValue) =>
         {
-            expect(() => new Color(value as any)).not.toThrow();
+            const value = structuredClone(originalValue);
+
+            expect(() => new Color(value)).not.toThrow();
+
+            expect(value).toEqual(originalValue);
         });
     });
 


### PR DESCRIPTION
##### Description of change
On `Color.ts` value setter normalize this._value once cloned so the original value is not modified.

Closes #10882 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
