### PR TITLE
fix: tiling sprite and nine slice sprite bounds being negative

### DIFF
--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -352,11 +352,11 @@ export class NineSliceSprite extends ViewContainer implements View
         const width = this._width;
         const height = this._height;
 
-        bounds.maxX = -anchor._x * width;
-        bounds.minX = bounds.maxX + width;
+        bounds.minX = -anchor._x * width;
+        bounds.maxX = bounds.minX + width;
 
-        bounds.maxY = -anchor._y * height;
-        bounds.minY = bounds.maxY + height;
+        bounds.minY = -anchor._y * height;
+        bounds.maxY = bounds.minY + height;
     }
 }
 

--- a/src/scene/sprite-nine-slice/NineSliceSpriteMixins.d.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpriteMixins.d.ts
@@ -1,0 +1,12 @@
+declare global
+{
+    namespace PixiMixins
+    {
+        interface RendererPipes
+        {
+            nineSliceSprite: import('./NineSliceSpritePipe').NineSliceSpritePipe;
+        }
+    }
+}
+
+export {};

--- a/src/scene/sprite-nine-slice/__tests__/NineSliceSprite.test.ts
+++ b/src/scene/sprite-nine-slice/__tests__/NineSliceSprite.test.ts
@@ -1,16 +1,15 @@
 import { Bounds } from '../../container/bounds/Bounds';
 import { getGlobalBounds } from '../../container/bounds/getGlobalBounds';
-import { Container } from '../../container/Container';
-import { TilingSprite } from '../TilingSprite';
-import '../init';
+import { NineSliceSprite } from '../NineSliceSprite';
 import '../../mesh/init';
-import { getTexture, getWebGLRenderer } from '@test-utils';
+import '../init';
+import { getTexture } from '@test-utils';
 import { Point } from '~/maths';
 import { Texture } from '~/rendering';
 
 import type { TextureSource } from '~/rendering';
 
