### PR TITLE
chore: update `Assets.ts` comment for src file ext

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -397,7 +397,7 @@ export class AssetsClass
      * // passing options to to the object
      * Assets.add({
      *     alias: 'bunnyBooBooSmooth',
-     *     src: 'bunny{png,webp}',
+     *     src: 'bunny.{png,webp}',
      *     data: { scaleMode: SCALE_MODES.NEAREST }, // Base texture options
      * });
      *
@@ -405,7 +405,7 @@ export class AssetsClass
      *
      * // The following all do the same thing:
      *
-     * Assets.add({alias: 'bunnyBooBoo', src: 'bunny{png,webp}'});
+     * Assets.add({alias: 'bunnyBooBoo', src: 'bunny.{png,webp}'});
      *
      * Assets.add({
      *     alias: 'bunnyBooBoo',


### PR DESCRIPTION
##### Description of change
Small comment fix, just adding the missing `.` in `bunny{png,webp}`, which should match the `bunny.png` and `bunny.webp` in the same comment.

(Currently, it's kinda confusing, I thought we need to put file ext like that and Pixi will add them automatically, i.e. `bunny{png,webp}` to `bunny.png` and `bunny.webp` but it's not)

This should fix the [online docs](https://pixijs.download/dev/docs/assets.Assets.html) too.

##### Pre-Merge Checklist
- [x] Documentation is changed or added