### PR TITLE
fix: Memory leak during canvas extraction

### DIFF
--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -230,7 +230,7 @@ export class ExtractSystem implements System
 
         const canvas = renderer.texture.generateCanvas(texture);
 
-        texture.destroy();
+        texture.destroy(true);
 
         return canvas;
     }

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -257,7 +257,7 @@ export class ExtractSystem implements System
         if (target instanceof Container)
         {
             // destroy generated texture
-            texture.destroy();
+            texture.destroy(true);
         }
 
         return pixelInfo;


### PR DESCRIPTION
When I tried to shard an image from a very large container, there was a serious memory leak

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
