### PR TITLE
chore: update typedoc and minor doc fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "typescript.preferences.autoImportFileExcludePatterns": [
       "src/*/**/index.ts",
       "src/index.ts",
+      "src/index.docs.ts",
       "src/bundle.*.ts",
     ],
     "typescript.preferences.autoImportSpecifierExcludeRegexes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "ts-jest": "^26.0.0",
         "ts-node": "^9.0.0",
         "tsc-silent": "^1.2.2",
-        "typedoc": "^0.28.4",
+        "typedoc": "^0.28.7",
         "typedoc-plugin-ga": "^1.0.5",
         "typedoc-plugin-mdn-links": "^5.0.2",
         "typedoc-plugin-no-inherit": "^1.6.1",
@@ -1758,16 +1758,16 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.0.tgz",
-      "integrity": "sha512-48lKoQegmfJ0iyR/jRz5OrYOSM3WewG9YWCPqUvYFEC54shQO8RsAaspaK/2PRHVVnjekRqfAFvq8pwCpIo5ig==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.7.0.tgz",
+      "integrity": "sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.4.0",
-        "@shikijs/langs": "^3.4.0",
-        "@shikijs/themes": "^3.4.0",
-        "@shikijs/types": "^3.4.0",
+        "@shikijs/engine-oniguruma": "^3.7.0",
+        "@shikijs/langs": "^3.7.0",
+        "@shikijs/themes": "^3.7.0",
+        "@shikijs/types": "^3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -1866,6 +1866,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1879,10 +1880,11 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1895,6 +1897,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1906,13 +1909,15 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1930,6 +1935,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1945,6 +1951,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -2884,6 +2891,7 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -3032,40 +3040,40 @@
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
-      "integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
+      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
-      "integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
+      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
-      "integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
+      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5685,7 +5693,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/easy-table": {
       "version": "1.2.0",
@@ -7418,12 +7427,13 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -7434,10 +7444,11 @@
       }
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -9177,15 +9188,13 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
-      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12454,10 +12463,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -13249,6 +13259,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -13355,29 +13372,28 @@
       "dev": true
     },
     "node_modules/path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -14278,59 +14294,58 @@
       "dev": true
     },
     "node_modules/rimraf": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
-      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "glob": "^10.2.5"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
-      "version": "10.2.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
-      "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -15648,6 +15663,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -15662,6 +15678,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -15762,6 +15779,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -16571,17 +16589,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
-      "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.7.tgz",
+      "integrity": "sha512-lpz0Oxl6aidFkmS90VQDQjk/Qf2iw0IUvFqirdONBdj7jPSN9mGXhy66BcGNDxx5ZMyKKiBVAREvPEzT6Uxipw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.2",
+        "@gerrit0/mini-shiki": "^3.7.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.1"
+        "yaml": "^2.8.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -16709,16 +16727,16 @@
       "license": "MIT"
     },
     "node_modules/typedoc/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/typescript": {
@@ -17250,6 +17268,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -17267,6 +17286,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -17282,6 +17302,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -17293,7 +17314,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -18526,15 +18548,15 @@
       }
     },
     "@gerrit0/mini-shiki": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.0.tgz",
-      "integrity": "sha512-48lKoQegmfJ0iyR/jRz5OrYOSM3WewG9YWCPqUvYFEC54shQO8RsAaspaK/2PRHVVnjekRqfAFvq8pwCpIo5ig==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.7.0.tgz",
+      "integrity": "sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==",
       "dev": true,
       "requires": {
-        "@shikijs/engine-oniguruma": "^3.4.0",
-        "@shikijs/langs": "^3.4.0",
-        "@shikijs/themes": "^3.4.0",
-        "@shikijs/types": "^3.4.0",
+        "@shikijs/engine-oniguruma": "^3.7.0",
+        "@shikijs/langs": "^3.7.0",
+        "@shikijs/themes": "^3.7.0",
+        "@shikijs/types": "^3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -18606,9 +18628,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
           "dev": true
         },
         "ansi-styles": {
@@ -19443,37 +19465,37 @@
       "dev": true
     },
     "@shikijs/engine-oniguruma": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
-      "integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
+      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
       "dev": true,
       "requires": {
-        "@shikijs/types": "3.4.0",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "@shikijs/langs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
-      "integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
+      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
       "dev": true,
       "requires": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.7.0"
       }
     },
     "@shikijs/themes": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
-      "integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
+      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
       "dev": true,
       "requires": {
-        "@shikijs/types": "3.4.0"
+        "@shikijs/types": "3.7.0"
       }
     },
     "@shikijs/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
       "dev": true,
       "requires": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -22605,19 +22627,19 @@
       "dev": true
     },
     "foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "dependencies": {
         "signal-exit": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-          "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
         }
       }
