### PR TITLE
fix: RenderableGC incorrectly cleaning up objects that are still in use 

### DIFF
--- a/src/rendering/renderers/shared/instructions/InstructionSet.ts
+++ b/src/rendering/renderers/shared/instructions/InstructionSet.ts
@@ -3,8 +3,6 @@ import { uid } from '../../../../utils/data/uid';
 import type { Renderable } from '../Renderable';
 import type { Instruction } from './Instruction';
 
-let _tick = 0;
-
 /**
  * A set of instructions that can be executed by the renderer.
  * Basically wraps an array, but with some extra properties that help the renderer
@@ -27,13 +25,13 @@ export class InstructionSet
     public renderPipes: any;
 
     public renderables: Renderable[] = [];
-    public tick = 0;
+    /** used by the garbage collector to track when the instruction set was last used */
+    public gcTick = 0;
 
     /** reset the instruction set so it can be reused set size back to 0 */
     public reset()
     {
         this.instructionSize = 0;
-        this.tick = _tick++;
     }
 
     /**

--- a/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
@@ -1,12 +1,15 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { cleanArray, cleanHash } from '../../../../utils/data/clean';
+import { type RenderOptions } from '../system/AbstractRenderer';
+import { type RenderGroup } from '~/scene/container/RenderGroup';
 
 import type { Container } from '../../../../scene/container/Container';
 import type { Renderer } from '../../types';
-import type { InstructionSet } from '../instructions/InstructionSet';
 import type { RenderPipe } from '../instructions/RenderPipe';
 import type { Renderable } from '../Renderable';
 import type { System } from '../system/System';
+
+let renderableGCTick = 0;
 
 /**
  * Options for the {@link RenderableGCSystem}.
@@ -37,16 +40,48 @@ export interface RenderableGCSystemOptions
      */
     renderableGCFrequency: number;
 }
