### PR TITLE
fix: avoid blank space in the DynamicBitmapFont resource

### DIFF
--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -150,6 +150,9 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
         let maxCharHeight = 0;
         let skipTexture = false;
 
+        const maxTextureWidth = canvas.width / this.resolution;
+        const maxTextureHeight = canvas.height / this.resolution;
+
         for (let i = 0; i < charList.length; i++)
         {
             const char = charList[i];
@@ -176,7 +179,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
                 maxCharHeight = Math.ceil(Math.max(paddedHeight, maxCharHeight));// / 1.5;
             }
 
-            if (currentX + paddedWidth > this._textureSize)
+            if (currentX + paddedWidth > maxTextureWidth)
             {
                 currentY += maxCharHeight;
 
@@ -184,7 +187,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
                 maxCharHeight = paddedHeight;
                 currentX = 0;
 
-                if (currentY + maxCharHeight > this._textureSize)
+                if (currentY + maxCharHeight > maxTextureHeight)
                 {
                     textureSource.update();
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

fix #11019

Use the actual texture size calculated from the canvas in `pageData.canvasAndContext` instead of using `this._textureSize` to fill up the blanks and reduce the size of the resource.

From
![image](https://github.com/user-attachments/assets/fc8710be-00eb-4209-935b-46678ecfbb36)

To
![image](https://github.com/user-attachments/assets/baeb94ef-8c18-4609-8c02-8a6ba0fdff29)


<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