@@ -23826,9 +23848,9 @@
       }
     },
     "jackspeak": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.2.1.tgz",
-      "integrity": "sha512-MXbxovZ/Pm42f6cDIDkl3xpwv1AGwObKwfmjs2nQePiy85tP3fatofl3FC1aBsOtP/6fq5SbtgHwWcMsLP+bDw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "requires": {
         "@isaacs/cliui": "^8.0.2",
@@ -26213,9 +26235,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
     },
     "mixin-deep": {
@@ -26795,6 +26817,12 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -26872,19 +26900,19 @@
       "dev": true
     },
     "path-scurry": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.9.2.tgz",
-      "integrity": "sha512-qSDLy2aGFPm8i4rsbHd4MNyTcrzHFsLQykrtbuGRknZZCBBVXSv2tSCDN2Cg6Rt/GFRw8GoW9y9Ecw5rIPG1sg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "requires": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "9.1.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
-          "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
         }
       }
@@ -27540,40 +27568,41 @@
       "dev": true
     },
     "rimraf": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.1.tgz",
-      "integrity": "sha512-OfFZdwtd3lZ+XZzYP/6gTACubwFcHdLRqS9UX3UwpU2dnGQYkPFISRwvM3w9IiB2w7bW5qGo/uAwE4SmXXSKvg==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
       "dev": true,
       "requires": {
-        "glob": "^10.2.5"
+        "glob": "^10.3.7"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
         "glob": {
-          "version": "10.2.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.7.tgz",
-          "integrity": "sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==",
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+          "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
-            "jackspeak": "^2.0.3",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2",
-            "path-scurry": "^1.7.0"
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^1.11.1"
           }
         },
         "minimatch": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-          "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -29283,16 +29312,16 @@
       }
     },
     "typedoc": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
