### PR TITLE
fix: Ignore autoDensity for OffscreenCanvas

### DIFF
--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -8,7 +8,11 @@ import type { TextureSourceOptions } from './TextureSource';
 
 export interface CanvasSourceOptions extends TextureSourceOptions<ICanvas>
 {
-    /** should the canvas be resized to preserve its screen width and height regardless of the resolution of the renderer */
+    /**
+     * Should the canvas be resized to preserve its screen width and height regardless
+     * of the resolution of the renderer, this is only supported for HTMLCanvasElement
+     * and will be ignored if the canvas is an OffscreenCanvas.
+     */
     autoDensity?: boolean;
     /** if true, this canvas will be set up to be transparent where possible */
     transparent?: boolean;
@@ -62,7 +66,7 @@ export class CanvasSource extends TextureSource<ICanvas>
 
     public resizeCanvas()
     {
-        if (this.autoDensity)
+        if (this.autoDensity && 'style' in this.resource)
         {
             this.resource.style.width = `${this.width}px`;
             this.resource.style.height = `${this.height}px`;

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -18,6 +18,7 @@ import type { Texture } from '../texture/Texture';
  * @property {number} [height=600] - The height of the screen.
  * @property {ICanvas} [canvas] - The canvas to use as a view, optional.
  * @property {boolean} [autoDensity=false] - Resizes renderer view in CSS pixels to allow for resolutions other than 1.
+ *  This is only supported for HTMLCanvasElement and will be ignored if the canvas is an OffscreenCanvas.
  * @property {number} [resolution] - The resolution / device pixel ratio of the renderer.
  * @property {boolean} [antialias=false] - Whether to enable anti-aliasing. This may affect performance.
  * @property {boolean} [depth] -
@@ -48,6 +49,9 @@ export interface ViewSystemOptions
     view?: ICanvas;
     /**
      * Resizes renderer view in CSS pixels to allow for resolutions other than 1.
+     *
+     * This is only supported for HTMLCanvasElement
+     * and will be ignored if the canvas is an OffscreenCanvas.
      * @memberof rendering.SharedRendererOptions
      */
     autoDensity?: boolean;
@@ -130,6 +134,7 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
 
     /**
      * Whether CSS dimensions of canvas view should be resized to screen dimensions automatically.
+     * This is only supported for HTMLCanvasElement and will be ignored if the canvas is an OffscreenCanvas.
      * @member {boolean}
      */
     public get autoDensity(): boolean


### PR DESCRIPTION
Closes #10993 

### Changes

* Fixes startup crash (or calling `resizeCanvas()`) when using `autoDensity` with an OffscreenCanvas