### PR TITLE
MeshPipe.addRenderable does not set the current geometry parameters

### DIFF
--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -122,9 +122,15 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
     {
         const batcher = this.renderer.renderPipes.batch;
 
-        const { batched } = this._getMeshData(mesh);
+        const meshData = this._getMeshData(mesh);
 
-        if (batched)
+        if (mesh.didViewUpdate)
+        {
+            meshData.indexSize = mesh._geometry.indices?.length;
+            meshData.vertexSize = mesh._geometry.positions?.length;
+        }
+
+        if (meshData.batched)
         {
             const gpuBatchableMesh = this._getBatchableMesh(mesh);
 
@@ -200,8 +206,8 @@ export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
     {
         this._meshDataHash[mesh.uid] = {
             batched: mesh.batched,
-            indexSize: mesh._geometry.indices?.length,
-            vertexSize: mesh._geometry.positions?.length,
+            indexSize: 0,
+            vertexSize: 0,
         };
 
         mesh.on('destroyed', this._destroyRenderableBound);


### PR DESCRIPTION
I came across glitches in practice when displaying Mesh. In my example, the Mesh may change its MeshGeometry frequently. A study of the code showed that when it does not come to validateRenderable (in the case of structureDidChange === true), calling addRenderable causes indexSize and vertexSize to be remembered only when initializing MeshData. My refinement is quite simple, it is updating the data in addRenderable when the didViewUpdate flag is raised.