### PR TITLE
feat: allow sharing device and adaptor with other engine

### DIFF
--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -42,6 +42,8 @@ export interface GpuContextOptions
      * @default false
      */
     forceFallbackAdapter: boolean;
+    /** Using shared device and adaptor from other engine */
+    gpu?: GPU;
 }
 
 /**
@@ -91,7 +93,7 @@ export class GpuDeviceSystem implements System<GpuContextOptions>
     {
         if (this._initPromise) return this._initPromise;
 
-        this._initPromise = this._createDeviceAndAdaptor(options)
+        this._initPromise = (options.gpu ? Promise.resolve(options.gpu) : this._createDeviceAndAdaptor(options))
             .then((gpu) =>
             {
                 this.gpu = gpu;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
By using webGPU, we can easily share canvas context in different engines without caring about state leak in webGL. However, it is impossible to share context in different devices and adaptors, so I added a new option to pass device and adaptor to Pixi.
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included 
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
