### PR TITLE
fix: set texture bug on batched mesh

### DIFF
--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -55,6 +55,20 @@ export class BatchableMesh implements DefaultBatchableMeshElement
         this._textureMatrixUpdateId = -1;
     }
 
+    /**
+     * Sets the texture for the batchable mesh.
+     * As it does so, it resets the texture matrix update ID.
+     * this is to ensure that the texture matrix is recalculated when the uvs are referenced
+     * @param value - The texture to set.
+     */
+    public setTexture(value: Texture)
+    {
+        if (this.texture === value) return;
+
+        this.texture = value;
+        this._textureMatrixUpdateId = -1;
+    }
+
     get uvs()
     {
         const geometry = this.geometry;

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -142,7 +142,8 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
         {
             const gpuBatchableMesh = this._gpuBatchableMeshHash[mesh.uid];
 
-            gpuBatchableMesh.texture = mesh._texture;
+            gpuBatchableMesh.setTexture(mesh._texture);
+
             gpuBatchableMesh.geometry = mesh._geometry;
 
             gpuBatchableMesh._batcher.updateElement(gpuBatchableMesh);

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -79,7 +79,7 @@ export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
             .update(sprite);
 
         // = sprite.bounds;
-        batchableSprite.texture = sprite._texture;
+        batchableSprite.setTexture(sprite._texture);
     }
 
     private _getGpuSprite(sprite: NineSliceSprite): BatchableMesh

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -102,7 +102,7 @@ export class TilingSpritePipe implements RenderPipe<TilingSprite>
                 batchableMesh.geometry = geometry;
                 batchableMesh.renderable = tilingSprite;
                 batchableMesh.transform = tilingSprite.groupTransform;
-                batchableMesh.texture = tilingSprite._texture;
+                batchableMesh.setTexture(tilingSprite._texture);
             }
 
             batchableMesh.roundPixels = (this._renderer._roundPixels | tilingSprite._roundPixels) as 0 | 1;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Fixed an issue where batched UVs were not being updated correctly when a texture was changed that had the same TextureSource.

fixes #11161

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
