### PR TITLE
fix: clipToViewport filter cropping at higher resolutions

### DIFF
--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -253,10 +253,6 @@ export class FilterSystem implements System
         // here we constrain the bounds to the viewport we will render too
         // this should not take into account the x, y offset of the viewport - as this is
         // handled by the viewport on the gpu.
-        // need to factor in resolutions also..
-        bounds
-            .scale(resolution);
-
         if (clipToViewport)
         {
             const viewPort = renderer.renderTarget.rootViewPort;
@@ -264,7 +260,9 @@ export class FilterSystem implements System
             bounds.fitBounds(0, viewPort.width, 0, viewPort.height);
         }
 
+        // round the bounds to the nearest pixel
         bounds
+            .scale(resolution)
             .ceil()
             .scale(1 / resolution)
             .pad(padding | 0);

--- a/tests/visual/scenes/filters/clip-top-viewport/clip-to-viewport.scene.ts
+++ b/tests/visual/scenes/filters/clip-top-viewport/clip-to-viewport.scene.ts
@@ -36,6 +36,8 @@ export const scene: TestScene = {
                 vertex: circleVert,
                 fragment: circleFrag,
             },
+            resolution: 2,
+
         });
 
         sprite.filters = customFilter;


### PR DESCRIPTION
##### Description of change

Fixes an issue where if a filter has a higher resolution than the root render target it was causing the bounds to be cropped. 
I also updated an existing test to cover this use case.

fixes #11051 


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