+
 /**
- * System plugin to the renderer to manage renderable garbage collection. When rendering
- * stuff with the renderer will assign resources to each renderable. This could be for example
- * a batchable Sprite, or a text texture. If the renderable is not used for a certain amount of time
- * its resources will be tided up by its render pipe.
- * @memberof rendering
+ * The RenderableGCSystem is responsible for cleaning up GPU resources that are no longer being used.
+ *
+ * When rendering objects like sprites, text, etc - GPU resources are created and managed by the renderer.
+ * If these objects are no longer needed but not properly destroyed (via sprite.destroy()), their GPU resources
+ * would normally leak. This system prevents that by automatically cleaning up unused GPU resources.
+ *
+ * Key features:
+ * - Runs every 30 seconds by default to check for unused resources
+ * - Cleans up resources not rendered for over 1 minute
+ * - Works independently of rendering - will clean up even when not actively rendering
+ * - When cleaned up resources are needed again, new GPU objects are quickly assigned from a pool
+ * - Can be disabled with renderableGCActive:false for manual control
+ *
+ * Best practices:
+ * - Always call destroy() explicitly when done with renderables (e.g. sprite.destroy())
+ * - This system is a safety net, not a replacement for proper cleanup
+ * - Adjust frequency and timeouts via options if needed
+ *
+ * Example:
+ * ```js
+ * // Sprite created but reference lost without destroy
+ * let sprite = new Sprite(texture);
+ *
+ * // internally the renderer will assign a resource to the sprite
+ * renderer.render(sprite);
+ *
+ * sprite = null; // Reference lost but GPU resources still exist
+ *
+ * // After 1 minute of not being rendered:
+ * // - RenderableGC will clean up the sprite's GPU resources
+ * // - JS garbage collector can then clean up the sprite itself
+ * ```
+ * @implements {System<RenderableGCSystemOptions>}
  */
 export class RenderableGCSystem implements System<RenderableGCSystemOptions>
 {
-    /** @ignore */
+    /**
+     * Extension metadata for registering this system with the renderer.
+     * @ignore
+     */
     public static extension = {
         type: [
             ExtensionType.WebGLSystem,
@@ -56,50 +91,57 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         priority: 0
     } as const;
 
-    /** default options for the renderableGCSystem */
+    /**
+     * Default configuration options for the garbage collection system.
+     * These can be overridden when initializing the renderer.
+     */
     public static defaultOptions: RenderableGCSystemOptions = {
-        /**
-         * If set to true, this will enable the garbage collector on the GPU.
-         * @default true
-         */
+        /** Enable/disable the garbage collector */
         renderableGCActive: true,
-        /**
-         * The maximum idle frames before a texture is destroyed by garbage collection.
-         * @default 60 * 60
-         */
+        /** Time in ms before an unused resource is collected (default 1 minute) */
         renderableGCMaxUnusedTime: 60000,
-        /**
-         * Frames between two garbage collections.
-         * @default 600
-         */
+        /** How often to run garbage collection in ms (default 30 seconds) */
         renderableGCFrequency: 30000,
     };
 
-    /**
-     * Maximum idle frames before a texture is destroyed by garbage collection.
-     * @see renderableGCSystem.defaultMaxIdle
-     */
+    /** Maximum time in ms a resource can be unused before being garbage collected */
     public maxUnusedTime: number;
 
+    /** Reference to the renderer this system belongs to */
     private _renderer: Renderer;
 
+    /** Array of renderables being tracked for garbage collection */
     private readonly _managedRenderables: Renderable[] = [];
+    /** ID of the main GC scheduler handler */
     private _handler: number;
+    /** How frequently GC runs in ms */
     private _frequency: number;
+    /** Current timestamp used for age calculations */
     private _now: number;
 
+    /** Array of hash objects being tracked for cleanup */
     private readonly _managedHashes: {context: any, hash: string}[] = [];
+    /** ID of the hash cleanup scheduler handler */
     private _hashHandler: number;
 
+    /** Array of arrays being tracked for cleanup */
     private readonly _managedArrays: {context: any, hash: string}[] = [];
+    /** ID of the array cleanup scheduler handler */
     private _arrayHandler: number;
 
-    /** @param renderer - The renderer this System works for. */
+    /**
+     * Creates a new RenderableGCSystem instance.
+     * @param renderer - The renderer this garbage collection system works for
+     */
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
     }
 
+    /**
+     * Initializes the garbage collection system with the provided options.
+     * @param options - Configuration options for the renderer
+     */
     public init(options: RenderableGCSystemOptions): void
     {
         options = { ...RenderableGCSystem.defaultOptions, ...options };
@@ -110,23 +152,34 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         this.enabled = options.renderableGCActive;
     }
 
+    /**
+     * Gets whether the garbage collection system is currently enabled.
+     * @returns True if GC is enabled, false otherwise
+     */
     get enabled(): boolean
     {
         return !!this._handler;
     }
 
+    /**
+     * Enables or disables the garbage collection system.
+     * When enabled, schedules periodic cleanup of resources.
+     * When disabled, cancels all scheduled cleanups.
+     */
     set enabled(value: boolean)
     {
         if (this.enabled === value) return;
 
         if (value)
         {
+            // Schedule periodic garbage collection
             this._handler = this._renderer.scheduler.repeat(
                 () => this.run(),
                 this._frequency,
                 false
             );
 
+            // Schedule periodic hash table cleanup
             this._hashHandler = this._renderer.scheduler.repeat(
                 () =>
                 {
@@ -138,6 +191,7 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
                 this._frequency
             );
 
+            // Schedule periodic array cleanup
             this._arrayHandler = this._renderer.scheduler.repeat(
                 () =>
                 {
@@ -151,51 +205,82 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         }
         else
         {
+            // Cancel all scheduled cleanups
             this._renderer.scheduler.cancel(this._handler);
             this._renderer.scheduler.cancel(this._hashHandler);
             this._renderer.scheduler.cancel(this._arrayHandler);
         }
     }
 
+    /**
+     * Adds a hash table to be managed by the garbage collector.
+     * @param context - The object containing the hash table
+     * @param hash - The property name of the hash table
+     */
     public addManagedHash<T>(context: T, hash: string): void
     {
         this._managedHashes.push({ context, hash: hash as string });
     }
 
+    /**
+     * Adds an array to be managed by the garbage collector.
+     * @param context - The object containing the array
+     * @param hash - The property name of the array
+     */
     public addManagedArray<T>(context: T, hash: string): void
     {
         this._managedArrays.push({ context, hash: hash as string });
     }
 
-    public prerender(): void
+    /**
+     * Updates the GC timestamp and tracking before rendering.
+     * @param options - The render options
+     * @param options.container - The container to render
+     */
+    public prerender({
+        container
+    }: RenderOptions): void
     {
         this._now = performance.now();
+
+        // The gcTick is a monotonically increasing counter that tracks render cycles
+        // Each time we render, we increment the global renderableGCTick counter
+        // and assign the new tick value to the render group being rendered.
+        // This lets us know which render groups were rendered in the current frame
+        // versus ones that haven't been rendered recently.
+        // The instruction set also gets updated with this tick value to track
+        // when its renderables were last used.
+        container.renderGroup.gcTick = renderableGCTick++;
+
+        this._updateInstructionGCTick(container.renderGroup, container.renderGroup.gcTick);
     }
 
-    public addRenderable(renderable: Renderable, instructionSet: InstructionSet): void
+    /**
+     * Starts tracking a renderable for garbage collection.
+     * @param renderable - The renderable to track
+     */
+    public addRenderable(renderable: Renderable): void
     {
         if (!this.enabled) return;
 
-        renderable._lastUsed = this._now;
-
-        if (renderable._lastInstructionTick === -1)
+        if (renderable._lastUsed === -1)
         {
             this._managedRenderables.push(renderable);
             renderable.once('destroyed', this._removeRenderable, this);
         }
 
-        renderable._lastInstructionTick = instructionSet.tick;
+        renderable._lastUsed = this._now;
     }
 
-    /** Runs the scheduled garbage collection */
+    /**
+     * Performs garbage collection by cleaning up unused renderables.
+     * Removes renderables that haven't been used for longer than maxUnusedTime.
+     */
     public run(): void
     {
-        const now = performance.now();
-
+        const now = this._now;
         const managedRenderables = this._managedRenderables;
-
         const renderPipes = this._renderer.renderPipes;
-
         let offset = 0;
 
         for (let i = 0; i < managedRenderables.length; i++)
@@ -209,19 +294,27 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
             }
 
             const renderGroup = renderable.renderGroup ?? renderable.parentRenderGroup;
-            const currentIndex = renderGroup?.instructionSet?.tick ?? -1;
+            const currentTick = renderGroup?.instructionSet?.gcTick ?? -1;
 
-            if (renderable._lastInstructionTick !== currentIndex && now - renderable._lastUsed > this.maxUnusedTime)
+            // Update last used time if the renderable's group was rendered this tick
+            if ((renderGroup?.gcTick ?? 0) === currentTick)
+            {
+                renderable._lastUsed = now;
+            }
+
+            // Clean up if unused for too long
+            if (now - renderable._lastUsed > this.maxUnusedTime)
             {
                 if (!renderable.destroyed)
                 {
                     const rp = renderPipes as unknown as Record<string, RenderPipe>;
 
+                    if (renderGroup)renderGroup.structureDidChange = false;
+
                     rp[renderable.renderPipeId].destroyRenderable(renderable);
                 }
 
-                // remove from the array as this has been destroyed..
-                renderable._lastInstructionTick = -1;
+                renderable._lastUsed = -1;
                 offset++;
                 renderable.off('destroyed', this._removeRenderable, this);
             }
@@ -234,6 +327,7 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         managedRenderables.length -= offset;
     }
 
+    /** Cleans up the garbage collection system. Disables GC and removes all tracked resources. */
     public destroy(): void
     {
         this.enabled = false;
@@ -243,6 +337,10 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         this._managedArrays.length = 0;
     }
 
+    /**
+     * Removes a renderable from being tracked when it's destroyed.
+     * @param renderable - The renderable to stop tracking
+     */
     private _removeRenderable(renderable: Container): void
     {
         const index = this._managedRenderables.indexOf(renderable as Renderable);
@@ -251,6 +349,21 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         {
             renderable.off('destroyed', this._removeRenderable, this);
             this._managedRenderables[index] = null;
+        }
+    }
+
+    /**
+     * Updates the GC tick counter for a render group and its children.
+     * @param renderGroup - The render group to update
+     * @param gcTick - The new tick value
+     */
+    private _updateInstructionGCTick(renderGroup: RenderGroup, gcTick: number): void
+    {
+        renderGroup.instructionSet.gcTick = gcTick;
+
+        for (const child of renderGroup.renderGroupChildren)
+        {
+            this._updateInstructionGCTick(child, gcTick);
         }
     }
 }

--- a/src/rendering/renderers/shared/view/View.ts
+++ b/src/rendering/renderers/shared/view/View.ts
@@ -29,8 +29,6 @@ export interface View
 
     /** @private */
     _lastUsed: number;
-    /** @private */
-    _lastInstructionTick: number
 
     /**
      *  Whether or not to round the x/y position of the object.

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -52,6 +52,7 @@ export class RenderGroup implements Instruction
     // these updates are transform changes..
     public readonly childrenToUpdate: Record<number, { list: Container[]; index: number; }> = Object.create(null);
     public updateTick = 0;
+    public gcTick = 0;
 
     // these update are renderable changes..
     public readonly childrenRenderablesToUpdate: { list: Container[]; index: number; } = { list: [], index: 0 };

--- a/src/scene/container/__tests__/DummyView.ts
+++ b/src/scene/container/__tests__/DummyView.ts
@@ -29,8 +29,7 @@ export class DummyView extends Container implements View
     public renderPipeId = 'dummy';
     public renderableUpdateRequested: boolean;
     public _roundPixels: 1 | 0 = 0;
-    public _lastUsed = 0;
-    public _lastInstructionTick = -1;
+    public _lastUsed = -1;
 
     public _onUpdate: () => void;
     public get bounds()

--- a/src/scene/container/utils/buildInstructions.ts
+++ b/src/scene/container/utils/buildInstructions.ts
@@ -95,7 +95,7 @@ function collectAllRenderablesSimple(
 
         rp[renderable.renderPipeId].addRenderable(renderable, instructionSet);
 
-        renderableGC.addRenderable(renderable, instructionSet);
+        renderableGC.addRenderable(renderable);
 
         renderable.didViewUpdate = false;
     }
@@ -147,7 +147,7 @@ function collectAllRenderablesAdvanced(
 
             pipe.addRenderable(renderable, instructionSet);
 
-            renderableGC.addRenderable(renderable, instructionSet);
+            renderableGC.addRenderable(renderable);
 
             renderable.didViewUpdate = false;
         }

--- a/src/scene/view/ViewContainer.ts
+++ b/src/scene/view/ViewContainer.ts
@@ -23,7 +23,7 @@ export abstract class ViewContainer extends Container implements View
     /** @private */
     public _roundPixels: 0 | 1 = 0;
     /** @private */
-    public _lastUsed = 0;
+    public _lastUsed = -1;
     /** @private */
     public _lastInstructionTick = -1;
 

--- a/src/scene/view/ViewContainer.ts
+++ b/src/scene/view/ViewContainer.ts
@@ -24,8 +24,6 @@ export abstract class ViewContainer extends Container implements View
     public _roundPixels: 0 | 1 = 0;
     /** @private */
     public _lastUsed = -1;
-    /** @private */
-    public _lastInstructionTick = -1;
 
     protected _bounds: Bounds = new Bounds(0, 1, 0, 0);
     protected _boundsDirty = true;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes up the `RenderableGC` class. A little bit of refactoring and tweaking to ensure it correctly destroys only what it needs to. I also added better documentaion. 

fixes #11135

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
