### PR TITLE
chore: simplify text systems

### DIFF
--- a/src/scene/text-html/HTMLTextStyle.ts
+++ b/src/scene/text-html/HTMLTextStyle.ts
@@ -1,7 +1,6 @@
 /* eslint-disable accessor-pairs */
 import { warn } from '../../utils/logging/warn';
 import { TextStyle } from '../text/TextStyle';
-import { generateTextStyleKey } from '../text/utils/generateTextStyleKey';
 import { textStyleToCSS } from './utils/textStyleToCSS';
 
 import type { FillInput, StrokeInput } from '../graphics/shared/FillTypes';
@@ -71,13 +70,6 @@ export class HTMLTextStyle extends TextStyle
     get cssOverrides(): string[]
     {
         return this._cssOverrides;
-    }
-
-    protected override _generateKey(): string
-    {
-        this._styleKey = generateTextStyleKey(this) + this._cssOverrides.join('-');
-
-        return this._styleKey;
     }
 
     public update()

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -21,13 +21,6 @@ import type { PoolItem } from '../../utils/pool/Pool';
 import type { HTMLTextOptions } from './HTMLText';
 import type { FontCSSStyleOptions } from './utils/loadFontCSS';
 
-interface HTMLTextTexture
-{
-    texture: Texture,
-    usageCount: number,
-    promise: Promise<Texture>,
-}
-
 /**
  * System plugin to the renderer to manage HTMLText
  * @memberof rendering
@@ -50,8 +43,6 @@ export class HTMLTextSystem implements System
         fontWeight: 'normal',
     };
 
-    private _activeTextures: Record<string, HTMLTextTexture> = {};
-
     /**
      * WebGPU has a cors issue when uploading an image that is an SVGImage
      * To get around this we need to create a canvas draw the image to it and upload that instead.
@@ -66,52 +57,27 @@ export class HTMLTextSystem implements System
         this._createCanvas = renderer.type === RendererType.WEBGPU;
     }
 
+    /**
+     * @param options
+     * @deprecated Use getTexturePromise instead
+     */
     public getTexture(options: HTMLTextOptions): Promise<Texture>
     {
-        return this._buildTexturePromise(
-            options.text as string,
-            options.resolution,
-            options.style as HTMLTextStyle
-        );
+        return this.getTexturePromise(options);
     }
 
-    public getManagedTexture(
-        text: string,
-        resolution: number,
-        style: HTMLTextStyle,
-        textKey: string
-    ): Promise<Texture>
+    public getTexturePromise(options: HTMLTextOptions): Promise<Texture>
     {
-        if (this._activeTextures[textKey])
-        {
-            this._increaseReferenceCount(textKey);
-
-            return this._activeTextures[textKey].promise;
-        }
-
-        const promise = this._buildTexturePromise(text, resolution, style)
-            .then((texture) =>
-            {
-                this._activeTextures[textKey].texture = texture;
-
-                return texture;
-            });
-
-        this._activeTextures[textKey] = {
-            texture: null,
-            promise,
-            usageCount: 1,
-        };
-
-        return promise;
+        return this._buildTexturePromise(options);
     }
 
-    private async _buildTexturePromise(
+    private async _buildTexturePromise(options: {
         text: string,
-        resolution: number,
         style: HTMLTextStyle,
-    )
+        resolution: number,
+    })
     {
+        const { text, style, resolution } = options;
         const htmlTextData = BigPool.get(HTMLTextRenderData);
         const fontFamilies = extractFontFamilies(text, style);
         const fontCSS = await getFontCss(
@@ -162,60 +128,29 @@ export class HTMLTextSystem implements System
         return texture;
     }
 
-    private _increaseReferenceCount(textKey: string)
+    public returnTexturePromise(texturePromise: Promise<Texture>)
     {
-        this._activeTextures[textKey].usageCount++;
-    }
-
-    public decreaseReferenceCount(textKey: string)
-    {
-        const activeTexture = this._activeTextures[textKey];
-
-        // TODO SHOULD NOT BE NEEDED
-        if (!activeTexture) return;
-
-        activeTexture.usageCount--;
-
-        if (activeTexture.usageCount === 0)
+        texturePromise.then((texture) =>
         {
-            if (activeTexture.texture)
-            {
-                this._cleanUp(activeTexture);
-            }
-            else
-            {
-                // we did not resolve...
-                activeTexture.promise.then((texture) =>
-                {
-                    activeTexture.texture = texture;
-
-                    this._cleanUp(activeTexture);
-                }).catch(() =>
-                {
-                    // #if _DEBUG
-                    warn('HTMLTextSystem: Failed to clean texture');
-                    // #endif
-                });
-            }
-
-            this._activeTextures[textKey] = null;
-        }
+            this._cleanUp(texture);
+        }).catch(() =>
+        {
+            // #if _DEBUG
+            warn('HTMLTextSystem: Failed to clean texture');
+            // #endif
+        });
     }
 
