### PR TITLE
match uv size if non is provided

### DIFF
--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -14,7 +14,7 @@ export interface MeshGeometryOptions
 {
     /** The positions of the mesh. */
     positions?: Float32Array;
-    /** The UVs of the mesh. */
+    /** The UVs of the mesh. If not provided, they will be filled with 0 and match the size of the positions. */
     uvs?: Float32Array;
     /** The indices of the mesh. */
     indices?: Uint32Array;

--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -63,7 +63,21 @@ export class MeshGeometry extends Geometry
         options = { ...MeshGeometry.defaultOptions, ...options };
 
         const positions = options.positions || new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
-        const uvs = options.uvs || new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+
+        let uvs = options.uvs;
+
+        if (!uvs)
+        {
+            if (options.positions)
+            {
+                uvs = new Float32Array(positions.length);
+            }
+            else
+            {
+                uvs = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+            }
+        }
+
         const indices = options.indices || new Uint32Array([0, 1, 2, 0, 2, 3]);
 
         const shrinkToFit = options.shrinkBuffersToFit;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Fixes a little issue, where if only positions are provided when creating a `MeshGeometry`  the uvs are an incorrect size and the geometry does not render correctly.

fixes #11207 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
