### PR TITLE
Feat: Add PaddingSides to text

### DIFF
--- a/src/filters/PaddingSides.ts
+++ b/src/filters/PaddingSides.ts
@@ -1,0 +1,164 @@
+import type { Filter } from './Filter';
+
+/**
+ * class used for paddings of text styles and filters
+ * @category filters
+ * @advanced
+ */
+export class PaddingSides
+{
+    public top: number = 0;
+    public right: number = 0;
+    public bottom: number = 0;
+    public left: number = 0;
+
+    get horizontal()
+    {
+        return this.left + this.right;
+    }
+
+    get vertical()
+    {
+        return this.top + this.bottom;
+    }
+
+    public copyFrom(sides: IPaddingSidesLike): this
+    {
+        if (!sides)
+        {
+            this.top = 0;
+            this.right = 0;
+            this.bottom = 0;
+            this.left = 0;
+        }
+        else if (typeof sides === 'number')
+        {
+            this.top = sides;
+            this.right = sides;
+            this.bottom = sides;
+            this.left = sides;
+        }
+        else if (sides instanceof Array)
+        {
+            this.top = (sides as any)[0];
+            this.right = (sides as any)[1];
+            this.bottom = (sides as any)[2];
+            this.left = (sides as any)[3];
+        }
+        else
+        {
+            this.top = sides.top || 0;
+            this.right = sides.right || 0;
+            this.bottom = sides.bottom || 0;
+            this.left = sides.left || 0;
+        }
+
+        return this;
+    }
+
+    public unite(sides: IPaddingSidesLike): this
+    {
+        if (!sides)
+        {
+            return this;
+        }
+
+        if (typeof sides === 'number')
+        {
+            this.top = Math.max(this.top, sides);
+            this.right = Math.max(this.right, sides);
+            this.bottom = Math.max(this.bottom, sides);
+            this.left = Math.max(this.left, sides);
+
+            return this;
+        }
+
+        if (sides instanceof Array)
+        {
+            this.top = Math.max(this.top, sides[0]);
+            this.right = Math.max(this.right, sides[1]);
+            this.bottom = Math.max(this.bottom, sides[2]);
+            this.left = Math.max(this.left, sides[3]);
+
+            return this;
+        }
+
+        this.top = Math.max(this.top, sides.top);
+        this.right = Math.max(this.right, sides.right);
+        this.bottom = Math.max(this.bottom, sides.bottom);
+        this.left = Math.max(this.left, sides.left);
+
+        return this;
+    }
+
+    public ceil(): this
+    {
+        this.top = Math.ceil(this.top);
+        this.right = Math.ceil(this.right);
+        this.bottom = Math.ceil(this.bottom);
+        this.left = Math.ceil(this.left);
+
+        return this;
+    }
+
+    /**
+     * Pads PaddingSides object, making it grow in all directions.
+     * If paddingY is omitted, both paddingX and paddingY will be set to paddingX.
+     * @param paddingX - The horizontal padding amount.
+     * @param paddingY - The vertical padding amount.
+     */
+    public pad(paddingX: number, paddingY: number = paddingX): this
+    {
+        this.left += paddingX;
+        this.right += paddingX;
+
+        this.top += paddingY;
+        this.bottom += paddingY;
+
+        return this;
+    }
+
+    public static fromDistanceRotation(rotation: number, distance: number, blur: number = 0): PaddingSides | number
+    {
+        if (!distance)
+        {
+            return blur;
+        }
+
+        const res = new PaddingSides();
+
+        const x = Math.cos(rotation) * distance;
+        const y = Math.sin(rotation) * distance;
+
+        res.top = -Math.min(0, y - blur);
+        res.bottom = Math.max(0, y + blur);
+        res.left = -Math.min(0, x - blur);
+        res.right = Math.max(0, x + blur);
+
+        return res.ceil();
+    }
+
+    public static applyFilters(padding: PaddingSides | number, filters: Filter[]): PaddingSides | number
+    {
+        let filterPadding = 0;
+
+        for (let i = 0; i < filters.length; i++)
+        {
+            filterPadding += filters[i].padding;
+        }
+
+        if (typeof padding === 'number')
+        {
+            return padding + filterPadding;
+        }
+
+        return padding.pad(filterPadding);
+    }
+}
+
+/**
+ * Padding data that can be passed to text or filter: single number, or array, or object. Like in CSS.
+ * @category filters
+ * @standard
+ */
+export type IPaddingSidesLike = PaddingSides | [number, number, number, number] | number;

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -318,6 +318,17 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
         return this.orig.height;
     }
 
