### PR TITLE
fix: HTMLTextStyle clone and css overrides assignment

### DIFF
--- a/src/scene/text-html/HTMLTextStyle.ts
+++ b/src/scene/text-html/HTMLTextStyle.ts
@@ -55,7 +55,7 @@ export class HTMLTextStyle extends TextStyle
     {
         super(options);
 
-        this.cssOverrides ??= options.cssOverrides;
+        this.cssOverrides = options.cssOverrides ?? [];
         this.tagStyles = options.tagStyles ?? {};
     }
 
@@ -101,6 +101,7 @@ export class HTMLTextStyle extends TextStyle
             wordWrap: this.wordWrap,
             wordWrapWidth: this.wordWrapWidth,
             cssOverrides: this.cssOverrides,
+            tagStyles: { ...this.tagStyles },
         });
     }
 

--- a/src/scene/text-html/__tests__/HTMLTextStyle.test.ts
+++ b/src/scene/text-html/__tests__/HTMLTextStyle.test.ts
@@ -105,4 +105,89 @@ describe('HTMLTextStyle', () =>
             expect(style.cssStyle).toMatchSnapshot();
         });
     });
+
+    describe('clone', () =>
+    {
+        it('should clone', () =>
+        {
+            const style = new HTMLTextStyle({
+                fontFamily: 'Times',
+                fontSize: 12,
+            });
+
+            const clone = style.clone();
+
+            expect(clone).toBeInstanceOf(HTMLTextStyle);
+            expect(clone.fontFamily).toBe('Times');
+            expect(clone.fontSize).toBe(12);
+        });
+
+        it('should clone css overrides', () =>
+        {
+            const style = new HTMLTextStyle({
+                fontFamily: 'Times',
+                fontSize: 12,
+            });
+
+            style.addOverride('color: red');
+
+            const clone = style.clone();
+
+            expect(clone.cssOverrides).toHaveLength(1);
+            expect(clone.cssOverrides[0]).toBe('color: red');
+
+            delete style.cssOverrides[0];
+            expect(clone.cssOverrides).toHaveLength(1);
+        });
+
+        it('should clone drop shadow', () =>
+        {
+            const style = new HTMLTextStyle({
+                fontFamily: 'Times',
+                fontSize: 12,
+                dropShadow: {
+                    color: 0xff0000,
+                    alpha: 1,
+                    blur: 2,
+                    angle: Math.PI / 4,
+                    distance: 5,
+                },
+            });
+
+            const clone = style.clone();
+
+            expect(clone.dropShadow).toEqual({
+                color: 0xff0000,
+                alpha: 1,
+                blur: 2,
+                angle: Math.PI / 4,
+                distance: 5,
+            });
+            expect(clone.dropShadow).not.toBe(style.dropShadow);
+        });
+
+        it('should clone tag styles', () =>
+        {
+            const style = new HTMLTextStyle({
+                fontFamily: 'Times',
+                fontSize: 12,
+                tagStyles: {
+                    red: {
+                        fontFamily: 'Arial',
+                        fontSize: 14,
+                    },
+                },
+            });
+
+            const clone = style.clone();
+
+            expect(clone.tagStyles).toEqual({
+                red: {
+                    fontFamily: 'Arial',
+                    fontSize: 14,
+                },
+            });
+            expect(clone.tagStyles).not.toBe(style.tagStyles);
+        });
+    });
 });


### PR DESCRIPTION
Fixes cloning of css overrides and tag styles in HTMLTextStyle.
Ensures that cloned styles have independent copies of css overrides
and tag styles.

Also, ensures that cssOverrides is initialized as an empty array
instead of relying on the nullish coalescing operator.
