### PR TITLE
fix: gif loader base64 path matching

### DIFF
--- a/src/gif/GifAsset.ts
+++ b/src/gif/GifAsset.ts
@@ -20,7 +20,7 @@ const GifAsset = {
     },
     loader: {
         name: 'gifLoader',
-        test: (url) => path.extname(url) === '.gif',
+        test: (url) => path.extname(url) === '.gif' || url.startsWith('data:image/gif'),
         load: async (url, asset) =>
         {
             const response = await DOMAdapter.get().fetch(url);

--- a/src/gif/__tests__/GifAsset.test.ts
+++ b/src/gif/__tests__/GifAsset.test.ts
@@ -1,6 +1,6 @@
 import { GifAsset } from '../GifAsset';
 import { GifSource } from '../GifSource';
-import { basePath } from '@test-utils';
+import { basePath, blobToBase64, toArrayBuffer } from '@test-utils';
 import { Assets } from '~/assets';
 import { extensions } from '~/extensions';
 
@@ -28,6 +28,26 @@ describe('GifSpriteLoader', () =>
     it('should load a gif file', async () =>
     {
         const test = await Assets.load<GifSource>({ alias: 'test', src: 'gif/example.gif' });
+
+        expect(test).toBeInstanceOf(GifSource);
+        expect(test.totalFrames).toBeGreaterThan(0);
+        expect(test.width).toBeGreaterThan(0);
+        expect(test.height).toBeGreaterThan(0);
+        expect(test.frames).toBeDefined();
+        expect(test.textures).toBeDefined();
+        await Assets.unload('test');
+        expect(test.frames).toBe(null);
+        expect(test.textures).toBe(null);
+    });
+
+    it('should load base64 gif file', async () =>
+    {
+        const arrayBuffer = toArrayBuffer('gif/example.gif');
+        const blob = new Blob([arrayBuffer], { type: 'image/gif' });
+
+        const base64Data = await blobToBase64(blob);
+
+        const test = await Assets.load<GifSource>({ alias: 'test', src: base64Data });
 
         expect(test).toBeInstanceOf(GifSource);
         expect(test.totalFrames).toBeGreaterThan(0);

--- a/tests/utils/blobToBase64.ts
+++ b/tests/utils/blobToBase64.ts
@@ -1,0 +1,28 @@
+function blobToBase64(blob: Blob)
+{
+    return new Promise((resolve, reject) =>
+    {
+        const reader = new FileReader();
+
+        reader.onloadend = () =>
+        {
+            if (typeof reader.result === 'string')
+            {
+                resolve(reader.result);
+            }
+            else
+            {
+                reject(new Error('Failed to convert blob to base64'));
+            }
+        };
+
+        reader.onerror = () =>
+        {
+            reject(new Error('Failed to convert blob to base64'));
+        };
+
+        reader.readAsDataURL(blob);
+    });
+}
+
+export { blobToBase64 };

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './async';
 export * from './basePath';
+export * from './blobToBase64';
 export * from './getApp';
 export * from './getGeometry';
 export * from './getGlProgram';


### PR DESCRIPTION
##### Description of change
Base64 gifs were not detected by the loader, this change fixes that. 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