-      "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.7.tgz",
+      "integrity": "sha512-lpz0Oxl6aidFkmS90VQDQjk/Qf2iw0IUvFqirdONBdj7jPSN9mGXhy66BcGNDxx5ZMyKKiBVAREvPEzT6Uxipw==",
       "dev": true,
       "requires": {
-        "@gerrit0/mini-shiki": "^3.2.2",
+        "@gerrit0/mini-shiki": "^3.7.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.1"
+        "yaml": "^2.8.0"
       },
       "dependencies": {
         "brace-expansion": {
@@ -29355,9 +29384,9 @@
           "dev": true
         },
         "yaml": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-          "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+          "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "ts-jest": "^26.0.0",
     "ts-node": "^9.0.0",
     "tsc-silent": "^1.2.2",
-    "typedoc": "^0.28.4",
+    "typedoc": "^0.28.7",
     "typedoc-plugin-ga": "^1.0.5",
     "typedoc-plugin-mdn-links": "^5.0.2",
     "typedoc-plugin-no-inherit": "^1.6.1",

--- a/src/maths/shapes/Circle.ts
+++ b/src/maths/shapes/Circle.ts
@@ -184,9 +184,9 @@ export class Circle implements ShapePrimitive
      * const isOnStroke = circle.strokeContains(150, 100, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = circle.strokeContains(150, 100, 4, 0);   // Inside
+     * const innerStroke = circle.strokeContains(150, 100, 4, 1);   // Inside
      * const centerStroke = circle.strokeContains(150, 100, 4, 0.5); // Centered
-     * const outerStroke = circle.strokeContains(150, 100, 4, 1);   // Outside
+     * const outerStroke = circle.strokeContains(150, 100, 4, 0);   // Outside
      * ```
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -181,9 +181,9 @@ export class Ellipse implements ShapePrimitive
      * const isOnStroke = ellipse.strokeContains(150, 100, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = ellipse.strokeContains(150, 100, 4, 0);   // Inside
+     * const innerStroke = ellipse.strokeContains(150, 100, 4, 1);   // Inside
      * const centerStroke = ellipse.strokeContains(150, 100, 4, 0.5); // Centered
-     * const outerStroke = ellipse.strokeContains(150, 100, 4, 1);   // Outside
+     * const outerStroke = ellipse.strokeContains(150, 100, 4, 0);   // Outside
      * ```
      * @remarks
      * - Uses normalized ellipse equations
@@ -192,7 +192,7 @@ export class Ellipse implements ShapePrimitive
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
-     * @param alignment - The alignment of the stroke (0 = inner, 0.5 = centered, 1 = outer)
+     * @param alignment - The alignment of the stroke (1 = inner, 0.5 = centered, 0 = outer)
      * @returns Whether the x/y coords are within this ellipse's stroke
      * @see {@link Ellipse.contains} For checking fill containment
      * @see {@link Ellipse.getBounds} For getting stroke bounds

--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -301,14 +301,14 @@ export class Polygon implements ShapePrimitive
      * const isOnStroke = polygon.strokeContains(25, 25, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = polygon.strokeContains(25, 25, 4, 0);   // Inside
+     * const innerStroke = polygon.strokeContains(25, 25, 4, 1);   // Inside
      * const centerStroke = polygon.strokeContains(25, 25, 4, 0.5); // Centered
-     * const outerStroke = polygon.strokeContains(25, 25, 4, 1);   // Outside
+     * const outerStroke = polygon.strokeContains(25, 25, 4, 0);   // Outside
      * ```
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
-     * @param alignment - The alignment of the stroke (0 = inner, 0.5 = centered, 1 = outer)
+     * @param alignment - The alignment of the stroke (1 = inner, 0.5 = centered, 0 = outer)
      * @returns Whether the x/y coordinates are within this polygon's stroke
      * @see {@link Polygon.contains} For checking fill containment
      * @see {@link Polygon.getBounds} For getting stroke bounds

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -409,14 +409,14 @@ export class Rectangle implements ShapePrimitive
      * const isOnStroke = rect.strokeContains(150, 100, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = rect.strokeContains(150, 100, 4, 0);   // Inside
+     * const innerStroke = rect.strokeContains(150, 100, 4, 1);   // Inside
      * const centerStroke = rect.strokeContains(150, 100, 4, 0.5); // Centered
-     * const outerStroke = rect.strokeContains(150, 100, 4, 1);   // Outside
+     * const outerStroke = rect.strokeContains(150, 100, 4, 0);   // Outside
      * ```
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
-     * @param alignment - The alignment of the stroke (0 = inner, 0.5 = centered, 1 = outer)
+     * @param alignment - The alignment of the stroke (1 = inner, 0.5 = centered, 0 = outer)
      * @returns Whether the x/y coordinates are within this rectangle's stroke
      * @see {@link Rectangle.contains} For checking fill containment
      * @see {@link Rectangle.getBounds} For getting stroke bounds

--- a/src/maths/shapes/RoundedRectangle.ts
+++ b/src/maths/shapes/RoundedRectangle.ts
@@ -337,14 +337,14 @@ export class RoundedRectangle implements ShapePrimitive
      * const isOnStroke = rect.strokeContains(150, 100, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = rect.strokeContains(150, 100, 4, 0);   // Inside
+     * const innerStroke = rect.strokeContains(150, 100, 4, 1);   // Inside
      * const centerStroke = rect.strokeContains(150, 100, 4, 0.5); // Centered
-     * const outerStroke = rect.strokeContains(150, 100, 4, 1);   // Outside
+     * const outerStroke = rect.strokeContains(150, 100, 4, 0);   // Outside
      * ```
      * @param pX - The X coordinate of the point to test
      * @param pY - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
-     * @param alignment - The alignment of the stroke (0 = inner, 0.5 = centered, 1 = outer)
+     * @param alignment - The alignment of the stroke (1 = inner, 0.5 = centered, 0 = outer)
      * @returns Whether the x/y coordinates are within this rectangle's stroke
      * @see {@link RoundedRectangle.contains} For checking fill containment
      * @see {@link RoundedRectangle.getBounds} For getting stroke bounds

--- a/src/maths/shapes/Triangle.ts
+++ b/src/maths/shapes/Triangle.ts
@@ -177,14 +177,14 @@ export class Triangle implements ShapePrimitive
      * const isOnStroke = triangle.strokeContains(25, 25, 4); // 4px line width
      *
      * // Check with different alignments
-     * const innerStroke = triangle.strokeContains(25, 25, 4, 0);   // Inside
+     * const innerStroke = triangle.strokeContains(25, 25, 4, 1);   // Inside
      * const centerStroke = triangle.strokeContains(25, 25, 4, 0.5); // Centered
-     * const outerStroke = triangle.strokeContains(25, 25, 4, 1);   // Outside
+     * const outerStroke = triangle.strokeContains(25, 25, 4, 0);   // Outside
      * ```
      * @param pointX - The X coordinate of the point to test
      * @param pointY - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
-     * @param _alignment - The alignment of the stroke (0 = inner, 0.5 = centered, 1 = outer)
+     * @param _alignment - The alignment of the stroke (1 = inner, 0.5 = centered, 0 = outer)
      * @returns Whether the x/y coordinates are within this triangle's stroke
      * @see {@link Triangle.contains} For checking fill containment
      * @see {@link Triangle.getBounds} For getting stroke bounds

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -85,11 +85,7 @@ export interface WebGLOptions
     ExtractRendererOptions<typeof DefaultWebGLSystems>,
     PixiMixins.WebGLOptions {}
 
-/**
- * The default WebGL renderer, uses WebGL2 contexts.
- * @category rendering
- * @standard
- */
+// eslint-disable-next-line requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
     extends AbstractRenderer<WebGLPipes, WebGLOptions, T>,
     WebGLSystems {}

--- a/src/scene/__docs__/scene-text-overview.md
+++ b/src/scene/__docs__/scene-text-overview.md
@@ -126,7 +126,6 @@ const richText = new HTMLText({
     }
     textureStyle: {
         scaleMode: 'linear',
-        resolution: 2
     }
 });
 ```

--- a/src/scene/graphics/shared/FillTypes.ts
+++ b/src/scene/graphics/shared/FillTypes.ts
@@ -215,7 +215,7 @@ export interface FillStyle
  *     color: 0x0000ff, // Or use a Color object
  *     join: 'miter',
  *     miterLimit: 3,   // Limit how far miter extends
- *     alignment: 1     // Outside alignment
+ *     alignment: 0     // Outside alignment
  * });
  *
  * // Pixel-perfect line
@@ -245,17 +245,17 @@ export interface StrokeAttributes
 
     /**
      * The alignment of the stroke relative to the path.
-     * - 0: Inside the shape
+     * - 1: Inside the shape
      * - 0.5: Centered on the path (default)
-     * - 1: Outside the shape
+     * - 0: Outside the shape
      * @example
      * ```ts
      * // Inside alignment
-     * const stroke = { alignment: 0 };
+     * const stroke = { alignment: 1 };
      * // Centered alignment
      * const stroke = { alignment: 0.5 };
      * // Outside alignment
-     * const stroke = { alignment: 1 };
+     * const stroke = { alignment: 0 };
      * ```
      * @default 0.5
      */
@@ -366,7 +366,7 @@ export interface StrokeAttributes
  *     stroke: {
  *         width: 4,
  *         color: 0x000000,
- *         alignment: 1  // Outside stroke
+ *         alignment: 0  // Outside stroke
  *     }
  * });
  *

--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -52,7 +52,6 @@ let fontCount = 0;
  *     skipKerning: false,      // Enable kerning
  *     textureStyle: {
  *         scaleMode: 'linear',
- *         premultiplyAlpha: true
  *     }
  * });
  *
@@ -178,8 +177,6 @@ export interface BitmapFontInstallOptions
      *     name: 'CrispFont',
      *     textureStyle: {
      *         scaleMode: 'nearest',
-     *         resolution: 2,
-     *         format: 'rgba8unorm'
      *     }
      * });
      * ```

--- a/src/scene/text-html/HTMLText.ts
+++ b/src/scene/text-html/HTMLText.ts
@@ -40,7 +40,6 @@ import type { HTMLTextStyleOptions } from './HTMLTextStyle';
  *     }
  *     textureStyle: {
  *         scaleMode: 'linear',
- *         resolution: 2
  *     }
  * });
  * ```
@@ -64,9 +63,6 @@ export interface HTMLTextOptions extends TextOptions<HTMLTextStyle, HTMLTextStyl
      *     text: 'Crisp Text',
      *     textureStyle: {
      *         scaleMode: 'nearest', // Pixel-perfect scaling
-     *         format: 'rgba',       // Include alpha channel
-     *         resolution: 2,        // Higher resolution
-     *         premultiplyAlpha: true
      *     }
      * });
      * ```
