### PR TITLE
fix: a few render bugs

### DIFF
--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -272,7 +272,9 @@ export class FilterSystem implements System
         {
             const viewPort = renderer.renderTarget.rootViewPort;
 
-            bounds.fitBounds(0, viewPort.width, 0, viewPort.height);
+            const rootResolution = renderer.renderTarget.renderTarget.resolution;
+
+            bounds.fitBounds(0, viewPort.width / rootResolution, 0, viewPort.height / rootResolution);
         }
 
         // round the bounds to the nearest pixel

--- a/src/scene/container/RenderGroupPipe.ts
+++ b/src/scene/container/RenderGroupPipe.ts
@@ -108,6 +108,8 @@ export class RenderGroupPipe implements InstructionPipe<RenderGroup>
 
             executeInstructions(renderGroup, this._renderer.renderPipes);
 
+            this._renderer.renderTarget.finishRenderPass();
+
             this._renderer.renderTarget.pop();
             this._renderer.globalUniforms.pop();
         }

--- a/tests/visual/scenes/container/cache-as-texture.scene.ts
+++ b/tests/visual/scenes/container/cache-as-texture.scene.ts
@@ -34,7 +34,17 @@ export const scene: TestScene = {
 
             container.addChild(text);
 
-            container.cacheAsTexture(true);
+            if (i === 0)
+            {
+                container.cacheAsTexture({
+                    antialias: true,
+                    resolution: 2
+                });
+            }
+            else
+            {
+                container.cacheAsTexture(true);
+            }
 
             last.addChild(container);
 


### PR DESCRIPTION


<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes two issues
- when exporting a lower (or higher) resolution texture the bounds of the item were cliiped wrong if there was a filter in the exported items as the resolution was not being taken into account. 
- when using cacheAsTexture with antialiasing the texture was not rendering as the final blit call was not there. (test updated to accomodate this)

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
