### PR TITLE
remove `math-extras` mixin import

### DIFF
--- a/types/PixiMixins.d.ts
+++ b/types/PixiMixins.d.ts
@@ -11,5 +11,4 @@
 /// <reference path="../src/scene/text-bitmap/TextBitmapMixins.d.ts" />
 /// <reference path="../src/scene/text-html/TextHTMLMixins.d.ts" />
 /// <reference path="../src/scene/particle-container/ParticleMixins.d.ts" />
-/// <reference path="../src/math-extras/MathExtraMixins.d.ts" />
 /// <reference path="../src/filters/FilterMixins.d.ts" />


### PR DESCRIPTION
Given that the functionality for `math-extras` is not included in the main `pixi.js` bundle when you're installing `pixi.js`, these types hint to the consumer they should be able to use methods that don't exist.

##### Description of change
Removed `MathExtraMixins.d.ts` mixin from `types/PixiMixins.d.ts`

##### Pre-Merge Checklist
- [X] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
