### PR TITLE
fix: gif export

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,9 +187,9 @@
     "./lib/rendering/init.*",
     "./lib/spritesheet/init.*",
     "./lib/rendering/renderers/shared/texture/utils/textureFrom.*",
+    "./lib/gif/init.*",
     "./lib/accessibility/init.*",
     "./lib/advanced-blend-modes/init.*",
-    "./lib/gif/init.*",
     "./lib/app/init.*",
     "./lib/compressed-textures/dds/init.*",
     "./lib/compressed-textures/ktx/init.*",
@@ -236,6 +236,16 @@
         "default": "./lib/environment-webworker/webworkerAll.js"
       }
     },
+    "./gif": {
+      "import": {
+        "types": "./lib/gif/init.d.ts",
+        "default": "./lib/gif/init.mjs"
+      },
+      "require": {
+        "types": "./lib/gif/init.d.ts",
+        "default": "./lib/gif/init.js"
+      }
+    },
     "./accessibility": {
       "import": {
         "default": "./lib/accessibility/init.mjs"
@@ -250,14 +260,6 @@
       },
       "require": {
         "default": "./lib/advanced-blend-modes/init.js"
-      }
-    },
-    "./gif": {
-      "import": {
-        "default": "./lib/gif/init.mjs"
-      },
-      "require": {
-        "default": "./lib/gif/init.js"
       }
     },
     "./app": {

--- a/scripts/utils/exports.ts
+++ b/scripts/utils/exports.ts
@@ -7,7 +7,6 @@ import { readJSONSync, writeJSONSync } from 'fs-extra';
 const subImports = [
     ['./accessibility', './lib/accessibility'],
     ['./advanced-blend-modes', './lib/advanced-blend-modes'],
-    ['./gif', './lib/gif'],
     ['./app', './lib/app'],
     ['./dds', './lib/compressed-textures/dds'],
     ['./ktx', './lib/compressed-textures/ktx'],
@@ -67,6 +66,16 @@ const exportFields: Record<string, ExportField> = {
             default: './lib/environment-webworker/webworkerAll.js',
         },
     },
+    './gif': {
+        import: {
+            types: './lib/gif/init.d.ts',
+            default: './lib/gif/init.mjs',
+        },
+        require: {
+            types: './lib/gif/init.d.ts',
+            default: './lib/gif/init.js',
+        },
+    },
 };
 const sideEffects = [
     './lib/environment-browser/browserAll.*',
@@ -75,6 +84,7 @@ const sideEffects = [
     './lib/rendering/init.*',
     './lib/spritesheet/init.*',
     './lib/rendering/renderers/shared/texture/utils/textureFrom.*',
+    './lib/gif/init.*',
 ];
 
 for (const [name, path] of subImports)

--- a/src/gif/init.ts
+++ b/src/gif/init.ts
@@ -1,5 +1,6 @@
 import { extensions } from '../extensions/Extensions';
 import { GifAsset } from './GifAsset';
 
-extensions.add(GifAsset);
+export * from './index';
 
+extensions.add(GifAsset);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ export * from './environment-webworker';
 export * from './events';
 export * from './extensions';
 export * from './filters';
-export * from './gif';
 export * from './maths';
 export * from './prepare';
 export * from './rendering';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from './environment-webworker';
 export * from './events';
 export * from './extensions';
 export * from './filters';
+export * from './gif';
 export * from './maths';
 export * from './prepare';
 export * from './rendering';


### PR DESCRIPTION
We are currently not exporting the new gif classes and this PR allows for them to be imported like this:

```ts
import { GifSprite } from 'pixi.js/gif' // asset extension is added automatically 

// use gif
```