### PR TITLE
fix: re-parent on render group issue

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -639,14 +639,16 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         const child = children[0];
 
+        const renderGroup = this.renderGroup || this.parentRenderGroup;
+
         if (child.parent === this)
         {
             this.children.splice(this.children.indexOf(child), 1);
             this.children.push(child);
 
-            if (this.parentRenderGroup)
+            if (renderGroup)
             {
-                this.parentRenderGroup.structureDidChange = true;
+                renderGroup.structureDidChange = true;
             }
 
             return child;
@@ -668,8 +670,6 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         // TODO - OPtimise this? could check what the parent has set?
         child._updateFlags = 0b1111;
-
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
 
         if (renderGroup)
         {

--- a/tests/scene/RenderGroup.tests.ts
+++ b/tests/scene/RenderGroup.tests.ts
@@ -628,5 +628,28 @@ describe('RenderGroup', () =>
 
         renderer.destroy();
     });
+
+    it('should flag a render group as dirty if a order is changed', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        BigPool.getPool(RenderGroup).clear();
+
+        const container = new Container({ isRenderGroup: true });
+
+        const a = new Container();
+        const b = new Container();
+
+        container.addChild(a);
+        container.addChild(b);
+
+        renderer.render(container);
+
+        // should now be at the top!
+        container.addChild(a);
+
+        // this should now be true as the order has changed
+        expect(container.renderGroup.structureDidChange).toBeTrue();
+    });
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Fixes an issue where adding a child to its existing parent that has render group enabled will not cause the scene to rebuild. 
Added a test to cover this situation too.

fixes #11039 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
