### PR TITLE
fix: Restore gl extensions state on context restore

### DIFF
--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -422,6 +422,7 @@ export class GlContextSystem implements System<ContextSystemOptions>
     /** Handles a restored webgl context. */
     protected handleContextRestored(): void
     {
+        this.getExtensions(); // restore extensions state
         this._renderer.runners.contextChange.emit(this.gl);
     }
 

--- a/tests/visual/scenes/compressed-textures/restore-context.scene.ts
+++ b/tests/visual/scenes/compressed-textures/restore-context.scene.ts
@@ -1,0 +1,23 @@
+import '~/compressed-textures/dds/init';
+import { Assets } from '~/assets';
+import { Sprite } from '~/scene';
+
+import type { TestScene } from '../../types';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should render compressed texture after context restore',
+    create: async (scene: Container, renderer: Renderer) =>
+    {
+        renderer?.context?.forceContextLoss();
+        const texture = await Assets.load('explosion_dxt5_mip.dds');
+
+        const sprite = new Sprite(texture);
+
+        sprite.width = 128;
+        sprite.height = 128;
+
+        scene.addChild(sprite);
+    },
+};

--- a/tests/visual/scenes/compressed-textures/restore-context.scene.ts
+++ b/tests/visual/scenes/compressed-textures/restore-context.scene.ts
@@ -10,7 +10,10 @@ export const scene: TestScene = {
     it: 'should render compressed texture after context restore',
     create: async (scene: Container, renderer: Renderer) =>
     {
-        renderer?.context?.forceContextLoss();
+        if ('context' in renderer)
+        {
+            renderer.context?.forceContextLoss();
+        }
         const texture = await Assets.load('explosion_dxt5_mip.dds');
 
         const sprite = new Sprite(texture);


### PR DESCRIPTION
##### Description of change
After restoring the context, you usually need to reactivate or reinitialize any WebGL extensions manually because they are not automatically restored.

This is related to https://github.com/pixijs/pixijs/issues/11247 and possibly another issues concerning context restoration.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
