### PR TITLE
feat: clean hashes and arrays

### DIFF
--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -49,6 +49,8 @@ export class GlBufferSystem implements System
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+
+        this._renderer.renderableGC.addManagedHash(this, '_gpuBuffers');
     }
 
     /**

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -62,6 +62,8 @@ export class GlGeometrySystem implements System
 
         this.hasVao = true;
         this.hasInstance = true;
+
+        this._renderer.renderableGC.addManagedHash(this, '_geometryVaoHash');
     }
 
     /** Sets up the renderer context and necessary buffers. */

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -60,6 +60,7 @@ export class GlShaderSystem implements ShaderSystem
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_programDataHash');
     }
 
     protected contextChange(gl: GlRenderingContext): void

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -68,6 +68,8 @@ export class GlTextureSystem implements System, CanvasGenerator
     constructor(renderer: WebGLRenderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_glTextures');
+        this._renderer.renderableGC.addManagedHash(this, '_glSamplers');
     }
 
     protected contextChange(gl: GlRenderingContext): void

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -34,6 +34,7 @@ export class BindGroupSystem implements System
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_hash');
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -36,6 +36,7 @@ export class GpuUniformBatchPipe
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_bindGroupHash');
 
         this._batchBuffer = new UboBatch({ minUniformOffsetAlignment });
 

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -4,6 +4,7 @@ import { fastCopy } from '../../shared/buffer/utils/fastCopy';
 import type { Buffer } from '../../shared/buffer/Buffer';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
+import type { WebGPURenderer } from '../WebGPURenderer';
 
 /**
  * System plugin to the renderer to manage buffers.
@@ -24,6 +25,11 @@ export class GpuBufferSystem implements System
     private readonly _managedBuffers: Buffer[] = [];
 
     private _gpu: GPU;
+
+    constructor(renderer: WebGPURenderer)
+    {
+        renderer.renderableGC.addManagedHash(this, '_gpuBuffers');
+    }
 
     protected contextChange(gpu: GPU): void
     {

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -56,6 +56,10 @@ export class GpuTextureSystem implements System, CanvasGenerator
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+        renderer.renderableGC.addManagedHash(this, '_gpuSources');
+        renderer.renderableGC.addManagedHash(this, '_gpuSamplers');
+        renderer.renderableGC.addManagedHash(this, '_bindGroupHash');
+        renderer.renderableGC.addManagedHash(this, '_textureViewHash');
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -190,6 +190,7 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        renderer.renderableGC.addManagedHash(this, '_gpuRenderTargetHash');
     }
 
     /** called when dev wants to finish a render pass */

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -8,6 +8,7 @@ import { buildContextBatches } from './utils/buildContextBatches';
 
 import type { Batcher } from '../../../rendering/batcher/shared/Batcher';
 import type { System } from '../../../rendering/renderers/shared/system/System';
+import type { Renderer } from '../../../rendering/renderers/types';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
 import type { GraphicsContext } from './GraphicsContext';
@@ -107,6 +108,12 @@ export class GraphicsContextSystem implements System<GraphicsContextSystemOption
     private _gpuContextHash: Record<number, GpuGraphicsContext> = {};
     // used for non-batchable graphics
     private _graphicsDataContextHash: Record<number, GraphicsContextRenderData> = Object.create(null);
