### PR TITLE
fix: nineslice garbage collector bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watch:build": "run-s build:index build:rollup build:tsc build:dts postbuild",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
-    "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",
+    "test:debug": "cross-env DEBUG_MODE=1 npx jest",
     "test:server": "npx http-server -p 8080 -c-1",
     "test:scene": "npx jest --silent --testPathPattern=tests/visual",
     "test:scene:debug": "cross-env DEBUG_MODE=1 npx jest --testPathPattern=tests/visual",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "watch:build": "run-s build:index build:rollup build:tsc build:dts postbuild",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
-    "test:debug": "cross-env DEBUG_MODE=1 npx jest",
+    "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",
     "test:server": "npx http-server -p 8080 -c-1",
     "test:scene": "npx jest --silent --testPathPattern=tests/visual",
     "test:scene:debug": "cross-env DEBUG_MODE=1 npx jest --testPathPattern=tests/visual",

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -102,6 +102,12 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 
         this._gpuSpriteHash[sprite.uid] = batchableMesh;
 
+        // if the sprite has not been updated by the view, we need to update the batchable mesh now.
+        if (!sprite.didViewUpdate)
+        {
+            this._updateBatchableSprite(sprite, batchableMesh);
+        }
+
         // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
         sprite.on('destroyed', this._destroyRenderableBound);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
fixes #11002
This will ensure that when resurrrected, the nineslice sprite renders correctly. Went for this approach, as did not want the pipe to explicitly set the `didViewUpdate` property, as it should only be reading that prop to keep the data flow simple.


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
