### PR TITLE
fix: remove special number casing for particle tint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     ],
     "typescript.preferences.autoImportSpecifierExcludeRegexes": [
         "~/.*",
-    ]
+    ],
+    "jestrunner.jestCommand": "npx jest"
   }

--- a/src/scene/particle-container/shared/Particle.ts
+++ b/src/scene/particle-container/shared/Particle.ts
@@ -391,14 +391,7 @@ export class Particle implements IParticle
 
     set tint(value: ColorSource)
     {
-        if (typeof value === 'number')
-        {
-            this._tint = value;
-        }
-        else
-        {
-            this._tint = Color.shared.setValue(value ?? 0xFFFFFF).toBgrNumber();
-        }
+        this._tint = Color.shared.setValue(value ?? 0xFFFFFF).toBgrNumber();
 
         this._updateColor();
     }

--- a/src/scene/particle-container/shared/__tests__/Particle.test.ts
+++ b/src/scene/particle-container/shared/__tests__/Particle.test.ts
@@ -1,0 +1,28 @@
+import { Particle } from '../Particle';
+import { Texture } from '~/rendering';
+
+describe('Particle', () =>
+{
+    describe('tint', () =>
+    {
+        it('should apply number tint correctly', () =>
+        {
+            const particle = new Particle({
+                texture: Texture.WHITE,
+                tint: 0xffcc99,
+            });
+
+            expect(particle.tint).toBe(0xffcc99);
+        });
+
+        it('should apply string tint correctly', () =>
+        {
+            const particle = new Particle({
+                texture: Texture.WHITE,
+                tint: '#ffcc99',
+            });
+
+            expect(particle.tint).toBe(0xffcc99);
+        });
+    });
+});


### PR DESCRIPTION
* Fix: Always normalize Particle's `tint` input as RGB format, even for integers.

Closes #11478