### PR TITLE
fix: Reset defaultPrevented in Events

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -1420,6 +1420,7 @@ export class EventBoundary
 
         event.eventPhase = event.NONE;
         event.currentTarget = null;
+        event.defaultPrevented = false;
         event.path = null;
         event.target = null;
 

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -804,6 +804,7 @@ export class EventSystem implements System<EventSystemOptions>
         event.client.x = nativeEvent.clientX;
         event.client.y = nativeEvent.clientY;
         event.ctrlKey = nativeEvent.ctrlKey;
+        event.defaultPrevented = nativeEvent.defaultPrevented;
         event.metaKey = nativeEvent.metaKey;
         event.movement.x = nativeEvent.movementX;
         event.movement.y = nativeEvent.movementY;

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -804,7 +804,6 @@ export class EventSystem implements System<EventSystemOptions>
         event.client.x = nativeEvent.clientX;
         event.client.y = nativeEvent.clientY;
         event.ctrlKey = nativeEvent.ctrlKey;
-        event.defaultPrevented = nativeEvent.defaultPrevented;
         event.metaKey = nativeEvent.metaKey;
         event.movement.x = nativeEvent.movementX;
         event.movement.y = nativeEvent.movementY;


### PR DESCRIPTION
Fix #9749

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Reset `defaultPrevented` when allocating events. This makes subsequent events behave correctly after `preventDefault()` has been called.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
