### PR TITLE
fix: remove redundant/incorrect condition

### DIFF
--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -55,12 +55,7 @@ export class CanvasSource extends TextureSource<ICanvas>
 
         this.autoDensity = options.autoDensity;
 
-        const canvas = options.resource;
-
-        if (this.pixelWidth !== canvas.width || this.pixelWidth !== canvas.height)
-        {
-            this.resizeCanvas();
-        }
+        this.resizeCanvas();
 
         this.transparent = !!options.transparent;
     }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Removed incorrect (both canvas.height/width were checking against pixelWidth!) and redundant condtion, since `resizeCanvas` already has the correct condition in place for skipping resizing if the canvas is already the correct size.

![image](https://github.com/user-attachments/assets/feceaa82-7d8c-42bc-b1da-c56f0519af40)


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
