### PR TITLE
fix: correct texture dimension comparison in glUploadImageResource.ts

### DIFF
--- a/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
+++ b/src/rendering/renderers/gl/texture/uploaders/glUploadImageResource.ts
@@ -63,7 +63,7 @@ export const glUploadImageResource = {
                 );
             }
         }
-        else if (glWidth === textureWidth || glHeight === textureHeight)
+        else if (glWidth === textureWidth && glHeight === textureHeight)
         {
             gl.texSubImage2D(
                 gl.TEXTURE_2D,


### PR DESCRIPTION
Updated the condition for checking texture dimensions to ensure both width and height are equal, improving the accuracy of texture uploads.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
A little oversight on an if check in image uploader.

fixes #10866


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
