### PR TITLE
fix: Typo in documentation Texture.ts

### DIFF
--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -89,7 +89,7 @@ export type TextureSourceLike = TextureSource | TextureResourceOrOptions | strin
  * A texture must have a loaded resource passed to it to work. It does not contain any
  * loading mechanisms.
  *
- * The Assets class can be used to load an texture from a file. This is the recommended
+ * The Assets class can be used to load a texture from a file. This is the recommended
  * way as it will handle the loading and caching for you.
  *
  * ```js


### PR DESCRIPTION
changes "an texture" to "a texture"

##### Description of change
Fixes a typo in the documentation.

##### Pre-Merge Checklist
None applicable.
