### PR TITLE
chore: Rename "returnTexture" to "addTexture"

### DIFF
--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -376,7 +376,7 @@ export class FilterSystem implements System
             filters[0].apply(this, inputTexture, filterData.previousRenderSurface, false);
 
             // return the texture to the pool so we can reuse the next frame
-            TexturePool.returnTexture(inputTexture);
+            TexturePool.addTexture(inputTexture);
         }
         else
         {
@@ -407,14 +407,14 @@ export class FilterSystem implements System
             filters[i].apply(this, flip, filterData.previousRenderSurface, false);
 
             // return those textures for later!
-            TexturePool.returnTexture(flip);
-            TexturePool.returnTexture(flop);
+            TexturePool.addTexture(flip);
+            TexturePool.addTexture(flop);
         }
 
         // if we made a background texture, lets return that also
         if (filterData.blendRequired)
         {
-            TexturePool.returnTexture(backTexture);
+            TexturePool.addTexture(backTexture);
         }
     }
 

--- a/src/filters/defaults/blur/BlurFilter.ts
+++ b/src/filters/defaults/blur/BlurFilter.ts
@@ -137,7 +137,7 @@ export class BlurFilter extends Filter
             this.blurYFilter.blendMode = this.blendMode;
             this.blurYFilter.apply(filterManager, tempTexture, output, clearMode);
 
-            TexturePool.returnTexture(tempTexture);
+            TexturePool.addTexture(tempTexture);
         }
         else if (yStrength)
         {

--- a/src/filters/defaults/blur/BlurFilterPass.ts
+++ b/src/filters/defaults/blur/BlurFilterPass.ts
@@ -124,7 +124,7 @@ export class BlurFilterPass extends Filter
 
             this._state.blend = true;
             filterManager.applyFilter(this, flip, output, clearMode);
-            TexturePool.returnTexture(tempTexture);
+            TexturePool.addTexture(tempTexture);
         }
     }
 

--- a/src/rendering/mask/alpha/AlphaMaskPipe.ts
+++ b/src/rendering/mask/alpha/AlphaMaskPipe.ts
@@ -248,7 +248,7 @@ export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
 
             if (renderMask)
             {
-                TexturePool.returnTexture(maskData.filterTexture);
+                TexturePool.addTexture(maskData.filterTexture);
             }
 
             BigPool.return(maskData.filterEffect);

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -1,4 +1,5 @@
 import { nextPow2 } from '../../../../maths/misc/pow2';
+import { deprecation } from '../../../../utils/logging/deprecation';
 import { TextureSource } from './sources/TextureSource';
 import { Texture } from './Texture';
 
@@ -133,11 +134,23 @@ export class TexturePoolClass
      * Place a render texture back into the pool.
      * @param renderTexture - The renderTexture to free
      */
-    public returnTexture(renderTexture: Texture): void
+    public addTexture(renderTexture: Texture): void
     {
         const key = this._poolKeyHash[renderTexture.uid];
 
         this._texturePool[key].push(renderTexture);
+    }
+
+    /**
+     * @deprecated since 8.9.0
+     * @param renderTexture
+     */
+    public returnTexture(renderTexture: Texture): void
+    {
+        // #if _DEBUG
+        deprecation('8.9.0', 'TexturePool.returnTexture is deprecated use TexturePool.addTexture');
+        // #endif
+        this.addTexture(renderTexture);
     }
 
     /**

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -150,7 +150,7 @@ export class RenderGroup implements Instruction
         this.isCachedAsTexture = false;
         if (this.texture)
         {
-            TexturePool.returnTexture(this.texture);
+            TexturePool.addTexture(this.texture);
             this.texture = null;
         }
     }

--- a/src/scene/container/RenderGroupSystem.ts
+++ b/src/scene/container/RenderGroupSystem.ts
@@ -132,7 +132,7 @@ export class RenderGroupSystem implements System
 
                 if (renderGroup.texture)
                 {
-                    TexturePool.returnTexture(renderGroup.texture);
+                    TexturePool.addTexture(renderGroup.texture);
                 }
 
                 const renderer = this._renderer;
@@ -160,7 +160,7 @@ export class RenderGroupSystem implements System
         }
         else if (renderGroup.texture)
         {
-            TexturePool.returnTexture(renderGroup.texture);
+            TexturePool.addTexture(renderGroup.texture);
             renderGroup.texture = null;
         }
     }

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -204,7 +204,7 @@ export class HTMLTextSystem implements System
 
     private _cleanUp(activeTexture: HTMLTextTexture)
     {
-        TexturePool.returnTexture(activeTexture.texture);
+        TexturePool.addTexture(activeTexture.texture);
         activeTexture.texture.source.resource = null;
         activeTexture.texture.source.uploadMethodId = 'unknown';
     }

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -178,7 +178,7 @@ export class CanvasTextSystem implements System
      * Handy if you are done with a texture and want to return it to the pool.
      * @param texture - The texture to be returned.
      */
-    public returnTexture(texture: Texture)
+    public addTexture(texture: Texture)
     {
         const source = texture.source;
 
@@ -186,7 +186,19 @@ export class CanvasTextSystem implements System
         source.uploadMethodId = 'unknown';
         source.alphaMode = 'no-premultiply-alpha';
 
-        TexturePool.returnTexture(texture);
+        TexturePool.addTexture(texture);
+    }
+
+    /**
+     * @deprecated since 8.9.0
+     * @param texture
+     */
+    public returnTexture(texture: Texture)
+    {
+        // #if _DEBUG
+        deprecation('8.9.0', 'CanvasTextSystem.returnTexture is deprecated use CanvasTextSystem.addTexture');
+        // #endif
+        this.addTexture(texture);
     }
 
     public decreaseReferenceCount(textKey: string)
@@ -199,7 +211,7 @@ export class CanvasTextSystem implements System
         {
             CanvasPool.returnCanvasAndContext(activeTexture.canvasAndContext);
 
-            this.returnTexture(activeTexture.texture);
+            this.addTexture(activeTexture.texture);
 
             this._activeTextures[textKey] = null;
         }


### PR DESCRIPTION
Follow-up to #11269 

### Changed

* Renames `returnTexture` to `addTexture` in `CanvasTextSystem`
* Renames `returnTexture` to `addTexture` in `TexturePool`

### Rationale

The method name `returnTexture` is somewhat confusing because the method doesn't actually `return` any value. The verb here means "return this to the pool" but is a little overload in the context of a JavaScript function. A better approach is `addTexture`, as it "add this to the pool". We use this verb heavily in PixiJS already e.g., "addChild", "addGroup", "addAttribute", "addManifest", etc.