### PR TITLE
fix: advanced blend mode not applying when only belnd modes are active

### DIFF
--- a/src/rendering/renderers/shared/blendModes/BlendModePipe.ts
+++ b/src/rendering/renderers/shared/blendModes/BlendModePipe.ts
@@ -69,6 +69,15 @@ export class BlendModePipe implements InstructionPipe<AdvancedBlendInstruction>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.runners.prerender.add(this);
+    }
+
+    public prerender()
+    {
+        // make sure we reset the blend modes to normal
+        // this way the next render will register any changes
+        this._activeBlendMode = 'normal';
+        this._isAdvanced = false;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes an edgecase bug where if only a single advanced-blend-mode is used then the renderer was not rendering it correctly applied. 

fixes #11229

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
