### PR TITLE
fix: gif export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './environment-webworker';
 export * from './events';
 export * from './extensions';
 export * from './filters';
+export * from './gif';
 export * from './maths';
 export * from './prepare';
 export * from './rendering';


### PR DESCRIPTION
We are currently not exporting the new gif classes and there is two ways to fix it with slightly different ux

This approach would look like this:

```ts
import 'pixi.js/gif'. // force asset extension to be added
import { GifSprite } from 'pixi.js'

// use gif
```

The alternative can be found here: https://github.com/pixijs/pixijs/pull/11226 
and would look like this:

```ts
import { GifSprite } from 'pixi.js/gif' // asset extension is added automatically 

// use gif
```

I'm fine with either direction and both support tree shaking. Gif is the first optional package of pixi that also needed to export something which is why we have run into this issue now