### PR TITLE
feat: add onRender option to Container interface and corresponding test

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -152,6 +152,8 @@ export interface ContainerOptions<C extends ContainerChild = ContainerChild> ext
     y?: number;
     /** @see scene.Container#boundArea */
     boundsArea?: Rectangle;
+    /** @see scene.Container#onRender */
+    onRender?: () => void;
 }
 
 export interface Container<C extends ContainerChild>

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -15,6 +15,14 @@ describe('Container', () =>
             expect(object.renderable).toBe(true);
             expect(object.visible).toBe(true);
         });
+
+        it('should allow setting onRender function via constructor', () =>
+        {
+            const mockOnRender = jest.fn();
+            const container = new Container({ onRender: mockOnRender });
+
+            expect(container.onRender).toBe(mockOnRender);
+        });
     });
 
     describe('setTransform', () =>


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
This change introduces the ability to provide an `onRender` callback function directly within the `Container` constructor options.

Previously, the `onRender` property could only be set after the `Container` instance was created. This update adds the `onRender` field to the `ContainerOptions` interface and ensures it is assigned during object instantiation. A corresponding unit test has been added to verify this new constructor behavior.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added <!-- Add 'x' if you updated JSDoc for ContainerOptions -->
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
