### PR TITLE
fix: origin calculation to ensure it scales from origin point

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1819,10 +1819,10 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         lt.tx = position._x - ((px * lt.a) + (py * lt.c)) // Pivot offset
             + ((ox * lt.a) + (oy * lt.c)) // Origin offset for rotation and scaling
-            - (ox * sx); // Remove unscaled origin to maintain position
+            - ox; // Remove origin to maintain position
         lt.ty = position._y - ((px * lt.b) + (py * lt.d)) // Pivot offset
             + ((ox * lt.b) + (oy * lt.d)) // Origin offset for rotation and scaling
-            - (oy * sy); // Remove unscaled origin to maintain position
+            - oy; // Remove origin to maintain position
     }
 
     // / ///// color related stuff


### PR DESCRIPTION
Corrects the origin calculation within the local transform update logic, ensuring accurate positioning when scaling and rotating.
