### PR TITLE
feat: add `autoPlay` to `AnimatedSprite`

### DIFF
--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -16,6 +16,8 @@ export interface AnimatedSpriteOptions extends Omit<SpriteOptions, 'texture'>
 {
     /** The speed that the AnimatedSprite will play at. Higher is faster, lower is slower. */
     animationSpeed?: number;
+    /** Whether to start the animation immediately on creation. */
+    autoPlay?: boolean;
     /** Whether to use Ticker.shared to auto update animation time. */
     autoUpdate?: boolean;
     /** Whether or not the animate sprite repeats after playing. */
@@ -165,6 +167,7 @@ export class AnimatedSprite extends Sprite
 
         const {
             animationSpeed = 1,
+            autoPlay = false,
             autoUpdate = true,
             loop = true,
             onComplete = null,
@@ -199,6 +202,11 @@ export class AnimatedSprite extends Sprite
         this._previousFrame = null;
 
         this.textures = textures;
+
+        if (autoPlay)
+        {
+            this.play();
+        }
     }
 
     /** Stops the AnimatedSprite. */

--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -362,7 +362,7 @@ export class AnimatedSprite extends Sprite
 
         this.texture = this._textures[currentFrame];
 
-        if (this.updateAnchor)
+        if (this.updateAnchor && this.texture.defaultAnchor)
         {
             this.anchor.copyFrom(this.texture.defaultAnchor);
         }

--- a/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
+++ b/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
@@ -11,17 +11,19 @@ describe('AnimatedSprite', () =>
 {
     describe('instance', () =>
     {
+        let animationSpeed: number;
         let textures: Texture[];
         let sprite: AnimatedSprite;
 
         beforeEach(() =>
         {
+            animationSpeed = 1;
             textures = [Texture.EMPTY];
         });
 
         afterEach(() =>
         {
-            expect(sprite.animationSpeed).toEqual(1);
+            expect(sprite.animationSpeed).toEqual(animationSpeed);
             expect(sprite.loop).toBe(true);
             expect(sprite.onComplete).toBeNull();
             expect(sprite.onFrameChange).toBeNull();
@@ -58,6 +60,25 @@ describe('AnimatedSprite', () =>
             expect(sprite['_autoUpdate']).toBe(true);
             sprite.autoUpdate = false;
             expect(sprite['_autoUpdate']).toBe(false);
+        });
+
+        it('should be correct with animationSpeed', () =>
+        {
+            animationSpeed = 0.5;
+            sprite = new AnimatedSprite({ textures, animationSpeed });
+            expect(sprite.animationSpeed).toBe(0.5);
+        });
+
+        it('should be correct with loop', () =>
+        {
+            sprite = new AnimatedSprite({ textures, loop: true });
+            expect(sprite.loop).toBe(true);
+        });
+
+        it('should be correct with updateAnchor', () =>
+        {
+            sprite = new AnimatedSprite({ textures, updateAnchor: true });
+            expect(sprite.updateAnchor).toBe(true);
         });
     });
 

--- a/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
+++ b/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
@@ -12,12 +12,14 @@ describe('AnimatedSprite', () =>
     describe('instance', () =>
     {
         let animationSpeed: number;
+        let isAutoPlay: boolean;
         let textures: Texture[];
         let sprite: AnimatedSprite;
 
         beforeEach(() =>
         {
             animationSpeed = 1;
+            isAutoPlay = false;
             textures = [Texture.EMPTY];
         });
 
@@ -28,7 +30,7 @@ describe('AnimatedSprite', () =>
             expect(sprite.onComplete).toBeNull();
             expect(sprite.onFrameChange).toBeNull();
             expect(sprite.onLoop).toBeNull();
-            expect(sprite.playing).toBe(false);
+            expect(sprite.playing).toBe(isAutoPlay);
 
             sprite.destroy();
             sprite = null;
@@ -67,6 +69,13 @@ describe('AnimatedSprite', () =>
             animationSpeed = 0.5;
             sprite = new AnimatedSprite({ textures, animationSpeed });
             expect(sprite.animationSpeed).toBe(0.5);
+        });
+
+        it('should be correct with autoPlay', () =>
+        {
+            isAutoPlay = true;
+            sprite = new AnimatedSprite({ textures, autoPlay: isAutoPlay });
+            expect(sprite['_playing']).toBe(true);
         });
 
         it('should be correct with loop', () =>


### PR DESCRIPTION
##### Description of change
Adds `autoPlay` to the constructor options of `AnimatedSprite`. Passing this when creating an `AnimatedSprite` allows the animation to be started without having to call `.play()` after instantiation.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
