### PR TITLE
fix: different batch shaders being bound incorrectly the first time they are used

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch:build": "run-s build:tsc:silent build:index build:pkg build:pkg build:rollup build:dts",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
-    "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",
+    "test:debug": "cross-env DEBUG_MODE=1 npx jest",
     "test:server": "npx http-server -p 8080 -c-1",
     "test:scene": "npx jest --silent --testPathPattern=tests/visual",
     "test:scene:debug": "cross-env DEBUG_MODE=1 npx jest --testPathPattern=tests/visual",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch:build": "run-s build:tsc:silent build:index build:pkg build:pkg build:rollup build:dts",
     "test": "run-s test:unit test:scene",
     "test:unit": "npx jest --silent --testPathIgnorePatterns=tests/visual",
-    "test:debug": "cross-env DEBUG_MODE=1 npx jest",
+    "test:debug": "cross-env DEBUG_MODE=1 npx jest --testPathIgnorePatterns=tests/visual",
     "test:server": "npx http-server -p 8080 -c-1",
     "test:scene": "npx jest --silent --testPathPattern=tests/visual",
     "test:scene:debug": "cross-env DEBUG_MODE=1 npx jest --testPathPattern=tests/visual",

--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -45,10 +45,15 @@ export class GlBatchAdaptor implements BatcherAdaptor
     {
         const renderer = batchPipe.renderer as WebGLRenderer;
 
-        // only want to sync the shade ron its first bind!
-        renderer.shader.bind(shader, this._didUploadHash[shader.uid]);
+        const didUpload = this._didUploadHash[shader.uid];
 
-        this._didUploadHash[shader.uid] = true;
+        // only want to sync the shade ron its first bind!
+        renderer.shader.bind(shader, didUpload);
+
+        if (!didUpload)
+        {
+            this._didUploadHash[shader.uid] = true;
+        }
 
         renderer.shader.updateUniformGroup(renderer.globalUniforms.uniformGroup);
 

--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -22,9 +22,15 @@ export class GlBatchAdaptor implements BatcherAdaptor
         name: 'batch',
     } as const;
 
-    private _didUpload = false;
     private readonly _tempState = State.for2d();
 
+    /**
+     * We only want to sync the a batched shaders uniforms once on first use
+     * this is a hash of shader uids to a boolean value.  When the shader is first bound
+     * we set the value to true.  When the shader is bound again we check the value and
+     * if it is true we know that the uniforms have already been synced and we skip it.
+     */
+    private _didUploadHash: Record<string, boolean> = {};
     public init(batcherPipe: BatcherPipe): void
     {
         batcherPipe.renderer.runners.contextChange.add(this);
@@ -32,7 +38,7 @@ export class GlBatchAdaptor implements BatcherAdaptor
 
     public contextChange(): void
     {
-        this._didUpload = false;
+        this._didUploadHash = {};
     }
 
     public start(batchPipe: BatcherPipe, geometry: Geometry, shader: Shader): void
@@ -40,7 +46,9 @@ export class GlBatchAdaptor implements BatcherAdaptor
         const renderer = batchPipe.renderer as WebGLRenderer;
 
         // only want to sync the shade ron its first bind!
-        renderer.shader.bind(shader, this._didUpload);
+        renderer.shader.bind(shader, this._didUploadHash[shader.uid]);
+
+        this._didUploadHash[shader.uid] = true;
 
         renderer.shader.updateUniformGroup(renderer.globalUniforms.uniformGroup);
 
@@ -50,8 +58,6 @@ export class GlBatchAdaptor implements BatcherAdaptor
     public execute(batchPipe: BatcherPipe, batch: Batch): void
     {
         const renderer = batchPipe.renderer as WebGLRenderer;
-
-        this._didUpload = true;
 
         this._tempState.blendMode = batch.blendMode;
 

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -4,6 +4,7 @@ import { BindGroup } from '../../gpu/shader/BindGroup';
 import { GpuProgram } from '../../gpu/shader/GpuProgram';
 import { RendererType } from '../../types';
 import { UniformGroup } from './UniformGroup';
+import { uid } from '~/utils/data/uid';
 
 import type { GlProgramOptions } from '../../gl/shader/GlProgram';
 import type { BindResource } from '../../gpu/shader/BindResource';
@@ -144,6 +145,8 @@ export type ShaderFromResources = (GlShaderFromWith | GpuShaderFromWith)
  */
 export class Shader extends EventEmitter<{'destroy': Shader}>
 {
+    /** A unique identifier for the shader */
+    public readonly uid: number = uid('shader');
     /** An instance of the GPU program used by the WebGPU renderer */
     public gpuProgram: GpuProgram;
     /** An instance of the GL program used by the WebGL renderer */

--- a/src/utils/data/uid.ts
+++ b/src/utils/data/uid.ts
@@ -24,7 +24,8 @@ type UIDNames =
     | 'uniform' //
     | 'spriteView' //
     | 'textView' //
-    | 'tilingSpriteView'; // ;
+    | 'tilingSpriteView' //
+    | 'shader';
 
 /**
  * Gets the next unique identifier


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

An alternative to #11194 (thanks for the intial PR and debugging @davidetan, made this very easy to make). This fixes different batch shaders being bound incorrectly the first time they are used

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
