### PR TITLE
Add back filter clearMode from v5-v7

### DIFF
--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -78,6 +78,16 @@ export type FilterWithShader = FilterOptions & IShaderWithResources;
 export type FilterAntialias = 'on' | 'off' | 'inherit';
 
 /**
+ * Clear mode
+ * - `blend` - (same as false) filter output already has something drawn, we have to blend it
+ * - `clear` - (same as true) filter output should be cleared fully
+ * - `auto` - depends on the platform, output can be cleared or just copied into
+ * @category filters
+ * @advanced
+ */
+export type FilterClearMode = 'blend' | 'clear' | 'auto' | false | true;
+
+/**
  * The Filter class is the base for all filter effects used in Pixi.js
  * As it extends a shader, it requires that a glProgram is parsed in to work with WebGL and a gpuProgram for WebGPU.
  * If you don't proved one, then the filter is skipped and just rendered as if it wasn't there for that renderer.
@@ -222,7 +232,7 @@ export class Filter extends Shader
         filterManager: FilterSystem,
         input: Texture,
         output: RenderSurface,
-        clearMode: boolean
+        clearMode: FilterClearMode
     ): void
     {
         filterManager.applyFilter(this, input, output, clearMode);

--- a/src/filters/defaults/blur/BlurFilter.ts
+++ b/src/filters/defaults/blur/BlurFilter.ts
@@ -1,12 +1,11 @@
 import { TexturePool } from '../../../rendering/renderers/shared/texture/TexturePool';
 import { RendererType } from '../../../rendering/renderers/types';
 import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
-import { Filter } from '../../Filter';
+import { Filter, type FilterClearMode, type FilterOptions } from '../../Filter';
 import { BlurFilterPass } from './BlurFilterPass';
 
 import type { RenderSurface } from '../../../rendering/renderers/shared/renderTarget/RenderTargetSystem';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
-import type { FilterOptions } from '../../Filter';
 import type { FilterSystem } from '../../FilterSystem';
 
 /**
@@ -219,7 +218,7 @@ export class BlurFilter extends Filter
         filterManager: FilterSystem,
         input: Texture,
         output: RenderSurface,
-        clearMode: boolean
+        clearMode: FilterClearMode
     ): void
     {
         const xStrength = Math.abs(this.blurXFilter.strength);
@@ -230,7 +229,7 @@ export class BlurFilter extends Filter
             const tempTexture = TexturePool.getSameSizeTexture(input);
 
             this.blurXFilter.blendMode = 'normal';
-            this.blurXFilter.apply(filterManager, input, tempTexture, true);
+            this.blurXFilter.apply(filterManager, input, tempTexture, 'clear');
             this.blurYFilter.blendMode = this.blendMode;
             this.blurYFilter.apply(filterManager, tempTexture, output, clearMode);
 

--- a/src/filters/defaults/blur/BlurFilterPass.ts
+++ b/src/filters/defaults/blur/BlurFilterPass.ts
@@ -1,6 +1,5 @@
 import { TexturePool } from '../../../rendering/renderers/shared/texture/TexturePool';
-import { RendererType } from '../../../rendering/renderers/types';
-import { Filter } from '../../Filter';
+import { Filter, type FilterClearMode } from '../../Filter';
 import { generateBlurGlProgram } from './gl/generateBlurGlProgram';
 import { generateBlurProgram } from './gpu/generateBlurProgram';
 
@@ -102,7 +101,7 @@ export class BlurFilterPass extends Filter
         filterManager: FilterSystem,
         input: Texture,
         output: RenderSurface,
-        clearMode: boolean
+        clearMode: FilterClearMode
     ): void
     {
         this._uniforms.uStrength = this.strength / this.passes;
@@ -120,11 +119,9 @@ export class BlurFilterPass extends Filter
 
             this._state.blend = false;
 
-            const shouldClear = filterManager.renderer.type === RendererType.WEBGPU;
-
             for (let i = 0; i < this.passes - 1; i++)
             {
-                filterManager.applyFilter(this, flip, flop, i === 0 ? true : shouldClear);
+                filterManager.applyFilter(this, flip, flop, i === 0 ? 'clear' : 'auto');
 
                 const temp = flop;
 

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -5,14 +5,13 @@ import { GpuProgram } from '../../../rendering/renderers/gpu/shader/GpuProgram';
 import { UniformGroup } from '../../../rendering/renderers/shared/shader/UniformGroup';
 import { Sprite } from '../../../scene/sprite/Sprite';
 import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
-import { Filter } from '../../Filter';
+import { Filter, type FilterClearMode, type FilterOptions } from '../../Filter';
 import fragment from './displacement.frag';
 import vertex from './displacement.vert';
 import source from './displacement.wgsl';
 
 import type { PointData } from '../../../maths/point/PointData';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
-import type { FilterOptions } from '../../Filter';
 import type { FilterSystem } from '../../FilterSystem';
 
 /**
@@ -187,7 +186,7 @@ export class DisplacementFilter extends Filter
         filterManager: FilterSystem,
         input: Texture,
         output: Texture,
-        clearMode: boolean
+        clearMode: FilterClearMode
     ): void
     {
         const uniforms = this.resources.filterUniforms.uniforms;

--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -3,14 +3,13 @@ import { GlProgram } from '../../rendering/renderers/gl/shader/GlProgram';
 import { GpuProgram } from '../../rendering/renderers/gpu/shader/GpuProgram';
 import { UniformGroup } from '../../rendering/renderers/shared/shader/UniformGroup';
 import { TextureMatrix } from '../../rendering/renderers/shared/texture/TextureMatrix';
-import { Filter } from '../Filter';
+import { Filter, type FilterClearMode, type FilterOptions } from '../Filter';
 import fragment from './mask.frag';
 import vertex from './mask.vert';
 import source from './mask.wgsl';
 
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { Sprite } from '../../scene/sprite/Sprite';
-import type { FilterOptions } from '../Filter';
 import type { FilterSystem } from '../FilterSystem';
 
 /** @internal */
@@ -86,7 +85,7 @@ export class MaskFilter extends Filter
         filterManager: FilterSystem,
         input: Texture,
         output: Texture,
-        clearMode: boolean
+        clearMode: FilterClearMode
     ): void
     {
         // will trigger an update if the texture changed..


### PR DESCRIPTION
I noticed `renderer.type === RendererType.WEBGPU;` in BlurFilterPass, so its time to bring that back