### PR TITLE
fix: accessibility system being added to shared systems

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -121,29 +121,27 @@ export class AccessibilitySystem implements System<AccessibilitySystemOptions>
     } as const;
 
     /** default options used by the system */
-    public static defaultOptions: AccessibilitySystemOptions = {
-        accessibilityOptions: {
-            /**
-             * Whether to enable accessibility features on initialization
-             * @default false
-             */
-            enabledByDefault: false,
-            /**
-             * Whether to visually show the accessibility divs for debugging
-             * @default false
-             */
-            debug: false,
-            /**
-             * Whether to activate accessibility when tab key is pressed
-             * @default true
-             */
-            activateOnTab: true,
-            /**
-             * Whether to deactivate accessibility when mouse moves
-             * @default true
-             */
-            deactivateOnMouseMove: true,
-        },
+    public static defaultOptions: AccessibilityOptions = {
+        /**
+         * Whether to enable accessibility features on initialization
+         * @default false
+         */
+        enabledByDefault: false,
+        /**
+         * Whether to visually show the accessibility divs for debugging
+         * @default false
+         */
+        debug: false,
+        /**
+         * Whether to activate accessibility when tab key is pressed
+         * @default true
+         */
+        activateOnTab: true,
+        /**
+         * Whether to deactivate accessibility when mouse moves
+         * @default true
+         */
+        deactivateOnMouseMove: true,
     };
 
     /** Whether accessibility divs are visible for debugging */
@@ -449,7 +447,7 @@ export class AccessibilitySystem implements System<AccessibilitySystemOptions>
         const defaultOpts = AccessibilitySystem.defaultOptions;
         const mergedOptions = {
             accessibilityOptions: {
-                ...defaultOpts.accessibilityOptions,
+                ...defaultOpts,
                 ...(options?.accessibilityOptions || {})
             }
         };

--- a/src/rendering/renderers/shared/system/SharedSystems.ts
+++ b/src/rendering/renderers/shared/system/SharedSystems.ts
@@ -1,4 +1,3 @@
-import { AccessibilitySystem } from '../../../../accessibility/AccessibilitySystem';
 import { CustomRenderPipe } from '../../../../scene/container/CustomRenderPipe';
 import { RenderGroupPipe } from '../../../../scene/container/RenderGroupPipe';
 import { RenderGroupSystem } from '../../../../scene/container/RenderGroupSystem';
@@ -22,7 +21,6 @@ import { ViewSystem } from '../view/ViewSystem';
 import type { ExtractRendererOptions } from './utils/typeUtils';
 
 export const SharedSystems = [
-    AccessibilitySystem,
     BackgroundSystem,
     GlobalUniformSystem,
     HelloSystem,


### PR DESCRIPTION
A couple of things slipped through the #11107 PR 
- accessibility system being added to shared systems resulting is causing circular type issues
- default options for accessibility system being nested incorrectly