### PR TITLE
fix: iOS issue loading video when autoplay is false and preload is true.

### DIFF
--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -214,7 +214,8 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
-            if (asset.data.preload && !asset.data.autoplay) {
+            if (asset.data.preload && !asset.data.autoplay)
+            {
                 videoElement.load();
             }
 

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -214,7 +214,7 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
-            if (options.preload && !options.autoplay)
+            if (options.preload && !options.autoPlay)
             {
                 videoElement.load();
             }

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -214,6 +214,10 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
+            if (asset.data.preload && !asset.data.autoplay) {
+                videoElement.load();
+            }
+
             videoElement.addEventListener('canplay', onCanPlay);
             videoElement.appendChild(sourceElement);
         });

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -214,7 +214,7 @@ export const loadVideoTextures = {
                 resolve(createTexture(base, loader, url));
             };
 
-            if (asset.data.preload && !asset.data.autoplay)
+            if (options.preload && !options.autoplay)
             {
                 videoElement.load();
             }


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
This fixes bug #10633, tested on both an iPad and iPhone. load() is not called on the video element at all when autoload is false and preload is true.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