+    /**
+     * Used by Texture pools, for text
+     * @param orig
+     * @param trim
+     */
+    public setOrigTrim(orig: Rectangle = null, trim: Rectangle = null)
+    {
+        (this as any).orig = orig || this.frame;
+        (this as any).trim = trim;
+    }
+
     /** Call this function when you have modified the frame of this texture. */
     public updateUvs()
     {

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -1,5 +1,6 @@
 import { Cache } from '../../assets/cache/Cache';
 import { ExtensionType } from '../../extensions/Extensions';
+import { PaddingSides } from '../../filters/PaddingSides';
 import { Graphics } from '../graphics/shared/Graphics';
 import { CanvasTextMetrics } from '../text/canvas/CanvasTextMetrics';
 import { SdfShader } from '../text/sdfShader/SdfShader';
@@ -11,6 +12,8 @@ import type { RenderPipe } from '../../rendering/renderers/shared/instructions/R
 import type { Renderable } from '../../rendering/renderers/shared/Renderable';
 import type { Renderer } from '../../rendering/renderers/types';
 import type { BitmapText } from './BitmapText';
+
+const tempPadding = new PaddingSides();
 
 /** @internal */
 export class BitmapTextGraphics extends Graphics
@@ -129,7 +132,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
 
         let index = 0;
 
-        const padding = style.padding;
+        const padding = tempPadding.copyFrom(style.padding);
         const scale = bitmapTextLayout.scale;
 
         let tx = bitmapTextLayout.width;
@@ -142,7 +145,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
         }
 
         context
-            .translate((-bitmapText._anchor._x * tx) - padding, (-bitmapText._anchor._y * ty) - padding)
+            .translate((-bitmapText._anchor._x * tx) - padding.left, (-bitmapText._anchor._y * ty) - padding.top)
             .scale(scale, scale);
 
         const tint = bitmapFont.applyFillAsTint ? style._fill.color : 0xFFFFFF;

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from '../../extensions/Extensions';
+import { PaddingSides } from '../../filters/PaddingSides';
 import { type CanvasAndContext, CanvasPool } from '../../rendering/renderers/shared/texture/CanvasPool';
 import { TexturePool } from '../../rendering/renderers/shared/texture/TexturePool';
 import { type TextureStyle } from '../../rendering/renderers/shared/texture/TextureStyle';
@@ -7,6 +8,7 @@ import { isSafari } from '../../utils/browser/isSafari';
 import { warn } from '../../utils/logging/warn';
 import { BigPool } from '../../utils/pool/PoolGroup';
 import { getPo2TextureFromSource } from '../text/utils/getPo2TextureFromSource';
+import { adjustTextTexture } from '../text/utils/updateTextBounds';
 import { HTMLTextRenderData } from './HTMLTextRenderData';
 import { HTMLTextStyle } from './HTMLTextStyle';
 import { extractFontFamilies } from './utils/extractFontFamilies';
@@ -20,6 +22,8 @@ import type { System } from '../../rendering/renderers/shared/system/System';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { PoolItem } from '../../utils/pool/Pool';
 import type { HTMLTextOptions } from './HTMLText';
