### PR TITLE
chore: replace updateQuadBounds with updateTextBounds in text

### DIFF
--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -166,7 +166,7 @@ export class Sprite extends ViewContainer
      */
     get visualBounds()
     {
-        updateQuadBounds(this._visualBounds, this._anchor, this._texture, 0);
+        updateQuadBounds(this._visualBounds, this._anchor, this._texture);
 
         return this._visualBounds;
     }

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -1,8 +1,8 @@
 import { ExtensionType } from '../../extensions/Extensions';
 import { Texture } from '../../rendering/renderers/shared/texture/Texture';
-import { updateQuadBounds } from '../../utils/data/updateQuadBounds';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { BatchableSprite } from '../sprite/BatchableSprite';
+import { updateTextBounds } from '../text/utils/updateTextBounds';
 
 import type { InstructionSet } from '../../rendering/renderers/shared/instructions/InstructionSet';
 import type { RenderPipe } from '../../rendering/renderers/shared/instructions/RenderPipe';
@@ -144,9 +144,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
         htmlText._didTextUpdate = false;
 
-        const padding = htmlText._style.padding;
-
-        updateQuadBounds(batchableSprite.bounds, htmlText._anchor, batchableSprite.texture, padding);
+        updateTextBounds(batchableSprite, htmlText);
     }
 
     private async _updateGpuText(htmlText: HTMLText)
@@ -183,9 +181,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         gpuText.textureNeedsUploading = true;
         htmlText.onViewUpdate();
 
-        const padding = htmlText._style.padding;
-
-        updateQuadBounds(batchableSprite.bounds, htmlText._anchor, batchableSprite.texture, padding);
+        updateTextBounds(batchableSprite, htmlText);
     }
 
     private _getGpuText(htmlText: HTMLText)

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -1,7 +1,7 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { updateQuadBounds } from '../../../utils/data/updateQuadBounds';
 import { BigPool } from '../../../utils/pool/PoolGroup';
 import { BatchableSprite } from '../../sprite/BatchableSprite';
+import { updateTextBounds } from '../utils/updateTextBounds';
 
 import type { InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import type { RenderPipe } from '../../../rendering/renderers/shared/instructions/RenderPipe';
@@ -129,9 +129,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
 
         text._didTextUpdate = false;
 
-        const padding = text._style.padding;
-
-        updateQuadBounds(batchableSprite.bounds, text._anchor, batchableSprite.texture, padding);
+        updateTextBounds(batchableSprite, text);
     }
 
     private _updateGpuText(text: Text)

--- a/src/scene/text/utils/updateTextBounds.ts
+++ b/src/scene/text/utils/updateTextBounds.ts
@@ -1,0 +1,29 @@
+import { updateQuadBounds } from '../../../utils/data/updateQuadBounds';
+import { type BatchableSprite } from '../../sprite/BatchableSprite';
+import { type AbstractText } from '../AbstractText';
+
+/**
+ * Updates the bounds of the given batchable sprite based on the provided text object.
+ *
+ * This function adjusts the bounds of the batchable sprite to match the dimensions
+ * and anchor point of the text's texture. Additionally, it compensates for any padding
+ * specified in the text's style to ensure the text is rendered correctly on screen.
+ * @param {BatchableSprite} batchableSprite - The sprite whose bounds need to be updated.
+ * @param {AbstractText} text - The text object containing the texture and style information.
+ */
+export function updateTextBounds(batchableSprite: BatchableSprite, text: AbstractText)
+{
+    const { texture, bounds } = batchableSprite;
+
+    updateQuadBounds(bounds, text._anchor, texture);
+
+    // When HTML text textures are created, they include the padding around the text content
+    // to prevent text clipping and provide a buffer zone. This padding is built into
+    // the texture itself. However, we don't want this padding to affect the text's
+    // actual position on screen.
+    // To compensate, we shift the render position back by the padding amount,
+    // ensuring the text appears exactly where intended while maintaining the
+    // buffer zone around it.
+    bounds.minX -= text._style.padding;
+    bounds.minY -= text._style.padding;
+}

--- a/src/utils/data/updateQuadBounds.ts
+++ b/src/utils/data/updateQuadBounds.ts
@@ -2,36 +2,45 @@ import type { ObservablePoint } from '../../maths/point/ObservablePoint';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { BoundsData } from '../../scene/container/bounds/Bounds';
 
+/**
+ * Updates the bounds of a quad (a rectangular area) based on the provided texture and anchor point.
+ *
+ * This function calculates the minimum and maximum x and y coordinates of the bounds, taking into
+ * account the texture's original dimensions and any trimming that may have been applied to it.
+ * @param {BoundsData} bounds - The bounds object to be updated. It contains minX, maxX, minY, and maxY properties.
+ * @param {ObservablePoint} anchor - The anchor point of the texture, which affects the positioning of the bounds.
+ * @param {Texture} texture - The texture whose dimensions and trimming information are used to update the bounds.
+ */
 export function updateQuadBounds(
     bounds: BoundsData,
     anchor: ObservablePoint,
-    texture: Texture,
-    padding: number
-)
+    texture: Texture
+): void
 {
     const { width, height } = texture.orig;
     const trim = texture.trim;
 
+    // If the texture has trimming information, adjust the bounds accordingly
     if (trim)
     {
+        // Calculate the source width and height from the trim
         const sourceWidth = trim.width;
         const sourceHeight = trim.height;
 
-        bounds.minX = (trim.x) - (anchor._x * width) - padding;
+        // Update the bounds using the trim's x and y offsets and the anchor point
+        bounds.minX = trim.x - (anchor._x * width);
         bounds.maxX = bounds.minX + sourceWidth;
 
-        bounds.minY = (trim.y) - (anchor._y * height) - padding;
+        bounds.minY = trim.y - (anchor._y * height);
         bounds.maxY = bounds.minY + sourceHeight;
     }
-
+    // If there is no trimming, calculate the bounds based solely on the texture's original dimensions
     else
     {
-        bounds.minX = (-anchor._x * width) - padding;
+        bounds.minX = -anchor._x * width;
         bounds.maxX = bounds.minX + width;
 
-        bounds.minY = (-anchor._y * height) - padding;
+        bounds.minY = -anchor._y * height;
         bounds.maxY = bounds.minY + height;
     }
-
-    return;
 }


### PR DESCRIPTION


<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
- replaced updateQuadBounds with updateTextBounds in text renderering pipes
- Updated CanvasTextPipe and HTMLTextPipe to use the new updateTextBounds function for better handling of text bounds.
- Removed padding parameter from updateQuadBounds calls, simplifying the bounds update logic.
- Introduced updateTextBounds function to manage text-specific bounds adjustments, including padding compensation.
- Refactored Sprite visualBounds getter to remove unnecessary padding argument in updateQuadBounds.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