+
+    constructor(renderer: Renderer)
+    {
+        renderer.renderableGC.addManagedHash(this, '_gpuContextHash');
+        renderer.renderableGC.addManagedHash(this, '_graphicsDataContextHash');
+    }
 
     /**
      * Runner init called, update the default options

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -7,6 +7,7 @@ import { BatchableGraphics } from './BatchableGraphics';
 import type { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import type { BatchPipe, RenderPipe } from '../../../rendering/renderers/shared/instructions/RenderPipe';
 import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
+import type { RenderableGCSystem } from '../../../rendering/renderers/shared/texture/RenderableGCSystem';
 import type { PoolItem } from '../../../utils/pool/Pool';
 import type { Container } from '../../container/Container';
 import type { Graphics } from './Graphics';
@@ -22,6 +23,7 @@ export interface GraphicsAdaptor
 export interface GraphicsSystem
 {
     graphicsContext: GraphicsContextSystem;
+    renderableGC: RenderableGCSystem;
     renderPipes: {
         batch: BatchPipe
     }
@@ -54,6 +56,8 @@ export class GraphicsPipe implements RenderPipe<Graphics>
 
         this._adaptor = adaptor;
         this._adaptor.init();
+
+        this.renderer.renderableGC.addManagedHash(this, '_graphicsBatchesHash');
     }
 
     public validateRenderable(graphics: Graphics): boolean

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -70,6 +70,9 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
         this._adaptor = adaptor;
 
         this._adaptor.init();
+
+        renderer.renderableGC.addManagedHash(this, '_gpuBatchableMeshHash');
+        renderer.renderableGC.addManagedHash(this, '_meshDataHash');
     }
 
     public validateRenderable(mesh: Mesh): boolean

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -29,6 +29,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_gpuSpriteHash');
     }
 
     public addRenderable(sprite: NineSliceSprite, instructionSet: InstructionSet)

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -48,6 +48,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_tilingSpriteDataHash');
     }
 
     public validateRenderable(renderable: TilingSprite): boolean

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -28,6 +28,7 @@ export class SpritePipe implements RenderPipe<Sprite>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_gpuSpriteHash');
     }
 
     public addRenderable(sprite: Sprite, instructionSet: InstructionSet)

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -33,6 +33,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_gpuBitmapText');
     }
 
     public validateRenderable(bitmapText: BitmapText): boolean

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -39,6 +39,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         this._renderer.runners.resolutionChange.add(this);
+        this._renderer.renderableGC.addManagedHash(this, '_gpuText');
     }
 
     public resolutionChange()

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -36,6 +36,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         this._renderer.runners.resolutionChange.add(this);
+        this._renderer.renderableGC.addManagedHash(this, '_gpuText');
     }
 
     public resolutionChange()

--- a/src/utils/data/clean.ts
+++ b/src/utils/data/clean.ts
@@ -1,0 +1,76 @@
+/**
+ * Takes a hash and removes all the `undefined`/`null` values from it.
+ * In PixiJS, we tend to null properties instead of using 'delete' for performance reasons.
+ * However, in some cases, this could be a problem if the hash grows too large over time,
+ * this function can be used to clean a hash.
+ * @param hash - The hash to clean.
+ * @returns A new hash with all the `undefined`/`null` values removed.
+ * @memberof utils
+ */
+export function cleanHash<T>(hash: Record<string, T>): Record<string, T>
+{
+    let clean = false;
+
+    for (const i in hash)
+    {
+        // eslint-disable-next-line eqeqeq
+        if (hash[i] == undefined)
+        {
+            clean = true;
+            break;
+        }
+    }
+
+    if (!clean) return hash;
+
+    const cleanHash = Object.create(null);
+
+    for (const i in hash)
+    {
+        const value = hash[i];
+
+        if (value)
+        {
+            cleanHash[i] = value;
+        }
+    }
+
+    return cleanHash;
+}
+
+/**
+ * Removes all `undefined`/`null` elements from the given array and compacts the array.
+ *
+ * This function iterates through the array, shifting non-undefined elements to the left
+ * to fill gaps created by `undefined` elements. The length of the array is then adjusted
+ * to remove the trailing `undefined` elements.
+ * @param arr - The array to be cleaned.
+ * @returns The cleaned array with all `undefined` elements removed.
+ * @example
+ * // Example usage:
+ * const arr = [1, undefined, 2, undefined, 3];
+ * const cleanedArr = cleanArray(arr);
+ * console.log(cleanedArr); // Output: [1, 2, 3]
+ * @memberof utils
+ */
+export function cleanArray<T>(arr: T[]): T[]
+{
+    let offset = 0;
+
+    for (let i = 0; i < arr.length; i++)
+    {
+        // eslint-disable-next-line eqeqeq
+        if (arr[i] == undefined)
+        {
+            offset++;
+        }
+        else
+        {
+            arr[i - offset] = arr[i];
+        }
+    }
+
+    arr.length = arr.length - offset;
+
+    return arr;
+}

--- a/tests/renderering/UniformBatch.test.ts
+++ b/tests/renderering/UniformBatch.test.ts
@@ -1,4 +1,6 @@
 import { GpuUniformBatchPipe } from '../../src/rendering/renderers/gpu/GpuUniformBatchPipe';
+import { SchedulerSystem } from '../../src/rendering/renderers/shared/SchedulerSystem';
+import { RenderableGCSystem } from '../../src/rendering/renderers/shared/texture/RenderableGCSystem';
 
 import type { WebGPURenderer } from '../../src/rendering/renderers/gpu/WebGPURenderer';
 
@@ -6,7 +8,12 @@ describe('UniformBatch', () =>
 {
     it('should get a bind group correctly', () =>
     {
-        const uniformBatchPipe = new GpuUniformBatchPipe({} as WebGPURenderer);
+        const scheduler = new SchedulerSystem();
+
+        const uniformBatchPipe = new GpuUniformBatchPipe({
+            scheduler,
+            renderableGC: new RenderableGCSystem({} as WebGPURenderer),
+        } as WebGPURenderer);
 
         const bufferResource = uniformBatchPipe.getArrayBufferResource(new Float32Array(32));
 
@@ -22,5 +29,7 @@ describe('UniformBatch', () =>
 
         expect(bufferResource3.buffer).toBe(uniformBatchPipe['_buffers'][0]);
         expect(bufferResource3.offset).toBe(256);
+
+        scheduler.destroy();
     });
 });


### PR DESCRIPTION
Replacement for #10793

In PixiJS we make use of hashes to map data to things like renderables within pipes. To keep things efficinat we do not use 'delete' when an item needs to be removed, instead we simply set the property to null. Over time (with lots of destroy / create) the hashes could grow to be pretty large.

To prevent hashes from growing to large this PR introduces two new methods to the `RenderableGCSystem` that allow it to schedule clean up operations for hashes and arrays.

