### PR TITLE
chore: fix up batch property names

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -76,49 +76,155 @@ function returnBatchToPool(batch: Batch)
     batchPool[batchPoolIndex++] = batch;
 }
 
+/**
+ * Represents an element that can be batched for rendering.
+ * @interface
+ */
 export interface BatchableElement
 {
-    // what batcher to use, must be registered.
+    /**
+     * The name of the batcher to use. Must be registered.
+     * @type {string}
+     */
     batcherName: string;
 
-    // properties required to batch all batches
+    /**
+     * The texture to be used for rendering.
+     * @type {Texture}
+     */
     texture: Texture;
+
+    /**
+     * The blend mode to be applied.
+     * @type {BLEND_MODES}
+     */
     blendMode: BLEND_MODES;
 
-    // the size of the index and attribute data
+    /**
+     * The size of the index data.
+     * @type {number}
+     */
     indexSize: number;
+
+    /**
+     * The size of the attribute data.
+     * @type {number}
+     */
     attributeSize: number;
 
-    // sprite specific optimizations
-    // packing a quad will give better perf!
+    /**
+     * Whether the element should be packed as a quad for better performance.
+     * @type {boolean}
+     */
     packAsQuad: boolean;
 
-    // stored for efficient updating..
+    /**
+     * The texture ID, stored for efficient updating.
+     * @type {number}
+     * @private
+     */
     _textureId: number;
-    _attributeStart: number; // location in the buffer
+
+    /**
+     * The starting position in the attribute buffer.
+     * @type {number}
+     * @private
+     */
+    _attributeStart: number;
+
+    /**
+     * The starting position in the index buffer.
+     * @type {number}
+     * @private
+     */
     _indexStart: number;
+
+    /**
+     * Reference to the batcher.
+     * @type {Batcher}
+     * @private
+     */
     _batcher: Batcher;
+
+    /**
+     * Reference to the batch.
+     * @type {Batch}
+     * @private
+     */
     _batch: Batch;
 }
 
+/**
+ * Represents a batchable quad element.
+ * @extends BatchableElement
+ */
 export interface BatchableQuadElement extends BatchableElement
 {
+    /**
+     * Indicates that this element should be packed as a quad.
+     * @type {true}
+     */
     packAsQuad: true;
+
+    /**
+     * The size of the attribute data for this quad element.
+     * @type {4}
+     */
     attributeSize: 4;
+
+    /**
+     * The size of the index data for this quad element.
+     * @type {6}
+     */
     indexSize: 6;
+
+    /**
+     * The bounds data for this quad element.
+     * @type {BoundsData}
+     */
     bounds: BoundsData;
 }
 
+/**
+ * Represents a batchable mesh element.
+ * @extends BatchableElement
+ */
 export interface BatchableMeshElement extends BatchableElement
 {
-    // attributes required for all batches..
+    /**
+     * The UV coordinates of the mesh.
+     * @type {number[] | Float32Array}
+     */
     uvs: number[] | Float32Array;
+
+    /**
+     * The vertex positions of the mesh.
+     * @type {number[] | Float32Array}
+     */
     positions: number[] | Float32Array;
+
+    /**
+     * The indices of the mesh.
+     * @type {number[] | Uint16Array | Uint32Array}
+     */
     indices: number[] | Uint16Array | Uint32Array;
 
+    /**
+     * The offset in the index buffer.
+     * @type {number}
+     */
     indexOffset: number;
+
+    /**
+     * The offset in the attribute buffer.
+     * @type {number}
+     */
     attributeOffset: number;
 
+    /**
+     * Indicates that this element should not be packed as a quad.
+     * @type {false}
+     */
     packAsQuad: false;
 }
 

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -17,7 +17,7 @@ interface DefaultBatchElements
 }
 
 export interface DefaultBatchableQuadElement extends BatchableQuadElement, DefaultBatchElements {}
-export interface DefaultBatchableElement extends BatchableMeshElement, DefaultBatchElements {}
+export interface DefaultBatchableMeshElement extends BatchableMeshElement, DefaultBatchElements {}
 
 /** The default batcher is used to batch quads and meshes. */
 export class DefaultBatcher extends Batcher
