### PR TITLE
fix: FillGradient leak

### DIFF
--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -63,6 +63,8 @@ export class FillGradient implements CanvasGradient
     // TODO move to the system!
     public buildLinearGradient(): void
     {
+        if (this.texture) return;
+
         const defaultSize = FillGradient.defaultTextureSize;
 
         const { gradientStops } = this;

--- a/tests/graphics/GraphicsFill.tests.ts
+++ b/tests/graphics/GraphicsFill.tests.ts
@@ -2,7 +2,7 @@ import { Color } from '../../src/color/Color';
 import { Texture } from '../../src/rendering/renderers/shared/texture/Texture';
 import { FillGradient } from '../../src/scene/graphics/shared/fill/FillGradient';
 import { FillPattern } from '../../src/scene/graphics/shared/fill/FillPattern';
-import { toStrokeStyle } from '../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
+import { toFillStyle, toStrokeStyle } from '../../src/scene/graphics/shared/utils/convertFillInputToFillStyle';
 
 import type { ConvertedStrokeStyle } from '../../src/scene/graphics/shared/FillTypes';
 
@@ -151,5 +151,19 @@ describe('convertStrokeInputToStrokeStyle', () =>
             texture: gradient.texture,
             matrix: gradient.transform
         });
+    });
+
+    it('should only build FillGradient once', () =>
+    {
+        const defaultStyle = getDefaultValue();
+        const gradient = new FillGradient(0, 0, 200, 0);
+
+        toFillStyle(gradient, defaultStyle);
+
+        const texture = gradient.texture;
+
+        toFillStyle(gradient, defaultStyle);
+
+        expect(texture).toBe(gradient.texture);
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Silly us, we were creating the texture for the gradient each frame. This is no longer the case, create once use - often!

fixes #10936 and #11059 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
