### PR TITLE
fix: warn when trying to change BitmapText resolution

### DIFF
--- a/src/scene/text-bitmap/BitmapText.ts
+++ b/src/scene/text-bitmap/BitmapText.ts
@@ -1,3 +1,4 @@
+import { warn } from '../../utils/logging/warn';
 import { AbstractText, ensureOptions } from '../text/AbstractText';
 import { TextStyle } from '../text/TextStyle';
 import { BitmapFontManager } from './BitmapFontManager';
@@ -143,5 +144,22 @@ export class BitmapText extends AbstractText<TextStyle, TextStyleOptions> implem
         bounds.maxX = bounds.minX + width;
         bounds.minY = (-anchor._y * (height + offset));
         bounds.maxY = bounds.minY + height;
+    }
+
+    /**
+     * The resolution / device pixel ratio of the canvas.
+     * @default 1
+     */
+    override set resolution(_value: number)
+    {
+        warn(
+            // eslint-disable-next-line max-len
+            '[BitmapText] dynamically updating the resolution is not supported. Resolution should be managed by the BitmapFont.'
+        );
+    }
+
+    override get resolution(): number
+    {
+        return this._resolution;
     }
 }

--- a/src/scene/text-bitmap/BitmapText.ts
+++ b/src/scene/text-bitmap/BitmapText.ts
@@ -152,10 +152,12 @@ export class BitmapText extends AbstractText<TextStyle, TextStyleOptions> implem
      */
     override set resolution(_value: number)
     {
+        // #if _DEBUG
         warn(
             // eslint-disable-next-line max-len
             '[BitmapText] dynamically updating the resolution is not supported. Resolution should be managed by the BitmapFont.'
         );
+        // #endif
     }
 
     override get resolution(): number


### PR DESCRIPTION
fixes: #10668

just adding a warning that you cant change the resolution of a bitmap text