### PR TITLE
fix default values on removeParticles logic

### DIFF
--- a/src/scene/particle-container/shared/ParticleContainer.ts
+++ b/src/scene/particle-container/shared/ParticleContainer.ts
@@ -300,10 +300,13 @@ export class ParticleContainer extends ViewContainer implements Instruction
      * @param endIndex - The ending position. Default value is size of the container.
      * @returns - List of removed particles
      */
-    public removeParticles(beginIndex?: number, endIndex?: number)
-    {
-        const children = this.particleChildren.splice(beginIndex, endIndex);
-
+    public removeParticles(beginIndex?: number, endIndex?: number) {
+        // Default beginIndex to 0 if not provided
+        const start = beginIndex ?? 0;
+        // Default endIndex to the length of particleChildren if not provided
+        const end = endIndex ?? this.particleChildren.length;
+        // Remove the correct range
+        const children = this.particleChildren.splice(start, end);
         this.onViewUpdate();
 
         return children;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change

Fix the `removeParticles` logic to match the description provided. We are now setting the endIndex to default to the container length

Closes #11357 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
