### PR TITLE
ShapeBuilder.build > boolean

### DIFF
--- a/src/scene/graphics/shared/buildCommands/ShapeBuildCommand.ts
+++ b/src/scene/graphics/shared/buildCommands/ShapeBuildCommand.ts
@@ -4,7 +4,7 @@ import type { ShapePrimitive } from '../../../../maths/shapes/ShapePrimitive';
 export interface ShapeBuildCommand<T extends ShapePrimitive = ShapePrimitive>
 {
     extension: ExtensionMetadataDetails
-    build(shape: T, points: number[]): void;
+    build(shape: T, points: number[]): boolean;
     triangulate(
         points: number[],
         vertices: number[],

--- a/src/scene/graphics/shared/buildCommands/buildCircle.ts
+++ b/src/scene/graphics/shared/buildCommands/buildCircle.ts
@@ -20,7 +20,7 @@ export const buildCircle: ShapeBuildCommand<RoundedShape> = {
         name: 'circle',
     },
 
-    build(shape: RoundedShape, points: number[])
+    build(shape: RoundedShape, points: number[]): boolean
     {
         let x;
         let y;
@@ -65,7 +65,7 @@ export const buildCircle: ShapeBuildCommand<RoundedShape> = {
 
         if (!(rx >= 0 && ry >= 0 && dx >= 0 && dy >= 0))
         {
-            return points;
+            return false;
         }
 
         // Choose a number of segments such that the maximum absolute deviation from the circle is approximately 0.029
@@ -74,7 +74,7 @@ export const buildCircle: ShapeBuildCommand<RoundedShape> = {
 
         if (m === 0)
         {
-            return points;
+            return false;
         }
 
         if (n === 0)
@@ -84,7 +84,7 @@ export const buildCircle: ShapeBuildCommand<RoundedShape> = {
             points[2] = points[4] = x - dx;
             points[5] = points[7] = y - dy;
 
-            return points;
+            return true;
         }
 
         let j1 = 0;
@@ -153,7 +153,7 @@ export const buildCircle: ShapeBuildCommand<RoundedShape> = {
             points[--j4] = x2;
         }
 
-        return points;
+        return true;
     },
 
     triangulate(points, vertices, verticesStride, verticesOffset, indices, indicesOffset)

--- a/src/scene/graphics/shared/buildCommands/buildPolygon.ts
+++ b/src/scene/graphics/shared/buildCommands/buildPolygon.ts
@@ -19,14 +19,14 @@ export const buildPolygon: ShapeBuildCommand<Polygon> = {
         name: 'polygon',
     },
 
-    build(shape: Polygon, points: number[]): number[]
+    build(shape: Polygon, points: number[]): boolean
     {
         for (let i = 0; i < shape.points.length; i++)
         {
             points[i] = shape.points[i];
         }
 
-        return points;
+        return true;
     },
 
     triangulate(

--- a/src/scene/graphics/shared/buildCommands/buildRectangle.ts
+++ b/src/scene/graphics/shared/buildCommands/buildRectangle.ts
@@ -16,7 +16,7 @@ export const buildRectangle: ShapeBuildCommand<Rectangle> = {
         name: 'rectangle',
     },
 
-    build(shape: Rectangle, points: number[]): number[]
+    build(shape: Rectangle, points: number[]): boolean
     {
         const rectData = shape;
         const x = rectData.x;
@@ -26,7 +26,7 @@ export const buildRectangle: ShapeBuildCommand<Rectangle> = {
 
         if (!(width >= 0 && height >= 0))
         {
-            return points;
+            return false;
         }
 
         points[0] = x;
@@ -38,7 +38,7 @@ export const buildRectangle: ShapeBuildCommand<Rectangle> = {
         points[6] = x;
         points[7] = y + height;
 
-        return points;
+        return true;
     },
 
     triangulate(

--- a/src/scene/graphics/shared/buildCommands/buildTriangle.ts
+++ b/src/scene/graphics/shared/buildCommands/buildTriangle.ts
@@ -16,7 +16,7 @@ export const buildTriangle: ShapeBuildCommand<Triangle> = {
         name: 'triangle',
     },
 
-    build(shape: Triangle, points: number[]): number[]
+    build(shape: Triangle, points: number[]): boolean
     {
         points[0] = shape.x;
         points[1] = shape.y;
@@ -25,7 +25,7 @@ export const buildTriangle: ShapeBuildCommand<Triangle> = {
         points[4] = shape.x3;
         points[5] = shape.y3;
 
-        return points;
+        return true;
     },
 
     triangulate(

--- a/src/scene/graphics/shared/utils/buildContextBatches.ts
+++ b/src/scene/graphics/shared/utils/buildContextBatches.ts
@@ -87,18 +87,11 @@ function addTextureToGeometryData(
     }
 )
 {
-    const { vertices, uvs, indices } = geometryData;
-
-    const indexOffset = indices.length;
-    const vertOffset = vertices.length / 2;
-
     const points: number[] = [];
 
     const build = shapeBuilders.rectangle;
 
     const rect = tempRect;
-
-    const texture = data.image;
 
     rect.x = data.dx;
     rect.y = data.dy;
@@ -108,7 +101,15 @@ function addTextureToGeometryData(
     const matrix = data.transform;
 
     // TODO - this can be cached...
-    build.build(rect, points);
+    if (!build.build(rect, points))
+    {
+        return;
+    }
+
+    const { vertices, uvs, indices } = geometryData;
+
+    const indexOffset = indices.length;
+    const vertOffset = vertices.length / 2;
 
     if (matrix)
     {
@@ -117,6 +118,7 @@ function addTextureToGeometryData(
 
     build.triangulate(points, vertices, 2, vertOffset, indices, indexOffset);
 
+    const texture = data.image;
     const textureUvs = texture.uvs;
 
     uvs.push(
@@ -159,19 +161,21 @@ function addShapePathToGeometryData(
 
     shapePath.shapePrimitives.forEach(({ shape, transform: matrix, holes }) =>
     {
-        const indexOffset = indices.length;
-        const vertOffset = vertices.length / 2;
-
         const points: number[] = [];
-
         const build = shapeBuilders[shape.type];
-        let topology: Topology = 'triangle-list';
         // TODO - this can be cached...
         // TODO - THIS IS DONE TWICE!!!!!!
         // ONCE FOR STROKE AND ONCE FOR FILL
         // move to the ShapePath2D class itself?
 
-        build.build(shape, points);
+        if (!build.build(shape, points))
+        {
+            return;
+        }
+
+        const indexOffset = indices.length;
+        const vertOffset = vertices.length / 2;
+        let topology: Topology = 'triangle-list';
 
         if (matrix)
         {
@@ -264,9 +268,10 @@ function getHoleArrays(holePrimitives: ShapePrimitiveWithHoles[])
 
         const holeBuilder = shapeBuilders[holePrimitive.type] as ShapeBuildCommand;
 
-        holeBuilder.build(holePrimitive, holePoints);
-
-        holeArrays.push(holePoints);
+        if (holeBuilder.build(holePrimitive, holePoints))
+        {
+            holeArrays.push(holePoints);
+        }
     }
 
     return holeArrays;


### PR DESCRIPTION
ShapeBuilder includes 2 methods: build, triangulate. Using the build Rectangle example, we see that there is a check (width >= 0 && height >= 0). In this case, the points are not added, and then triangulate (which adds undefined) is performed and BatchableGraphics is created for the discarded primitive. I suggest an option in which build decides what to do with the primitive, and if it is incorrect, false will be returned. In this case, we will not add BatchableGraphics and run this primitive in pipe.
