### PR TITLE
fix: custom render pipe crashing with gc

### DIFF
--- a/src/scene/container/CustomRenderPipe.ts
+++ b/src/scene/container/CustomRenderPipe.ts
@@ -1,7 +1,7 @@
 import { ExtensionType } from '../../extensions/Extensions';
 
 import type { InstructionSet } from '../../rendering/renderers/shared/instructions/InstructionSet';
-import type { InstructionPipe } from '../../rendering/renderers/shared/instructions/RenderPipe';
+import type { InstructionPipe, RenderPipe } from '../../rendering/renderers/shared/instructions/RenderPipe';
 import type { Renderer } from '../../rendering/renderers/types';
 import type { RenderContainer } from './RenderContainer';
 
@@ -18,7 +18,7 @@ import type { RenderContainer } from './RenderContainer';
  * })
  * @memberof rendering
  */
-export class CustomRenderPipe implements InstructionPipe<RenderContainer>
+export class CustomRenderPipe implements InstructionPipe<RenderContainer>, RenderPipe<RenderContainer>
 {
     public static extension = {
         type: [
@@ -35,6 +35,10 @@ export class CustomRenderPipe implements InstructionPipe<RenderContainer>
     {
         this._renderer = renderer;
     }
+
+    public updateRenderable() { /** empty */ }
+    public destroyRenderable() { /** empty */ }
+    public validateRenderable() { return false; }
 
     public addRenderable(container: RenderContainer, instructionSet: InstructionSet): void
     {


### PR DESCRIPTION
fixes the issue where the `RenderableGCSystem` is calling `destroyRenderable` on the `CusomtRenderPipe` but it does not exist