### PR TITLE
fix: webgl uniform buffers (#10738)

### DIFF
--- a/src/rendering/renderers/gl/buffer/GlBuffer.ts
+++ b/src/rendering/renderers/gl/buffer/GlBuffer.ts
@@ -7,6 +7,9 @@ export class GlBuffer
     public byteLength: number;
     public type: number;
 
+    public _lastBindBaseLocation: number = -1;
+    public _lastBindCallId: number = -1;
+
     constructor(buffer: WebGLBuffer, type: BUFFER_TYPE)
     {
         this.buffer = buffer || null;

--- a/src/rendering/renderers/gl/shader/GenerateShaderSyncCode.ts
+++ b/src/rendering/renderers/gl/shader/GenerateShaderSyncCode.ts
@@ -32,7 +32,6 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
     `];
 
     let addedTextreSystem = false;
-    let blockIndex = 0;
     let textureCount = 0;
 
     const programData = shaderSystem._getProgramData(shader.glProgram);
@@ -53,11 +52,13 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
             {
                 if (resource.ubo)
                 {
+                    const resName = shader._uniformBindMap[i][Number(j)];
+
                     funcFragments.push(`
                         sS.bindUniformBlock(
                             resources[${j}],
-                            sS._uniformBindMap[${i}[${j}],
-                            ${blockIndex++}
+                            '${resName}',
+                            ${shader.glProgram._uniformBlockData[resName].index}
                         );
                     `);
                 }
@@ -70,11 +71,13 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
             }
             else if (resource instanceof BufferResource)
             {
+                const resName = shader._uniformBindMap[i][Number(j)];
+
                 funcFragments.push(`
                     sS.bindUniformBlock(
                         resources[${j}],
-                        sS._uniformBindMap[${i}[${j}],
-                        ${blockIndex++}
+                        '${resName}',
+                        ${shader.glProgram._uniformBlockData[resName].index}
                     );
                 `);
             }

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -51,6 +51,8 @@ export interface GlProgramOptions
     preferredVertexPrecision?: string;
     /** the preferred fragment precision for the shader, this may not be used if the device does not support it  */
     preferredFragmentPrecision?: string;
+
+    transformFeedbackVaryings?: {names: string[], bufferMode: 'separate' | 'interleaved'};
 }
 
 const processes: Record<string, ((source: string, options: any, isFragment?: boolean) => string)> = {
@@ -177,6 +179,8 @@ export class GlProgram
 
         this.fragment = fragment;
         this.vertex = vertex;
+
+        this.transformFeedbackVaryings = options.transformFeedbackVaryings;
 
         this._key = createIdFromString(`${this.vertex}:${this.fragment}`, 'gl-program');
     }

--- a/src/rendering/renderers/gl/shader/utils/generateArraySyncSTD40.ts
+++ b/src/rendering/renderers/gl/shader/utils/generateArraySyncSTD40.ts
@@ -15,6 +15,7 @@ export function generateArraySyncSTD40(uboElement: UboElement, offsetToAdd: numb
     const elementSize = (uboElement.data.value as Array<number>).length / uboElement.data.size;// size / rowSize;
 
     const remainder = (4 - (elementSize % 4)) % 4;
+    const data = uboElement.data.type.indexOf('i32') >= 0 ? 'dataInt32' : 'data';
 
     return `
         v = uv.${uboElement.data.name};
@@ -28,7 +29,7 @@ export function generateArraySyncSTD40(uboElement: UboElement, offsetToAdd: numb
         {
             for(var j = 0; j < ${elementSize}; j++)
             {
-                data[arrayOffset++] = v[t++];
+                ${data}[arrayOffset++] = v[t++];
             }
             ${remainder !== 0 ? `arrayOffset += ${remainder};` : ''}
         }

--- a/src/rendering/renderers/gpu/shader/utils/generateArraySyncWGSL.ts
+++ b/src/rendering/renderers/gpu/shader/utils/generateArraySyncWGSL.ts
@@ -15,6 +15,7 @@ export function generateArraySyncWGSL(uboElement: UboElement, offsetToAdd: numbe
     const { size, align } = WGSL_ALIGN_SIZE_DATA[uboElement.data.type];
 
     const remainder = (align - size) / 4;
+    const data = uboElement.data.type.indexOf('i32') >= 0 ? 'dataInt32' : 'data';
 
     return `
          v = uv.${uboElement.data.name};
@@ -28,7 +29,7 @@ export function generateArraySyncWGSL(uboElement: UboElement, offsetToAdd: numbe
          {
              for(var j = 0; j < ${size / 4}; j++)
              {
-                 data[arrayOffset++] = v[t++];
+                 ${data}[arrayOffset++] = v[t++];
              }
              ${remainder !== 0 ? `arrayOffset += ${remainder};` : ''}
          }

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -140,6 +140,8 @@ export class Buffer extends EventEmitter<{
 
     private _data: TypedArray;
 
+    private _dataInt32: Int32Array = null;
+
     /**
      * should the GPU buffer be shrunk when the data becomes smaller?
      * changing this will cause the buffer to be destroyed and a new one created on the GPU
@@ -199,6 +201,16 @@ export class Buffer extends EventEmitter<{
         this.setDataWithSize(value, value.length, true);
     }
 
+    get dataInt32()
+    {
+        if (!this._dataInt32)
+        {
+            this._dataInt32 = new Int32Array((this.data as any).buffer);
+        }
+
+        return this._dataInt32;
+    }
+
     /** whether the buffer is static or not */
     get static()
     {
@@ -243,11 +255,12 @@ export class Buffer extends EventEmitter<{
         const oldData = this._data;
 
         this._data = value;
+        this._dataInt32 = null;
 
         // Event handling
-        if (oldData.length !== value.length)
+        if (!oldData || oldData.length !== value.length)
         {
-            if (!this.shrinkToFit && value.byteLength < oldData.byteLength)
+            if (!this.shrinkToFit && oldData && value.byteLength < oldData.byteLength)
             {
                 if (syncGPU) this.emit('update', this);
             }

--- a/src/rendering/renderers/shared/shader/UboSystem.ts
+++ b/src/rendering/renderers/shared/shader/UboSystem.ts
@@ -21,7 +21,7 @@ export class UboSystem implements System
     /** Cache of uniform buffer layouts and sync functions, so we don't have to re-create them */
     private _syncFunctionHash: Record<string, {
         layout: UboLayout,
-        syncFunction: (uniforms: Record<string, any>, data: Float32Array, offset: number) => void
+        syncFunction: (uniforms: Record<string, any>, data: Float32Array, dataInt32: Int32Array, offset: number) => void
     }> = Object.create(null);
 
     private readonly _adaptor: UboAdaptor;
@@ -102,10 +102,16 @@ export class UboSystem implements System
             usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
         });
 
-        data ||= (uniformGroup.buffer.data as Float32Array);
+        let dataInt32: Int32Array = null;
+
+        if (!data)
+        {
+            data = uniformGroup.buffer.data as Float32Array;
+            dataInt32 = uniformGroup.buffer.dataInt32;
+        }
         offset ||= 0;
 
-        uniformGroupData.syncFunction(uniformGroup.uniforms, data, offset);
+        uniformGroupData.syncFunction(uniformGroup.uniforms, data, dataInt32, offset);
 
         return true;
     }

--- a/src/rendering/renderers/shared/shader/types.ts
+++ b/src/rendering/renderers/shared/shader/types.ts
@@ -13,7 +13,10 @@ export const UNIFORM_TYPES_VALUES = [
     'mat2x3<f32>',
     'mat4x3<f32>',
     'mat2x4<f32>',
-    'mat3x4<f32>'
+    'mat3x4<f32>',
+    'vec2<i32>',
+    'vec3<i32>',
+    'vec4<i32>',
 ] as const;
 
 /** useful for checking if a type is supported - a map of supported types with a true value. */

--- a/src/rendering/renderers/shared/shader/utils/createUboSyncFunction.ts
+++ b/src/rendering/renderers/shared/shader/utils/createUboSyncFunction.ts
@@ -79,6 +79,7 @@ export function createUboSyncFunction(
     return new Function(
         'uv',
         'data',
+        'dataInt32',
         'offset',
         fragmentSrc,
     ) as UniformsSyncCallback;

--- a/src/rendering/renderers/shared/shader/utils/uboSyncFunctions.ts
+++ b/src/rendering/renderers/shared/shader/utils/uboSyncFunctions.ts
@@ -15,7 +15,7 @@ export const uboSyncFunctionsSTD40: Record<UNIFORM_TYPES_SINGLE, string> = {
     f32: `
         data[offset] = v;`,
     i32: `
-        data[offset] = v;`,
+        dataInt32[offset] = v;`,
     'vec2<f32>': `
         data[offset] = v[0];
         data[offset + 1] = v[1];`,
@@ -28,6 +28,18 @@ export const uboSyncFunctionsSTD40: Record<UNIFORM_TYPES_SINGLE, string> = {
         data[offset + 1] = v[1];
         data[offset + 2] = v[2];
         data[offset + 3] = v[3];`,
+    'vec2<i32>': `
+        dataInt32[offset] = v[0];
+        dataInt32[offset + 1] = v[1];`,
+    'vec3<i32>': `
+        dataInt32[offset] = v[0];
+        dataInt32[offset + 1] = v[1];
+        dataInt32[offset + 2] = v[2];`,
+    'vec4<i32>': `
+        dataInt32[offset] = v[0];
+        dataInt32[offset + 1] = v[1];
+        dataInt32[offset + 2] = v[2];
+        dataInt32[offset + 3] = v[3];`,
     'mat2x2<f32>': `
         data[offset] = v[0];
         data[offset + 1] = v[1];

--- a/tests/renderering/createUBOElementsSTD40.test.ts
+++ b/tests/renderering/createUBOElementsSTD40.test.ts
@@ -76,8 +76,8 @@ describe('createUBOElements', () =>
                 values: ['vec3<f32>', 'mat3x3<f32>', 'vec2<f32>'],
                 expected: {
                     size: [12, 48, 8],
-                    offset: [0, 32, 80],
-                    totalSize: 96
+                    offset: [0, 16, 64],
+                    totalSize: 80
                 },
             },
 


### PR DESCRIPTION
Redo of #10738 on dev branch

WebGL UBO doesnt work in v8 at all, here's the fix that makes real app work. The app that can use all UBO slots in the same frame and sometimes need TransformFeedback

1. [STD140](https://www.oreilly.com/library/view/opengl-programming-guide/9780132748445/app09lev1sec2.html) , called sometimes STD40 in our code, never worked in pixi the right way. We managed to ignore smaller impl from threejs, and wrote something .. strange, that someimtes skips 8 floats to put next `vec3f`. Now it works.
2. Thing that puts Uniform Buffers into special slots was broken. "ok, first UBO exists, there's location. Second UBO? its not activated, lets use.. random location, maybe the same as first UBO"
3. It also does not account for buffers that can be used in TransformFeedback - and those locations are actually shared! Lets give 0-th slot to shaders that need TF when its needed.
4. UBO sync code was broken.
5. Now there's an option to use `i32` in UBO. Also, any buffer has a view for it, if you request.

Tests might be added later, maybe with usage of `vec3f` shortcuts and `cloneValues` hack