@@ -142,7 +138,6 @@ export interface HTMLText extends PixiMixins.HTMLText, AbstractText<
  *     },
  *     textureStyle: {
  *         scaleMode: 'nearest',
- *         resolution: 2,
  *     }
  * });
  * ```

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -40,7 +40,6 @@ export interface Text extends PixiMixins.Text, AbstractText<
  *     },
  *     textureStyle: {
  *         scaleMode: 'nearest',
- *         resolution: 2
  *     }
  * });
  * ```
@@ -65,9 +64,6 @@ export interface CanvasTextOptions extends TextOptions
      *     text: 'Crisp Text',
      *     textureStyle: {
      *         scaleMode: 'nearest', // Pixel-perfect scaling
-     *         format: 'rgba',       // Include alpha channel
-     *         resolution: 2,        // Higher resolution
-     *         premultiplyAlpha: true
      *     }
      * });
      * ```
@@ -129,8 +125,6 @@ export interface CanvasTextOptions extends TextOptions
  *     },
  *     textureStyle: {
  *         scaleMode: 'nearest',
- *         resolution: 2,
- *         format: 'rgba',
  *     }
  * });
  *


### PR DESCRIPTION
Updates TypeDoc to the latest version. This fixes the issue of random frag/vert files appearing in the docs.
Updates documentation for `alignment` and `textureStyle`. fixes #11494
