### PR TITLE
fix: flags not being updated after all enableRenderGroup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    testPathIgnorePatterns: ['/node_modules/', '/src/', '/dist/', '/lib/'],
+    testPathIgnorePatterns: ['/node_modules/', '/dist/', '/lib/'],
     preset: 'ts-jest/presets/js-with-ts',
     runner: '@pixi/jest-electron/runner',
     testEnvironment: '@pixi/jest-electron/environment',

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -127,7 +127,12 @@ export class RenderGroup implements Instruction
 
         for (let i = 0; i < children.length; i++)
         {
-            this.addChild(children[i]);
+            const child = children[i];
+
+            // make sure the children are all updated on the first pass..
+            child._updateFlags = 0b1111;
+
+            this.addChild(child);
         }
     }
 

--- a/src/scene/container/__tests__/RenderGroup.test.ts
+++ b/src/scene/container/__tests__/RenderGroup.test.ts
@@ -1,6 +1,7 @@
 import { Sprite } from '../../sprite/Sprite';
 import { Container } from '../Container';
 import { RenderGroup } from '../RenderGroup';
+import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
 import { getWebGLRenderer } from '@test-utils';
 import { Texture } from '~/rendering';
 import { BigPool } from '~/utils';
@@ -648,6 +649,31 @@ describe('RenderGroup', () =>
 
         // this should now be true as the order has changed
         expect(container.renderGroup.structureDidChange).toBeTrue();
+    });
+
+    it('should update the children on the first pass after conversion to render group', async () =>
+    {
+        const root = new Container({
+            isRenderGroup: true
+        });
+
+        const container = new Container();
+
+        root.addChild(container);
+
+        const child = new Container();
+
+        container.addChild(child);
+
+        expect(child._updateFlags).toEqual(0b1111);
+
+        updateRenderGroupTransforms(root.renderGroup, false);
+
+        expect(child._updateFlags).toEqual(0b0);
+
+        container.enableRenderGroup();
+
+        expect(child._updateFlags).toEqual(0b1111);
     });
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

fixes a small issue that would not immediatly update the tints of children after calling `enableRenderGroup()`. 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
