### PR TITLE
fix: reset transform when returning canvas to CanvasPool

### DIFF
--- a/src/rendering/renderers/shared/texture/CanvasPool.ts
+++ b/src/rendering/renderers/shared/texture/CanvasPool.ts
@@ -101,6 +101,7 @@ export class CanvasPoolClass
 
         const key = (width << 17) + (height << 1);
 
+        canvasAndContext.context.resetTransform();
         canvasAndContext.context.clearRect(0, 0, width, height);
 
         this._canvasPool[key].push(canvasAndContext);


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Resets the transform of contexts returned to the `CanvasPool`. 

When creating `DynamicBitmapFont`, the canvas context used is scaled to match the `resolution` option supplied. If this font is later destroyed, the canvas and context are returned to the `CanvasPool` for potential re-use. If the context gets re-used, the previous scale is still present. So if the previous font had a `resolution` other than 1, the scale ends up incorrect. 

Example: https://pixiplayground.com/#/edit/oz0ynP2N-YUMyLQ7ft1ae

In the example, the third font re-uses the canvas context from the second font, which already had a scale of 2, resulting in a scale of 4, and the font appearing incorrect.

I'm not sure if it's best to either reset the transform when returning the canvas, or to reset it before scaling in `DynamicBitmapFont` here.
https://github.com/pixijs/pixijs/blob/40dbf2442d11cc1016a61c17b3e0163168186991/src/scene/text-bitmap/DynamicBitmapFont.ts#L368
But most things using the CanvasPool seem to assume the contexts are clean, so it probably makes sense to do it on return. 

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
