### PR TITLE
feat: optimizing the BitmapFontManager.getLayout call

### DIFF
--- a/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
+++ b/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
@@ -15,6 +15,8 @@ export interface BitmapTextLayoutData
         spaceWidth: number
         spacesIndex: number[]
     }[];
+    originChars: string[];
+    font: AbstractBitmapFont<any>
 }
 
 export function getBitmapTextLayout(
@@ -35,7 +37,9 @@ export function getBitmapTextLayout(
             spaceWidth: 0,
             spacesIndex: [],
             chars: [],
-        }]
+        }],
+        originChars: chars,
+        font
     };
 
     layoutData.offsetY = font.baseLineOffset;

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -261,8 +261,8 @@ describe('Text', () =>
             });
 
             // answer locally is 99.999999999999 which is acceptable!
-            expect(text.width).toEqual(100);
-            expect(text.height).toEqual(100);
+            expect(text.width).toBeCloseTo(100, 5);
+            expect(text.height).toBeCloseTo(100, 5);
         });
     });
 


### PR DESCRIPTION
If you look at the logic of BitmapText (and SDF in particular), you can see the call to the layout operation of the same text several times (getBitmapTextLayout). This is a very good place to use the cache and, if possible, not create many new structures when composing text, but this is for the future.

Specifically, the current solution uses the idea of reducing the layout to one time, while we will immediately calculate the data for bounds. The cost of such a calculation is minimal. In addition, the size of the text (bounds) is the data that is needed for proper layout, and in most cases it always leads to repeated unnecessary layout. Moreover, the size is usually required before the first rendering, and in this case there is also a desire to save on calling getBitmapTextLayout again.

Additionally, we get isolation of the text layout from pipe. And the last one is the initGpuText function, which previously required a layout, without in any way marking that it has already been done.

I also changed the aesthetic code, which I just did not have - "should set width and height on the constructor"
