### PR TITLE
fix: properly iterate assets array in Resolver._getPreferredOrder

### DIFF
--- a/src/assets/resolver/Resolver.ts
+++ b/src/assets/resolver/Resolver.ts
@@ -487,8 +487,7 @@ export class Resolver
             // we dont need to create string variations for the src if it is a ResolvedAsset
             const srcsToUse: (string | ResolvedSrc)[][] = convertToList<AssetSrc>(src).map((src) =>
             {
-                if (typeof src === 'string')
-                { return createStringVariations(src); }
+                if (typeof src === 'string') { return createStringVariations(src); }
 
                 return Array.isArray(src) ? src : [src];
             });
@@ -601,7 +600,7 @@ export class Resolver
      * @returns All the bundles assets or a hash of assets for each bundle specified
      */
     public resolveBundle(bundleIds: ArrayOr<string>):
-    Record<string, ResolvedAsset> | Record<string, Record<string, ResolvedAsset>>
+        Record<string, ResolvedAsset> | Record<string, Record<string, ResolvedAsset>>
     {
         const singleAsset = isSingleItem(bundleIds);
 
@@ -755,7 +754,7 @@ export class Resolver
     {
         for (let i = 0; i < assets.length; i++)
         {
-            const asset = assets[0];
+            const asset = assets[i];
 
             const preferred = this._preferredOrder.find((preference: PreferOrder) =>
                 preference.params.format.includes(asset.format));


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
This fixes the simple bug raised in https://github.com/pixijs/pixijs/issues/11181

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Lint process passed (`npm run lint`)
