### PR TITLE
chore: Update BitmapFont.ts doc for 8.x

### DIFF
--- a/src/scene/text-bitmap/BitmapFont.ts
+++ b/src/scene/text-bitmap/BitmapFont.ts
@@ -113,7 +113,7 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
      * import { BitmapFont, BitmapText } from 'pixi.js';
      *
      * BitmapFont.install({
-     *     name: 'TitleFont', 
+     *     name: 'TitleFont',
      *     style: {
      *         fontFamily: 'Arial',
      *         fontSize: 12,

--- a/src/scene/text-bitmap/BitmapFont.ts
+++ b/src/scene/text-bitmap/BitmapFont.ts
@@ -112,11 +112,14 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
      * @example
      * import { BitmapFont, BitmapText } from 'pixi.js';
      *
-     * BitmapFont.install('TitleFont', {
-     *     fontFamily: 'Arial',
-     *     fontSize: 12,
-     *     strokeThickness: 2,
-     *     fill: 'purple',
+     * BitmapFont.install({
+     *     name: 'TitleFont', 
+     *     style: {
+     *         fontFamily: 'Arial',
+     *         fontSize: 12,
+     *         strokeThickness: 2,
+     *         fill: 'purple',
+     *     }
      * });
      *
      * const title = new BitmapText({ text: 'This is the title', fontFamily: 'TitleFont' });


### PR DESCRIPTION
##### Description of change
This updates the BitmapFont doc to match the new signature for 8.x. The `BitmapFont.install(...)` part of the example wasn't updated from 7.x.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
