### PR TITLE
fix: bitmap font texture takes into account incoming texture rotation

### DIFF
--- a/src/scene/text-bitmap/BitmapFont.ts
+++ b/src/scene/text-bitmap/BitmapFont.ts
@@ -47,6 +47,7 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
             const {
                 frame: textureFrame,
                 source: textureSource,
+                rotate: textureRotate
             } = textures[charData.page];
 
             const frameReal = new Rectangle(
@@ -58,7 +59,8 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
 
             const texture = new Texture({
                 source: textureSource,
-                frame: frameReal
+                frame: frameReal,
+                rotate: textureRotate
             });
 
             this.chars[key] = {

--- a/tests/renderering/text/BitmapFont.tests.ts
+++ b/tests/renderering/text/BitmapFont.tests.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { groupD8 } from '../../../src';
 import { Cache } from '../../../src/assets/cache/Cache';
 import { Rectangle } from '../../../src/maths/shapes/Rectangle';
 import { Texture } from '../../../src/rendering/renderers/shared/texture/Texture';
@@ -139,6 +140,38 @@ describe('BitmapFont', () =>
 
             expect(font.chars.a.texture.frame.x).toBe(10);
             expect(font.chars.a.texture.frame.y).toBe(20);
+        });
+
+        it('should take texture rotation into account', () =>
+        {
+            const texture = new Texture({ rotate: groupD8.S });
+            const font = new BitmapFont({
+                textures: [texture],
+                data: {
+                    baseLineOffset: 0,
+                    chars: {
+                        a: {
+                            id: 65,
+                            page: 0,
+                            x: 0,
+                            y: 0,
+                            width: 10,
+                            height: 10,
+                            letter: 'a',
+                            xOffset: 0,
+                            yOffset: 0,
+                            kerning: {},
+                            xAdvance: 0,
+                        },
+                    },
+                    pages: [{ id: 0, file: '' }],
+                    lineHeight: 10,
+                    fontSize: 10,
+                    fontFamily: 'font'
+                }
+            });
+
+            expect(font.chars.a.texture.rotate).toBe(groupD8.S);
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Bitmap font takes into account the incoming texture's rotation property so the resulting bitmap characters render in the correct orientation.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
