### PR TITLE
fix: DDS BC format need Alignment Blocks

### DIFF
--- a/src/compressed-textures/dds/parseDDS.ts
+++ b/src/compressed-textures/dds/parseDDS.ts
@@ -55,8 +55,11 @@ function getMipmapLevelBuffers(format: TEXTURE_FORMATS, width: number, height: n
 
     for (let level = 0; level < mipmapCount; ++level)
     {
+        // Each dimension must be aligned to a multiple of 4
+        const alignedWidth = Math.ceil(Math.max(4, mipWidth) / 4) * 4;
+        const alignedHeight = Math.ceil(Math.max(4, mipHeight) / 4) * 4;
         const byteLength = blockBytes
-            ? Math.max(4, mipWidth) / 4 * Math.max(4, mipHeight) / 4 * blockBytes
+            ? alignedWidth / 4 * alignedHeight / 4 * blockBytes
             : mipWidth * mipHeight * 4;
 
         const levelBuffer = new Uint8Array(arrayBuffer, offset, byteLength);


### PR DESCRIPTION
Each dimension must be aligned to a multiple of 4 for BC formats. If a dimension isn’t a multiple of 4, round up to the nearest multiple of 4

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Each dimension must be aligned to a multiple of 4 for BC formats. If a dimension isn’t a multiple of 4, round up to the nearest multiple of 4.
![image](https://github.com/user-attachments/assets/3764dac4-77c4-499f-b8e9-c9c30970aeb6)

Current calculated values in dev
![image](https://github.com/user-attachments/assets/50b42b66-2c9a-49c1-9fe5-92a117db6480)

Renderer only show the dds image in maximum size, but using any of mipmap no work because the warning
File used:
[acolyteofchayulaascendancy.zip](https://github.com/user-attachments/files/18455270/acolyteofchayulaascendancy.zip)
