### PR TITLE
fix: don't use alias for `PointData` import

### DIFF
--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -6,9 +6,9 @@ import { Texture } from '../../../../rendering/renderers/shared/texture/Texture'
 import { uid } from '../../../../utils/data/uid';
 import { deprecation } from '../../../../utils/logging/deprecation';
 import { definedProps } from '../../../container/utils/definedProps';
-import { type PointData } from '~/maths/point/PointData';
 
 import type { ColorSource } from '../../../../color/Color';
+import type { PointData } from '../../../../maths/point/PointData';
 import type { CanvasAndContext } from '../../../../rendering/renderers/shared/texture/CanvasPool';
 import type { TextureSpace } from '../FillTypes';
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Right now, aliases are not converted to relative imports during build. This causes invalid imports to appear in the final .d.ts files. One of them is the `PointData` import in `FillGradient` (you can see it [here](https://unpkg.com/browse/pixi.js@8.8.1/lib/scene/graphics/shared/fill/FillGradient.d.ts#L3), for example).

So I replaced the alias import of `PointData` with a relative one and also made it fully type-only

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)