### PR TITLE
fix: reset premultiply alpha state on resetState call and update WebGL settings

### DIFF
--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -441,6 +441,12 @@ export class GlTextureSystem implements System, CanvasGenerator
         this._activeTextureLocation = -1;
         this._boundTextures.fill(Texture.EMPTY.source);
         this._boundSamplers = Object.create(null);
+
+        const gl = this._gl;
+
+        this._premultiplyAlpha = false;
+
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this._premultiplyAlpha);
     }
 }
 

--- a/src/rendering/renderers/shared/texture/__tests__/GLTextureSystem.test.ts
+++ b/src/rendering/renderers/shared/texture/__tests__/GLTextureSystem.test.ts
@@ -25,4 +25,23 @@ describe('GLTextureSystem', () =>
         expect(pixelInfo.width).toBe(texture.width);
         expect(pixelInfo.height).toBe(texture.height);
     });
+
+    it('should reset premultiply alpha state when resetState is called', async () =>
+    {
+        const renderer = await getWebGLRenderer({}) as WebGLRenderer;
+
+        const gl = renderer.gl;
+
+        // Force internal state to true (different from default)
+        renderer.texture['_premultiplyAlpha'] = true;
+
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+        // Call reset state
+        renderer.texture.resetState();
+
+        // Verify internal state was reset
+        expect(renderer.texture['_premultiplyAlpha']).toBe(false);
+
+        expect(gl.getParameter(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL)).toBe(false);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

fixes #11341

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
