### PR TITLE
fix: Dom Container on scaled canvas

### DIFF
--- a/src/dom/DOMPipe.ts
+++ b/src/dom/DOMPipe.ts
@@ -122,7 +122,10 @@ export class DOMPipe implements RenderPipe<DOMContainer>
             canvas.parentNode?.appendChild(this._domElement);
         }
 
-        this._domElement.style.transform = `translate(${canvas.offsetLeft}px, ${canvas.offsetTop}px)`;
+        const scale = (parseFloat(canvas.style.height) / canvas.height) * this._renderer.resolution;
+
+        // scale according to the canvas scale and translate
+        this._domElement.style.transform = `translate(${canvas.offsetLeft}px, ${canvas.offsetTop}px) scale(${scale})`;
 
         for (let i = 0; i < attachedDomElements.length; i++)
         {


### PR DESCRIPTION
##### Description of change
This change fixes an issue in `DOMPipe` where DOM elements managed by `DOMContainer` would not be positioned correctly if the parent canvas element was scaled using CSS properties like `width` or `height`.

Previously, the container `div` for DOM elements was only translated based on the canvas `offsetLeft` and `offsetTop`. This fix introduces scaling to the container `div`'s transform. The scale factor is calculated based on the ratio of the canvas's CSS `style.height` to its `canvas.height`, multiplied by the renderer's resolution. This ensures that the DOM elements align correctly with the PixiJS scene, even when the canvas itself is scaled via CSS.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)