### PR TITLE
fix: Allow to sync gl shaders after first one when there are multiple batchers

### DIFF
--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -22,7 +22,7 @@ export class GlBatchAdaptor implements BatcherAdaptor
         name: 'batch',
     } as const;
 
-    private _didUpload = false;
+    private readonly _didUploadSet: Set<Shader> = new Set();
     private readonly _tempState = State.for2d();
 
     public init(batcherPipe: BatcherPipe): void
@@ -32,15 +32,15 @@ export class GlBatchAdaptor implements BatcherAdaptor
 
     public contextChange(): void
     {
-        this._didUpload = false;
+        this._didUploadSet.clear();
     }
 
     public start(batchPipe: BatcherPipe, geometry: Geometry, shader: Shader): void
     {
         const renderer = batchPipe.renderer as WebGLRenderer;
 
-        // only want to sync the shade ron its first bind!
-        renderer.shader.bind(shader, this._didUpload);
+        // only want to sync the shader on its first bind!
+        renderer.shader.bind(shader, this._didUploadSet.has(shader));
 
         renderer.shader.updateUniformGroup(renderer.globalUniforms.uniformGroup);
 
@@ -51,7 +51,7 @@ export class GlBatchAdaptor implements BatcherAdaptor
     {
         const renderer = batchPipe.renderer as WebGLRenderer;
 
-        this._didUpload = true;
+        this._didUploadSet.add(batch.batcher.shader);
 
         this._tempState.blendMode = batch.blendMode;
 


### PR DESCRIPTION
### Description of Change
This issue occurs only with WebGL, not WebGPU. I am not entirely confident in this fix, so I have marked it as a draft.

The issue arises when two Pixi objects in the scene use two different textures. The first object uses the default batcher, while the second object uses a custom batcher, specifically the [`DarkTintBatcher`](https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-ts/spine-pixi-v8/src/darktint/DarkTintBatcher.ts) from `spine-pixi`.

The second object ends up using the wrong texture. It appears that the shader for the batcher of the second object has misaligned texture uniforms. When I inspect a WebGL context snapshot, the texture uniform are not coherent with the `batch` data on the Pixi side.

The `GlBatchAdaptor` has a `_didUpload` field that is set to `true` when a batch is executed and remains unchanged unless a context change occurs. This `_didUpload` field is passed to `Shader.bind` to synchronize the shader when a `startBatch` is detected. However, this means that a `startBatch` for the second batcher can never fully synchronize its shader.

To demonstrate this issue, I have created a [CodeSandbox example](https://codesandbox.io/p/sandbox/cool-moon-c8f6hh) based on the description above. The scene contains two objects, each with two textures:  
- The first object (black and white) uses the default batcher.  
- The second object (colored) uses the custom batcher.

The expected behavior is for the square and circle from each object to render correctly using their respective textures. Here’s how it behaves in practice:  

- **Current behavior**:  
  <img width="277" alt="image" src="https://github.com/user-attachments/assets/cca91be6-558d-445d-bc94-9cc63079bbd7" />  
  The first object renders correctly, with both the square and circle displayed properly.  
  The second object renders incorrectly. The square is ok, but the circle uses the texture of the square, appearing as a square.

- **Expected behavior**:  
  <img width="277" alt="image" src="https://github.com/user-attachments/assets/8cac74ca-b8eb-4871-81a6-04c20e1aefc2" />  
  This is the expected behaviour that can be obtained by commenting line 5 and uncommenting line 6 (I've added a build with this fix). Both objects render their textures correctly.

I tried to set up a test, but it's definitely not easy for this use case.

---

### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included.
- [x] Linting completed (`npm run lint`).
- [x] Tests passed (`npm run test`).