### PR TITLE
fix: issue with premultiply alpha and non image based uploading

### DIFF
--- a/src/rendering/renderers/__tests__/Extract.test.ts
+++ b/src/rendering/renderers/__tests__/Extract.test.ts
@@ -150,7 +150,7 @@ describe('GenerateTexture', () =>
             resource: texturePixels,
             width: 2,
             height: 2,
-            alphaMode: 'premultiply-alpha-on-upload',
+            alphaMode: 'premultiplied-alpha',
         });
 
         const sprite = new Sprite(texture);
@@ -176,7 +176,7 @@ describe('GenerateTexture', () =>
             resource: texturePixels,
             width: 2,
             height: 2,
-            alphaMode: 'premultiply-alpha-on-upload',
+            alphaMode: 'premultiplied-alpha',
         });
 
         const sprite = new Sprite(texture);
@@ -208,7 +208,7 @@ describe('GenerateTexture', () =>
             resource: texturePixels,
             width: 2,
             height: 2,
-            alphaMode: 'premultiply-alpha-on-upload',
+            alphaMode: 'premultiplied-alpha',
         });
 
         const sprite = new Sprite(texture);
@@ -231,6 +231,7 @@ describe('GenerateTexture', () =>
             resource: texturePixels,
             width: 2,
             height: 2,
+            alphaMode: 'premultiplied-alpha',
         });
         const sprite = new Sprite(texture);
         const extract = renderer.extract;
@@ -257,7 +258,7 @@ describe('GenerateTexture', () =>
             width: 2,
             height: 2,
             resource: texturePixels,
-            alphaMode: 'premultiply-alpha-on-upload',
+            alphaMode: 'premultiplied-alpha',
             scaleMode: 'nearest'
         });
 
@@ -297,7 +298,7 @@ describe('GenerateTexture', () =>
             width: 2,
             height: 2,
             resource: texturePixels,
-            alphaMode: 'premultiply-alpha-on-upload',
+            alphaMode: 'premultiplied-alpha',
             scaleMode: 'nearest'
         });
 

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -62,6 +62,8 @@ export class GlTextureSystem implements System, CanvasGenerator
     private _mapFormatToType: Record<string, number>;
     private _mapFormatToFormat: Record<string, number>;
 
+    private _premultiplyAlpha = false;
+
     // TODO - separate samplers will be a cool thing to add, but not right now!
     private readonly _useSeparateSamplers = false;
 
@@ -87,6 +89,7 @@ export class GlTextureSystem implements System, CanvasGenerator
         this._glTextures = Object.create(null);
         this._glSamplers = Object.create(null);
         this._boundSamplers = Object.create(null);
+        this._premultiplyAlpha = false;
 
         for (let i = 0; i < 16; i++)
         {
@@ -279,6 +282,14 @@ export class GlTextureSystem implements System, CanvasGenerator
         gl.bindTexture(gl.TEXTURE_2D, glTexture.texture);
 
         this._boundTextures[this._activeTextureLocation] = source;
+
+        const premultipliedAlpha = source.alphaMode === 'premultiply-alpha-on-upload';
+
+        if (this._premultiplyAlpha !== premultipliedAlpha)
+        {
+            this._premultiplyAlpha = premultipliedAlpha;
+            gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultipliedAlpha);
+        }
 
         if (this._uploads[source.uploadMethodId])
         {

--- a/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
+++ b/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
@@ -10,10 +10,6 @@ export const glUploadImageResource = {
 
     upload(source: ImageSource | CanvasSource, glTexture: GlTexture, gl: GlRenderingContext, webGLVersion: number)
     {
-        const premultipliedAlpha = source.alphaMode === 'premultiply-alpha-on-upload';
-
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultipliedAlpha);
-
         const glWidth = glTexture.width;
         const glHeight = glTexture.height;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Fixes an issue where `gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL` was not being set for any upload that is not an image.
Moved this check to outside of the image upload function and into GlTextureSystem.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
