### PR TITLE
chore: Clean-up verbose testing imports

### DIFF
--- a/src/accessibility/__tests__/AccessibilitySystem.test.ts
+++ b/src/accessibility/__tests__/AccessibilitySystem.test.ts
@@ -1,7 +1,7 @@
 import { AccessibilitySystem } from '../AccessibilitySystem';
 import '../init';
 import { getWebGLRenderer } from '@test-utils';
-import { Container } from '~/scene/container/Container';
+import { Container } from '~/scene';
 
 describe('AccessibilitySystem', () =>
 {

--- a/src/accessibility/__tests__/accessibleTarget.test.ts
+++ b/src/accessibility/__tests__/accessibleTarget.test.ts
@@ -1,7 +1,7 @@
 import { AccessibilitySystem } from '../AccessibilitySystem';
 import '../init';
 import { getWebGLRenderer } from '@test-utils';
-import { Container } from '~/scene/container/Container';
+import { Container } from '~/scene';
 
 describe('accessibleTarget', () =>
 {

--- a/src/app/__tests__/Application.test.ts
+++ b/src/app/__tests__/Application.test.ts
@@ -1,7 +1,7 @@
-import { extensions, ExtensionType } from '../../extensions/Extensions';
-import { Container } from '../../scene/container/Container';
 import { Application } from '../Application';
 import { getApp, nextTick } from '@test-utils';
+import { extensions, ExtensionType } from '~/extensions';
+import { Container } from '~/scene';
 
 import type { ApplicationOptions } from '../Application';
 

--- a/src/assets/__tests__/Assets.test.ts
+++ b/src/assets/__tests__/Assets.test.ts
@@ -2,8 +2,8 @@ import { setTimeout } from 'timers/promises';
 import '~/spritesheet/init';
 import { Assets } from '../Assets';
 import { basePath } from '@test-utils';
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { loadTextures } from '~/assets';
+import { Texture } from '~/rendering';
 
 describe('Assets', () =>
 {

--- a/src/assets/__tests__/bundle.test.ts
+++ b/src/assets/__tests__/bundle.test.ts
@@ -1,8 +1,8 @@
 import { setTimeout } from 'timers/promises';
 import { Assets } from '../Assets';
 import { basePath, getApp } from '@test-utils';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Spritesheet } from '~/spritesheet/Spritesheet';
+import { Texture } from '~/rendering';
+import { Spritesheet } from '~/spritesheet';
 
 import type { BundleIdentifierOptions } from '../resolver/Resolver';
 

--- a/src/assets/__tests__/detections.test.ts
+++ b/src/assets/__tests__/detections.test.ts
@@ -5,7 +5,7 @@ import { detectMp4 } from '../detections/parsers/detectMp4';
 import { detectOgv } from '../detections/parsers/detectOgv';
 import { detectWebm } from '../detections/parsers/detectWebm';
 import { detectWebp } from '../detections/parsers/detectWebp';
-import { ExtensionType } from '~/extensions/Extensions';
+import { ExtensionType } from '~/extensions';
 
 describe('Assets', () =>
 {

--- a/src/assets/__tests__/loadVideo.test.ts
+++ b/src/assets/__tests__/loadVideo.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Assets } from '../Assets';
 import { basePath, getApp } from '@test-utils';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Texture } from '~/rendering';
 
 describe('loadVideo', () =>
 {

--- a/src/assets/__tests__/unresolved.test.ts
+++ b/src/assets/__tests__/unresolved.test.ts
@@ -2,7 +2,7 @@ import '~/spritesheet/init';
 import { Assets } from '../Assets';
 import { basePath, getApp } from '@test-utils';
 
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import type { Texture } from '~/rendering';
 
 describe('Assets Unresolved', () =>
 {

--- a/src/assets/loader/__tests__/Loader.test.ts
+++ b/src/assets/loader/__tests__/Loader.test.ts
@@ -5,10 +5,10 @@ import { loadWebFont } from '../parsers/loadWebFont';
 import { loadSvg } from '../parsers/textures/loadSVG';
 import { loadTextures } from '../parsers/textures/loadTextures';
 import { basePath } from '@test-utils';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Texture } from '~/rendering';
 
 import type { LoaderParser } from '../parsers/LoaderParser';
-import type { GraphicsContext } from '~/scene/graphics/shared/GraphicsContext';
+import type { GraphicsContext } from '~/scene';
 
 describe('Loader', () =>
 {

--- a/src/assets/resolver/__tests__/Resolver.test.ts
+++ b/src/assets/resolver/__tests__/Resolver.test.ts
@@ -3,8 +3,8 @@ import { resolveJsonUrl } from '../parsers/resolveJsonUrl';
 import { resolveTextureUrl } from '../parsers/resolveTextureUrl';
 import { getUrlExtension, Resolver } from '../Resolver';
 import { manifest } from './sampleManifest';
-import { extensions, ExtensionType } from '~/extensions/Extensions';
-import { spritesheetAsset } from '~/spritesheet/spritesheetAsset';
+import { extensions, ExtensionType } from '~/extensions';
+import { spritesheetAsset } from '~/spritesheet';
 
 import type { FormatDetectionParser } from '../../detections/types';
 

--- a/src/compressed-textures/__tests__/CompressedTextures.test.ts
+++ b/src/compressed-textures/__tests__/CompressedTextures.test.ts
@@ -2,11 +2,9 @@ import { detectBasis } from '../basis/detectBasis';
 import { loadDDS } from '../dds/loadDDS';
 import { detectCompressed } from '../shared/detectCompressed';
 import { resolveCompressedTextureUrl } from '../shared/resolveCompressedTextureUrl';
-import { Assets } from '~/assets/Assets';
-import { Loader } from '~/assets/loader/Loader';
-import { Resolver } from '~/assets/resolver/Resolver';
+import { Assets, Loader, Resolver } from '~/assets';
 
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import type { Texture } from '~/rendering';
 
 describe('Compressed Loader', () =>
 {

--- a/src/culling/__tests__/Culler.test.ts
+++ b/src/culling/__tests__/Culler.test.ts
@@ -1,15 +1,12 @@
 import { Culler } from '../Culler';
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
-import { extensions } from '~/extensions/Extensions';
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets, loadTextures } from '~/assets';
+import { extensions } from '~/extensions';
+import { AlphaFilter } from '~/filters';
+import { Rectangle } from '~/maths';
+import { Container, Graphics, Sprite } from '~/scene';
 
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import type { Texture } from '~/rendering';
 
 describe('Culler', () =>
 {

--- a/src/events/__tests__/EventBoundary.test.ts
+++ b/src/events/__tests__/EventBoundary.test.ts
@@ -1,8 +1,7 @@
 import { EventBoundary } from '../EventBoundary';
 import { FederatedPointerEvent } from '../FederatedPointerEvent';
 import { getApp } from '@test-utils';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Container, Graphics } from '~/scene';
 
 function graphicsWithRect(x: number, y: number, width: number, height: number)
 {

--- a/src/events/__tests__/EventSystem.test.ts
+++ b/src/events/__tests__/EventSystem.test.ts
@@ -3,11 +3,10 @@ import '~/scene/graphics/init';
 import { EventSystem } from '../EventSystem';
 import '../init';
 import { getApp, getWebGLRenderer } from '@test-utils';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Rectangle } from '~/maths';
+import { Container, Graphics } from '~/scene';
 
-import type { RendererOptions } from '~/rendering/renderers/types';
+import type { RendererOptions } from '~/rendering';
 
 async function createRenderer(
     canvas?: HTMLCanvasElement,

--- a/src/filters/__tests__/FilterEffect.test.ts
+++ b/src/filters/__tests__/FilterEffect.test.ts
@@ -1,6 +1,6 @@
 import { AlphaFilter } from '../defaults/alpha/AlphaFilter';
 import { NoiseFilter } from '../defaults/noise/NoiseFilter';
-import { Container } from '~/scene/container/Container';
+import { Container } from '~/scene';
 
 import type { FilterEffect } from '../FilterEffect';
 

--- a/src/filters/defaults/displacement/__tests__/DisplacementFilter.test.ts
+++ b/src/filters/defaults/displacement/__tests__/DisplacementFilter.test.ts
@@ -1,6 +1,6 @@
 import { DisplacementFilter } from '../DisplacementFilter';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 describe('DisplacementFilter', () =>
 {

--- a/src/math-extras/__tests__/Point.test.ts
+++ b/src/math-extras/__tests__/Point.test.ts
@@ -1,6 +1,5 @@
 import '../init';
-import { ObservablePoint } from '~/maths/point/ObservablePoint';
-import { Point } from '~/maths/point/Point';
+import { ObservablePoint, Point } from '~/maths';
 
 describe('Point', () =>
 {

--- a/src/math-extras/__tests__/Rectangle.test.ts
+++ b/src/math-extras/__tests__/Rectangle.test.ts
@@ -1,5 +1,5 @@
 import '../init';
-import { Rectangle } from '~/maths/shapes/Rectangle';
+import { Rectangle } from '~/maths';
 
 describe('Rectangle', () =>
 {

--- a/src/math-extras/__tests__/lineIntersection.test.ts
+++ b/src/math-extras/__tests__/lineIntersection.test.ts
@@ -1,5 +1,5 @@
 import { lineIntersection } from '../util';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 describe('lineIntersection', () =>
 {

--- a/src/math-extras/__tests__/segmentIntersection.test.ts
+++ b/src/math-extras/__tests__/segmentIntersection.test.ts
@@ -1,5 +1,5 @@
 import { segmentIntersection } from '../util';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 describe('segmentIntersection', () =>
 {

--- a/src/maths/__tests__/Matrix.test.ts
+++ b/src/maths/__tests__/Matrix.test.ts
@@ -1,5 +1,5 @@
 import { Matrix } from '../matrix/Matrix';
-import { Transform } from '~/utils/misc/Transform';
+import { Transform } from '~/utils';
 
 describe('Matrix', () =>
 {

--- a/src/maths/__tests__/Transform.test.ts
+++ b/src/maths/__tests__/Transform.test.ts
@@ -1,4 +1,4 @@
-import { Transform } from '~/utils/misc/Transform';
+import { Transform } from '~/utils';
 
 describe('Transform', () =>
 {

--- a/src/prepare/__tests__/PrepareSystem.test.ts
+++ b/src/prepare/__tests__/PrepareSystem.test.ts
@@ -3,12 +3,8 @@ import '~/scene/text-bitmap/init';
 import '~/scene/text-html/init';
 import { PrepareSystem } from '../PrepareSystem';
 import { getWebGLRenderer } from '@test-utils';
-import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
-import { Text } from '~/scene/text/Text';
+import { Texture, TextureSource } from '~/rendering';
+import { Container, Graphics, Sprite, Text } from '~/scene';
 
 describe('PrepareSystem', () =>
 {

--- a/src/rendering/batcher/__tests__/checkCanUseTexture.test.ts
+++ b/src/rendering/batcher/__tests__/checkCanUseTexture.test.ts
@@ -1,12 +1,10 @@
 import '~/rendering/renderers/shared/texture/sources/ImageSource';
 import { TestBatcher } from './TestBatcher';
-import { Matrix } from '~/maths/matrix/Matrix';
-import { InstructionSet } from '~/rendering/renderers/shared/instructions/InstructionSet';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Matrix } from '~/maths';
+import { InstructionSet, Texture } from '~/rendering';
 
 import type { Batch, BatchableMeshElement, Batcher } from '../shared/Batcher';
-import type { Topology } from '~/rendering/renderers/shared/geometry/const';
-import type { BLEND_MODES } from '~/rendering/renderers/shared/state/const';
+import type { BLEND_MODES, Topology } from '~/rendering';
 
 class DummyBatchableObject implements BatchableMeshElement
 {

--- a/src/rendering/renderers/__tests__/BindGroup.test.ts
+++ b/src/rendering/renderers/__tests__/BindGroup.test.ts
@@ -6,7 +6,7 @@ import { UniformGroup } from '../shared/shader/UniformGroup';
 import { RenderTexture } from '../shared/texture/RenderTexture';
 import { TextureSource } from '../shared/texture/sources/TextureSource';
 import { TextureStyle } from '../shared/texture/TextureStyle';
-import { resetUids } from '~/utils/data/uid';
+import { resetUids } from '~/utils';
 
 describe('BindGroup', () =>
 {

--- a/src/rendering/renderers/__tests__/Extract.test.ts
+++ b/src/rendering/renderers/__tests__/Extract.test.ts
@@ -5,10 +5,8 @@ import { ImageSource } from '../shared/texture/sources/ImageSource';
 import { Texture } from '../shared/texture/Texture';
 import '../../init';
 import { getTexture, getWebGLRenderer } from '@test-utils';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Rectangle } from '~/maths';
+import { Container, Graphics, Sprite } from '~/scene';
 
 import type { WebGLRenderer } from '../gl/WebGLRenderer';
 

--- a/src/rendering/renderers/__tests__/GlBackBufferSystem.test.ts
+++ b/src/rendering/renderers/__tests__/GlBackBufferSystem.test.ts
@@ -1,6 +1,6 @@
 import { RenderTexture } from '../shared/texture/RenderTexture';
 import { getWebGLRenderer } from '@test-utils';
-import { Container } from '~/scene/container/Container';
+import { Container } from '~/scene';
 
 import type { WebGLRenderer } from '../gl/WebGLRenderer';
 

--- a/src/rendering/renderers/__tests__/GlobalUniformSystem.test.ts
+++ b/src/rendering/renderers/__tests__/GlobalUniformSystem.test.ts
@@ -1,6 +1,5 @@
 import { GlobalUniformSystem } from '../shared/renderTarget/GlobalUniformSystem';
-import { Matrix } from '~/maths/matrix/Matrix';
-import { Point } from '~/maths/point/Point';
+import { Matrix, Point } from '~/maths';
 
 import type { WebGLRenderer } from '../gl/WebGLRenderer';
 import type { UboSystem } from '../shared/shader/UboSystem';

--- a/src/rendering/renderers/__tests__/RenderTarget.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTarget.test.ts
@@ -5,7 +5,7 @@ import { RenderTexture } from '../shared/texture/RenderTexture';
 import { CanvasSource } from '../shared/texture/sources/CanvasSource';
 import { Texture } from '../shared/texture/Texture';
 import { getWebGLRenderer } from '@test-utils';
-import { DOMAdapter } from '~/environment/adapter';
+import { DOMAdapter } from '~/environment';
 
 describe('isRenderingToScreen', () =>
 {

--- a/src/rendering/renderers/gl/shader/program/__tests__/glEnsureAttributes.test.ts
+++ b/src/rendering/renderers/gl/shader/program/__tests__/glEnsureAttributes.test.ts
@@ -1,10 +1,7 @@
 import { ensureAttributes } from '../ensureAttributes';
 import { generateProgram } from '../generateProgram';
 import { getTestContext } from '../getTestContext';
-import { GlProgram } from '~/rendering/renderers/gl/shader/GlProgram';
-import { Buffer } from '~/rendering/renderers/shared/buffer/Buffer';
-import { BufferUsage } from '~/rendering/renderers/shared/buffer/const';
-import { Geometry } from '~/rendering/renderers/shared/geometry/Geometry';
+import { Buffer, BufferUsage, Geometry, GlProgram } from '~/rendering';
 
 describe('glEnsureAttributes', () =>
 {

--- a/src/rendering/renderers/gl/shader/utils/__tests__/createUboElementsSTD40.test.ts
+++ b/src/rendering/renderers/gl/shader/utils/__tests__/createUboElementsSTD40.test.ts
@@ -1,6 +1,6 @@
 import { createUboElementsSTD40 } from '../createUboElementsSTD40';
 
-import type { UNIFORM_TYPES, UniformData } from '~/rendering/renderers/shared/shader/types';
+import type { UNIFORM_TYPES, UniformData } from '~/rendering';
 
 describe('createUboElementsSTD40', () =>
 {

--- a/src/rendering/renderers/gpu/shader/utils/__tests__/createUboElementsWGSL.test.ts
+++ b/src/rendering/renderers/gpu/shader/utils/__tests__/createUboElementsWGSL.test.ts
@@ -1,6 +1,6 @@
 import { createUboElementsWGSL } from '../createUboElementsWGSL';
 
-import type { UniformData } from '~/rendering/renderers/shared/shader/types';
+import type { UniformData } from '~/rendering';
 
 describe('createUboElementsWGSL', () =>
 {

--- a/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
+++ b/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
@@ -1,8 +1,7 @@
 import { Buffer } from '../Buffer';
 import { getWebGLRenderer, getWebGPURenderer, itLocalOnly } from '@test-utils';
 
-import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
-import type { WebGPURenderer } from '~/rendering/renderers/gpu/WebGPURenderer';
+import type { WebGLRenderer, WebGPURenderer } from '~/rendering';
 
 describe('Buffer', () =>
 {

--- a/src/rendering/renderers/shared/geometry/utils/__tests__/getGeometryBounds.test.ts
+++ b/src/rendering/renderers/shared/geometry/utils/__tests__/getGeometryBounds.test.ts
@@ -1,6 +1,6 @@
 import { getGeometryBounds } from '../getGeometryBounds';
 import { getGeometry } from '@test-utils';
-import { Bounds } from '~/scene/container/bounds/Bounds';
+import { Bounds } from '~/scene';
 
 describe('getGeometryBounds', () =>
 {

--- a/src/rendering/renderers/shared/state/__tests__/State.test.ts
+++ b/src/rendering/renderers/shared/state/__tests__/State.test.ts
@@ -1,7 +1,7 @@
 import { State } from '../State';
 import { getWebGLRenderer } from '@test-utils';
 
-import type { GlStateSystem } from '~/rendering/renderers/gl/state/GlStateSystem';
+import type { GlStateSystem } from '~/rendering';
 
 describe('State', () =>
 {

--- a/src/rendering/renderers/shared/texture/__tests__/CanvasSource.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/CanvasSource.test.ts
@@ -1,7 +1,7 @@
 import { CanvasSource } from '../sources/CanvasSource';
 import { TextureSource } from '../sources/TextureSource';
 import { Texture } from '../Texture';
-import { DOMAdapter } from '~/environment/adapter';
+import { DOMAdapter } from '~/environment';
 
 describe('getCanvasTexture', () =>
 {

--- a/src/rendering/renderers/shared/texture/__tests__/GLTextureSystem.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/GLTextureSystem.test.ts
@@ -1,6 +1,6 @@
 import { getTexture, getWebGLRenderer } from '@test-utils';
 
-import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+import type { WebGLRenderer } from '~/rendering';
 
 describe('GLTextureSystem', () =>
 {

--- a/src/rendering/renderers/shared/texture/__tests__/GenerateTexture.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/GenerateTexture.test.ts
@@ -1,8 +1,8 @@
 import { Texture } from '../Texture';
 import { getWebGLRenderer } from '@test-utils';
-import { Container } from '~/scene/container/Container';
+import { Container } from '~/scene';
 
-import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+import type { WebGLRenderer } from '~/rendering';
 
 describe('GenerateTexture', () =>
 {

--- a/src/rendering/renderers/shared/texture/__tests__/Textures.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/Textures.test.ts
@@ -1,6 +1,6 @@
 import '~/rendering/init';
 import { Texture } from '../Texture';
-import { Cache } from '~/assets/cache/Cache';
+import { Cache } from '~/assets';
 
 describe('Texture', () =>
 {

--- a/src/rendering/renderers/shared/texture/__tests__/VideoSource.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/VideoSource.test.ts
@@ -1,7 +1,7 @@
 import '~/environment-browser/browserAll';
 import { VideoSource } from '../sources/VideoSource';
 import { getAsset } from '@test-utils';
-import { Assets } from '~/assets/Assets';
+import { Assets } from '~/assets';
 
 import type { VideoSourceOptions } from '../sources/VideoSource';
 import type { Texture } from '../Texture';

--- a/src/rendering/renderers/shared/texture/utils/__tests__/getCanvasTexture.test.ts
+++ b/src/rendering/renderers/shared/texture/utils/__tests__/getCanvasTexture.test.ts
@@ -2,7 +2,7 @@ import {
     getCanvasTexture,
     hasCachedCanvasTexture
 } from '../getCanvasTexture';
-import { DOMAdapter } from '~/environment/adapter';
+import { DOMAdapter } from '~/environment';
 
 describe('Get Canvas Texture', () =>
 {

--- a/src/scene/__tests__/RenderablesGC.test.ts
+++ b/src/scene/__tests__/RenderablesGC.test.ts
@@ -9,7 +9,7 @@ import { Text } from '../text/Text';
 import { BitmapText } from '../text-bitmap/BitmapText';
 import { HTMLText } from '../text-html/HTMLText';
 import { getWebGLRenderer } from '@test-utils';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Texture } from '~/rendering';
 
 describe('RenderableGC', () =>
 {

--- a/src/scene/__tests__/roundPixels.test.ts
+++ b/src/scene/__tests__/roundPixels.test.ts
@@ -7,10 +7,9 @@ import { TilingSprite } from '../sprite-tiling/TilingSprite';
 import { QuadGeometry } from '../sprite-tiling/utils/QuadGeometry';
 import { Text } from '../text/Text';
 import { HTMLText } from '../text-html/HTMLText';
-import { Application } from '~/app/Application';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Application } from '~/app';
+import { Rectangle } from '~/maths';
+import { Texture, WebGLRenderer } from '~/rendering';
 
 import type { GlGraphicsAdaptor } from '../graphics/gl/GlGraphicsAdaptor';
 

--- a/src/scene/container/__tests__/Container.Visual.test.ts
+++ b/src/scene/container/__tests__/Container.Visual.test.ts
@@ -1,7 +1,7 @@
 import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
-import { DEG_TO_RAD, RAD_TO_DEG } from '~/maths/misc/const';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { DEG_TO_RAD, RAD_TO_DEG } from '~/maths';
+import { Sprite } from '~/scene';
 
 describe('Container Visual', () =>
 {

--- a/src/scene/container/__tests__/RenderGroup.test.ts
+++ b/src/scene/container/__tests__/RenderGroup.test.ts
@@ -2,8 +2,8 @@ import { Sprite } from '../../sprite/Sprite';
 import { Container } from '../Container';
 import { RenderGroup } from '../RenderGroup';
 import { getWebGLRenderer } from '@test-utils';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { BigPool } from '~/utils/pool/PoolGroup';
+import { Texture } from '~/rendering';
+import { BigPool } from '~/utils';
 
 // now that we don't actually remove the items, but instead ensure that they are skipped
 // in the update loop, this function will return the new list and index removing items that are intended to be skipped

--- a/src/scene/container/__tests__/RenderGroupSystem.test.ts
+++ b/src/scene/container/__tests__/RenderGroupSystem.test.ts
@@ -2,7 +2,7 @@ import '~/rendering/renderers/shared/texture/Texture';
 import { Container } from '../Container';
 import '../../text/init';
 import { getWebGLRenderer } from '@test-utils';
-import { Text } from '~/scene/text/Text';
+import { Text } from '~/scene';
 
 describe('RenderGroupSystem', () =>
 {

--- a/src/scene/container/__tests__/getGlobalBounds.test.ts
+++ b/src/scene/container/__tests__/getGlobalBounds.test.ts
@@ -4,8 +4,8 @@ import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
 import { DummyEffect } from './DummyEffect';
 import { DummyView } from './DummyView';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { addMaskBounds } from '~/rendering/mask/utils/addMaskBounds';
+import { Rectangle } from '~/maths';
+import { addMaskBounds } from '~/rendering';
 
 describe('getGlobalBounds', () =>
 {

--- a/src/scene/container/__tests__/getGlobalFastBounds.test.ts
+++ b/src/scene/container/__tests__/getGlobalFastBounds.test.ts
@@ -4,8 +4,8 @@ import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
 import { DummyEffect } from './DummyEffect';
 import { DummyView } from './DummyView';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { logScene } from '~/utils/logging/logScene';
+import { Rectangle } from '~/maths';
+import { logScene } from '~/utils';
 
 describe('getGlobalFastBounds', () =>
 {

--- a/src/scene/container/__tests__/getGlobalTransform.test.ts
+++ b/src/scene/container/__tests__/getGlobalTransform.test.ts
@@ -1,5 +1,5 @@
 import { Container } from '../Container';
-import { Matrix } from '~/maths/matrix/Matrix';
+import { Matrix } from '~/maths';
 
 describe('getGlobalTransform', () =>
 {

--- a/src/scene/container/__tests__/getLocalBounds.test.ts
+++ b/src/scene/container/__tests__/getLocalBounds.test.ts
@@ -5,12 +5,8 @@ import { getLocalBounds } from '../bounds/getLocalBounds';
 import { Container } from '../Container';
 import { DummyEffect } from './DummyEffect';
 import { DummyView } from './DummyView';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { StencilMask } from '~/rendering/mask/stencil/StencilMask';
-import { addMaskLocalBounds } from '~/rendering/mask/utils/addMaskLocalBounds';
-import { RenderTexture } from '~/rendering/renderers/shared/texture/RenderTexture';
-import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Rectangle } from '~/maths';
+import { addMaskLocalBounds, RenderTexture, StencilMask, Texture, TextureSource } from '~/rendering';
 
 describe('getLocalBounds', () =>
 {

--- a/src/scene/container/__tests__/toGlobal.test.ts
+++ b/src/scene/container/__tests__/toGlobal.test.ts
@@ -1,5 +1,5 @@
 import { Container } from '../Container';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 describe('toGlobal', () =>
 {

--- a/src/scene/container/__tests__/toLocal.test.ts
+++ b/src/scene/container/__tests__/toLocal.test.ts
@@ -1,5 +1,5 @@
 import { Container } from '../Container';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 describe('toLocal', () =>
 {

--- a/src/scene/container/__tests__/transform.test.ts
+++ b/src/scene/container/__tests__/transform.test.ts
@@ -1,7 +1,7 @@
 import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
 import { DummyView } from './DummyView';
-import { Matrix } from '~/maths/matrix/Matrix';
+import { Matrix } from '~/maths';
 
 describe('Transform updates', () =>
 {

--- a/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Bounds.test.ts
@@ -1,5 +1,5 @@
 import { Graphics } from '../shared/Graphics';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 describe('Graphics Bounds', () =>
 {

--- a/src/scene/graphics/__tests__/Graphics.Drawing.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Drawing.test.ts
@@ -2,11 +2,11 @@ import { Bounds } from '../../container/bounds/Bounds';
 import { getLocalBounds } from '../../container/bounds/getLocalBounds';
 import { Graphics } from '../shared/Graphics';
 import { GraphicsContext } from '../shared/GraphicsContext';
-import { Matrix } from '~/maths/matrix/Matrix';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Matrix } from '~/maths';
+import { Texture } from '~/rendering';
 
 import type { FillInstruction } from '../shared/GraphicsContext';
-import type { PointData } from '~/maths/point/PointData';
+import type { PointData } from '~/maths';
 
 describe('Graphics Drawing', () =>
 {

--- a/src/scene/graphics/__tests__/Graphics.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.test.ts
@@ -3,8 +3,8 @@ import { GraphicsContext } from '../shared/GraphicsContext';
 import { GraphicsPath } from '../shared/path/GraphicsPath';
 import { toFillStyle } from '../shared/utils/convertFillInputToFillStyle';
 import { getWebGLRenderer } from '@test-utils';
-import { Matrix } from '~/maths/matrix/Matrix';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Matrix } from '~/maths';
+import { Texture } from '~/rendering';
 
 describe('Graphics', () =>
 {

--- a/src/scene/graphics/shared/__tests__/Graphics.AdaptiveBezierSmoothing.test.ts
+++ b/src/scene/graphics/shared/__tests__/Graphics.AdaptiveBezierSmoothing.test.ts
@@ -1,9 +1,9 @@
 import '~/environment-browser/browserAll';
 import { Graphics } from '../Graphics';
 import { GraphicsContextSystem } from '../GraphicsContextSystem';
-import { Application } from '~/app/Application';
+import { Application } from '~/app';
 
-import type { Polygon } from '~/maths/shapes/Polygon';
+import type { Polygon } from '~/maths';
 
 describe('Graphics Adaptive Bezier Smoothing', () =>
 {

--- a/src/scene/graphics/shared/utils/__tests__/convertStrokeInputToStrokeStyle.test.ts
+++ b/src/scene/graphics/shared/utils/__tests__/convertStrokeInputToStrokeStyle.test.ts
@@ -1,8 +1,8 @@
 import { FillGradient } from '../../fill/FillGradient';
 import { FillPattern } from '../../fill/FillPattern';
 import { toFillStyle, toStrokeStyle } from '../convertFillInputToFillStyle';
-import { Color } from '~/color/Color';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Color } from '~/color';
+import { Texture } from '~/rendering';
 
 import type { ConvertedStrokeStyle } from '../../FillTypes';
 

--- a/src/scene/particle-container/shared/__tests__/ParticleContainer.test.ts
+++ b/src/scene/particle-container/shared/__tests__/ParticleContainer.test.ts
@@ -1,9 +1,8 @@
 import { ParticleContainer } from '../ParticleContainer';
 import { getWebGLRenderer } from '@test-utils';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Container } from '~/scene/container/Container';
-import { Particle } from '~/scene/particle-container/shared/Particle';
+import { Rectangle } from '~/maths';
+import { Texture } from '~/rendering';
+import { Container, Particle } from '~/scene';
 
 describe('ParticleContainer', () =>
 {

--- a/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
+++ b/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
@@ -1,7 +1,7 @@
 import { AnimatedSprite } from '../AnimatedSprite';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Texture } from '~/rendering';
 
-import type { Ticker } from '~/ticker/Ticker';
+import type { Ticker } from '~/ticker';
 
 const ticker1 = { deltaTime: 1 } as Ticker;
 const ticker4 = { deltaTime: 4 } as Ticker;

--- a/src/scene/sprite-tiling/__tests__/TilingSprite.test.ts
+++ b/src/scene/sprite-tiling/__tests__/TilingSprite.test.ts
@@ -5,10 +5,10 @@ import { TilingSprite } from '../TilingSprite';
 import '../init';
 import '../../mesh/init';
 import { getTexture, getWebGLRenderer } from '@test-utils';
-import { Point } from '~/maths/point/Point';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Point } from '~/maths';
+import { Texture } from '~/rendering';
 
-import type { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
+import type { TextureSource } from '~/rendering';
 
 describe('TilingSprite', () =>
 {

--- a/src/scene/sprite/__tests__/Sprite.test.ts
+++ b/src/scene/sprite/__tests__/Sprite.test.ts
@@ -2,11 +2,8 @@ import { Container } from '../../container/Container';
 import { NineSliceSprite } from '../../sprite-nine-slice/NineSliceSprite';
 import { Sprite } from '../Sprite';
 import { getTexture, getWebGLRenderer } from '@test-utils';
-import { Point } from '~/maths/point/Point';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { RenderTexture } from '~/rendering/renderers/shared/texture/RenderTexture';
-import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Point, Rectangle } from '~/maths';
+import { RenderTexture, Texture, TextureSource } from '~/rendering';
 
 describe('Sprite', () =>
 {

--- a/src/scene/text-bitmap/__tests__/BitmapFont.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapFont.test.ts
@@ -2,9 +2,9 @@
 import { TextStyle } from '../../text/TextStyle';
 import { BitmapFont } from '../BitmapFont';
 import { BitmapFontManager } from '../BitmapFontManager';
-import { Cache } from '~/assets/cache/Cache';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Cache } from '~/assets';
+import { Rectangle } from '~/maths';
+import { Texture } from '~/rendering';
 
 describe('BitmapFont', () =>
 {

--- a/src/scene/text-bitmap/__tests__/BitmapFontLoader.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapFontLoader.test.ts
@@ -2,12 +2,9 @@ import { Sprite } from '../../sprite/Sprite';
 import { loadBitmapFont } from '../asset/loadBitmapFont';
 import { BitmapFont } from '../BitmapFont';
 import { basePath, getWebGLRenderer } from '@test-utils';
-import { Cache } from '~/assets/cache/Cache';
-import { Loader } from '~/assets/loader/Loader';
-import { loadTxt } from '~/assets/loader/parsers/loadTxt';
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
+import { Cache, Loader, loadTextures, loadTxt } from '~/assets';
 
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import type { Texture } from '~/rendering';
 
 describe('BitmapFontLoader', () =>
 {

--- a/src/scene/text-bitmap/__tests__/BitmapFontManager.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapFontManager.test.ts
@@ -1,6 +1,6 @@
 import { TextStyle } from '../../text/TextStyle';
 import { BitmapFontManager } from '../BitmapFontManager';
-import { Cache } from '~/assets/cache/Cache';
+import { Cache } from '~/assets';
 
 import type { BitmapFont } from '../BitmapFont';
 

--- a/src/scene/text-bitmap/__tests__/BitmapText.test.ts
+++ b/src/scene/text-bitmap/__tests__/BitmapText.test.ts
@@ -5,10 +5,7 @@ import '../../text/init';
 import '../init';
 import '../../graphics/init';
 import { basePath, getWebGLRenderer } from '@test-utils';
-import { Cache } from '~/assets/cache/Cache';
-import { Loader } from '~/assets/loader/Loader';
-import { loadTxt } from '~/assets/loader/parsers/loadTxt';
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
+import { Cache, Loader, loadTextures, loadTxt } from '~/assets';
 
 import type { BitmapFont } from '../BitmapFont';
 

--- a/src/scene/text-html/__tests__/getFontCss.test.ts
+++ b/src/scene/text-html/__tests__/getFontCss.test.ts
@@ -1,7 +1,7 @@
 import { HTMLTextStyle } from '../HTMLTextStyle';
 import { getFontCss } from '../utils/getFontCss';
 import { basePath, getApp } from '@test-utils';
-import { Assets } from '~/assets/Assets';
+import { Assets } from '~/assets';
 
 describe('getFontCss', () =>
 {

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -8,7 +8,7 @@ import '../../graphics/init';
 import '../../text-bitmap/init';
 import '../init';
 import { getWebGLRenderer } from '@test-utils';
-import { Point } from '~/maths/point/Point';
+import { Point } from '~/maths';
 
 import type { DestroyOptions } from '../../container/destroyTypes';
 

--- a/src/scene/text/__tests__/TextStyle.test.ts
+++ b/src/scene/text/__tests__/TextStyle.test.ts
@@ -4,8 +4,8 @@ import { FillPattern } from '../../graphics/shared/fill/FillPattern';
 import { GraphicsContext } from '../../graphics/shared/GraphicsContext';
 import { HTMLTextStyle } from '../../text-html/HTMLTextStyle';
 import { TextStyle } from '../TextStyle';
-import { Color } from '~/color/Color';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Color } from '~/color';
+import { Texture } from '~/rendering';
 
 import type { TextStyleOptions } from '../TextStyle';
 

--- a/src/spritesheet/__tests__/Spritesheet.test.ts
+++ b/src/spritesheet/__tests__/Spritesheet.test.ts
@@ -1,8 +1,7 @@
 import path from 'path';
 import { Spritesheet } from '../Spritesheet';
 import { getAsset } from '@test-utils';
-import { ImageSource } from '~/rendering/renderers/shared/texture/sources/ImageSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { ImageSource, Texture } from '~/rendering';
 
 import type { SpritesheetData, SpritesheetFrameData } from '../Spritesheet';
 

--- a/src/spritesheet/__tests__/spritesheetAsset.test.ts
+++ b/src/spritesheet/__tests__/spritesheetAsset.test.ts
@@ -1,15 +1,11 @@
 import { Spritesheet } from '../Spritesheet';
 import { spritesheetAsset } from '../spritesheetAsset';
 import { basePath } from '@test-utils';
-import { Cache } from '~/assets/cache/Cache';
-import { Loader } from '~/assets/loader/Loader';
-import { loadJson } from '~/assets/loader/parsers/loadJson';
-import { loadSvg } from '~/assets/loader/parsers/textures/loadSVG';
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+import { Cache, Loader, loadJson, loadSvg, loadTextures } from '~/assets';
+import { Texture } from '~/rendering';
 
 import type { SpriteSheetJson } from '../spritesheetAsset';
-import type { CacheParser } from '~/assets/cache/CacheParser';
+import type { CacheParser } from '~/assets';
 
 describe('spritesheetAsset', () =>
 {

--- a/src/ticker/__tests__/TickerPlugin.test.ts
+++ b/src/ticker/__tests__/TickerPlugin.test.ts
@@ -1,6 +1,6 @@
 import { UPDATE_PRIORITY } from '../const';
 import { Ticker } from '../Ticker';
-import { TickerPlugin } from '~/app/TickerPlugin';
+import { TickerPlugin } from '~/app';
 
 describe('TickerPlugin', () =>
 {

--- a/src/utils/__tests__/detectVideoAlphaMode.test.ts
+++ b/src/utils/__tests__/detectVideoAlphaMode.test.ts
@@ -1,12 +1,9 @@
 import { detectVideoAlphaMode } from '../browser/detectVideoAlphaMode';
 import { getWebGLRenderer } from '@test-utils';
-import { RenderTexture } from '~/rendering/renderers/shared/texture/RenderTexture';
-import { VideoSource } from '~/rendering/renderers/shared/texture/sources/VideoSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Container } from '~/scene/container/Container';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { RenderTexture, Texture, VideoSource } from '~/rendering';
+import { Container, Sprite } from '~/scene';
 
-import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+import type { WebGLRenderer } from '~/rendering';
 
 describe('detectVideoAlphaMode', () =>
 {

--- a/tests/visual/scenes/blend-modes/blend-mode-max.scene.ts
+++ b/tests/visual/scenes/blend-modes/blend-mode-max.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should max blend correctly',

--- a/tests/visual/scenes/blend-modes/blend-mode-min.scene.ts
+++ b/tests/visual/scenes/blend-modes/blend-mode-min.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should min blend correctly',

--- a/tests/visual/scenes/blend-modes/blend-mode-render-texture.scene.ts
+++ b/tests/visual/scenes/blend-modes/blend-mode-render-texture.scene.ts
@@ -1,11 +1,9 @@
 import '~/advanced-blend-modes/init';
-import { OverlayBlend } from '~/advanced-blend-modes/OverlayBlend';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { OverlayBlend } from '~/advanced-blend-modes';
+import { Container, Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
+import type { Renderer } from '~/rendering';
 
 export const scene: TestScene = {
     it: 'should have correct alpha when blending on a transparent texture',

--- a/tests/visual/scenes/compressed-textures/dds.scene.ts
+++ b/tests/visual/scenes/compressed-textures/dds.scene.ts
@@ -1,9 +1,9 @@
 import '~/compressed-textures/dds/init';
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should load a dds texture',

--- a/tests/visual/scenes/compressed-textures/ktx.scene.ts
+++ b/tests/visual/scenes/compressed-textures/ktx.scene.ts
@@ -1,9 +1,9 @@
 import '~/compressed-textures/ktx/init';
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should load a ktx texture',

--- a/tests/visual/scenes/container/cache-as-texture.scene.ts
+++ b/tests/visual/scenes/container/cache-as-texture.scene.ts
@@ -1,5 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Text } from '~/scene/text/Text';
+import { Container, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/container/container-swap.scene.ts
+++ b/tests/visual/scenes/container/container-swap.scene.ts
@@ -1,8 +1,8 @@
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render swapped children correctly',

--- a/tests/visual/scenes/container/container-visibility.scene.ts
+++ b/tests/visual/scenes/container/container-visibility.scene.ts
@@ -1,8 +1,8 @@
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 const size = 16;
 

--- a/tests/visual/scenes/container/custom-render.scene.ts
+++ b/tests/visual/scenes/container/custom-render.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { RenderContainer } from '~/scene/container/RenderContainer';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { RenderContainer, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a custom container GPU code',

--- a/tests/visual/scenes/container/nested-container.scene.ts
+++ b/tests/visual/scenes/container/nested-container.scene.ts
@@ -1,10 +1,9 @@
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { getCanvasTexture } from '~/rendering/renderers/shared/texture/utils/getCanvasTexture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { AlphaFilter } from '~/filters';
+import { getCanvasTexture } from '~/rendering';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 const canvas = document.createElement('canvas');
 

--- a/tests/visual/scenes/container/render-group.scene.ts
+++ b/tests/visual/scenes/container/render-group.scene.ts
@@ -1,5 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/container/skip-filter.scene.ts
+++ b/tests/visual/scenes/container/skip-filter.scene.ts
@@ -1,7 +1,5 @@
-import { ColorMatrixFilter } from '~/filters/defaults/color-matrix/ColorMatrixFilter';
-import { NoiseFilter } from '~/filters/defaults/noise/NoiseFilter';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { ColorMatrixFilter, NoiseFilter } from '~/filters';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/container/transform.scene.ts
+++ b/tests/visual/scenes/container/transform.scene.ts
@@ -1,6 +1,5 @@
-import { Assets } from '~/assets/Assets';
-import { Container } from '~/scene/container/Container';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Container, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/filters/alpha-filter.scene.ts
+++ b/tests/visual/scenes/filters/alpha-filter.scene.ts
@@ -1,6 +1,5 @@
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { AlphaFilter } from '~/filters';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/filters/anitalias-filter.scene.ts
+++ b/tests/visual/scenes/filters/anitalias-filter.scene.ts
@@ -1,10 +1,8 @@
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { BlurFilter } from '~/filters/defaults/blur/BlurFilter';
-import { ColorMatrixFilter } from '~/filters/defaults/color-matrix/ColorMatrixFilter';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { AlphaFilter, BlurFilter, ColorMatrixFilter } from '~/filters';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render filters correctly with antialiasing',

--- a/tests/visual/scenes/filters/clip-top-viewport/clip-to-viewport.scene.ts
+++ b/tests/visual/scenes/filters/clip-top-viewport/clip-to-viewport.scene.ts
@@ -1,12 +1,12 @@
 import circleFrag from './circle.frag';
 import circleVert from './circle.vert';
 import circleWgsl from './circle.wgsl';
-import { Assets } from '~/assets/Assets';
-import { Filter } from '~/filters/Filter';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Filter } from '~/filters';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'clip to viewport filter texture',

--- a/tests/visual/scenes/filters/clip-top-viewport/do-not-clip-to-viewport.scene.ts
+++ b/tests/visual/scenes/filters/clip-top-viewport/do-not-clip-to-viewport.scene.ts
@@ -1,12 +1,12 @@
 import circleFrag from './circle.frag';
 import circleVert from './circle.vert';
 import circleWgsl from './circle.wgsl';
-import { Assets } from '~/assets/Assets';
-import { Filter } from '~/filters/Filter';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Filter } from '~/filters';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'do not clip to viewport filter texture',

--- a/tests/visual/scenes/filters/filter-area.scene.ts
+++ b/tests/visual/scenes/filters/filter-area.scene.ts
@@ -1,9 +1,9 @@
-import { ColorMatrixFilter } from '~/filters/defaults/color-matrix/ColorMatrixFilter';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { ColorMatrixFilter } from '~/filters';
+import { Rectangle } from '~/maths';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'Filter Area should be applied correctly',

--- a/tests/visual/scenes/filters/filter-render-textures.scene.ts
+++ b/tests/visual/scenes/filters/filter-render-textures.scene.ts
@@ -1,13 +1,11 @@
-import { ColorMatrixFilter } from '~/filters/defaults/color-matrix/ColorMatrixFilter';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { ColorMatrixFilter } from '~/filters';
+import { Rectangle } from '~/maths';
+import { Texture, TextureSource } from '~/rendering';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'Filter should render correctly when a render texture frame is not  0, 0',

--- a/tests/visual/scenes/filters/nested-filters.scene.ts
+++ b/tests/visual/scenes/filters/nested-filters.scene.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-len */
-import { Assets } from '~/assets/Assets';
-import { ColorMatrixFilter } from '~/filters/defaults/color-matrix/ColorMatrixFilter';
-import { Container } from '~/scene/container/Container';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { ColorMatrixFilter } from '~/filters';
+import { Container, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/graphics/bezier.scene.ts
+++ b/tests/visual/scenes/graphics/bezier.scene.ts
@@ -1,5 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/graphics/circle-black.scene.ts
+++ b/tests/visual/scenes/graphics/circle-black.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should correctly render a black circle',

--- a/tests/visual/scenes/graphics/circle-clone.scene.ts
+++ b/tests/visual/scenes/graphics/circle-clone.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render cloned circles',

--- a/tests/visual/scenes/graphics/circle.scene.ts
+++ b/tests/visual/scenes/graphics/circle.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render circles',

--- a/tests/visual/scenes/graphics/color-alpha.scene.ts
+++ b/tests/visual/scenes/graphics/color-alpha.scene.ts
@@ -1,8 +1,8 @@
-import { Color } from '~/color/Color';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Color } from '~/color';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render alpha from a Color',

--- a/tests/visual/scenes/graphics/extras.scene.ts
+++ b/tests/visual/scenes/graphics/extras.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render regular/rounded polygons, fillet/chamfer rects',

--- a/tests/visual/scenes/graphics/graphics-blend.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-blend.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should set blend of graphics correctly',

--- a/tests/visual/scenes/graphics/graphics-fill-cut-fill-cut.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-fill-cut-fill-cut.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render fill, cut, fill, cut.',

--- a/tests/visual/scenes/graphics/graphics-pixel-line.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-pixel-line.scene.ts
@@ -1,8 +1,8 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a pixel line correctly',

--- a/tests/visual/scenes/graphics/graphics-texture.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-texture.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render rect',

--- a/tests/visual/scenes/graphics/graphics-tile.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-tile.scene.ts
@@ -1,8 +1,8 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should tile a texture correctly',

--- a/tests/visual/scenes/graphics/graphics-tint.scene.ts
+++ b/tests/visual/scenes/graphics/graphics-tint.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should set tint of graphics correctly',

--- a/tests/visual/scenes/graphics/holes.scene.ts
+++ b/tests/visual/scenes/graphics/holes.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should cut holes',

--- a/tests/visual/scenes/graphics/lines-arc.scene.ts
+++ b/tests/visual/scenes/graphics/lines-arc.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should continue drawing from next point of path',

--- a/tests/visual/scenes/graphics/oddsize-polygon.scene.ts
+++ b/tests/visual/scenes/graphics/oddsize-polygon.scene.ts
@@ -1,8 +1,7 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
+import type { Renderer } from '~/rendering';
 
 export const scene: TestScene = {
     it: 'should render odd sized polygon correctly',

--- a/tests/visual/scenes/graphics/poly.scene.ts
+++ b/tests/visual/scenes/graphics/poly.scene.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render polygon correctly',

--- a/tests/visual/scenes/graphics/rect-fills.scene.ts
+++ b/tests/visual/scenes/graphics/rect-fills.scene.ts
@@ -1,12 +1,11 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { Matrix } from '~/maths/matrix/Matrix';
-import { FillGradient } from '~/scene/graphics/shared/fill/FillGradient';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Assets } from '~/assets';
+import { Matrix } from '~/maths';
+import { FillGradient, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import type { Container } from '~/scene/container/Container';
+import type { Texture } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render rects with fills, strokes, gradients using textures',

--- a/tests/visual/scenes/graphics/rect-stroke-alignment.scene.ts
+++ b/tests/visual/scenes/graphics/rect-stroke-alignment.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text stroke alignment',

--- a/tests/visual/scenes/graphics/rect-stroke.scene.ts
+++ b/tests/visual/scenes/graphics/rect-stroke.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text stroke',

--- a/tests/visual/scenes/graphics/rect.scene.ts
+++ b/tests/visual/scenes/graphics/rect.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render rect',

--- a/tests/visual/scenes/graphics/regular-poly.scene.ts
+++ b/tests/visual/scenes/graphics/regular-poly.scene.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render regularPoly correctly',

--- a/tests/visual/scenes/graphics/shared-context.scene.ts
+++ b/tests/visual/scenes/graphics/shared-context.scene.ts
@@ -1,8 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { GraphicsContext } from '~/scene/graphics/shared/GraphicsContext';
+import { Graphics, GraphicsContext } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render graphics with shared context',

--- a/tests/visual/scenes/graphics/svg-graphics-context.scene.ts
+++ b/tests/visual/scenes/graphics/svg-graphics-context.scene.ts
@@ -1,10 +1,9 @@
 /* eslint-disable max-len */
-import { Assets } from '~/assets/Assets';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Assets } from '~/assets';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
-import type { GraphicsContext } from '~/scene/graphics/shared/GraphicsContext';
+import type { Container, GraphicsContext } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render svg a GraphicsContext texture',

--- a/tests/visual/scenes/graphics/svg-texture.scene.ts
+++ b/tests/visual/scenes/graphics/svg-texture.scene.ts
@@ -1,10 +1,10 @@
 /* eslint-disable max-len */
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import type { Container } from '~/scene/container/Container';
+import type { Texture } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render svg as texture',

--- a/tests/visual/scenes/graphics/svg.scene.ts
+++ b/tests/visual/scenes/graphics/svg.scene.ts
@@ -1,8 +1,8 @@
 /* eslint-disable max-len */
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render svg graphics paths',

--- a/tests/visual/scenes/graphics/two-circles.scene.ts
+++ b/tests/visual/scenes/graphics/two-circles.scene.ts
@@ -1,8 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should correctly swap bind groups and render to non batched circles with a sprite in the middle',

--- a/tests/visual/scenes/graphics/v7-compatibility-complex.scene.ts
+++ b/tests/visual/scenes/graphics/v7-compatibility-complex.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should graphics with v7 backwards compatible api',

--- a/tests/visual/scenes/graphics/v7-compatibility-simple.scene.ts
+++ b/tests/visual/scenes/graphics/v7-compatibility-simple.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should graphics with v7 backwards compatible api',

--- a/tests/visual/scenes/mask/alpha-inverse-mask.scene.ts
+++ b/tests/visual/scenes/mask/alpha-inverse-mask.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Color } from '~/color/Color';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Color } from '~/color';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render inverse alpha mask',

--- a/tests/visual/scenes/mask/alpha-mask-cache-as-texture.scene.ts
+++ b/tests/visual/scenes/mask/alpha-mask-cache-as-texture.scene.ts
@@ -1,7 +1,6 @@
-import { Assets } from '~/assets/Assets';
-import { Point } from '~/maths/point/Point';
-import { Container } from '~/scene/container/Container';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Point } from '~/maths';
+import { Container, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/mask/alpha-mask.scene.ts
+++ b/tests/visual/scenes/mask/alpha-mask.scene.ts
@@ -1,10 +1,9 @@
-import { Color } from '~/color/Color';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Color } from '~/color';
+import { Texture } from '~/rendering';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render alpha mask',

--- a/tests/visual/scenes/mask/circle-mask.scene.ts
+++ b/tests/visual/scenes/mask/circle-mask.scene.ts
@@ -1,7 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render circle mask correctly',

--- a/tests/visual/scenes/mask/layer-mask.scene.ts
+++ b/tests/visual/scenes/mask/layer-mask.scene.ts
@@ -1,5 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Container, Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/mask/nested-mask.scene.ts
+++ b/tests/visual/scenes/mask/nested-mask.scene.ts
@@ -1,7 +1,5 @@
-import { Assets } from '~/assets/Assets';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Container, Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/mask/stencil-inverse-mask.scene.ts
+++ b/tests/visual/scenes/mask/stencil-inverse-mask.scene.ts
@@ -1,8 +1,8 @@
-import { Color } from '~/color/Color';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Color } from '~/color';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render inverse stencil mask',

--- a/tests/visual/scenes/mask/stencil-mask.scene.ts
+++ b/tests/visual/scenes/mask/stencil-mask.scene.ts
@@ -1,8 +1,8 @@
-import { Color } from '~/color/Color';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Color } from '~/color';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render stencil mask',

--- a/tests/visual/scenes/mask/stencil-nested-render-group.scene.ts
+++ b/tests/visual/scenes/mask/stencil-nested-render-group.scene.ts
@@ -1,8 +1,8 @@
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { AlphaFilter } from '~/filters';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should handle nested masks in render group correctly',

--- a/tests/visual/scenes/mesh/custom-mesh-instanced.scene.ts
+++ b/tests/visual/scenes/mesh/custom-mesh-instanced.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Geometry } from '~/rendering/renderers/shared/geometry/Geometry';
-import { Shader } from '~/rendering/renderers/shared/shader/Shader';
-import { Mesh } from '~/scene/mesh/shared/Mesh';
+import { Assets } from '~/assets';
+import { Geometry, Shader } from '~/rendering';
+import { Mesh } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a custom instanced mesh correctly',

--- a/tests/visual/scenes/mesh/custom-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/custom-mesh.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Geometry } from '~/rendering/renderers/shared/geometry/Geometry';
-import { Shader } from '~/rendering/renderers/shared/shader/Shader';
-import { Mesh } from '~/scene/mesh/shared/Mesh';
+import { Assets } from '~/assets';
+import { Geometry, Shader } from '~/rendering';
+import { Mesh } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a custom mesh correctly',

--- a/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/fully-custom-mesh.scene.ts
@@ -1,11 +1,8 @@
-import { GlProgram } from '~/rendering/renderers/gl/shader/GlProgram';
-import { GpuProgram } from '~/rendering/renderers/gpu/shader/GpuProgram';
-import { Geometry } from '~/rendering/renderers/shared/geometry/Geometry';
-import { Shader } from '~/rendering/renderers/shared/shader/Shader';
-import { Mesh } from '~/scene/mesh/shared/Mesh';
+import { Geometry, GlProgram, GpuProgram, Shader } from '~/rendering';
+import { Mesh } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 /**
  * NOTE on the result:

--- a/tests/visual/scenes/mesh/mesh-textures.scene.ts
+++ b/tests/visual/scenes/mesh/mesh-textures.scene.ts
@@ -1,9 +1,9 @@
-import { Point } from '~/maths/point/Point';
-import { MeshRope } from '~/scene/mesh-simple/MeshRope';
+import { Point } from '~/maths';
+import { MeshRope } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should multiple textures on a complex mesh',

--- a/tests/visual/scenes/mesh/meshplane.scene.ts
+++ b/tests/visual/scenes/mesh/meshplane.scene.ts
@@ -1,9 +1,9 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { MeshPlane } from '~/scene/mesh-plane/MeshPlane';
+import { Assets } from '~/assets';
+import { MeshPlane } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render mesh plane',

--- a/tests/visual/scenes/mesh/meshrope.scene.ts
+++ b/tests/visual/scenes/mesh/meshrope.scene.ts
@@ -1,7 +1,6 @@
-import { Assets } from '~/assets/Assets';
-import { Point } from '~/maths/point/Point';
-import { Container } from '~/scene/container/Container';
-import { MeshRope } from '~/scene/mesh-simple/MeshRope';
+import { Assets } from '~/assets';
+import { Point } from '~/maths';
+import { Container, MeshRope } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/mesh/perspective-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/perspective-mesh.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { PerspectiveMesh } from '~/scene/mesh-perspective/PerspectiveMesh';
+import { Assets } from '~/assets';
+import { PerspectiveMesh } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a perspective mesh',

--- a/tests/visual/scenes/mesh/sprite-sheet-mesh.scene.ts
+++ b/tests/visual/scenes/mesh/sprite-sheet-mesh.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { MeshPlane } from '~/scene/mesh-plane/MeshPlane';
-import { MeshRope } from '~/scene/mesh-simple/MeshRope';
+import { Assets } from '~/assets';
+import { MeshPlane, MeshRope } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
-import type { Spritesheet } from '~/spritesheet/Spritesheet';
+import type { Container } from '~/scene';
+import type { Spritesheet } from '~/spritesheet';
 
 export const scene: TestScene = {
     it: 'should render meshes from sprite sheets',

--- a/tests/visual/scenes/mesh/triangle.scene.ts
+++ b/tests/visual/scenes/mesh/triangle.scene.ts
@@ -1,9 +1,8 @@
-import { Geometry } from '~/rendering/renderers/shared/geometry/Geometry';
-import { Shader } from '~/rendering/renderers/shared/shader/Shader';
-import { Mesh } from '~/scene/mesh/shared/Mesh';
+import { Geometry, Shader } from '~/rendering';
+import { Mesh } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a custom triangle correctly',

--- a/tests/visual/scenes/particle/particle.scene.ts
+++ b/tests/visual/scenes/particle/particle.scene.ts
@@ -1,9 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Particle } from '~/scene/particle-container/shared/Particle';
-import { ParticleContainer } from '~/scene/particle-container/shared/ParticleContainer';
+import { Assets } from '~/assets';
+import { Particle, ParticleContainer } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render particle container',

--- a/tests/visual/scenes/scene/alpha-tint.scene.ts
+++ b/tests/visual/scenes/scene/alpha-tint.scene.ts
@@ -1,6 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { GraphicsContext } from '~/scene/graphics/shared/GraphicsContext';
+import { Container, Graphics, GraphicsContext } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/scene/layer-tint.scene.ts
+++ b/tests/visual/scenes/scene/layer-tint.scene.ts
@@ -1,6 +1,4 @@
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { GraphicsContext } from '~/scene/graphics/shared/GraphicsContext';
+import { Container, Graphics, GraphicsContext } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/sprite/nine-slice.scene.ts
+++ b/tests/visual/scenes/sprite/nine-slice.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { NineSliceSprite } from '~/scene/sprite-nine-slice/NineSliceSprite';
+import { Assets } from '~/assets';
+import { NineSliceSprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a nine slice sprite correctly',

--- a/tests/visual/scenes/sprite/sprite-asset-sheet.scene.ts
+++ b/tests/visual/scenes/sprite/sprite-asset-sheet.scene.ts
@@ -1,10 +1,10 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
-import type { Spritesheet } from '~/spritesheet/Spritesheet';
+import type { Container } from '~/scene';
+import type { Spritesheet } from '~/spritesheet';
 
 export const scene: TestScene = {
     it: 'should render from sprite sheets',

--- a/tests/visual/scenes/sprite/sprite-reparent.scene.ts
+++ b/tests/visual/scenes/sprite/sprite-reparent.scene.ts
@@ -1,6 +1,5 @@
-import { Assets } from '~/assets/Assets';
-import { Container } from '~/scene/container/Container';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Container, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/sprite/sprite-sizing.scene.ts
+++ b/tests/visual/scenes/sprite/sprite-sizing.scene.ts
@@ -1,9 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render sprite',

--- a/tests/visual/scenes/sprite/sprite-trim.scene.ts
+++ b/tests/visual/scenes/sprite/sprite-trim.scene.ts
@@ -1,7 +1,5 @@
-import { Assets } from '~/assets/Assets';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Container, Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/sprite/sprite.scene.ts
+++ b/tests/visual/scenes/sprite/sprite.scene.ts
@@ -1,9 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { AlphaFilter } from '~/filters';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render sprite',

--- a/tests/visual/scenes/sprite/tiling-sprite-clamp-offset.scene.ts
+++ b/tests/visual/scenes/sprite/tiling-sprite-clamp-offset.scene.ts
@@ -1,11 +1,10 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
-import { TilingSprite } from '~/scene/sprite-tiling/TilingSprite';
+import { Assets } from '~/assets';
+import { Sprite, TilingSprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render tiling sprite with clampOffset correctly',

--- a/tests/visual/scenes/sprite/tiling-sprite-uvs.scene.ts
+++ b/tests/visual/scenes/sprite/tiling-sprite-uvs.scene.ts
@@ -1,8 +1,6 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { TilingSprite } from '~/scene/sprite-tiling/TilingSprite';
+import { Assets } from '~/assets';
+import { Container, Graphics, TilingSprite } from '~/scene';
 
 import type { TestScene } from '../../types';
 

--- a/tests/visual/scenes/sprite/tiling-sprite.scene.ts
+++ b/tests/visual/scenes/sprite/tiling-sprite.scene.ts
@@ -1,9 +1,9 @@
 import { basePath } from '@test-utils';
-import { Assets } from '~/assets/Assets';
-import { TilingSprite } from '~/scene/sprite-tiling/TilingSprite';
+import { Assets } from '~/assets';
+import { TilingSprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render tiling sprite',

--- a/tests/visual/scenes/text/bitmap-install-layout-text.scene.ts
+++ b/tests/visual/scenes/text/bitmap-install-layout-text.scene.ts
@@ -1,9 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapFont } from '~/scene/text-bitmap/BitmapFont';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapFont, BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render installed bitmap layout text correctly',

--- a/tests/visual/scenes/text/bitmap-install-text.scene.ts
+++ b/tests/visual/scenes/text/bitmap-install-text.scene.ts
@@ -1,9 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapFont } from '~/scene/text-bitmap/BitmapFont';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapFont, BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render installed bitmap text correctly',

--- a/tests/visual/scenes/text/bitmap-text-fill.scene.ts
+++ b/tests/visual/scenes/text/bitmap-text-fill.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render bitmap text fill correctly',

--- a/tests/visual/scenes/text/bitmap-text-install.scene.ts
+++ b/tests/visual/scenes/text/bitmap-text-install.scene.ts
@@ -1,11 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { TextStyle } from '~/scene/text/TextStyle';
-import { BitmapFont } from '~/scene/text-bitmap/BitmapFont';
-import { BitmapFontManager } from '~/scene/text-bitmap/BitmapFontManager';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapFont, BitmapFontManager, BitmapText, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render an installed font correctly',

--- a/tests/visual/scenes/text/bitmap-text-stroke.scene.ts
+++ b/tests/visual/scenes/text/bitmap-text-stroke.scene.ts
@@ -1,9 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Text } from '~/scene/text/Text';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapText, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render both canvas and bitmap text with a stroke',

--- a/tests/visual/scenes/text/bitmap-text.scene.ts
+++ b/tests/visual/scenes/text/bitmap-text.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
-import { Text } from '~/scene/text/Text';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { AlphaFilter } from '~/filters';
+import { BitmapText, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render both canvas and bitmap text of the same style',

--- a/tests/visual/scenes/text/create-text.scene.ts
+++ b/tests/visual/scenes/text/create-text.scene.ts
@@ -1,8 +1,8 @@
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should create a texture correctly createTexture',

--- a/tests/visual/scenes/text/dynamic-bitmap-text.scene.ts
+++ b/tests/visual/scenes/text/dynamic-bitmap-text.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render both canvas and bitmap text of the same style',

--- a/tests/visual/scenes/text/html-text-family.scene.ts
+++ b/tests/visual/scenes/text/html-text-family.scene.ts
@@ -1,9 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { HTMLText } from '~/scene/text-html/HTMLText';
+import { Assets } from '~/assets';
+import { HTMLText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render html-text correctly with tag styles for family',

--- a/tests/visual/scenes/text/html-text-loaded-font.scene.ts
+++ b/tests/visual/scenes/text/html-text-loaded-font.scene.ts
@@ -1,10 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
-import { HTMLTextStyle } from '~/scene/text-html/HTMLTextStyle';
+import { Assets } from '~/assets';
+import { HTMLTextStyle, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render html-text correctly',

--- a/tests/visual/scenes/text/html-text.scene.ts
+++ b/tests/visual/scenes/text/html-text.scene.ts
@@ -1,9 +1,8 @@
-import { Sprite } from '~/scene/sprite/Sprite';
-import { HTMLTextStyle } from '~/scene/text-html/HTMLTextStyle';
+import { HTMLTextStyle, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render html-text correctly',

--- a/tests/visual/scenes/text/italics-large.scene.ts
+++ b/tests/visual/scenes/text/italics-large.scene.ts
@@ -1,8 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { BitmapText, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render large italics correctly',

--- a/tests/visual/scenes/text/italics.scene.ts
+++ b/tests/visual/scenes/text/italics.scene.ts
@@ -1,8 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { BitmapText, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render italics correctly',

--- a/tests/visual/scenes/text/load-ttf-font.scene.ts
+++ b/tests/visual/scenes/text/load-ttf-font.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Text } from '~/scene/text/Text';
+import { Assets } from '~/assets';
+import { Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should load and display ttf correctly',

--- a/tests/visual/scenes/text/mipmap-render-texture.scene.ts
+++ b/tests/visual/scenes/text/mipmap-render-texture.scene.ts
@@ -1,10 +1,9 @@
-import { RenderTexture } from '~/rendering/renderers/shared/texture/RenderTexture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { RenderTexture } from '~/rendering';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render renderTextures with mipmaps correctly',

--- a/tests/visual/scenes/text/msdf-text.scene.ts
+++ b/tests/visual/scenes/text/msdf-text.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render msdf-text correctly',

--- a/tests/visual/scenes/text/sdf-text.scene.ts
+++ b/tests/visual/scenes/text/sdf-text.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { Assets } from '~/assets';
+import { BitmapText } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render sdf-text correctly',

--- a/tests/visual/scenes/text/text-baseline.scene.ts
+++ b/tests/visual/scenes/text/text-baseline.scene.ts
@@ -1,9 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Graphics, Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text with baseline correctly',

--- a/tests/visual/scenes/text/text-bounds.scene.ts
+++ b/tests/visual/scenes/text/text-bounds.scene.ts
@@ -1,9 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Text } from '~/scene/text/Text';
+import { Assets } from '~/assets';
+import { Graphics, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text with the correct bounds',

--- a/tests/visual/scenes/text/text-drop-shadow.scene.ts
+++ b/tests/visual/scenes/text/text-drop-shadow.scene.ts
@@ -1,8 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text with correct drop shadow',

--- a/tests/visual/scenes/text/text-dynamic-res.scene.ts
+++ b/tests/visual/scenes/text/text-dynamic-res.scene.ts
@@ -1,9 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
-import { HTMLText } from '~/scene/text-html/HTMLText';
+import { HTMLText, Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text at new resolution',

--- a/tests/visual/scenes/text/text-dynamic-update.scene.ts
+++ b/tests/visual/scenes/text/text-dynamic-update.scene.ts
@@ -1,8 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render two text correctly with the same style and value',

--- a/tests/visual/scenes/text/text-dynamic.scene.ts
+++ b/tests/visual/scenes/text/text-dynamic.scene.ts
@@ -1,8 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text at new resolution',

--- a/tests/visual/scenes/text/text-pattern-gradient.scene.ts
+++ b/tests/visual/scenes/text/text-pattern-gradient.scene.ts
@@ -1,11 +1,9 @@
-import { loadTextures } from '~/assets/loader/parsers/textures/loadTextures';
-import { FillGradient } from '~/scene/graphics/shared/fill/FillGradient';
-import { FillPattern } from '~/scene/graphics/shared/fill/FillPattern';
-import { Text } from '~/scene/text/Text';
+import { loadTextures } from '~/assets';
+import { FillGradient, FillPattern, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import type { Container } from '~/scene/container/Container';
+import type { Texture } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render FillPattern and FillGradient in text stroke',

--- a/tests/visual/scenes/text/text-stroke-alpha.scene.ts
+++ b/tests/visual/scenes/text/text-stroke-alpha.scene.ts
@@ -1,9 +1,7 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { BitmapText, Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render stroke and fill alpha separately',

--- a/tests/visual/scenes/text/text-stroke-anchor.scene.ts
+++ b/tests/visual/scenes/text/text-stroke-anchor.scene.ts
@@ -1,8 +1,7 @@
-import { TextStyle } from '~/scene/text/TextStyle';
-import { BitmapText } from '~/scene/text-bitmap/BitmapText';
+import { BitmapText, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text stroke if it has a width greater than one',

--- a/tests/visual/scenes/text/text-stroke-fills.scene.ts
+++ b/tests/visual/scenes/text/text-stroke-fills.scene.ts
@@ -1,10 +1,8 @@
-import { Color } from '~/color/Color';
-import { FillGradient } from '~/scene/graphics/shared/fill/FillGradient';
-import { Text } from '~/scene/text/Text';
+import { Color } from '~/color';
+import { FillGradient, Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
-import type { FillStyle, StrokeStyle } from '~/scene/graphics/shared/FillTypes';
+import type { Container, FillStyle, StrokeStyle } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should update text fill/stroke through proxy',

--- a/tests/visual/scenes/text/text-stroke.scene.ts
+++ b/tests/visual/scenes/text/text-stroke.scene.ts
@@ -1,9 +1,7 @@
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Graphics, Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text stroke if it has a width greater than one',

--- a/tests/visual/scenes/text/text-trim-dynamic.scene.ts
+++ b/tests/visual/scenes/text/text-trim-dynamic.scene.ts
@@ -1,9 +1,8 @@
-import { Text } from '~/scene/text/Text';
-import { TextStyle } from '~/scene/text/TextStyle';
+import { Text, TextStyle } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text correctly if style changes',

--- a/tests/visual/scenes/text/text-trim.scene.ts
+++ b/tests/visual/scenes/text/text-trim.scene.ts
@@ -1,8 +1,8 @@
-import { Text } from '~/scene/text/Text';
+import { Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text correctly if style changes',

--- a/tests/visual/scenes/text/text.scene.ts
+++ b/tests/visual/scenes/text/text.scene.ts
@@ -1,7 +1,7 @@
-import { Text } from '~/scene/text/Text';
+import { Text } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render text correctly if style changes',

--- a/tests/visual/scenes/textures/canvas-texture.scene.ts
+++ b/tests/visual/scenes/textures/canvas-texture.scene.ts
@@ -1,8 +1,8 @@
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Texture } from '~/rendering';
+import { Graphics } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should not clear a canvas after it has been resized',

--- a/tests/visual/scenes/textures/dynamic-texture.scene.ts
+++ b/tests/visual/scenes/textures/dynamic-texture.scene.ts
@@ -1,11 +1,11 @@
-import { Assets } from '~/assets/Assets';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Rectangle } from '~/maths';
+import { Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render a dynamic texture',

--- a/tests/visual/scenes/textures/extract.scene.ts
+++ b/tests/visual/scenes/textures/extract.scene.ts
@@ -1,13 +1,11 @@
-import { Assets } from '~/assets/Assets';
-import { DOMAdapter } from '~/environment/adapter';
-import { CanvasSource } from '~/rendering/renderers/shared/texture/sources/CanvasSource';
-import { ImageSource } from '~/rendering/renderers/shared/texture/sources/ImageSource';
-import { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { DOMAdapter } from '~/environment';
+import { CanvasSource, ImageSource, Texture } from '~/rendering';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 const cellSize = 35;
 

--- a/tests/visual/scenes/textures/mipmap.scene.ts
+++ b/tests/visual/scenes/textures/mipmap.scene.ts
@@ -1,9 +1,9 @@
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Texture } from '~/rendering/renderers/shared/texture/Texture';
-import type { Container } from '~/scene/container/Container';
+import type { Texture } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render mipmapped texture',

--- a/tests/visual/scenes/textures/non-premultiplied-alpha.scene.ts
+++ b/tests/visual/scenes/textures/non-premultiplied-alpha.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render no-premultiply-alpha',

--- a/tests/visual/scenes/textures/premultiplied-alpha.scene.ts
+++ b/tests/visual/scenes/textures/premultiplied-alpha.scene.ts
@@ -1,8 +1,8 @@
-import { Assets } from '~/assets/Assets';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Container } from '~/scene/container/Container';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render premultiply-alpha correctly',

--- a/tests/visual/scenes/textures/render-texture.scene.ts
+++ b/tests/visual/scenes/textures/render-texture.scene.ts
@@ -1,11 +1,10 @@
-import { Assets } from '~/assets/Assets';
-import { RenderTexture } from '~/rendering/renderers/shared/texture/RenderTexture';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
-import { Sprite } from '~/scene/sprite/Sprite';
+import { Assets } from '~/assets';
+import { RenderTexture } from '~/rendering';
+import { Graphics, Sprite } from '~/scene';
 
 import type { TestScene } from '../../types';
-import type { Renderer } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
 
 export const scene: TestScene = {
     it: 'should render texture correctly',

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -2,13 +2,12 @@ import { ensureDirSync, existsSync, readFileSync, writeFile } from 'fs-extra';
 import { dirname } from 'path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
-import { Rectangle } from '~/maths/shapes/Rectangle';
-import { autoDetectRenderer } from '~/rendering/renderers/autoDetectRenderer';
-import { Container } from '~/scene/container/Container';
-import { Graphics } from '~/scene/graphics/shared/Graphics';
+import { Rectangle } from '~/maths';
+import { autoDetectRenderer } from '~/rendering';
+import { Container, Graphics } from '~/scene';
 
 import type { RenderType } from './types';
-import type { Renderer, RendererOptions } from '~/rendering/renderers/types';
+import type { Renderer, RendererOptions } from '~/rendering';
 
 function toArrayBuffer(buf: Buffer): ArrayBuffer
 {

--- a/tests/visual/types.ts
+++ b/tests/visual/types.ts
@@ -1,5 +1,5 @@
-import type { Renderer, RendererOptions } from '~/rendering/renderers/types';
-import type { Container } from '~/scene/container/Container';
+import type { Renderer, RendererOptions } from '~/rendering';
+import type { Container } from '~/scene';
 
 export type RenderType = 'webgl1' | 'webgl2' | 'webgpu';
 export type RenderTypeFlags = Record<RenderType, boolean>;

--- a/tests/visual/visuals.test.ts
+++ b/tests/visual/visuals.test.ts
@@ -3,8 +3,8 @@ import path from 'path';
 import '~/environment-browser/browserAll';
 import { isCI } from '../utils/basePath';
 import { renderTest } from './tester';
-import { Assets } from '~/assets/Assets';
-import { TexturePool } from '~/rendering/renderers/shared/texture/TexturePool';
+import { Assets } from '~/assets';
+import { TexturePool } from '~/rendering';
 
 import type { RenderType, RenderTypeFlags } from './types';
 


### PR DESCRIPTION
Builds on the work of #11129 and #11126

### Changes

* Utilize the barrel files for imports within tests to be less verbose

### Example

#### Before

```js
import { Container } from '~/scene/container/Container';
import { Graphics } from '~/scene/graphics/shared/Graphics';
import { Sprite } from '~/scene/sprite/Sprite';
import { Text } from '~/scene/text/Text';
```

### After

```js
import { Container, Graphics, Sprite, Text } from '~/scene';
```