### PR TITLE
fix: unload family font caching

### DIFF
--- a/src/assets/loader/parsers/loadWebFont.ts
+++ b/src/assets/loader/parsers/loadWebFont.ts
@@ -189,7 +189,7 @@ export const loadWebFont = {
         (Array.isArray(font) ? font : [font])
             .forEach((t) =>
             {
-                Cache.remove(t.family);
+                Cache.remove(`${t.family}-and-url`);
                 DOMAdapter.get().getFontFaceSet().delete(t);
             });
     }


### PR DESCRIPTION
- Since changed font name when caching, can't find that font from it font family name.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
