### PR TITLE
fix: strokeContains should use alignment

### DIFF
--- a/src/maths/__tests__/Circle.test.ts
+++ b/src/maths/__tests__/Circle.test.ts
@@ -75,6 +75,23 @@ describe('Circle', () =>
 
         expect(circle.strokeContains(20 + 5, 10, 4)).toBe(false);
         expect(circle.strokeContains(10, 20 + 5, 4)).toBe(false);
+
+        // alignment, outer stroke
+        expect(circle.strokeContains(10 + 5 + 0.0, 10, 2, 0)).toBe(false);
+        expect(circle.strokeContains(10 + 5 + 0.1, 10, 2, 0)).toBe(true);
+        expect(circle.strokeContains(10 + 5 + 2.0, 10, 2, 0)).toBe(true);
+
+        // alignment, center stroke
+        expect(circle.strokeContains(10 + 5 - 1.0, 10, 2, 0.5)).toBe(false);
+        expect(circle.strokeContains(10 + 5 - 0.9, 10, 2, 0.5)).toBe(true);
+        expect(circle.strokeContains(10 + 5 + 1.0, 10, 2, 0.5)).toBe(true);
+        expect(circle.strokeContains(10 + 5 + 1.1, 10, 2, 0.5)).toBe(false);
+
+        // alignment, inner stroke
+        expect(circle.strokeContains(10 + 5 - 2.0, 10, 2, 1)).toBe(false);
+        expect(circle.strokeContains(10 + 5 - 1.9, 10, 2, 1)).toBe(true);
+        expect(circle.strokeContains(10 + 5 + 0.0, 10, 2, 1)).toBe(true);
+        expect(circle.strokeContains(10 + 5 + 0.1, 10, 2, 1)).toBe(false);
     });
 
     it('should return framing rectangle', () =>

--- a/src/maths/__tests__/Ellipse.test.ts
+++ b/src/maths/__tests__/Ellipse.test.ts
@@ -62,15 +62,58 @@ describe('Ellipse', () =>
         expect(ellipse2.contains(10, 10)).toBe(false);
     });
 
