### PR TITLE
Fix letter spacing support getter

### DIFF
--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -157,7 +157,7 @@ export class CanvasTextMetrics
     {
         let result = CanvasTextMetrics._experimentalLetterSpacingSupported;
 
-        if (result !== undefined)
+        if (result === undefined)
         {
             const proto = DOMAdapter.get().getCanvasRenderingContext2D().prototype;
 

--- a/src/scene/text/canvas/__tests__/CanvasTextMetrics.test.ts
+++ b/src/scene/text/canvas/__tests__/CanvasTextMetrics.test.ts
@@ -1,0 +1,16 @@
+import '~/environment-browser/browserAll';
+import { CanvasTextMetrics } from '../CanvasTextMetrics';
+
+describe('CanvasTextMetrics.experimentalLetterSpacingSupported', () =>
+{
+    it('should return a boolean on first call', () =>
+    {
+        CanvasTextMetrics._experimentalLetterSpacingSupported = undefined as any;
+
+        const result = CanvasTextMetrics.experimentalLetterSpacingSupported;
+
+        expect(typeof result).toBe('boolean');
+        expect(typeof CanvasTextMetrics._experimentalLetterSpacingSupported).toBe('boolean');
+        expect(CanvasTextMetrics._experimentalLetterSpacingSupported).toBe(result);
+    });
+});


### PR DESCRIPTION
## Summary
- fix conditional logic in `experimentalLetterSpacingSupported`
- ensure result cached to `_experimentalLetterSpacingSupported`
- add test verifying getter returns boolean on first call

## Testing
- `npm run test:unit` *(fails: EHOSTUNREACH when trying to download jest)*