### PR TITLE
feat: add a `resetState` function to allow integration with other WebGL libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prewatch": "npm run build",
     "watch": "nodemon --watch \"./src/*\" --exec \"npm run watch:build\" -e ts,js,vert,frag,wgsl,d.ts --ignore \"index.ts\"",
     "watch:lib": "cross-env LIB_ONLY=1 nodemon --watch \"./src/*\" --exec \"npm run watch:build\" -e ts,js,vert,frag,wgsl,d.ts --ignore \"index.ts\"",
-    "watch:build": "run-s build:rollup build:tsc build:dts postbuild",
+    "watch:build": "run-s build:rollup build:tsc build:dts",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
     "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -39,7 +39,7 @@ export class GlBufferSystem implements System
     private _gpuBuffers: {[key: number]: GlBuffer} = Object.create(null);
 
     /** Cache keeping track of the base bound buffer bases */
-    private readonly _boundBufferBases: {[key: number]: GlBuffer} = Object.create(null);
+    private _boundBufferBases: {[key: number]: GlBuffer} = Object.create(null);
 
     private _renderer: WebGLRenderer;
 
@@ -317,5 +317,10 @@ export class GlBufferSystem implements System
         buffer.on('destroy', this.onBufferDestroy, this);
 
         return glBuffer;
+    }
+
+    public resetState(): void
+    {
+        this._boundBufferBases = Object.create(null);
     }
 }

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -139,7 +139,7 @@ export class GlGeometrySystem implements System
     }
 
     /** Reset and unbind any active VAO and geometry. */
-    public reset(): void
+    public resetState(): void
     {
         this.unbind();
     }

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -216,4 +216,9 @@ export class GlShaderSystem implements ShaderSystem
     {
         return generateShaderSyncCode(shader, shaderSystem);
     }
+
+    public resetState(): void
+    {
+        this._activeProgram = null;
+    }
 }

--- a/src/rendering/renderers/gl/state/GlStateSystem.ts
+++ b/src/rendering/renderers/gl/state/GlStateSystem.ts
@@ -106,7 +106,7 @@ export class GlStateSystem implements System
 
         this.blendModesMap = mapWebGLBlendModesToPixi(gl);
 
-        this.reset();
+        this.resetState();
     }
 
     /**
@@ -279,7 +279,7 @@ export class GlStateSystem implements System
 
     // used
     /** Resets all the logic and disables the VAOs. */
-    public reset(): void
+    public resetState(): void
     {
         this.gl.pixelStorei(this.gl.UNPACK_FLIP_Y_WEBGL, false);
 

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -424,5 +424,12 @@ export class GlTextureSystem implements System, CanvasGenerator
 
         (this._renderer as null) = null;
     }
+
+    public resetState(): void
+    {
+        this._activeTextureLocation = -1;
+        this._boundTextures.fill(Texture.EMPTY.source);
+        this._boundSamplers = Object.create(null);
+    }
 }
 

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -540,4 +540,10 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
         return this._gpuRenderTargetHash[renderTarget.uid]
         || (this._gpuRenderTargetHash[renderTarget.uid] = this.adaptor.initGpuRenderTarget(renderTarget));
     }
+
+    public resetState(): void
+    {
+        this.renderTarget = null;
+        this.renderSurface = null;
+    }
 }

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -69,7 +69,7 @@ const defaultRunners = [
     'destroy',
     'contextChange',
     'resolutionChange',
-    'reset',
+    'resetState',
     'renderEnd',
     'renderStart',
     'render',
@@ -544,5 +544,30 @@ export class AbstractRenderer<
             throw new Error('Current environment does not allow unsafe-eval, '
                + 'please use pixi.js/unsafe-eval module to enable support.');
         }
+    }
+    /**
+     * Resets the rendering state of the renderer.
+     * This is useful when you want to use the WebGL context directly and need to ensure PixiJS's internal state
+     * stays synchronized. When modifying the WebGL context state externally, calling this method before the next Pixi
+     * render will reset all internal caches and ensure it executes correctly.
+     *
+     * This is particularly useful when combining PixiJS with other rendering engines like Three.js:
+     * ```js
+     * // Reset Three.js state
+     * threeRenderer.resetState();
+     *
+     * // Render a Three.js scene
+     * threeRenderer.render(threeScene, threeCamera);
+     *
+     * // Reset PixiJS state since Three.js modified the WebGL context
+     * pixiRenderer.resetState();
+     *
+     * // Now render Pixi content
+     * pixiRenderer.render(pixiScene);
+     * ```
+     */
+    public resetState(): void
+    {
+        this.runners.resetState.emit();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Add resetState() method to AbstractRenderer

### Overview
This PR adds a new resetState() method to the AbstractRenderer class that allows developers to reset PixiJS's internal rendering state. This is particularly useful when integrating PixiJS with other WebGL libraries or frameworks that modify the WebGL context state.

### Use Case
When using PixiJS alongside other WebGL renderers (like Three.js), the WebGL context state can get out of sync since multiple renderers are modifying it. The resetState() method provides a clean way to reset PixiJS's internal state caches and ensure correct rendering after external WebGL state modifications.

WebGPU does not really rely on state as much and so does not require any changes!

### Example usage:

```ts
// Reset Three.js state
threeRenderer.resetState();

// Render Three.js scene
threeRenderer.render(threeScene, threeCamera);

// Reset PixiJS state before rendering
pixiRenderer.resetState();

// Now render Pixi content
pixiRenderer.render(pixiScene);
```
### Implementation
Added resetState() method to AbstractRenderer that emits the 'resetState' runner event
Systems can listen to this event to reset their internal state as needed
Method is exposed publicly for easy access

### Benefits
Improves interoperability with other GPU libraries
Provides a clean API for managing renderer state
Helps prevent rendering artifacts when mixing different renderers


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
