### PR TITLE
fix issue when resolution change crashes text system

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -46,6 +46,9 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         for (const i in this._gpuText)
         {
             const gpuText = this._gpuText[i];
+
+            if (!gpuText) continue;
+
             const text = gpuText.batchableSprite.renderable as HTMLText;
 
             if (text._autoResolution)

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -43,6 +43,9 @@ export class CanvasTextPipe implements RenderPipe<Text>
         for (const i in this._gpuText)
         {
             const gpuText = this._gpuText[i];
+
+            if (!gpuText) continue;
+
             const text = gpuText.batchableSprite.renderable as Text;
 
             if (text._autoResolution)

--- a/tests/renderering/text/HTMLText.tests.ts
+++ b/tests/renderering/text/HTMLText.tests.ts
@@ -1,4 +1,5 @@
 import { HTMLText } from '../../../src/scene/text-html/HTMLText';
+import { getWebGLRenderer } from '../../utils/getRenderer';
 
 describe('HTMLText', () =>
 {
@@ -27,5 +28,20 @@ describe('HTMLText', () =>
         expect(text.height).toBeLessThan(35);
 
         text.destroy();
+    });
+
+    it('should handle resolution changes after html text destruction', async () =>
+    {
+        const text = new HTMLText({ text: 'foo' });
+
+        const renderer = await getWebGLRenderer();
+
+        renderer.render(text);
+
+        text.destroy();
+
+        expect(() => { renderer.resolution = 3; }).not.toThrow();
+
+        renderer.destroy();
     });
 });

--- a/tests/renderering/text/Text.tests.ts
+++ b/tests/renderering/text/Text.tests.ts
@@ -72,6 +72,21 @@ describe('Text', () =>
 
             renderer.destroy();
         });
+
+        it('should handle resolution changes after text destruction', async () =>
+        {
+            const text = new Text({ text: 'foo' });
+
+            const renderer = await getWebGLRenderer();
+
+            renderer.render(text);
+
+            text.destroy();
+
+            expect(() => { renderer.resolution = 3; }).not.toThrow();
+
+            renderer.destroy();
+        });
     });
 
     describe('destroy', () =>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Added a `null` check for destroyed GPU text.
fixes #10907

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
