### PR TITLE
Fix: Event Boundry IncludeInBuild Check

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -548,7 +548,7 @@ export class EventBoundary
     private _interactivePrune(container: Container): boolean
     {
         // If container is a mask, invisible, or not renderable then it cannot be hit directly.
-        if (!container || !container.visible || !container.renderable || !container.includeInBuild || !container.measurable)
+        if (!container || !container.visible || !container.renderable || !container.measurable)
         {
             return true;
         }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Removing the`includeInBuild` check from EventBoundry hitText. This is not really required as `includeInBuild` is used to render things outside of the regular render loop (eg render a mask, but not as a regular item)

Arguably this could also have a better name! But that can be for another PR. 

This actually fixes an issue we saw in the latest spine release where items attached slot objects lose their interation. This PR fixes that issue!

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
