### PR TITLE
fix: html text being removed by GC

### DIFF
--- a/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
@@ -250,9 +250,7 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
         // versus ones that haven't been rendered recently.
         // The instruction set also gets updated with this tick value to track
         // when its renderables were last used.
-        container.renderGroup.gcTick = renderableGCTick++;
-
-        this._updateInstructionGCTick(container.renderGroup, container.renderGroup.gcTick);
+        this._updateInstructionGCTick(container.renderGroup, renderableGCTick++);
     }
 
     /**
@@ -360,6 +358,7 @@ export class RenderableGCSystem implements System<RenderableGCSystemOptions>
     private _updateInstructionGCTick(renderGroup: RenderGroup, gcTick: number): void
     {
         renderGroup.instructionSet.gcTick = gcTick;
+        renderGroup.gcTick = gcTick;
 
         for (const child of renderGroup.renderGroupChildren)
         {

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -209,6 +209,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
         htmlText._resolution = htmlText._autoResolution ? this._renderer.resolution : htmlText.resolution;
         this._gpuText[htmlText.uid] = gpuTextData;
+        this._updateText(htmlText);
         // TODO perhaps manage this outside this pipe? (a bit like how we update / add)
         htmlText.on('destroyed', this._destroyRenderableBound);
 


### PR DESCRIPTION
fixes: #11244

This PR fixes two issue, one being that if you made a new render group the `gcTick` was never being updated which meant the renderables inside of it would be constantly tidied up and the second issue is we now make sure that we regenerate the html text texture after it has been tidied up by the renderable gc.