### PR TITLE
feat: add configurable props to `AnimatedSpriteOptions`

### DIFF
--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -12,7 +12,7 @@ export type AnimatedSpriteFrames = Texture[] | FrameObject[];
  * @see {@link scene.AnimatedSprite}
  * @memberof scene
  */
-export interface AnimatedSpriteOptions extends SpriteOptions
+export interface AnimatedSpriteOptions extends Omit<SpriteOptions, 'texture'>
 {
     /** The speed that the AnimatedSprite will play at. Higher is faster, lower is slower. */
     animationSpeed?: number;

--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -14,10 +14,24 @@ export type AnimatedSpriteFrames = Texture[] | FrameObject[];
  */
 export interface AnimatedSpriteOptions extends SpriteOptions
 {
-    /** An array of {@link Texture} or frame objects that make up the animation. */
-    textures: AnimatedSpriteFrames;
+    /** The speed that the AnimatedSprite will play at. Higher is faster, lower is slower. */
+    animationSpeed?: number;
     /** Whether to use Ticker.shared to auto update animation time. */
     autoUpdate?: boolean;
+    /** Whether or not the animate sprite repeats after playing. */
+    loop?: boolean;
+    /** User-assigned function to call when an AnimatedSprite finishes playing. */
+    onComplete?: () => void;
+    /** User-assigned function to call when an AnimatedSprite changes which texture is being rendered. */
+    onFrameChange?: (currentFrame: number) => void;
+    /**
+     * User-assigned function to call when `loop` is true, and an AnimatedSprite is played and loops around to start again.
+     */
+    onLoop?: () => void;
+    /** An array of {@link Texture} or frame objects that make up the animation. */
+    textures: AnimatedSpriteFrames;
+    /** Update anchor to [Texture's defaultAnchor]{@link Texture#defaultAnchor} when frame changes. */
+    updateAnchor?: boolean;
 }
 
 /**
@@ -149,7 +163,17 @@ export class AnimatedSprite extends Sprite
             };
         }
 
-        const { textures, autoUpdate, ...rest } = options;
+        const {
+            animationSpeed = 1,
+            autoUpdate = true,
+            loop = true,
+            onComplete = null,
+            onFrameChange = null,
+            onLoop = null,
+            textures,
+            updateAnchor = false,
+            ...rest
+        } = options;
         const [firstFrame] = textures;
 
         super({
@@ -159,15 +183,15 @@ export class AnimatedSprite extends Sprite
 
         this._textures = null;
         this._durations = null;
-        this._autoUpdate = autoUpdate ?? true;
+        this._autoUpdate = autoUpdate;
         this._isConnectedToTicker = false;
 
-        this.animationSpeed = 1;
-        this.loop = true;
-        this.updateAnchor = false;
-        this.onComplete = null;
-        this.onFrameChange = null;
-        this.onLoop = null;
+        this.animationSpeed = animationSpeed;
+        this.loop = loop;
+        this.updateAnchor = updateAnchor;
+        this.onComplete = onComplete;
+        this.onFrameChange = onFrameChange;
+        this.onLoop = onLoop;
 
         this._currentTime = 0;
 


### PR DESCRIPTION
##### Description of change
Adds several of `AnimatedSprite`'s configurable options to its constructor options. This allows the following properties to be set when creating a new `AnimatedSprite`:
* `animationSpeed`
* `loop`
* `onComplete`
* `onFrameChange`
* `onLoop`
* `updateAnchor`

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
