### PR TITLE
fix: Set framebuffer to null only when canvas source matches main canvas

### DIFF
--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -165,7 +165,7 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
         // we are rendering to the main canvas..
         const colorTexture = renderTarget.colorTexture;
 
-        if (CanvasSource.test(colorTexture.resource))
+        if (colorTexture.resource === renderer.canvas)
         {
             this._renderer.context.ensureCanvasSize(renderTarget.colorTexture.resource);
 


### PR DESCRIPTION
##### Description of change

In my work on @pixi-essentials/svg, I was seeing that copying from a canvas to a render texture was not working using `renderer.renderTarget.copyToTexture`, even though the signature accepts canvas sources. I traced it to PixiJS assigning the canvas texture a `null` framebuffer on binding to WebGL. This is because it incorrectly assumes that a canvas input must be the main canvas.

https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindFramebuffer

> A [WebGLFramebuffer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLFramebuffer) object to bind, or [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null) for binding the [HTMLCanvasElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement) or [OffscreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas) object associated with the rendering context.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
