### PR TITLE
fix: stroke should use alignment when extending bounds

### DIFF
--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1046,7 +1046,9 @@ export class GraphicsContext extends EventEmitter<{
             {
                 const data = instruction.data as StrokeInstruction['data'];
 
-                const padding = data.style.width / 2;
+                const alignment = data.style.alignment;
+
+                const padding = (data.style.width * (1 - alignment));
 
                 const _bounds = data.path.bounds;
 

--- a/tests/renderering/graphics/Graphics.Bounds.test.ts
+++ b/tests/renderering/graphics/Graphics.Bounds.test.ts
@@ -19,7 +19,7 @@ describe('Graphics Bounds', () =>
             expect(height).toEqual(200);
         });
 
-        it('should give correct bounds with stroke', () =>
+        it('should give correct bounds with stroke, default alignment', () =>
         {
             const graphics = new Graphics();
 
@@ -34,6 +34,40 @@ describe('Graphics Bounds', () =>
             expect(y).toEqual(18); // <- received 20
             expect(width).toEqual(104); // <- received 100
             expect(height).toEqual(204); // <- received 200
+        });
+
+        it('should give correct bounds with stroke, alignment 1', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics
+                .rect(10, 20, 100, 200)
+                .fill(0)
+                .stroke({ width: 4, color: 0xff0000, alignment: 1 });
+
+            const { x, y, width, height } = graphics.context.bounds;
+
+            expect(x).toEqual(10);
+            expect(y).toEqual(20);
+            expect(width).toEqual(100);
+            expect(height).toEqual(200);
+        });
+
+        it('should give correct bounds with stroke, alignment 0', () =>
+        {
+            const graphics = new Graphics();
+
+            graphics
+                .rect(10, 20, 100, 200)
+                .fill(0)
+                .stroke({ width: 4, color: 0xff0000, alignment: 0 });
+
+            const { x, y, width, height } = graphics.context.bounds;
+
+            expect(x).toEqual(6);
+            expect(y).toEqual(16);
+            expect(width).toEqual(108);
+            expect(height).toEqual(208);
         });
 
         it('should be zero for empty Graphics', () =>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
When stroke instruction is used, bounds are extended by width of the stroke.
It should use alignment not hardcoded 0.5 multiplier.

Before this change, the element has increased size even if the alignment is set to 1 and stroke is inside of the original shape which should not affect bounds.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
