### PR TITLE
Fix stable sort for extension priority

### DIFF
--- a/src/extensions/Extensions.ts
+++ b/src/extensions/Extensions.ts
@@ -1,3 +1,5 @@
+import { stableSort } from '../utils/data/stableSort';
+
 /**
  * Collection of valid extension types.
  * @category extensions
@@ -391,7 +393,7 @@ const extensions = {
                 if (index >= 0) return;
 
                 map.push({ name: extension.name, value: extension.ref });
-                map.sort((a, b) =>
+                stableSort(map, (a, b) =>
                     normalizeExtensionPriority(b.value, defaultPriority)
                     - normalizeExtensionPriority(a.value, defaultPriority));
             },
@@ -427,7 +429,7 @@ const extensions = {
                 }
 
                 list.push(extension.ref);
-                list.sort((a, b) =>
+                stableSort(list, (a, b) =>
                     normalizeExtensionPriority(b, defaultPriority) - normalizeExtensionPriority(a, defaultPriority));
             },
             (extension) =>

--- a/src/extensions/__tests__/extensions.test.ts
+++ b/src/extensions/__tests__/extensions.test.ts
@@ -105,6 +105,63 @@ describe('extensions', () =>
             expect(list[1]).toBe(ext1);
             expect(list[2]).toBe(ext3);
         });
+
+        it('should maintain insertion order when priorities are equal', () =>
+        {
+            const ext1 = {
+                extension: {
+                    priority: 1,
+                    type: exampleType,
+                },
+            };
+            const ext2 = {
+                extension: {
+                    priority: 1,
+                    type: exampleType,
+                },
+            };
+            const list: any[] = [];
+
+            extensions.handleByList(exampleType, list);
+            extensions.add(ext1);
+            extensions.add(ext2);
+
+            expect(list[0]).toBe(ext1);
+            expect(list[1]).toBe(ext2);
+
+            extensions.remove(ext1, ext2);
+        });
+    });
+
+    describe('handleByNamedList', () =>
+    {
+        it('should maintain insertion order for equal priority', () =>
+        {
+            const list: { name: string; value: any }[] = [];
+            const ext1 = {
+                extension: {
+                    priority: 1,
+                    name: 'a',
+                    type: exampleType,
+                },
+            };
+            const ext2 = {
+                extension: {
+                    priority: 1,
+                    name: 'b',
+                    type: exampleType,
+                },
+            };
+
+            extensions.handleByNamedList(exampleType, list);
+            extensions.add(ext1);
+            extensions.add(ext2);
+
+            expect(list[0].value).toBe(ext1);
+            expect(list[1].value).toBe(ext2);
+
+            extensions.remove(ext1, ext2);
+        });
     });
 
     describe('add', () =>

--- a/src/utils/data/stableSort.ts
+++ b/src/utils/data/stableSort.ts
@@ -1,0 +1,38 @@
+
+/**
+ * Stable in-place array sort that preserves the original
+ * order of equal elements. Useful for environments where
+ * `Array.sort` is unstable.
+ *
+ * @example
+ * ```ts
+ * const items = [
+ *     { id: 'a', priority: 1 },
+ *     { id: 'b', priority: 1 }
+ * ];
+ *
+ * stableSort(items, (a, b) => a.priority - b.priority);
+ * console.log(items.map(i => i.id)); // ['a', 'b']
+ * ```
+ *
+ * @param array - The array to sort.
+ * @param compareFn - Comparison function.
+ * @category utils
+ * @internal
+ */
+export function stableSort<T>(array: T[], compareFn: (a: T, b: T) => number): void
+{
+    const indexed = array.map((item, index) => ({ item, index }));
+
+    indexed.sort((a, b) =>
+    {
+        const result = compareFn(a.item, b.item);
+
+        return result === 0 ? a.index - b.index : result;
+    });
+
+    for (let i = 0; i < indexed.length; i++)
+    {
+        array[i] = indexed[i].item;
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,7 @@ export * from './const';
 export * from './data/clean';
 export * from './data/removeItems';
 export * from './data/uid';
+export * from './data/stableSort';
 export * from './data/updateQuadBounds';
 export * from './data/ViewableBuffer';
 export * from './global/globalHooks';


### PR DESCRIPTION
## Summary
- move `stableSort` to utils so it can be reused
- reference new helper from `Extensions` code
- export `stableSort` from the utils index
- document usage example for the helper

## Testing
- `npm test` *(fails: run-s not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842be66c0a48321967931ab724e0269