### PR TITLE
chore: update CanvasTextMetrics example to use correct class

### DIFF
--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -52,7 +52,7 @@ const contextSettings: ICanvasRenderingContext2DSettings = {
 /**
  * The TextMetrics object represents the measurement of a block of text with a specified style.
  * @example
- * import { TextMetrics, TextStyle } from 'pixi.js';
+ * import { CanvasTextMetrics, TextStyle } from 'pixi.js';
  *
  * const style = new TextStyle({
  *     fontFamily: 'Arial',
@@ -60,7 +60,7 @@ const contextSettings: ICanvasRenderingContext2DSettings = {
  *     fill: 0xff1010,
  *     align: 'center',
  * });
- * const textMetrics = TextMetrics.measureText('Your text', style);
+ * const textMetrics = CanvasTextMetrics.measureText('Your text', style);
  * @memberof text
  */
 export class CanvasTextMetrics


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Updates the example in CanvasTextMetrics documentation to use the correct `CanvasTextMetrics` class instead of the outdated `TextMetrics`.

Fixes #11205

##### Pre-Merge Checklist
- [x] Documentation is changed or added