### PR TITLE
chore: Prefer operator assignment

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
         "project": "./tsconfig.json"
     },
     "rules": {
+        "operator-assignment": [1, "always"],
         "camelcase": [1, { "allow": ["^v\\d{1,}_\\d{1,}_\\d{1,}$"] }],
         "@typescript-eslint/triple-slash-reference": [1, { "path": "always" }],
         "@typescript-eslint/consistent-type-imports": [1, { "disallowTypeAnnotations": false }],

--- a/src/rendering/renderers/gl/state/GlStateSystem.ts
+++ b/src/rendering/renderers/gl/state/GlStateSystem.ts
@@ -132,7 +132,7 @@ export class GlStateSystem implements System
                     this.map[i].call(this, !!(state.data & (1 << i)));
                 }
 
-                diff = diff >> 1;
+                diff >>= 1;
                 i++;
             }
 

--- a/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
@@ -231,7 +231,7 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
             }
         }
 
-        managedRenderables.length = managedRenderables.length - offset;
+        managedRenderables.length -= offset;
     }
 
     public destroy(): void

--- a/src/scene/container/utils/updateRenderGroupTransforms.ts
+++ b/src/scene/container/utils/updateRenderGroupTransforms.ts
@@ -105,7 +105,7 @@ export function updateTransformAndChildren(container: Container, updateTick: num
 
     if ((parent && !parent.renderGroup))
     {
-        updateFlags = updateFlags | container._updateFlags;
+        updateFlags |= container._updateFlags;
 
         container.relativeGroupTransform.appendFrom(
             localTransform,

--- a/src/utils/data/clean.ts
+++ b/src/utils/data/clean.ts
@@ -70,7 +70,7 @@ export function cleanArray<T>(arr: T[]): T[]
         }
     }
 
-    arr.length = arr.length - offset;
+    arr.length -= offset;
 
     return arr;
 }

--- a/tests/events/EventSystem.tests.ts
+++ b/tests/events/EventSystem.tests.ts
@@ -1191,7 +1191,7 @@ describe('EventSystem', () =>
         graphics.addEventListener('pointertap', (e) =>
         {
             expect(e.type).toEqual('click');
-            count += count + 1;
+            count += 1;
             if (count >= 2)
             {
                 controller.abort();

--- a/tests/events/EventSystem.tests.ts
+++ b/tests/events/EventSystem.tests.ts
@@ -1191,7 +1191,7 @@ describe('EventSystem', () =>
         graphics.addEventListener('pointertap', (e) =>
         {
             expect(e.type).toEqual('click');
-            count = count + 1;
+            count += count + 1;
             if (count >= 2)
             {
                 controller.abort();


### PR DESCRIPTION
Follow-up to #11103 by enforcing assignment operators with an ESLint warning. Found a few other instance of operator assignments to be fixed up.