+
+const tempPad = new PaddingSides();
 
 /**
  * System plugin to the renderer to manage HTMLText
@@ -83,9 +87,9 @@ export class HTMLTextSystem implements System
             HTMLTextStyle.defaultTextStyle as {fontWeight: string, fontStyle: string}
         );
         const measured = measureHtmlText(text, style, fontCSS, htmlTextData);
-
-        const width = Math.ceil(Math.ceil((Math.max(1, measured.width) + (style.padding * 2))) * resolution);
-        const height = Math.ceil(Math.ceil((Math.max(1, measured.height) + (style.padding * 2))) * resolution);
+        const padding = tempPad.copyFrom(style.padding);
+        const width = Math.ceil(Math.ceil((Math.max(1, measured.width) + padding.horizontal)) * resolution);
+        const height = Math.ceil(Math.ceil((Math.max(1, measured.height) + padding.vertical)) * resolution);
 
         const image = htmlTextData.image;
 
@@ -114,6 +118,7 @@ export class HTMLTextSystem implements System
             resolution
         );
 
+        adjustTextTexture(texture, padding);
         if (textureStyle) texture.source.style = textureStyle;
 
         if (this._createCanvas)

--- a/src/scene/text-html/utils/measureHtmlText.ts
+++ b/src/scene/text-html/utils/measureHtmlText.ts
@@ -1,9 +1,11 @@
+import { PaddingSides } from '../../../filters/PaddingSides';
 import { HTMLTextRenderData } from '../HTMLTextRenderData';
 
 import type { Size } from '../../../maths/misc/Size';
 import type { HTMLTextStyle } from '../HTMLTextStyle';
 
 let tempHTMLTextRenderData: HTMLTextRenderData;
+const tempPadding = new PaddingSides();
 
 /**
  * Measures the HTML text without actually generating an image.
@@ -42,11 +44,10 @@ export function measureHtmlText(
 
     svgRoot.remove();
 
-    // padding is included in the CSS calculation, so we need to remove it here
-    const doublePadding = style.padding * 2;
+    const padding = tempPadding.copyFrom(style.padding);
 
     return {
-        width: contentBounds.width - doublePadding,
-        height: contentBounds.height - doublePadding,
+        width: contentBounds.width - padding.horizontal,
+        height: contentBounds.height - padding.vertical,
     };
 }

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -2,10 +2,8 @@ import { ObservablePoint } from '../../maths/point/ObservablePoint';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { ViewContainer, type ViewContainerOptions } from '../view/ViewContainer';
 
-import type { Size } from '../../maths/misc/Size';
 import type { PointData } from '../../maths/point/PointData';
 import type { View } from '../../rendering/renderers/shared/view/View';
-import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../text-html/HTMLTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
@@ -476,124 +474,6 @@ export abstract class AbstractText<
 
         this._style.on('update', this.onViewUpdate, this);
         this.onViewUpdate();
-    }
-
-    /**
-     * The width of the sprite, setting this will actually modify the scale to achieve the value set.
-     * @example
-     * ```ts
-     * // Set width directly
-     * texture.width = 200;
-     * console.log(texture.scale.x); // Scale adjusted to match width
-     *
-     * // For better performance when setting both width and height
-     * texture.setSize(300, 400); // Avoids recalculating bounds twice
-     * ```
-     */
-    override get width(): number
-    {
-        return Math.abs(this.scale.x) * this.bounds.width;
-    }
-
-    override set width(value: number)
-    {
-        this._setWidth(value, this.bounds.width);
-    }
-
-    /**
-     * The height of the sprite, setting this will actually modify the scale to achieve the value set.
-     * @example
-     * ```ts
-     * // Set height directly
-     * texture.height = 200;
-     * console.log(texture.scale.y); // Scale adjusted to match height
-     *
-     * // For better performance when setting both width and height
-     * texture.setSize(300, 400); // Avoids recalculating bounds twice
-     * ```
-     */
-    override get height(): number
-    {
-        return Math.abs(this.scale.y) * this.bounds.height;
-    }
-
-    override set height(value: number)
-    {
-        this._setHeight(value, this.bounds.height);
-    }
-
-    /**
-     * Retrieves the size of the Text as a [Size]{@link Size} object based on the texture dimensions and scale.
-     * This is faster than getting width and height separately as it only calculates the bounds once.
-     * @example
-     * ```ts
-     * // Basic size retrieval
-     * const text = new Text({
-     *     text: 'Hello Pixi!',
-     *     style: { fontSize: 24 }
-     * });
-     * const size = text.getSize();
-     * console.log(`Size: ${size.width}x${size.height}`);
-     *
-     * // Reuse existing size object
-     * const reuseSize = { width: 0, height: 0 };
-     * text.getSize(reuseSize);
-     * ```
-     * @param out - Optional object to store the size in, to avoid allocating a new object
-     * @returns The size of the Sprite
-     * @see {@link Text#width} For getting just the width
-     * @see {@link Text#height} For getting just the height
-     * @see {@link Text#setSize} For setting both width and height
-     */
-    public override getSize(out?: Size): Size
-    {
-        out ||= {} as Size;
-        out.width = Math.abs(this.scale.x) * this.bounds.width;
-        out.height = Math.abs(this.scale.y) * this.bounds.height;
-
-        return out;
-    }
-
-    /**
-     * Sets the size of the Text to the specified width and height.
-     * This is faster than setting width and height separately as it only recalculates bounds once.
-     * @example
-     * ```ts
-     * // Basic size setting
-     * const text = new Text({
-     *    text: 'Hello Pixi!',
-     *    style: { fontSize: 24 }
-     * });
-     * text.setSize(100, 200); // Width: 100, Height: 200
-     *
-     * // Set uniform size
-     * text.setSize(100); // Sets both width and height to 100
-     *
-     * // Set size with object
-     * text.setSize({
-     *     width: 200,
-     *     height: 300
-     * });
-     * ```
-     * @param value - This can be either a number or a {@link Size} object
-     * @param height - The height to set. Defaults to the value of `width` if not provided
-     * @see {@link Text#width} For setting width only
-     * @see {@link Text#height} For setting height only
-     */
-    public override setSize(value: number | Optional<Size, 'height'>, height?: number)
-    {
-        if (typeof value === 'object')
-        {
-            height = value.height ?? value.width;
-            value = value.width;
-        }
-        else
-        {
-            height ??= value;
-        }
-
-        value !== undefined && this._setWidth(value, this.bounds.width);
-        height !== undefined && this._setHeight(height, this.bounds.height);
     }
 
     /**

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -1,7 +1,6 @@
 import { TextureStyle, type TextureStyleOptions } from '../../rendering/renderers/shared/texture/TextureStyle';
 import { AbstractText, ensureTextOptions } from './AbstractText';
 import { type BatchableText } from './canvas/BatchableText';
-import { CanvasTextGenerator } from './canvas/CanvasTextGenerator';
 import { CanvasTextMetrics } from './canvas/CanvasTextMetrics';
 import { TextStyle } from './TextStyle';
 
@@ -198,32 +197,12 @@ export class Text
         const bounds = this._bounds;
         const anchor = this._anchor;
 
-        let width = 0;
-        let height = 0;
+        const canvasMeasurement = CanvasTextMetrics.measureText(
+            this._text,
+            this._style
+        );
 
-        if (this._style.trim)
-        {
-            const { frame, canvasAndContext } = CanvasTextGenerator.getCanvasAndContext({
-                text: this.text,
-                style: this._style,
-                resolution: 1,
-            });
-
-            CanvasTextGenerator.returnCanvasAndContext(canvasAndContext);
-
-            width = frame.width;
-            height = frame.height;
-        }
-        else
-        {
-            const canvasMeasurement = CanvasTextMetrics.measureText(
-                this._text,
-                this._style
-            );
-
-            width = canvasMeasurement.width;
-            height = canvasMeasurement.height;
-        }
+        const { width, height } = canvasMeasurement;
 
         bounds.minX = (-anchor._x * width);
         bounds.maxX = bounds.minX + width;

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -11,6 +11,7 @@ import {
 } from '../graphics/shared/utils/convertFillInputToFillStyle';
 import { generateTextStyleKey } from './utils/generateTextStyleKey';
 
+import type { IPaddingSidesLike } from '../../filters/PaddingSides';
 import type { TextureDestroyOptions, TypeOrBool } from '../container/destroyTypes';
 import type {
     ConvertedFillStyle,
@@ -601,7 +602,7 @@ export interface TextStyleOptions
      * Occasionally some fonts are cropped. Adding some padding will prevent this from
      * happening by adding padding to all sides of the text.
      */
