### PR TITLE
fix: Window support for fixing types script

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       SOURCE_DIR: '.s3_uploads'
-    runs-on: windows-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       SOURCE_DIR: '.s3_uploads'
-    runs-on: ubuntu-22.04
+    runs-on: windows-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -29,6 +29,9 @@ function addMixinReferencePaths()
     {
         const name = file.split(`${process.cwd()}/src`)[1];
 
+        // eslint-disable-next-line no-console
+        console.log('Adding reference path:', `/// <reference path=".${name}" />`);
+
         lines.push(`/// <reference path=".${name}" />`);
     });
 

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -20,14 +20,18 @@ import * as path from 'node:path';
  */
 function addMixinReferencePaths()
 {
-    const globPath = `${path.join(process.cwd(), './src')}/**/*.d.ts`;
+    const srcPath = path.resolve(__dirname, '../../src');
+    const globPath = `${srcPath}/**/*.d.ts`;
     const files = glob.sync(globPath);
+
+    // eslint-disable-next-line no-console
+    console.log('Adding reference paths to mixins:', globPath, files);
 
     const lines: string[] = [];
 
     files.forEach((file) =>
     {
-        const name = file.split(`${process.cwd()}/src`)[1];
+        const name = file.split(srcPath)[1];
 
         // eslint-disable-next-line no-console
         console.log('Adding reference path:', `/// <reference path=".${name}" />`);
@@ -35,7 +39,7 @@ function addMixinReferencePaths()
         lines.push(`/// <reference path=".${name}" />`);
     });
 
-    const filePath = path.join(process.cwd(), './lib/index.d.ts');
+    const filePath = path.resolve(__dirname, '../../lib/index.d.ts');
     const contents = fs.readFileSync(filePath, 'utf8');
     const updatedContents = `${lines.join('\n')}\n${contents}`;
 
@@ -45,13 +49,13 @@ function addMixinReferencePaths()
 /** Copy the Shaders.d.ts file to the lib folder This is needed for proper frag,vert,wgsl support in the types */
 function copyShaders()
 {
-    const src = path.join(process.cwd(), './types');
-    const lib = path.join(process.cwd(), './lib');
+    const src = path.resolve(__dirname, '../../types');
+    const lib = path.resolve(__dirname, '../../lib');
 
-    fs.copyFileSync(`${src}/Shaders.d.ts`, `${lib}/Shaders.d.ts`);
+    fs.copyFileSync(path.join(src, 'Shaders.d.ts'), path.join(lib, 'Shaders.d.ts'));
 
     // add this to the index.d.ts file
-    const filePath = path.join(process.cwd(), './lib/index.d.ts');
+    const filePath = path.join(lib, 'index.d.ts');
     const contents = fs.readFileSync(filePath, 'utf8');
 
     if (!contents.includes('/// <reference path="./Shaders.d.ts" />'))

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -21,9 +21,8 @@ import * as path from 'node:path';
 function addMixinReferencePaths()
 {
     // Support windows paths, glob requires only forward slashes
-    const srcPath = path.resolve(__dirname, '../../src').replace(/\\/g, '/');
-    const globPath = `${srcPath}/**/*.d.ts`;
-    const files = glob.sync(globPath);
+    const srcPath = path.join(process.cwd(), 'src').replace(/\\/g, '/');
+    const files = glob.sync(`${srcPath}/**/*.d.ts`);
     const lines: string[] = [];
 
     files.forEach((file) =>
@@ -33,7 +32,7 @@ function addMixinReferencePaths()
         lines.push(`/// <reference path=".${name}" />`);
     });
 
-    const filePath = path.resolve(__dirname, '../../lib/index.d.ts');
+    const filePath = path.join(process.cwd(), './lib/index.d.ts');
     const contents = fs.readFileSync(filePath, 'utf8');
     const updatedContents = `${lines.join('\n')}\n${contents}`;
 
@@ -43,13 +42,13 @@ function addMixinReferencePaths()
 /** Copy the Shaders.d.ts file to the lib folder This is needed for proper frag,vert,wgsl support in the types */
 function copyShaders()
 {
-    const src = path.resolve(__dirname, '../../types');
-    const lib = path.resolve(__dirname, '../../lib');
+    const src = path.join(process.cwd(), './types');
+    const lib = path.join(process.cwd(), './lib');
 
-    fs.copyFileSync(path.join(src, 'Shaders.d.ts'), path.join(lib, 'Shaders.d.ts'));
+    fs.copyFileSync(`${src}/Shaders.d.ts`, `${lib}/Shaders.d.ts`);
 
     // add this to the index.d.ts file
-    const filePath = path.join(lib, 'index.d.ts');
+    const filePath = path.join(process.cwd(), './lib/index.d.ts');
     const contents = fs.readFileSync(filePath, 'utf8');
 
     if (!contents.includes('/// <reference path="./Shaders.d.ts" />'))

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path';
 function addMixinReferencePaths()
 {
     const srcPath = path.resolve(__dirname, '../../src');
-    const globPath = `${path.posix.normalize(srcPath)}/**/*.d.ts`;
+    const globPath = `${srcPath.replace(/\\/g, '/')}/**/*.d.ts`;
     const files = glob.sync(globPath);
 
     // eslint-disable-next-line no-console

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -24,18 +24,11 @@ function addMixinReferencePaths()
     const srcPath = path.resolve(__dirname, '../../src').replace(/\\/g, '/');
     const globPath = `${srcPath}/**/*.d.ts`;
     const files = glob.sync(globPath);
-
-    // eslint-disable-next-line no-console
-    console.log('Adding reference paths to mixins:', globPath, files);
-
     const lines: string[] = [];
 
     files.forEach((file) =>
     {
         const name = file.split(srcPath)[1];
-
-        // eslint-disable-next-line no-console
-        console.log('Adding reference path:', `/// <reference path=".${name}" />`);
 
         lines.push(`/// <reference path=".${name}" />`);
     });

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path';
 function addMixinReferencePaths()
 {
     const srcPath = path.resolve(__dirname, '../../src');
-    const globPath = `${srcPath}/**/*.d.ts`;
+    const globPath = `${path.posix.normalize(srcPath)}/**/*.d.ts`;
     const files = glob.sync(globPath);
 
     // eslint-disable-next-line no-console

--- a/scripts/types/fixTypes.ts
+++ b/scripts/types/fixTypes.ts
@@ -20,8 +20,9 @@ import * as path from 'node:path';
  */
 function addMixinReferencePaths()
 {
-    const srcPath = path.resolve(__dirname, '../../src');
-    const globPath = `${srcPath.replace(/\\/g, '/')}/**/*.d.ts`;
+    // Support windows paths, glob requires only forward slashes
+    const srcPath = path.resolve(__dirname, '../../src').replace(/\\/g, '/');
+    const globPath = `${srcPath}/**/*.d.ts`;
     const files = glob.sync(globPath);
 
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Closes #10464 

Our custom **fixTypes.ts** script was not handling Windows paths correctly with `glob`. Glob says: 

> Glob patterns should always use `/` as a path separator, even on Windows systems

Because we are using `process.cwd()`, this meant that mixins weren't getting added correctly causing type-chaos on dts-bundle.