@@ -39,7 +39,7 @@ export class DefaultBatcher extends Batcher
     public vertexSize = 6;
 
     public packAttributes(
-        element: DefaultBatchableElement,
+        element: DefaultBatchableMeshElement,
         float32View: Float32Array,
         uint32View: Uint32Array,
         index: number,

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -9,7 +9,7 @@ import type { BatchableMeshElement, BatchableQuadElement } from './Batcher';
 
 let defaultShader: Shader = null;
 
-interface DefaultBatchElements
+export interface DefaultBatchElements
 {
     /** The color of the element that will be multiplied with the texture color. */
     color: number;

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -1,17 +1,23 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { compileHighShaderGlProgram, compileHighShaderGpuProgram } from '../../high-shader/compileHighShaderToProgram';
-import { colorBit, colorBitGl } from '../../high-shader/shader-bits/colorBit';
-import { generateTextureBatchBit, generateTextureBatchBitGl } from '../../high-shader/shader-bits/generateTextureBatchBit';
-import { roundPixelsBit, roundPixelsBitGl } from '../../high-shader/shader-bits/roundPixelsBit';
-import { getBatchSamplersUniformGroup } from '../../renderers/gl/shader/getBatchSamplersUniformGroup';
-import { Shader } from '../../renderers/shared/shader/Shader';
-import { getMaxTexturesPerBatch } from '../gl/utils/maxRecommendedTextures';
 import { Batcher } from './Batcher';
 import { BatchGeometry } from './BatchGeometry';
+import { DefaultShader } from './DefaultShader';
 
+import type { Matrix } from '../../../maths/matrix/Matrix';
+import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { BatchableMeshElement, BatchableQuadElement } from './Batcher';
 
 let defaultShader: Shader = null;
+
+interface DefaultBatchElements
+{
+    color: number;
+    roundPixels: 0 | 1;
+    transform: Matrix;
+}
+
+export interface DefaultBatchableQuadElement extends BatchableQuadElement, DefaultBatchElements {}
+export interface DefaultBatchableElement extends BatchableMeshElement, DefaultBatchElements {}
 
 /** The default batcher is used to batch quads and meshes. */
 export class DefaultBatcher extends Batcher
@@ -25,55 +31,15 @@ export class DefaultBatcher extends Batcher
     } as const;
 
     public geometry = new BatchGeometry();
-    public shader: Shader;
+    public shader = defaultShader || (defaultShader = new DefaultShader(this.maxTextures));
 
     public name = DefaultBatcher.extension.name;
 
     /** The size of one attribute. 1 = 32 bit. x, y, u, v, color, textureIdAndRound -> total = 6 */
     public vertexSize = 6;
 
-    constructor()
-    {
-        const maxTextures = getMaxTexturesPerBatch();
-
-        super({
-            maxTextures,
-        });
-
-        if (!defaultShader)
-        {
-            const glProgram = compileHighShaderGlProgram({
-                name: 'batch',
-                bits: [
-                    colorBitGl,
-                    generateTextureBatchBitGl(maxTextures),
-                    roundPixelsBitGl,
-                ]
-            });
-
-            const gpuProgram = compileHighShaderGpuProgram({
-                name: 'batch',
-                bits: [
-                    colorBit,
-                    generateTextureBatchBit(getMaxTexturesPerBatch()),
-                    roundPixelsBit,
-                ]
-            });
-
-            defaultShader = new Shader({
-                glProgram,
-                gpuProgram,
-                resources: {
-                    batchSamplers: getBatchSamplersUniformGroup(maxTextures),
-                }
-            });
-        }
-
-        this.shader = defaultShader;
-    }
-
     public packAttributes(
-        element: BatchableMeshElement,
+        element: DefaultBatchableElement,
         float32View: Float32Array,
         uint32View: Uint32Array,
         index: number,
@@ -82,7 +48,7 @@ export class DefaultBatcher extends Batcher
     {
         const textureIdAndRound = (textureId << 16) | (element.roundPixels & 0xFFFF);
 
-        const wt = element.groupTransform;
+        const wt = element.transform;
 
         const a = wt.a;
         const b = wt.b;
@@ -117,17 +83,16 @@ export class DefaultBatcher extends Batcher
     }
 
     public packQuadAttributes(
-        element: BatchableQuadElement,
+        element: DefaultBatchableQuadElement,
         float32View: Float32Array,
         uint32View: Uint32Array,
         index: number,
         textureId: number
     )
     {
-        const sprite = element.renderable;
         const texture = element.texture;
 
-        const wt = sprite.groupTransform;
+        const wt = element.transform;
 
         const a = wt.a;
         const b = wt.b;
@@ -191,3 +156,4 @@ export class DefaultBatcher extends Batcher
         uint32View[index + 23] = textureIdAndRound;
     }
 }
+

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -11,8 +11,13 @@ let defaultShader: Shader = null;
 
 interface DefaultBatchElements
 {
+    /** The color of the element that will be multiplied with the texture color. */
     color: number;
+
+    /** Whether the element should be rounded to the nearest pixel. */
     roundPixels: 0 | 1;
+
+    /** The transform of the element. */
     transform: Matrix;
 }
 

--- a/src/rendering/batcher/shared/DefaultShader.ts
+++ b/src/rendering/batcher/shared/DefaultShader.ts
@@ -1,0 +1,38 @@
+import { compileHighShaderGlProgram, compileHighShaderGpuProgram } from '../../high-shader/compileHighShaderToProgram';
+import { colorBit, colorBitGl } from '../../high-shader/shader-bits/colorBit';
+import { generateTextureBatchBit, generateTextureBatchBitGl } from '../../high-shader/shader-bits/generateTextureBatchBit';
+import { roundPixelsBit, roundPixelsBitGl } from '../../high-shader/shader-bits/roundPixelsBit';
+import { getBatchSamplersUniformGroup } from '../../renderers/gl/shader/getBatchSamplersUniformGroup';
+import { Shader } from '../../renderers/shared/shader/Shader';
+
+export class DefaultShader extends Shader
+{
+    constructor(maxTextures: number)
+    {
+        const glProgram = compileHighShaderGlProgram({
+            name: 'batch',
+            bits: [
+                colorBitGl,
+                generateTextureBatchBitGl(maxTextures),
+                roundPixelsBitGl,
+            ]
+        });
+
+        const gpuProgram = compileHighShaderGpuProgram({
+            name: 'batch',
+            bits: [
+                colorBit,
+                generateTextureBatchBit(maxTextures),
+                roundPixelsBit,
+            ]
+        });
+
+        super({
+            glProgram,
+            gpuProgram,
+            resources: {
+                batchSamplers: getBatchSamplersUniformGroup(maxTextures),
+            }
+        });
+    }
+}

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -1,7 +1,8 @@
 import { Matrix } from '../../../maths/matrix/Matrix';
 import { multiplyHexColors } from '../../container/utils/multiplyHexColors';
 
-import type { Batch, BatchableMeshElement, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { Batch, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { DefaultBatchableElement } from '../../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { Graphics } from './Graphics';
 
@@ -11,18 +12,13 @@ const identityMatrix = new Matrix();
  * @ignore
  */
 
-export class BatchableGraphics implements BatchableMeshElement
+export class BatchableGraphics implements DefaultBatchableElement
 {
-    public packAsQuad = false;
-    public location = 0;
+    public readonly packAsQuad = false;
     public batcherName = 'default';
 
-    public indexStart: number;
-    public textureId: number;
     public texture: Texture;
-    public attributeStart: number;
-    public batcher: Batcher = null;
-    public batch: Batch = null;
+
     public renderable: Graphics;
     public indexOffset: number;
     public indexSize: number;
@@ -32,6 +28,12 @@ export class BatchableGraphics implements BatchableMeshElement
     public alpha: number;
     public applyTransform = true;
     public roundPixels: 0 | 1 = 0;
+
+    public _indexStart: number;
+    public _textureId: number;
+    public _attributeStart: number;
+    public _batcher: Batcher = null;
+    public _batch: Batch = null;
 
     public geometryData: { vertices: number[]; uvs: number[]; indices: number[]; };
 
@@ -74,7 +76,7 @@ export class BatchableGraphics implements BatchableMeshElement
         return bgr + ((this.alpha * 255) << 24);
     }
 
-    get groupTransform()
+    get transform()
     {
         return this.renderable?.groupTransform || identityMatrix;
     }

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -2,7 +2,7 @@ import { Matrix } from '../../../maths/matrix/Matrix';
 import { multiplyHexColors } from '../../container/utils/multiplyHexColors';
 
 import type { Batch, Batcher } from '../../../rendering/batcher/shared/Batcher';
-import type { DefaultBatchableElement } from '../../../rendering/batcher/shared/DefaultBatcher';
+import type { DefaultBatchableMeshElement } from '../../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { Graphics } from './Graphics';
 
@@ -12,7 +12,7 @@ const identityMatrix = new Matrix();
  * @ignore
  */
 
-export class BatchableGraphics implements DefaultBatchableElement
+export class BatchableGraphics implements DefaultBatchableMeshElement
 {
     public readonly packAsQuad = false;
     public batcherName = 'default';

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -110,7 +110,7 @@ export class GraphicsPipe implements RenderPipe<Graphics>
             {
                 const batch = batches[i];
 
-                batch.batcher.updateElement(batch);
+                batch._batcher.updateElement(batch);
             }
         }
     }

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -1,4 +1,6 @@
-import type { Batch, BatchableMeshElement, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { Matrix } from '../../../maths/matrix/Matrix';
+import type { Batch, Batcher } from '../../../rendering/batcher/shared/Batcher';
+import type { DefaultBatchableElement } from '../../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { ViewContainer } from '../../view/View';
 import type { MeshGeometry } from './MeshGeometry';
@@ -7,26 +9,27 @@ import type { MeshGeometry } from './MeshGeometry';
  * A batchable mesh object.
  * @ignore
  */
-export class BatchableMesh implements BatchableMeshElement
+export class BatchableMesh implements DefaultBatchableElement
 {
     public batcherName = 'default';
-    public packAsQuad = false;
+    public readonly packAsQuad = false;
     public location: number;
 
-    public indexOffset = 0;
+    public renderable: ViewContainer;
 
+    public indexOffset = 0;
     public attributeOffset = 0;
 
-    public indexStart: number;
-    public textureId: number;
     public texture: Texture;
-    public attributeStart: number;
-    public batcher: Batcher = null;
-    public batch: Batch = null;
-    public renderable: ViewContainer;
     public geometry: MeshGeometry;
-
+    public transform: Matrix;
     public roundPixels: 0 | 1 = 0;
+
+    public _attributeStart: number;
+    public _batcher: Batcher = null;
+    public _batch: Batch = null;
+    public _indexStart: number;
+    public _textureId: number;
 
     private _transformedUvs: Float32Array;
     private _uvUpdateId: number = -1;
@@ -38,8 +41,8 @@ export class BatchableMesh implements BatchableMeshElement
     {
         this.renderable = null;
         this.texture = null;
-        this.batcher = null;
-        this.batch = null;
+        this._batcher = null;
+        this._batch = null;
         this.geometry = null;
         this._uvUpdateId = -1;
         this._textureMatrixUpdateId = -1;

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -1,6 +1,6 @@
 import type { Matrix } from '../../../maths/matrix/Matrix';
 import type { Batch, Batcher } from '../../../rendering/batcher/shared/Batcher';
-import type { DefaultBatchableElement } from '../../../rendering/batcher/shared/DefaultBatcher';
+import type { DefaultBatchableMeshElement } from '../../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { ViewContainer } from '../../view/View';
 import type { MeshGeometry } from './MeshGeometry';
@@ -9,7 +9,7 @@ import type { MeshGeometry } from './MeshGeometry';
  * A batchable mesh object.
  * @ignore
  */
-export class BatchableMesh implements DefaultBatchableElement
+export class BatchableMesh implements DefaultBatchableMeshElement
 {
     public batcherName = 'default';
     public readonly packAsQuad = false;

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -108,7 +108,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
             {
                 if (batchableMesh.texture._source !== texture._source)
                 {
-                    return !batchableMesh.batcher.checkAndUpdateTexture(batchableMesh, texture);
+                    return !batchableMesh._batcher.checkAndUpdateTexture(batchableMesh, texture);
                 }
             }
         }
@@ -148,7 +148,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
             gpuBatchableMesh.texture = mesh._texture;
             gpuBatchableMesh.geometry = mesh._geometry;
 
-            gpuBatchableMesh.batcher.updateElement(gpuBatchableMesh);
+            gpuBatchableMesh._batcher.updateElement(gpuBatchableMesh);
         }
     }
 
@@ -218,6 +218,7 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 
         gpuMesh.renderable = mesh;
         gpuMesh.texture = mesh._texture;
+        gpuMesh.transform = mesh.groupTransform;
         gpuMesh.roundPixels = (this.renderer._roundPixels | mesh._roundPixels) as 0 | 1;
 
         this._gpuBatchableMeshHash[mesh.uid] = gpuMesh;

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -46,7 +46,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
         if (sprite._didSpriteUpdate) this._updateBatchableSprite(sprite, gpuSprite);
 
-        gpuSprite.batcher.updateElement(gpuSprite);
+        gpuSprite._batcher.updateElement(gpuSprite);
     }
 
     public validateRenderable(sprite: NineSliceSprite): boolean
@@ -56,7 +56,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
         if (gpuSprite.texture._source !== texture._source)
         {
-            return !gpuSprite.batcher.checkAndUpdateTexture(gpuSprite, texture);
+            return !gpuSprite._batcher.checkAndUpdateTexture(gpuSprite, texture);
         }
 
         return false;
@@ -96,6 +96,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
         batchableMesh.geometry = BigPool.get(NineSliceGeometry);
         batchableMesh.renderable = sprite;
+        batchableMesh.transform = sprite.groupTransform;
         batchableMesh.texture = sprite._texture;
         batchableMesh.roundPixels = (this._renderer._roundPixels | sprite._roundPixels) as 0 | 1;
 

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -67,7 +67,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
             // we are batching.. check a texture change!
             if (batchableMesh && batchableMesh.texture._source !== renderable.texture._source)
             {
-                return !batchableMesh.batcher.checkAndUpdateTexture(batchableMesh, renderable.texture);
+                return !batchableMesh._batcher.checkAndUpdateTexture(batchableMesh, renderable.texture);
             }
         }
 
@@ -104,6 +104,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
 
                 batchableMesh.geometry = geometry;
                 batchableMesh.renderable = tilingSprite;
+                batchableMesh.transform = tilingSprite.groupTransform;
                 batchableMesh.texture = tilingSprite._texture;
             }
 
