### PR TITLE
Fix: Correct color format in `addColorStop` function for Android WebV…

### DIFF
--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -54,7 +54,7 @@ export class FillGradient implements CanvasGradient
 
     public addColorStop(offset: number, color: ColorSource): this
     {
-        this.gradientStops.push({ offset, color: Color.shared.setValue(color).toHexa() });
+        this.gradientStops.push({ offset, color: Color.shared.setValue(color).toRgbaString() });
         this._styleKey = null;
 
         return this;

--- a/tests/renderering/text/TextStyle.tests.ts
+++ b/tests/renderering/text/TextStyle.tests.ts
@@ -238,9 +238,9 @@ describe('TextStyle', () =>
 
         expect(textStyle._fill.fill).toBeInstanceOf(FillGradient);
         expect((textStyle._fill.fill as FillGradient).gradientStops).toEqual([
-            { offset: 0, color: '#000000ff' },
-            { offset: 0.5, color: '#ff0000ff' },
-            { offset: 1, color: '#ffffffff' },
+            { offset: 0, color: 'rgba(0,0,0,1)' },
+            { offset: 0.5, color: 'rgba(255,0,0,1)' },
+            { offset: 1, color: 'rgba(255,255,255,1)' },
         ]);
     });
 });


### PR DESCRIPTION
Android WebView does not support the `#RRGGBBAA` color format in the `addColorStop` method. Using this format results in the following error:

```
SyntaxError: Failed to execute 'addColorStop' on 'CanvasGradient': The value provided ('#000000ff') could not be parsed as a color.
```
For further details, refer to the Chromium issue tracker: [Chromium Issue #40222657](https://issues.chromium.org/issues/40222657).