### PR TITLE
feat: Add option to `BitmapFontManager.measureText` to measure text with trailing whitespaces

### DIFF
--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -178,22 +178,28 @@ class BitmapFontManagerClass
      * Get the layout of a text for the specified style.
      * @param text - The text to get the layout for
      * @param style - The style to use
+     * @param trimEnd - Whether to ignore whitespaces at the end of each line
      */
-    public getLayout(text: string, style: TextStyle): BitmapTextLayoutData
+    public getLayout(text: string, style: TextStyle, trimEnd: boolean = true): BitmapTextLayoutData
     {
         const bitmapFont = this.getFont(text, style);
 
-        return getBitmapTextLayout([...text], style, bitmapFont);
+        return getBitmapTextLayout([...text], style, bitmapFont, trimEnd);
     }
 
     /**
      * Measure the text using the specified style.
      * @param text - The text to measure
      * @param style - The style to use
+     * @param trimEnd - Whether to ignore whitespaces at the end of each line
      */
-    public measureText(text: string, style: TextStyle): { width: number; height: number; scale: number; offsetY: number }
+    public measureText(
+        text: string,
+        style: TextStyle,
+        trimEnd: boolean = true
+    ): { width: number; height: number; scale: number; offsetY: number }
     {
-        return this.getLayout(text, style);
+        return this.getLayout(text, style, trimEnd);
     }
 
     /**

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -134,7 +134,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
         let currentY = bitmapFont.baseLineOffset;
 
         // measure our text...
-        const bitmapTextLayout = getBitmapTextLayout(chars, style, bitmapFont);
+        const bitmapTextLayout = getBitmapTextLayout(chars, style, bitmapFont, true);
 
         let index = 0;
 

--- a/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
+++ b/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
@@ -17,7 +17,12 @@ export interface BitmapTextLayoutData
     }[];
 }
 
-export function getBitmapTextLayout(chars: string[], style: TextStyle, font: AbstractBitmapFont<any>): BitmapTextLayoutData
+export function getBitmapTextLayout(
+    chars: string[],
+    style: TextStyle,
+    font: AbstractBitmapFont<any>,
+    trimEnd: boolean
+): BitmapTextLayoutData
 {
     const layoutData: BitmapTextLayoutData = {
         width: 0,
@@ -77,12 +82,16 @@ export function getBitmapTextLayout(chars: string[], style: TextStyle, font: Abs
     const nextLine = () =>
     {
         let index = currentLine.chars.length - 1;
-        let lastChar = currentLine.chars[index];
 
-        while (lastChar === ' ')
+        if (trimEnd)
         {
-            currentLine.width -= font.chars[lastChar].xAdvance;
-            lastChar = currentLine.chars[--index];
+            let lastChar = currentLine.chars[index];
+
+            while (lastChar === ' ')
+            {
+                currentLine.width -= font.chars[lastChar].xAdvance;
+                lastChar = currentLine.chars[--index];
+            }
         }
 
         layoutData.width = Math.max(layoutData.width, currentLine.width);

--- a/tests/renderering/text/BitmapFontManager.test.ts
+++ b/tests/renderering/text/BitmapFontManager.test.ts
@@ -41,4 +41,14 @@ describe('BitmapFontManager', () =>
 
         expect(layout).toBeDefined();
     });
+
+    it('should measure trailing whitespaces when trimEnd is disabled', () =>
+    {
+        const layout = BitmapFontManager.getLayout('foo', new TextStyle());
+        const layoutTrimmed = BitmapFontManager.getLayout('foo    ', new TextStyle());
+        const layoutUntrimmed = BitmapFontManager.getLayout('foo    ', new TextStyle(), false);
+
+        expect(layoutTrimmed.width).toEqual(layout.width);
+        expect(layoutUntrimmed.width).toBeGreaterThan(layout.width);
+    });
 });


### PR DESCRIPTION
##### Description of change
Closes #10893 

Adds a `trimEnd` option to `BitmapFontManager.measureText` to control whether or not whitespaces at the end of each lines are trimmed when calculating the text layout. By default it will keep trimming the whitespaces since in multi-line text trailing whitespaces should not cause a line break.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
