### PR TITLE
fix: loadTextures.load add onerror for Image case

### DIFF
--- a/src/assets/loader/__tests__/Loader.test.ts
+++ b/src/assets/loader/__tests__/Loader.test.ts
@@ -263,9 +263,13 @@ describe('Loader', () =>
         const loader = new Loader();
 
         loader['_parsers'].push(loadTextures);
-        loadTextures.config.preferCreateImageBitmap = false;
+        const config = loadTextures.config;
+        const defValue = config.preferCreateImageBitmap;
+
+        config.preferCreateImageBitmap = false;
         await loader.load(`${basePath}textures/bunny_no_img.png`).catch(
             (e) => expect(e).toBeInstanceOf(Error)
         );
+        config.preferCreateImageBitmap = defValue;
     });
 });

--- a/src/assets/loader/__tests__/Loader.test.ts
+++ b/src/assets/loader/__tests__/Loader.test.ts
@@ -257,4 +257,15 @@ describe('Loader', () =>
         expect(texture.width).toBe(26);
         expect(texture.height).toBe(37);
     });
+
+    it('should error out if loader fails (preferCreateImageBitmap = false)', async () =>
+    {
+        const loader = new Loader();
+
+        loader['_parsers'].push(loadTextures);
+        loadTextures.config.preferCreateImageBitmap = false;
+        await loader.load(`${basePath}textures/bunny_no_img.png`).catch(
+            (e) => expect(e).toBeInstanceOf(Error)
+        );
+    });
 });

--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -147,8 +147,9 @@ export const loadTextures: LoaderParser<Texture, TextureSourceOptions, LoadTextu
                 }
                 else
                 {
-                    src.onload = (): void =>
+                    src.onerror = src.onload = (): void =>
                     {
+                        src.onerror = src.onload = null;
                         resolve(src);
                     };
                 }

--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -135,7 +135,7 @@ export const loadTextures: LoaderParser<Texture, TextureSourceOptions, LoadTextu
         }
         else
         {
-            src = await new Promise((resolve) =>
+            src = await new Promise((resolve, reject) =>
             {
                 src = new Image();
                 src.crossOrigin = this.config.crossOrigin;
@@ -147,11 +147,11 @@ export const loadTextures: LoaderParser<Texture, TextureSourceOptions, LoadTextu
                 }
                 else
                 {
-                    src.onerror = src.onload = (): void =>
+                    src.onload = (): void =>
                     {
-                        src.onerror = src.onload = null;
                         resolve(src);
                     };
+                    src.onerror = reject;
                 }
             });
         }


### PR DESCRIPTION
Added error handling when using Image to upload images. Currently, in this mode, Promise will never be allowed (for example, in the case of an incorrect url)