-    padding?: number;
+    padding?: IPaddingSidesLike;
     /**
      * Stroke style for text outline.
      * @default null
@@ -784,7 +785,7 @@ export class TextStyle extends EventEmitter<{
     private _wordWrapWidth: number;
     private _filters: Filter[];
 
-    private _padding: number;
+    private _padding: IPaddingSidesLike;
 
     protected _styleKey: string;
     private _trim: boolean;
@@ -885,8 +886,8 @@ export class TextStyle extends EventEmitter<{
      * by adding padding to all sides of the text.
      * > [!NOTE] This will NOT affect the positioning or bounds of the text.
      */
-    get padding(): number { return this._padding; }
-    set padding(value: number) { this._padding = value; this.update(); }
+    get padding(): IPaddingSidesLike { return this._padding; }
+    set padding(value: IPaddingSidesLike) { this._padding = value; this.update(); }
     /**
      * An optional filter or array of filters to apply to the text, allowing for advanced visual effects.
      * These filters will be applied to the text as it is created, resulting in faster rendering for static text
@@ -1068,27 +1069,6 @@ export class TextStyle extends EventEmitter<{
             wordWrapWidth: this.wordWrapWidth,
             filters: this._filters ? [...this._filters] : undefined,
         });
-    }
-
-    /**
-     * Returns the final padding for the text style, taking into account any filters applied.
-     * Used internally for correct measurements
-     * @internal
-     * @returns {number} The final padding for the text style.
-     */
-    public _getFinalPadding(): number
-    {
-        let filterPadding = 0;
-
-        if (this._filters)
-        {
-            for (let i = 0; i < this._filters.length; i++)
-            {
-                filterPadding += this._filters[i].padding;
-            }
-        }
-
-        return Math.max(this._padding, filterPadding);
     }
 
     /**

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -6,6 +6,7 @@ import { deprecation } from '../../../utils/logging/deprecation';
 import { type CanvasTextOptions } from '../Text';
 import { TextStyle } from '../TextStyle';
 import { getPo2TextureFromSource } from '../utils/getPo2TextureFromSource';
+import { adjustTextTexture } from '../utils/updateTextBounds';
 import { CanvasTextGenerator } from './CanvasTextGenerator';
 
 import type { System } from '../../../rendering/renderers/shared/system/System';
@@ -87,23 +88,17 @@ export class CanvasTextSystem implements System
 
         const resolution = options.resolution ?? this._renderer.resolution;
 
-        const { frame, canvasAndContext } = CanvasTextGenerator.getCanvasAndContext({
+        const { padding, width, height, canvasAndContext } = CanvasTextGenerator.getCanvasAndContext({
             text: text as string,
             style: style as TextStyle,
             resolution,
         });
 
-        const texture = getPo2TextureFromSource(canvasAndContext.canvas, frame.width, frame.height, resolution);
+        const texture = getPo2TextureFromSource(canvasAndContext.canvas, width, height, resolution);
+
+        adjustTextTexture(texture, padding, style.trim);
 
         if (textureStyle) texture.source.style = textureStyle as TextureStyle;
-
-        if (style.trim)
-        {
-            // reapply the padding to the frame
-            frame.pad(style.padding);
-            texture.frame.copyFrom(frame);
-            texture.updateUvs();
-        }
 
         if (style.filters)
         {


### PR DESCRIPTION
New CSS-like API feature: `textStyle.padding = [top, right, bottom, left]` 

Improve code quality by affecting texture frame/orig/trim , remove override methods like `setSize` because they are the same as Sprite now