@@ -162,7 +163,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
 
             if (tilingSprite._didTilingSpriteUpdate) this._updateBatchableMesh(tilingSprite);
 
-            batchableMesh.batcher.updateElement(batchableMesh);
+            batchableMesh._batcher.updateElement(batchableMesh);
         }
         else if (tilingSprite._didTilingSpriteUpdate)
         {

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -1,4 +1,6 @@
-import type { Batch, BatchableQuadElement, Batcher } from '../../rendering/batcher/shared/Batcher';
+import type { Matrix } from '../../maths';
+import type { Batch, Batcher } from '../../rendering/batcher/shared/Batcher';
+import type { DefaultBatchableQuadElement } from '../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { BoundsData } from '../container/bounds/Bounds';
 import type { ViewContainer } from '../view/View';
@@ -7,27 +9,28 @@ import type { ViewContainer } from '../view/View';
  * A batchable sprite object.
  * @ignore
  */
-export class BatchableSprite implements BatchableQuadElement
+export class BatchableSprite implements DefaultBatchableQuadElement
 {
-    public packAsQuad = true;
     public batcherName = 'default';
-    public location: number;
-    public indexStart: number;
-    public renderable: ViewContainer;
-
-    public attributeOffset = 0;
 
     // batch specific..
-    public attributeSize = 4;
-    public indexSize = 6;
-    public texture: Texture;
+    public readonly attributeSize = 4;
+    public readonly indexSize = 6;
+    public readonly packAsQuad = true;
 
-    public textureId: number;
-    public attributeStart = 0; // location in the buffer
-    public batcher: Batcher = null;
-    public batch: Batch = null;
+    public transform: Matrix;
+
+    public renderable: ViewContainer;
+    public texture: Texture;
     public bounds: BoundsData;
+
     public roundPixels: 0 | 1 = 0;
+
+    public _indexStart: number;
+    public _textureId: number;
+    public _attributeStart = 0; // location in the buffer
+    public _batcher: Batcher = null;
+    public _batch: Batch = null;
 
     get blendMode() { return this.renderable.groupBlendMode; }
     get color() { return this.renderable.groupColorAlpha; }
@@ -36,8 +39,8 @@ export class BatchableSprite implements BatchableQuadElement
     {
         this.renderable = null;
         this.texture = null;
-        this.batcher = null;
-        this.batch = null;
+        this._batcher = null;
+        this._batch = null;
         this.bounds = null;
     }
 }

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -1,4 +1,4 @@
-import type { Matrix } from '../../maths';
+import type { Matrix } from '../../maths/matrix/Matrix';
 import type { Batch, Batcher } from '../../rendering/batcher/shared/Batcher';
 import type { DefaultBatchableQuadElement } from '../../rendering/batcher/shared/DefaultBatcher';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -46,7 +46,7 @@ export class SpritePipe implements RenderPipe<Sprite>
 
         if (sprite._didSpriteUpdate) this._updateBatchableSprite(sprite, gpuSprite);
 
-        gpuSprite.batcher.updateElement(gpuSprite);
+        gpuSprite._batcher.updateElement(gpuSprite);
     }
 
     public validateRenderable(sprite: Sprite): boolean
