### PR TITLE
fix: cacheAsTexture so that it does not take into account the alpha of itself

### DIFF
--- a/src/scene/container/RenderGroupPipe.ts
+++ b/src/scene/container/RenderGroupPipe.ts
@@ -103,7 +103,7 @@ export class RenderGroupPipe implements InstructionPipe<RenderGroup>
 
             this._renderer.globalUniforms.push({
                 worldTransformMatrix,
-                worldColor: renderGroup.worldColorAlpha,
+                worldColor: 0xFFFFFFFF,
             });
 
             executeInstructions(renderGroup, this._renderer.renderPipes);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes up cacheAsTexture so that it does not take into account the alpha of itself when rendering.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
