### PR TITLE
fix: particle container issue

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1343,7 +1343,15 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
         this.destroyed = true;
 
         // remove children is faster than removeChild..
-        const oldChildren = this.removeChildren(0, this.children.length);
+
+        let oldChildren: ContainerChild[];
+
+        // we add this check as calling removeChildren on particle container will throw an error
+        // As we know it does cannot have any children, check before calling the function.
+        if (this.children.length)
+        {
+            oldChildren = this.removeChildren(0, this.children.length);
+        }
 
         this.removeFromParent();
         this.parent = null;
@@ -1361,7 +1369,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         const destroyChildren = typeof options === 'boolean' ? options : options?.children;
 
-        if (destroyChildren)
+        if (destroyChildren && oldChildren)
         {
             for (let i = 0; i < oldChildren.length; ++i)
             {

--- a/tests/renderering/particle-container/ParticleContainer.test.ts
+++ b/tests/renderering/particle-container/ParticleContainer.test.ts
@@ -1,0 +1,92 @@
+import { Rectangle } from '../../../src/maths/shapes/Rectangle';
+import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
+import { Container } from '../../../src/scene/container/Container';
+import { Particle } from '../../../src/scene/particle-container/shared/Particle';
+import { ParticleContainer } from '../../../src/scene/particle-container/shared/ParticleContainer';
+import { getWebGLRenderer } from '../../utils/getRenderer';
+
+describe('ParticleContainer', () =>
+{
+    describe('constructor', () =>
+    {
+        it('should support no arguments', () =>
+        {
+            const container = new ParticleContainer();
+
+            expect(container).toBeDefined();
+            expect(container.texture).toEqual(null);
+
+            container.destroy();
+        });
+
+        it('should support options with no texture', () =>
+        {
+            const container = new ParticleContainer({
+                texture: Texture.WHITE,
+            });
+
+            expect(container).toBeDefined();
+            expect(container.texture).toEqual(Texture.WHITE);
+
+            container.destroy();
+        });
+    });
+
+    describe('destroy', () =>
+    {
+        it('should not throw when destroyed', () =>
+        {
+            const container = new ParticleContainer();
+
+            expect(() => container.destroy()).not.toThrow();
+        });
+
+        it('should clean up correctly on the pipe and system when destroyed', async () =>
+        {
+            const renderer = await getWebGLRenderer();
+
+            const container = new Container();
+
+            const particleContainer = new ParticleContainer();
+
+            particleContainer.addParticle(new Particle({
+                texture: Texture.WHITE
+            }));
+
+            container.addChild(particleContainer);
+
+            renderer.render({ container });
+
+            particleContainer.destroy();
+
+            expect(renderer.renderPipes.particle['_gpuBufferHash'][particleContainer.uid]).toBeNull();
+        });
+    });
+
+    describe('width', () =>
+    {
+        it('should set width correctly if no bounds is set', () =>
+        {
+            const container = new ParticleContainer();
+
+            container.width = 100;
+
+            // this should be 0 as no bounds have been specified
+            expect(container.width).toEqual(0);
+        });
+
+        it('should set bounds on the constructor', () =>
+        {
+            const container = new ParticleContainer({
+                texture: Texture.WHITE,
+                boundsArea: new Rectangle(0, 0, 50, 100),
+            });
+
+            expect(container.width).toEqual(50);
+            expect(container.height).toEqual(100);
+
+            container.width = 100;
+            expect(container.width).toEqual(100);
+        });
+    });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
fixes #10999

Avoid removeChildren being called in container.super.destroy if the length of the children is 0. This is always the case for particle container, and so will stop the issuse from happening.

Added some tests to particle container too, to cover this and a few other things!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
