### PR TITLE
feat: add multiview to webgl rendering

### DIFF
--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -3,7 +3,7 @@ import { ExtensionType } from '../../../../extensions/Extensions';
 import { warn } from '../../../../utils/logging/warn';
 import { type GpuPowerPreference } from '../../types';
 
-import type { ICanvas } from '../../../../environment';
+import type { ICanvas } from '../../../../environment/canvas/ICanvas';
 import type { System } from '../../shared/system/System';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { WebGLExtensions } from './WebGLExtensions';

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -3,6 +3,7 @@ import { ExtensionType } from '../../../../extensions/Extensions';
 import { warn } from '../../../../utils/logging/warn';
 import { type GpuPowerPreference } from '../../types';
 
+import type { ICanvas } from '../../../../environment';
 import type { System } from '../../shared/system/System';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { WebGLExtensions } from './WebGLExtensions';
@@ -63,6 +64,14 @@ export interface ContextSystemOptions
      * @memberof rendering.SharedRendererOptions
      */
     preferWebGLVersion?: 1 | 2;
+
+    /**
+     * Whether to enable multi-view rendering. Set to true when rendering to multiple
+     * canvases on the dom.
+     * @default false
+     * @memberof rendering.SharedRendererOptions
+     */
+    multiView: boolean;
 }
 
 /**
@@ -106,6 +115,11 @@ export class GlContextSystem implements System<ContextSystemOptions>
          * @default 2
          */
         preferWebGLVersion: 2,
+        /**
+         * {@link WebGLOptions.multiView}
+         * @default false
+         */
+        multiView: false
     };
 
     protected CONTEXT_UID: number;
@@ -148,6 +162,21 @@ export class GlContextSystem implements System<ContextSystemOptions>
 
     public webGLVersion: 1 | 2;
 
+    /**
+     * Whether to enable multi-view rendering. Set to true when rendering to multiple
+     * canvases on the dom.
+     * @default false
+     */
+    public multiView: boolean;
+
+    /**
+     * The canvas that the WebGL Context is rendering to.
+     * This will be the view canvas. But if multiView is enabled, this canvas will not be attached to the DOM.
+     * It will be rendered to and then copied to the target canvas.
+     * @readonly
+     */
+    public canvas: ICanvas;
+
     private _renderer: WebGLRenderer;
     private _contextLossForced: boolean;
 
@@ -186,6 +215,26 @@ export class GlContextSystem implements System<ContextSystemOptions>
     {
         options = { ...GlContextSystem.defaultOptions, ...options };
 
+        // TODO add to options
+        let multiView = this.multiView = options.multiView;
+
+        if (options.context && multiView)
+        {
+            // eslint-disable-next-line max-len
+            warn('Renderer created with both a context and multiview enabled. Disabling multiView as both cannot work together.');
+
+            multiView = false;
+        }
+
+        if (multiView)
+        {
+            this.canvas = DOMAdapter.get()
+                .createCanvas(this._renderer.canvas.width, this._renderer.canvas.height);
+        }
+        else
+        {
+            this.canvas = this._renderer.view.canvas;
+        }
         /*
          * The options passed in to create a new WebGL context.
          */
@@ -207,6 +256,27 @@ export class GlContextSystem implements System<ContextSystemOptions>
                 preserveDrawingBuffer: options.preserveDrawingBuffer,
                 powerPreference: options.powerPreference ?? 'default',
             });
+        }
+    }
+
+    public ensureCanvasSize(targetCanvas: ICanvas): void
+    {
+        if (!this.multiView)
+        {
+            if (targetCanvas !== this.canvas)
+            {
+                warn('multiView is disabled, but targetCanvas is not the main canvas');
+            }
+
+            return;
+        }
+
+        const { canvas } = this;
+
+        if (canvas.width < targetCanvas.width || canvas.height < targetCanvas.height)
+        {
+            canvas.width = Math.max(targetCanvas.width, targetCanvas.width);
+            canvas.height = Math.max(targetCanvas.height, targetCanvas.height);
         }
     }
 
