### PR TITLE
fix: loading unsupported video formats

### DIFF
--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -2,6 +2,7 @@ import { ExtensionType } from '../../../../extensions/Extensions';
 import { VideoSource } from '../../../../rendering/renderers/shared/texture/sources/VideoSource';
 import { detectVideoAlphaMode } from '../../../../utils/browser/detectVideoAlphaMode';
 import { getResolutionOfUrl } from '../../../../utils/network/getResolutionOfUrl';
+import { testVideoFormat } from '../../../detections/utils/testVideoFormat';
 import { checkDataUrl } from '../../../utils/checkDataUrl';
 import { checkExtension } from '../../../utils/checkExtension';
 import { createTexture } from './utils/createTexture';
@@ -12,8 +13,9 @@ import type { ResolvedAsset } from '../../../types';
 import type { Loader } from '../../Loader';
 import type { LoaderParser } from '../LoaderParser';
 
-const validVideoExtensions = ['.mp4', '.m4v', '.webm', '.ogg', '.ogv', '.h264', '.avi', '.mov'];
-const validVideoMIMEs = validVideoExtensions.map((ext) => `video/${ext.substring(1)}`);
+const potentialVideoExtensions = ['.mp4', '.m4v', '.webm', '.ogg', '.ogv', '.h264', '.avi', '.mov'];
+let validVideoExtensions: string[];
+let validVideoMIMEs: string[];
 
 /**
  * Set cross origin based detecting the url and the crossorigin
@@ -103,6 +105,37 @@ export function determineCrossOrigin(url: string, loc: Location = globalThis.loc
 }
 
 /**
+ * Get the supported video extensions and MIME types based on the browser's capabilities.
+ * This function checks the potential video extensions against the browser's supported formats.
+ * @returns An object containing valid video extensions and MIME types.
+ * @internal
+ */
+function getBrowserSupportedVideoExtensions()
+{
+    const supportedExtensions: string[] = [];
+    const supportedMimes: string[] = [];
+
+    for (const ext of potentialVideoExtensions)
+    {
+        const mimeType = VideoSource.MIME_TYPES[ext.substring(1)] || `video/${ext.substring(1)}`;
+
+        if (testVideoFormat(mimeType))
+        {
+            supportedExtensions.push(ext);
+            if (!supportedMimes.includes(mimeType))
+            {
+                supportedMimes.push(mimeType);
+            }
+        }
+    }
+
+    return {
+        validVideoExtensions: supportedExtensions,
+        validVideoMime: supportedMimes
+    };
+}
+
+/**
  * A simple plugin to load video textures.
  *
  * You can pass VideoSource options to the loader via the .data property of the asset descriptor
@@ -131,6 +164,13 @@ export const loadVideoTextures = {
 
     test(url: string): boolean
     {
+        if (!validVideoExtensions || !validVideoMIMEs)
+        {
+            const { validVideoExtensions: ve, validVideoMime: vm } = getBrowserSupportedVideoExtensions();
+
+            validVideoExtensions = ve;
+            validVideoMIMEs = vm;
+        }
         const isValidDataUrl = checkDataUrl(url, validVideoMIMEs);
         const isValidExtension = checkExtension(url, validVideoExtensions);
 


### PR DESCRIPTION
Fixes: #11376

Adds browser video format detection to only load supported video types. This prevents errors from unsupported video formats when loading assets.
