### PR TITLE
Apply #8679 to 7.x branch

### DIFF
--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -73,15 +73,15 @@ export class CanvasSpriteRenderer
         if (texture.trim)
         {
             if (groupD8.isVertical(texture.rotate))
-                {
-                    destWidth = texture.trim.height;
-                    destHeight = texture.trim.width;
-                }
-                else
-                {
-                    destWidth = texture.trim.width;
-                    destHeight = texture.trim.height;
-                }
+            {
+                destWidth = texture.trim.height;
+                destHeight = texture.trim.width;
+            }
+            else
+            {
+                destWidth = texture.trim.width;
+                destHeight = texture.trim.height;
+            }
         }
 
         let wt = sprite.transform.worldTransform;

--- a/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
+++ b/packages/canvas-sprite/src/CanvasSpriteRenderer.ts
@@ -72,8 +72,16 @@ export class CanvasSpriteRenderer
 
         if (texture.trim)
         {
-            destWidth = texture.trim.width;
-            destHeight = texture.trim.height;
+            if (groupD8.isVertical(texture.rotate))
+                {
+                    destWidth = texture.trim.height;
+                    destHeight = texture.trim.width;
+                }
+                else
+                {
+                    destWidth = texture.trim.width;
+                    destHeight = texture.trim.height;
+                }
         }
 
         let wt = sprite.transform.worldTransform;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This addresses issue https://github.com/pixijs/pixijs/issues/11021

When trying to setup canvas mode using pixi v7.4.2, I've been getting badly rendered images when they are rotated in a spritesheet.

I came across issue https://github.com/pixijs/spine/issues/460, and found that the patch to fix that issue is missing from the 7.x branch (https://github.com/pixijs/pixijs/pull/8679/files). I forked the code example from 460 and set it up the way I have setup the pixi application in my app to demonstrate the issue here: https://codesandbox.io/p/sandbox/vigorous-rain-tlrf68.

Adding the code from 8679 fixed the issue for me when testing locally.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
