### PR TITLE
fix: set tint fallback of Particle

### DIFF
--- a/src/scene/particle-container/shared/Particle.ts
+++ b/src/scene/particle-container/shared/Particle.ts
@@ -153,7 +153,7 @@ export class Particle implements IParticle
         }
         else
         {
-            this._tint = Color.shared.setValue(value).toBgrNumber();
+            this._tint = Color.shared.setValue(value ?? 0xFFFFFF).toBgrNumber();
         }
 
         this._updateColor();


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add tint fallback of `Particle`, the same behavior of `Container`

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
