### PR TITLE
chore: fix lint ignore and watch script

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import config from '@pixi/eslint-config';
 export default tseslint.config(
     ...config,
     {
-        ignores: ['/docs/**', '/dist/**', '/lib/**', 'transcoders', 'node_modules', 'src/*/**/index.ts'],
+        ignores: ['docs', 'dist', 'lib', 'transcoders', 'node_modules', 'src/*/**/index.ts'],
     },
     {
         files: ['**/*'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import config from '@pixi/eslint-config';
 export default tseslint.config(
     ...config,
     {
-        ignores: ['docs', 'dist', 'lib', 'transcoders', 'node_modules', 'src/*/**/index.ts'],
+        ignores: ['.s3_uploads', 'out', 'docs', 'dist', 'lib', 'transcoders', 'node_modules', 'src/*/**/index.ts'],
     },
     {
         files: ['**/*'],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prewatch": "npm run build",
     "watch": "nodemon --watch \"./src/*\" --exec \"npm run watch:build\" -e ts,js,vert,frag,wgsl,d.ts --ignore \"index.ts\"",
     "watch:lib": "cross-env LIB_ONLY=1 nodemon --watch \"./src/*\" --exec \"npm run watch:build\" -e ts,js,vert,frag,wgsl,d.ts --ignore \"index.ts\"",
-    "watch:build": "run-s build:rollup build:tsc build:dts postbuild",
+    "watch:build": "run-s build:rollup build:tsc build:dts",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
     "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",


### PR DESCRIPTION
fixes the ignore list for eslint and also the fixes the watch command to remove the removed `postbuild` script