### PR TITLE
fix: Issue with texture matrix corrupting on graphics fill

### DIFF
--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -119,7 +119,7 @@ function handleFillObject(value: FillStyle, defaultStyle: ConvertedFillStyle): C
     {
         if (style.texture !== Texture.WHITE)
         {
-            const m = style.matrix?.invert() || new Matrix();
+            const m = style.matrix?.clone().invert() || new Matrix();
 
             m.translate(style.texture.frame.x, style.texture.frame.y);
             m.scale(1 / style.texture.source.width, 1 / style.texture.source.height);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Ensure we clone the matrix of a graphcis texture fill, as this is modified internally. Not cloning it was causing strange side effects. 

[Example](https://www.pixiplayground.com/#/edit/loZfVFhDhbueDEPSESGrn)

Step 1 - show the application in landscape
Step 2 - resize the window so the app is in portrait
Step 3 - resize the window so the app is in landscape

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