@@ -56,7 +56,7 @@ export class SpritePipe implements RenderPipe<Sprite>
 
         if (gpuSprite.texture._source !== texture._source)
         {
-            return !gpuSprite.batcher.checkAndUpdateTexture(gpuSprite, texture);
+            return !gpuSprite._batcher.checkAndUpdateTexture(gpuSprite, texture);
         }
 
         return false;
@@ -92,6 +92,7 @@ export class SpritePipe implements RenderPipe<Sprite>
 
         batchableSprite.renderable = sprite;
 
+        batchableSprite.transform = sprite.groupTransform;
         batchableSprite.texture = sprite._texture;
         batchableSprite.bounds = sprite.bounds;
         batchableSprite.roundPixels = (this._renderer._roundPixels | sprite._roundPixels) as 0 | 1;

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -104,7 +104,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
             this._updateText(htmlText);
         }
 
-        batchableSprite.batcher.updateElement(batchableSprite);
+        batchableSprite._batcher.updateElement(batchableSprite);
     }
 
     public destroyRenderable(htmlText: HTMLText)
@@ -202,6 +202,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         const batchableSprite = gpuTextData.batchableSprite;
 
         batchableSprite.renderable = htmlText;
+        batchableSprite.transform = htmlText.groupTransform;
         batchableSprite.texture = Texture.EMPTY;
         batchableSprite.bounds = { minX: 0, maxX: 1, minY: 0, maxY: 0 };
         batchableSprite.roundPixels = (this._renderer._roundPixels | htmlText._roundPixels) as 0 | 1;

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -108,7 +108,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
             this._updateText(text);
         }
 