@@ -243,7 +313,8 @@ export class GlContextSystem implements System<ContextSystemOptions>
     protected createContext(preferWebGLVersion: 1 | 2, options: WebGLContextAttributes): void
     {
         let gl: WebGL2RenderingContext | WebGLRenderingContext;
-        const canvas = this._renderer.view.canvas;
+
+        const canvas = this.canvas;
 
         if (preferWebGLVersion === 2)
         {

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -95,6 +95,9 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends GlRenderTarget | GpuR
     /** finishes the current render pass */
     finishRenderPass(renderTarget: RenderTarget): void
 
+    /** called after the render pass is finished */
+    postrender?(renderTarget: RenderTarget,): void;
+
     /**
      * initializes a gpu render target. Both renderers use this function to initialize a gpu render target
      * Its different type of object depending on the renderer.
@@ -228,6 +231,11 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
         this.rootViewPort.copyFrom(this.viewport);
         this.rootRenderTarget = this.renderTarget;
         this.renderingToScreen = isRenderingToScreen(this.rootRenderTarget);
+    }
+
+    public postrender()
+    {
+        this.adaptor.postrender?.(this.rootRenderTarget);
     }
 
     /**

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -51,7 +51,10 @@ export interface RenderOptions extends ClearOptions
  */
 export interface ClearOptions
 {
-    /** The render target to render. */
+    /**
+     * The render target to render. if this target is a canvas and  you are using the WebGL renderer,
+     * please ensure you have set `multiView` to `true` on renderer.
+     */
     target?: RenderSurface;
     /** The color to clear with. */
     clearColor?: ColorSource;

--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -22,6 +22,8 @@ export class CanvasSource extends TextureSource<ICanvas>
     public autoDensity: boolean;
     public transparent: boolean;
 
+    private _context2D: CanvasRenderingContext2D;
+
     constructor(options: CanvasSourceOptions)
     {
         if (!options.resource)
@@ -95,5 +97,15 @@ export class CanvasSource extends TextureSource<ICanvas>
     {
         return (globalThis.HTMLCanvasElement && resource instanceof HTMLCanvasElement)
         || (globalThis.OffscreenCanvas && resource instanceof OffscreenCanvas);
+    }
+
+    /**
+     * Returns the 2D rendering context for the canvas.
+     * Caches the context after creating it.
+     * @returns The 2D rendering context of the canvas.
+     */
+    get context2D(): CanvasRenderingContext2D
+    {
+        return this._context2D || (this._context2D = this.resource.getContext('2d') as CanvasRenderingContext2D);
     }
 }

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -66,11 +66,6 @@ export interface ViewSystemOptions
      * @memberof rendering.SharedRendererOptions
      */
     depth?: boolean;
-    /**
-     * TODO: multiView
-     * @memberof rendering.SharedRendererOptions
-     */
-    multiView?: boolean;
 
     /**
      * Transparency of the background color, value from `0` (fully transparent) to `1` (fully opaque).
@@ -126,8 +121,6 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
          */
         antialias: false,
     };
-
-    public multiView: boolean;
 
     /** The canvas element that everything is drawn to. */
     public canvas!: ICanvas;
@@ -206,7 +199,6 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
         });
 
         (this.texture.source as CanvasSource).transparent = options.backgroundAlpha < 1;
-        this.multiView = !!options.multiView;
         this.resolution = options.resolution;
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
WebGPU has a pretty awesome feature, basically you can use a single render to draw to many canvases on the dom. It has one context and then treats each canvas as a texture to be rendered too. This is super nice and brings a few usful things:

- shared resources across canvas (different gl contexts are sand boxed)
- no limit to how many canvases can be rendered to (there is a limit to how many gl contexts can exist on the dom)

This PR fixes thees WebGL limitations by introducing a new property called `multiView`. If this is true, the WebGL renderer will behave exactly as the WebGPU renderer does and render to the canvas' with no fuss!  

```
const renderer = await autoDetectRenderer({
    multiView:true 
})

// render to a canvas on the dom
renderer.render({
    container,
    target: canvasOnDom1
})

// render to another canvas on the dom!
renderer.render({
    container,
    target: canvasOnDom2
})

```

The way this works is by having a single gl context behind the scenes that copy's its pixels to the relevant canvas as a final step (The copy is super fast as its a `canvas.drawImage` call)

As a follow up PR we will need to tweak interaction so that it can handle multiple canvases as right now only the first canvas (`renderer.view`) can be interactive.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