-    private _cleanUp(activeTexture: HTMLTextTexture)
+    private _cleanUp(texture: Texture)
     {
-        TexturePool.returnTexture(activeTexture.texture);
-        activeTexture.texture.source.resource = null;
-        activeTexture.texture.source.uploadMethodId = 'unknown';
+        TexturePool.returnTexture(texture);
+        texture.source.resource = null;
+        texture.source.uploadMethodId = 'unknown';
     }
 
-    public getReferenceCount(textKey: string)
+    public destroy()
     {
-        return this._activeTextures[textKey].usageCount;
-    }
-
-    public destroy(): void
-    {
-        this._activeTextures = null;
+        // BOOM!
+        (this._renderer as null) = null;
     }
 }

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -317,11 +317,6 @@ export abstract class AbstractText<
         super.onViewUpdate();
     }
 
-    public _getKey(): string
-    {
-        return `${this.text}:${this._style.styleKey}:${this._resolution}`;
-    }
-
     /**
      * Destroys this text renderable and optionally its style texture.
      * @param options - Options parameter. A boolean will act as if all options

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -65,7 +65,7 @@ describe('Text', () =>
 
             const renderer = await getWebGLRenderer({ resolution: 2 });
 
-            const texture = renderer.canvasText.getManagedTexture(text);
+            const texture = renderer.canvasText.getTexture(text);
 
             expect(texture.source.resolution).toEqual(3);
 
@@ -157,14 +157,9 @@ describe('Text', () =>
             container.addChild(text);
             renderer.render({ container });
 
-            const key = text._getKey();
-
-            expect(renderer.canvasText['_activeTextures'][key].usageCount).toBe(1);
-
             text.destroy();
 
             expect(renderer.renderPipes.text['_gpuText'][text.uid]).toBeNull();
-            expect(renderer.canvasText['_activeTextures'][key]).toBeNull();
         });
 
         it('should destroy bitmap text correctly on the pipes and systems', async () =>

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -196,8 +196,6 @@ export class CanvasTextMetrics
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private static __context: ICanvasRenderingContext2D;
 
-    private static readonly _measurementCache: Record<string, CanvasTextMetrics> = {};
-
     /**
      * @param text - the text that was measured
      * @param style - the style that was measured
@@ -238,13 +236,6 @@ export class CanvasTextMetrics
         wordWrap: boolean = style.wordWrap,
     ): CanvasTextMetrics
     {
-        const textKey = `${text}:${style.styleKey}`;
-
-        // TODO - if we find this starts to go nuts with memory, we can remove the cache
-        // or instead just stick a usage tick that we increment each time we return it.
-        // if some are not used, we can just tidy them up!
-        if (CanvasTextMetrics._measurementCache[textKey]) return CanvasTextMetrics._measurementCache[textKey];
-
         const font = fontStringFromTextStyle(style);
         const fontProperties = CanvasTextMetrics.measureFont(font);
 
@@ -302,8 +293,6 @@ export class CanvasTextMetrics
             maxLineWidth,
             fontProperties
         );
-
-        // CanvasTextMetrics._measurementCache[textKey] = measurements;
 
         return measurements;
     }

--- a/tests/visual/scenes/text/html-text-loaded-font.scene.ts
+++ b/tests/visual/scenes/text/html-text-loaded-font.scene.ts
@@ -11,7 +11,7 @@ export const scene: TestScene = {
     {
         await Assets.load({ alias: 'Crosterian', src: 'fonts/Crosterian.woff2' });
 
-        const htmlTexture = await renderer.htmlText.getTexture({
+        const htmlTexture = await renderer.htmlText.getTexturePromise({
             text: '<red>Arial</red>\n<blue>load</blue>',
             resolution: 1,
             style: new HTMLTextStyle({

--- a/tests/visual/scenes/text/html-text.scene.ts
+++ b/tests/visual/scenes/text/html-text.scene.ts
@@ -8,7 +8,7 @@ export const scene: TestScene = {
     it: 'should render html-text correctly',
     create: async (scene: Container, renderer: Renderer) =>
     {
-        const htmlTexture = await renderer.htmlText.getTexture({
+        const htmlTexture = await renderer.htmlText.getTexturePromise({
             text: '<red>Red</red>\n<blue>Blue</blue>\n<green>Green</green>',
             resolution: 1,
             style: new HTMLTextStyle({


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Removed a chunk of code for text to simlify things a bit. Rather than ref count text textures, we just have one texture for one Text. This keeps things much simpler especially as generally text is rarely the same in real life. 

This step also paves the way for further simplification PR and removal of the need for renderableGCSystem.

- Removed the `_getKey` method from `AbstractText` and related texture management logic from `CanvasTextSystem`, `CanvasTextPipe`, and `HTMLTextPipe`.
- Updated texture retrieval methods to use promises for better async handling.
- Cleaned up tests to reflect changes in texture management and ensure proper rendering of HTML text.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