-describe('TilingSprite', () =>
+describe('NineSliceSprite', () =>
 {
     type SetupOptions = {
         texture: Texture;
@@ -26,7 +25,7 @@ describe('TilingSprite', () =>
     {
         const { texture, source, width = 256, height = 256, x = 0, y = 0, anchor = { x: 0, y: 0 } } = options;
 
-        const sprite = new TilingSprite({
+        const sprite = new NineSliceSprite({
             texture: texture ?? new Texture({ source }),
             width,
             height,
@@ -65,48 +64,14 @@ describe('TilingSprite', () =>
 
         it('should not throw when destroyed', () =>
         {
-            const sprite = new TilingSprite();
+            const sprite = new NineSliceSprite({ texture: getTexture({ width: 256, height: 256 }) });
 
             expect(() => sprite.destroy()).not.toThrow();
         });
 
-        it('should clean up correctly on the pipe and system when destroyed using simple render', async () =>
-        {
-            const renderer = await getWebGLRenderer();
-
-            const container = new Container();
-
-            const sprite = new TilingSprite({
-                texture: getTexture({ width: 256, height: 256 })
-            });
-
-            container.addChild(sprite);
-
-            renderer.render({ container });
-
-            const renderData = renderer.renderPipes.tilingSprite['_tilingSpriteDataHash'][sprite.uid];
-
-            expect(renderData).not.toBeNull();
-
-            expect(renderData.shader).toBeUndefined();
-            expect(renderData.batchableMesh).not.toBeNull();
-
-            sprite.texture = getTexture({ width: 10, height: 10 });
-
-            renderer.render({ container });
-
-            expect(renderData.shader).not.toBeNull();
-
-            sprite.destroy();
-
-            expect(renderer.renderPipes.tilingSprite['_tilingSpriteDataHash'][sprite.uid]).toBeNull();
-
-            expect(sprite.texture).toBeNull();
-        });
-
         it('should global bounds to be correct', async () =>
         {
-            const sprite = new TilingSprite({
+            const sprite = new NineSliceSprite({
                 texture: getTexture({ width: 256, height: 256 })
             });
 
@@ -123,7 +88,7 @@ describe('TilingSprite', () =>
     {
         it('should have the correct bounds', async () =>
         {
-            const sprite = new TilingSprite({
+            const sprite = new NineSliceSprite({
                 texture: getTexture({ width: 256, height: 256 }),
                 anchor: 0.5
             });
@@ -196,16 +161,6 @@ describe('TilingSprite', () =>
             const sprite = setup({ texture });
 
             expect(sprite.texture).toEqual(texture);
-        });
-
-        it('should use empty texture when no texture passed', () =>
-        {
-            const tilingSprite = new TilingSprite({
-                width: 1,
-                height: 1,
-            });
-
-            expect(tilingSprite.texture).toEqual(Texture.EMPTY);
         });
     });
 

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -35,7 +35,7 @@ export interface TilingSpriteOptions extends ContainerOptions
      * The anchor point of the sprite
      * @default {x: 0, y: 0}
      */
-    anchor?: PointData
+    anchor?: PointData | number;
     /**
      * The offset of the image that is being tiled.
      * @default {x: 0, y: 0}
@@ -426,11 +426,11 @@ export class TilingSprite extends ViewContainer implements View, Instruction
         const width = this._width;
         const height = this._height;
 
-        bounds.maxX = -anchor._x * width;
-        bounds.minX = bounds.maxX + width;
+        bounds.minX = -anchor._x * width;
+        bounds.maxX = bounds.minX + width;
 
-        bounds.maxY = -anchor._y * height;
-        bounds.minY = bounds.maxY + height;
+        bounds.minY = -anchor._y * height;
+        bounds.maxY = bounds.minY + height;
     }
 
     /**

--- a/types/PixiMixins.d.ts
+++ b/types/PixiMixins.d.ts
@@ -7,6 +7,7 @@
 /// <reference path="../src/scene/graphics/GraphicsMixins.d.ts" />
 /// <reference path="../src/scene/mesh/MeshMixins.d.ts" />
 /// <reference path="../src/scene/sprite-tiling/TilingSpriteMixins.d.ts" />
+/// <reference path="../src/scene/sprite-nine-slice/NineSliceSpriteMixins.d.ts" />
 /// <reference path="../src/scene/text/TextMixins.d.ts" />
 /// <reference path="../src/scene/text-bitmap/TextBitmapMixins.d.ts" />
 /// <reference path="../src/scene/text-html/TextHTMLMixins.d.ts" />


### PR DESCRIPTION
This pull request focuses on fixing the bounds calculation and enhancing the test coverage for the `NineSliceSprite` and `TilingSprite` classes.

### Bounds Calculation Fixes:
* [`src/scene/sprite-nine-slice/NineSliceSprite.ts`](diffhunk://#diff-a4e272501ec4d6d11a1e7a36db50ea22626b8a5da500d9a4c234dfba174a050dL355-R359): Corrected the calculation of `minX`, `maxX`, `minY`, and `maxY` to ensure accurate bounds for the `NineSliceSprite` class.
* [`src/scene/sprite-tiling/TilingSprite.ts`](diffhunk://#diff-61def0fe2af7c28af1990483047578d8b9abcaaba48a626c0a65877f8c11660cL429-R433): Adjusted the calculation of `minX`, `maxX`, `minY`, and `maxY` to fix the bounds for the `TilingSprite` class.

### Test Enhancements:
* [`src/scene/sprite-nine-slice/__tests__/NineSliceSprite.test.ts`](diffhunk://#diff-d230732fb0b9c4a83afbe74da8898d945a6204b2a01e70a10d176b834804cb02R1-R183): Added comprehensive tests for the `NineSliceSprite` class, covering constructor arguments, destruction, bounds calculation, geometry transformations, point containment, dimension setting, texture construction, and anchor updates.
* [`src/scene/sprite-tiling/__tests__/TilingSprite.test.ts`](diffhunk://#diff-2987400928c0095b6c1377a8a383dc4a8f4834aaa5b586cc99271dcb1ebc2714R124-R135): Included a test to verify the bounds of the `TilingSprite` class.

### Interface Updates:
* [`src/scene/sprite-tiling/TilingSprite.ts`](diffhunk://#diff-61def0fe2af7c28af1990483047578d8b9abcaaba48a626c0a65877f8c11660cL38-R38): Updated the `anchor` property in the `TilingSpriteOptions` interface to accept either `PointData` or `number` to match signature of other leaf nodes.
