### PR TITLE
Fix typings compilation

### DIFF
--- a/src/scene/text-bitmap/AbstractBitmapFont.ts
+++ b/src/scene/text-bitmap/AbstractBitmapFont.ts
@@ -70,7 +70,7 @@ export interface BitmapFontData
         type: 'sdf' | 'msdf' | 'none';
         /** Range of the distance field in pixels */
         range: number;
-    };
+    } | undefined;
 }
 
 interface BitmapFontEvents<Type>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

When you add `pixi.js` to your project and build it with `skipLibCheck=false` in `tsconfig.json`. You get the following error:

```
node_modules/pixi.js/lib/scene/text-bitmap/AbstractBitmapFont.d.ts:74:31 - error TS2420: Class 'AbstractBitmapFont<FontType>' incorrectly implements interface 'Omit<BitmapFontData, "fontSize" | "chars" | "pages">'.
  Types of property 'distanceField' are incompatible.
    Type '{ type: "none" | "sdf" | "msdf"; range: number; } | undefined' is not assignable to type '{ type: "none" | "sdf" | "msdf"; range: number; }'.
      Type 'undefined' is not assignable to type '{ type: "none" | "sdf" | "msdf"; range: number; }'.

74 export declare abstract class AbstractBitmapFont<FontType> extends EventEmitter<BitmapFontEvents<FontType>> implements Omit<BitmapFontData, 'chars' | 'pages' | 'fontSize'> {
                                 ~~~~~~~~~~~~~~~~~~
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Lint process passed (`npm run lint`)
- [X] Tests passed (`npm run test`)