-    it('should check if point is within ellipse stroke', () =>
+    describe('strokeContains', () =>
     {
-        const ellipse = new Ellipse(2, 2, 10, 10);
+        it('alignment = 0, outside', () =>
+        {
+            const ellipse = new Ellipse(2, 2, 10, 10); // -8, 12 // for 3 width -8 -7 -6  10 11 12
 
-        expect(ellipse.strokeContains(2, 2, 5)).toBe(false);
-        expect(ellipse.strokeContains(7, 7, 10)).toBe(true);
-        expect(ellipse.strokeContains(8, 8, 5)).toBe(true);
-        expect(ellipse.strokeContains(12, 12, 10)).toBe(true);
-        expect(ellipse.strokeContains(15, 15, 5)).toBe(false);
+            expect(ellipse.strokeContains(-11, 0, 3, 0)).toBe(false);
+            expect(ellipse.strokeContains(-10, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(-9, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(-8, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(-7, 0, 3, 0)).toBe(false);
+
+            expect(ellipse.strokeContains(11, 0, 3, 0)).toBe(false);
+            expect(ellipse.strokeContains(12, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(13, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(14, 0, 3, 0)).toBe(true);
+            expect(ellipse.strokeContains(15, 0, 3, 0)).toBe(false);
+        });
+
+        it('alignment = 0.5, center', () =>
+        {
+            const ellipse = new Ellipse(2, 2, 10, 10); // -8, 12 // for 3 width -8 -7 -6  10 11 12
+
+            expect(ellipse.strokeContains(-10, 0, 3, 0.5)).toBe(false);
+            expect(ellipse.strokeContains(-9, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(-8, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(-7, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(-6, 0, 3, 0.5)).toBe(false);
+
+            expect(ellipse.strokeContains(10, 0, 3, 0.5)).toBe(false);
+            expect(ellipse.strokeContains(11, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(12, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(13, 0, 3, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(14, 0, 3, 0.5)).toBe(false);
+        });
+
+        it('alignment = 1, inside', () =>
+        {
+            const ellipse = new Ellipse(2, 2, 10, 10); // -8, 12 // for 3 width -8 -7 -6  10 11 12
+
+            expect(ellipse.strokeContains(-8, 0, 3, 1)).toBe(false);
+            expect(ellipse.strokeContains(-7, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(-6, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(-5, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(-4, 0, 3, 1)).toBe(false);
+
+            expect(ellipse.strokeContains(12, 0, 3, 1)).toBe(false);
+            expect(ellipse.strokeContains(11, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(10, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(9, 0, 3, 1)).toBe(true);
+            expect(ellipse.strokeContains(8, 0, 3, 1)).toBe(false);
+        });
     });
 
     it('should return framing rectangle', () =>

--- a/src/maths/__tests__/Polygon.test.ts
+++ b/src/maths/__tests__/Polygon.test.ts
@@ -127,7 +127,7 @@ describe('Polygon', () =>
         {
             expect(polygon.strokeContains(-3, -3, 2)).toBe(false);
             expect(polygon.strokeContains(15, 0, 4)).toBe(false);
-            expect(polygon.strokeContains(0, 12, 3)).toBe(false);
+            expect(polygon.strokeContains(0, 13, 3)).toBe(false);
         });
 
         const polygonClosePathTrue: Polygon = new Polygon([0, 0, 10, 0, 10, 10, 0, 10]);

--- a/src/maths/__tests__/Rectangle.test.ts
+++ b/src/maths/__tests__/Rectangle.test.ts
@@ -82,29 +82,130 @@ describe('Rectangle', () =>
     {
         const rectangle = new Rectangle(10, 10, 100, 100);
 
-        test('returns true for a point on the rectangle edge with small stroke width', () =>
+        describe('alignment 0', () =>
         {
-            expect(rectangle.strokeContains(10, 10, 1)).toBe(true);
-            expect(rectangle.strokeContains(60, 10, 1)).toBe(true);
-            expect(rectangle.strokeContains(110, 60, 1)).toBe(true);
-            expect(rectangle.strokeContains(10, 110, 1)).toBe(true);
+            it('point on narrow stroke', () =>
+            {
+                expect(rectangle.strokeContains(10, 50, 1, 0)).toBe(true);
+                expect(rectangle.strokeContains(110, 50, 1, 0)).toBe(true);
+                expect(rectangle.strokeContains(50, 10, 1, 0)).toBe(true);
+                expect(rectangle.strokeContains(50, 110, 1, 0)).toBe(true);
+            });
+
+            it('point on wide stroke', () =>
+            {
+                expect(rectangle.strokeContains(8, 50, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(10, 50, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(110, 50, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(112, 50, 20, 0)).toBe(true);
+
+                expect(rectangle.strokeContains(50, 8, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(50, 10, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(50, 110, 20, 0)).toBe(true);
+                expect(rectangle.strokeContains(50, 112, 20, 0)).toBe(true);
+            });
+
+            it('point outside stroke', () =>
+            {
+                expect(rectangle.strokeContains(4, 50, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(11, 50, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(109, 50, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(116, 50, 5, 0)).toBe(false);
+
+                expect(rectangle.strokeContains(50, 4, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(50, 11, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(50, 109, 5, 0)).toBe(false);
+                expect(rectangle.strokeContains(50, 116, 5, 0)).toBe(false);
+            });
         });
 
-        test('returns true for a point near the rectangle edge within stroke width', () =>
+        describe('alignment 1', () =>
+        {
+            it('point on narrow stroke', () =>
+            {
+                expect(rectangle.strokeContains(10, 50, 1, 1)).toBe(true);
+                expect(rectangle.strokeContains(110, 50, 1, 1)).toBe(true);
+                expect(rectangle.strokeContains(50, 10, 1, 1)).toBe(true);
+                expect(rectangle.strokeContains(50, 110, 1, 1)).toBe(true);
+            });
+
+            it('point on wide stroke', () =>
+            {
+                expect(rectangle.strokeContains(10, 50, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(12, 50, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(108, 50, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(110, 50, 20, 1)).toBe(true);
+
+                expect(rectangle.strokeContains(50, 10, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(50, 12, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(50, 108, 20, 1)).toBe(true);
+                expect(rectangle.strokeContains(50, 110, 20, 1)).toBe(true);
+            });
+
+            it('point outside stroke', () =>
+            {
+                expect(rectangle.strokeContains(9, 50, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(16, 50, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(104, 50, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(111, 50, 5, 1)).toBe(false);
+
+                expect(rectangle.strokeContains(50, 9, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(50, 16, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(50, 104, 5, 1)).toBe(false);
+                expect(rectangle.strokeContains(50, 111, 5, 1)).toBe(false);
+            });
+        });
+
+        describe('alignment 0.5', () =>
+        {
+            it('point on narrow stroke', () =>
+            {
+                expect(rectangle.strokeContains(10, 50, 1, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(110, 50, 1, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(50, 10, 1, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(50, 110, 1, 0.5)).toBe(true);
+            });
+
+            it('point on wide stroke', () =>
+            {
+                expect(rectangle.strokeContains(8, 50, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(12, 50, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(108, 50, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(112, 50, 20, 0.5)).toBe(true);
+
+                expect(rectangle.strokeContains(50, 8, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(50, 12, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(50, 108, 20, 0.5)).toBe(true);
+                expect(rectangle.strokeContains(50, 112, 20, 0.5)).toBe(true);
+            });
+
+            it('point outside stroke', () =>
+            {
+                expect(rectangle.strokeContains(7, 50, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(13, 50, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(107, 50, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(113, 50, 5, 0.5)).toBe(false);
+
+                expect(rectangle.strokeContains(50, 7, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(50, 13, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(50, 107, 5, 0.5)).toBe(false);
+                expect(rectangle.strokeContains(50, 113, 5, 0.5)).toBe(false);
+            });
+        });
+
+        it('returns true for a point near the rectangle edge within stroke width', () =>
         {
             expect(rectangle.strokeContains(107, 58, 20)).toBe(true);
             expect(rectangle.strokeContains(117, 70, 20)).toBe(true);
             expect(rectangle.strokeContains(14, 111, 20)).toBe(true);
         });
 
-        test('returns false for a point outside the rectangle and beyond the stroke width', () =>
+        it('returns false for a point outside the rectangle and beyond the stroke width', () =>
         {
             expect(rectangle.strokeContains(5, 5, 4)).toBe(false);
             expect(rectangle.strokeContains(115, 10, 4)).toBe(false);
             expect(rectangle.strokeContains(10, 115, 4)).toBe(false);
         });
-
-        // Add additional tests as necessary
     });
 
     it('should enlarge rectangle', () =>

--- a/src/maths/__tests__/RoundedRectangle.test.ts
+++ b/src/maths/__tests__/RoundedRectangle.test.ts
@@ -63,4 +63,36 @@ describe('RoundedRectangle', () =>
 
         expect(rrect4.contains(5, 5)).toBe(true);
     });
+
+    describe('strokeContains', () =>
+    {
+        const rectangle = new RoundedRectangle(0, 0, 100, 100, 10);
+
+        it('alignment 0', () =>
+        {
+            expect(rectangle.strokeContains(-9, -9, 20, 0)).toBe(true);
+            expect(rectangle.strokeContains(0, 0, 20, 0)).toBe(true);
+            expect(rectangle.strokeContains(10, 10, 20, 0)).toBe(false);
+            expect(rectangle.strokeContains(12, 12, 20, 0)).toBe(false);
+            expect(rectangle.strokeContains(25, 25, 20, 1)).toBe(false);
+        });
+
+        it('alignment 0.5', () =>
+        {
+            expect(rectangle.strokeContains(-9, -9, 20, 0.5)).toBe(false);
+            expect(rectangle.strokeContains(0, 0, 20, 0.5)).toBe(true);
+            expect(rectangle.strokeContains(10, 10, 20, 0.5)).toBe(true);
+            expect(rectangle.strokeContains(12, 12, 20, 0.5)).toBe(false);
+            expect(rectangle.strokeContains(25, 25, 20, 1)).toBe(false);
+        });
+
+        it('alignment 1', () =>
+        {
+            expect(rectangle.strokeContains(-9, -9, 20, 1)).toBe(false);
+            expect(rectangle.strokeContains(0, 0, 20, 1)).toBe(false);
+            expect(rectangle.strokeContains(10, 10, 20, 1)).toBe(true);
+            expect(rectangle.strokeContains(12, 12, 20, 1)).toBe(true);
+            expect(rectangle.strokeContains(25, 25, 20, 1)).toBe(false);
+        });
+    });
 });

--- a/src/maths/shapes/Circle.ts
+++ b/src/maths/shapes/Circle.ts
@@ -79,19 +79,20 @@ export class Circle implements ShapePrimitive
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param width - The width of the line to check
+     * @param alignment - The alignment of the stroke, 0.5 by default
      * @returns Whether the x/y coordinates are within this Circle
      */
-    public strokeContains(x: number, y: number, width: number): boolean
+    public strokeContains(x: number, y: number, width: number, alignment: number = 0.5): boolean
     {
         if (this.radius === 0) return false;
 
         const dx = (this.x - x);
         const dy = (this.y - y);
-        const r = this.radius;
-        const w2 = width / 2;
+        const radius = this.radius;
+        const outerWidth = (1 - alignment) * width;
         const distance = Math.sqrt((dx * dx) + (dy * dy));
 
-        return (distance < r + w2 && distance > r - w2);
+        return (distance <= radius + outerWidth && distance > radius - (width - outerWidth));
     }
 
     /**

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -94,10 +94,11 @@ export class Ellipse implements ShapePrimitive
      * Checks whether the x and y coordinates given are contained within this ellipse including stroke
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
-     * @param width
+     * @param strokeWidth - The width of the line to check
+     * @param alignment - The alignment of the stroke
      * @returns Whether the x/y coords are within this ellipse
      */
-    public strokeContains(x: number, y: number, width: number): boolean
+    public strokeContains(x: number, y: number, strokeWidth: number, alignment: number = 0.5): boolean
     {
         const { halfWidth, halfHeight } = this;
 
@@ -106,19 +107,23 @@ export class Ellipse implements ShapePrimitive
             return false;
         }
 
-        const halfStrokeWidth = width / 2;
-        const innerA = halfWidth - halfStrokeWidth;
-        const innerB = halfHeight - halfStrokeWidth;
-        const outerA = halfWidth + halfStrokeWidth;
-        const outerB = halfHeight + halfStrokeWidth;
+        const strokeOuterWidth = strokeWidth * (1 - alignment);
+        const strokeInnerWidth = strokeWidth - strokeOuterWidth;
+
+        const innerHorizontal = halfWidth - strokeInnerWidth;
+        const innerVertical = halfHeight - strokeInnerWidth;
+
+        const outerHorizontal = halfWidth + strokeOuterWidth;
+        const outerVertical = halfHeight + strokeOuterWidth;
 
         const normalizedX = x - this.x;
         const normalizedY = y - this.y;
 
-        const innerEllipse = ((normalizedX * normalizedX) / (innerA * innerA))
-                           + ((normalizedY * normalizedY) / (innerB * innerB));
-        const outerEllipse = ((normalizedX * normalizedX) / (outerA * outerA))
-                           + ((normalizedY * normalizedY) / (outerB * outerB));
+        const innerEllipse = ((normalizedX * normalizedX) / (innerHorizontal * innerHorizontal))
+            + ((normalizedY * normalizedY) / (innerVertical * innerVertical));
+
+        const outerEllipse = ((normalizedX * normalizedX) / (outerHorizontal * outerHorizontal))
+            + ((normalizedY * normalizedY) / (outerVertical * outerVertical));
 
         return innerEllipse > 1 && outerEllipse <= 1;
     }

--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -123,12 +123,15 @@ export class Polygon implements ShapePrimitive
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
+     * @param alignment - The alignment of the stroke, 0.5 by default
      * @returns Whether the x/y coordinates are within this polygon
      */
-    public strokeContains(x: number, y: number, strokeWidth: number): boolean
+    public strokeContains(x: number, y: number, strokeWidth: number, alignment = 0.5): boolean
     {
-        const halfStrokeWidth = strokeWidth / 2;
-        const halfStrokeWidthSqrd = halfStrokeWidth * halfStrokeWidth;
+        const strokeWidthSquared = strokeWidth * strokeWidth;
+        const rightWidthSquared = strokeWidthSquared * (1 - alignment);
+        const leftWidthSquared = strokeWidthSquared - rightWidthSquared;
+
         const { points } = this;
         const iterationLength = points.length - (this.closePath ? 0 : 2);
 
@@ -139,9 +142,11 @@ export class Polygon implements ShapePrimitive
             const x2 = points[(i + 2) % points.length];
             const y2 = points[(i + 3) % points.length];
 
-            const distanceSqrd = squaredDistanceToLineSegment(x, y, x1, y1, x2, y2);
+            const distanceSquared = squaredDistanceToLineSegment(x, y, x1, y1, x2, y2);
 
-            if (distanceSqrd <= halfStrokeWidthSqrd)
+            const sign = Math.sign(((x2 - x1) * (y - y1)) - ((y2 - y1) * (x - x1)));
+
+            if (distanceSquared <= (sign < 0 ? leftWidthSquared : rightWidthSquared))
             {
                 return true;
             }

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -181,9 +181,10 @@ export class Rectangle implements ShapePrimitive
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
+     * @param alignment - The alignment of the stroke, 0.5 by default
      * @returns Whether the x/y coordinates are within this rectangle
      */
-    public strokeContains(x: number, y: number, strokeWidth: number): boolean
+    public strokeContains(x: number, y: number, strokeWidth: number, alignment: number = 0.5): boolean
     {
         const { width, height } = this;
 
@@ -192,17 +193,21 @@ export class Rectangle implements ShapePrimitive
         const _x = this.x;
         const _y = this.y;
 
-        const outerLeft = _x - (strokeWidth / 2);
-        const outerRight = _x + width + (strokeWidth / 2);
-        const outerTop = _y - (strokeWidth / 2);
-        const outerBottom = _y + height + (strokeWidth / 2);
-        const innerLeft = _x + (strokeWidth / 2);
-        const innerRight = _x + width - (strokeWidth / 2);
-        const innerTop = _y + (strokeWidth / 2);
-        const innerBottom = _y + height - (strokeWidth / 2);
+        const strokeWidthOuter = strokeWidth * (1 - alignment);
+        const strokeWidthInner = strokeWidth - strokeWidthOuter;
+
+        const outerLeft = _x - strokeWidthOuter;
+        const outerRight = _x + width + strokeWidthOuter;
+        const outerTop = _y - strokeWidthOuter;
+        const outerBottom = _y + height + strokeWidthOuter;
+
+        const innerLeft = _x + strokeWidthInner;
+        const innerRight = _x + width - strokeWidthInner;
+        const innerTop = _y + strokeWidthInner;
+        const innerBottom = _y + height - strokeWidthInner;
 
         return (x >= outerLeft && x <= outerRight && y >= outerTop && y <= outerBottom)
-        && !(x > innerLeft && x < innerRight && y > innerTop && y < innerBottom);
+            && !(x > innerLeft && x < innerRight && y > innerTop && y < innerBottom);
     }
     /**
      * Determines whether the `other` Rectangle transformed by `transform` intersects with `this` Rectangle object.

--- a/src/maths/shapes/ShapePrimitive.ts
+++ b/src/maths/shapes/ShapePrimitive.ts
@@ -13,7 +13,7 @@ export interface ShapePrimitive
     /** Checks whether the x and y coordinates passed to this function are contained within this ShapePrimitive. */
     contains(x: number, y: number): boolean;
     /** Checks whether the x and y coordinates passed to this function are contained within the stroke of this shape */
-    strokeContains(x: number, y: number, strokeWidth: number): boolean;
+    strokeContains(x: number, y: number, strokeWidth: number, alignment?: number): boolean;
     /** Creates a clone of this ShapePrimitive instance. */
     clone(): ShapePrimitive;
     /** Copies the properties from another ShapePrimitive to this ShapePrimitive. */

--- a/src/maths/shapes/Triangle.ts
+++ b/src/maths/shapes/Triangle.ts
@@ -84,8 +84,7 @@ export class Triangle implements ShapePrimitive
         const s = ((this.x - this.x3) * (y - this.y3)) - ((this.y - this.y3) * (x - this.x3));
         const t = ((this.x2 - this.x) * (y - this.y)) - ((this.y2 - this.y) * (x - this.x));
 
-        if ((s < 0) !== (t < 0) && s !== 0 && t !== 0)
-        { return false; }
+        if ((s < 0) !== (t < 0) && s !== 0 && t !== 0) { return false; }
 
         const d = ((this.x3 - this.x2) * (y - this.y2)) - ((this.y3 - this.y2) * (x - this.x2));
 
@@ -97,9 +96,10 @@ export class Triangle implements ShapePrimitive
      * @param pointX - The X coordinate of the point to test
      * @param pointY - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
+     * @param _alignment - The alignment of the stroke
      * @returns Whether the x/y coordinates are within this triangle
      */
-    public strokeContains(pointX: number, pointY: number, strokeWidth: number): boolean
+    public strokeContains(pointX: number, pointY: number, strokeWidth: number, _alignment: number = 0.5): boolean
     {
         const halfStrokeWidth = strokeWidth / 2;
         const halfStrokeWidthSquared = halfStrokeWidth * halfStrokeWidth;

--- a/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
@@ -30,10 +30,10 @@ describe('Graphics Bounds', () =>
 
             const { x, y, width, height } = graphics.context.bounds;
 
-            expect(x).toEqual(8); // <- received 10
-            expect(y).toEqual(18); // <- received 20
-            expect(width).toEqual(104); // <- received 100
-            expect(height).toEqual(204); // <- received 200
+            expect(x).toEqual(8);
+            expect(y).toEqual(18);
+            expect(width).toEqual(104);
+            expect(height).toEqual(204);
         });
 
         it('should give correct bounds with stroke, alignment 1', () =>

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1050,15 +1050,15 @@ export class GraphicsContext extends EventEmitter<{
 
                 const alignment = data.style.alignment;
 
-                const padding = (data.style.width * (1 - alignment));
+                const outerPadding = (data.style.width * (1 - alignment));
 
                 const _bounds = data.path.bounds;
 
                 bounds.addFrame(
-                    _bounds.minX - padding,
-                    _bounds.minY - padding,
-                    _bounds.maxX + padding,
-                    _bounds.maxY + padding
+                    _bounds.minX - outerPadding,
+                    _bounds.minY - outerPadding,
+                    _bounds.maxX + outerPadding,
+                    _bounds.maxY + outerPadding
                 );
             }
         }
@@ -1107,7 +1107,9 @@ export class GraphicsContext extends EventEmitter<{
                 }
                 else
                 {
-                    hasHit = shape.strokeContains(transformedPoint.x, transformedPoint.y, (style as ConvertedStrokeStyle).width);
+                    const strokeStyle = (style as ConvertedStrokeStyle);
+
+                    hasHit = shape.strokeContains(transformedPoint.x, transformedPoint.y, strokeStyle.width, strokeStyle.alignment);
                 }
 
                 const holes = data.hole;

--- a/src/scene/graphics/shared/path/ShapePath.ts
+++ b/src/scene/graphics/shared/path/ShapePath.ts
@@ -345,7 +345,7 @@ export class ShapePath
 
         for (let i = 0; i < sides; i++)
         {
-            const angle = (i * delta) + startAngle;
+            const angle = startAngle - (i * delta);
 
             polygon.push(
                 x + (radius * Math.cos(angle)),


### PR DESCRIPTION
##### Description of change
Alignment for stroke is not used in strokeContains() methods, result of the function should vary depend on alignment.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
