### PR TITLE
fix: ObservablePoint toString

### DIFF
--- a/src/maths/__tests__/ObservablePoint.test.ts
+++ b/src/maths/__tests__/ObservablePoint.test.ts
@@ -46,5 +46,17 @@ describe('ObservablePoint', () =>
         p1.copyFrom(p3);
         expect(p1.y).toEqual(p3.y);
     });
+
+    it('should produce a debug string with coordinates', () =>
+    {
+        const cb = { _onUpdate: jest.fn() };
+        const pt = new ObservablePoint(cb, 3, 4);
+
+        expect(pt.toString()).toBe('[pixi.js/math:ObservablePoint x=3 y=4 scope=[object Object]]');
+
+        pt.set(5, 1);
+
+        expect(pt.toString()).toBe('[pixi.js/math:ObservablePoint x=5 y=1 scope=[object Object]]');
+    });
 });
 

--- a/src/maths/point/ObservablePoint.ts
+++ b/src/maths/point/ObservablePoint.ts
@@ -116,7 +116,7 @@ export class ObservablePoint implements PointLike
     // #if _DEBUG
     public toString(): string
     {
-        return `[pixi.js/math:ObservablePoint x=${0} y=${0} scope=${this._observer}]`;
+        return `[pixi.js/math:ObservablePoint x=${this._x} y=${this._y} scope=${this._observer}]`;
     }
     // #endif
 


### PR DESCRIPTION
## Summary
- add Jest spec checking `ObservablePoint.toString()` outputs current coordinates

## Testing
- `npm test` *(fails: run-s not found)*