-        batchableSprite.batcher.updateElement(batchableSprite);
+        batchableSprite._batcher.updateElement(batchableSprite);
     }
 
     public destroyRenderable(text: Text)
@@ -176,6 +176,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
         };
 
         gpuTextData.batchableSprite.renderable = text;
+        gpuTextData.batchableSprite.transform = text.groupTransform;
         gpuTextData.batchableSprite.bounds = { minX: 0, maxX: 1, minY: 0, maxY: 0 };
         gpuTextData.batchableSprite.roundPixels = (this._renderer._roundPixels | text._roundPixels) as 0 | 1;
 

--- a/tests/renderering/batch/checkCanUseTexture.tests.ts
+++ b/tests/renderering/batch/checkCanUseTexture.tests.ts
@@ -18,17 +18,17 @@ class DummyBatchableObject implements BatchableMeshElement
     color = 0xFFFFFFF;
     attributeOffset = 0;
     location = 0;
-    packAsQuad = false;
-    indexStart = 0;
+    readonly packAsQuad = false;
+    _indexStart = 0;
 
     texture: Texture;
     blendMode: BLEND_MODES = 'normal';
     attributeSize = 8;
     indexSize = 4;
-    textureId: number;
-    attributeStart: number;
-    batcher: Batcher = null;
-    batch: Batch = null;
+    _textureId: number;
+    _attributeStart: number;
+    _batcher: Batcher = null;
+    _batch: Batch = null;
     roundPixels: 0 | 1 = 0;
 }
 


### PR DESCRIPTION
extracted default shader

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
- Whilst im here in batcher land, figured it would be good to do a pass on some of the batcher property names. anything with a `_` prefix is a prop managed by the batcher, whilst anything else should be user defined.
- I also put some stronger types in for the `BatchableQuadElement` and `BatchableMeshElement`. 
- extracted `DefaultShader` from `DefaultBatcher`, making things a bit more readable!
- created `DefaultBatchableQuadElement` and `DefaultBatchableMeshElement` so they contain the props that onnly they care about. Making`DefaultBatchableElement` and `DefaultBatchableElement` more generic.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
