### PR TITLE
fix: resource leak in Graphics and fills

### DIFF
--- a/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
@@ -1,4 +1,5 @@
 import { Container } from '../../container/Container';
+import { FillGradient } from '../shared/fill/FillGradient';
 import { Graphics } from '../shared/Graphics';
 import { GraphicsContext } from '../shared/GraphicsContext';
 import '../init';
@@ -52,6 +53,40 @@ describe('Graphics Destroy', () =>
         expect(renderer.graphicsContext['_gpuContextHash'][context.uid]).toBeNull();
 
         expect(context.instructions).toBeNull();
+    });
+
+    it('should clean up its fill when destroyed', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        const container = new Container();
+
+        const graphics = new Graphics();
+        const fill = new FillGradient({});
+
+        graphics.context.rect(0, 0, 100, 100).fill(fill);
+
+        container.addChild(graphics);
+
+        renderer.render({ container });
+
+        // we will lose this ref once its destroyed:
+        const context = graphics.context;
+
+        graphics.destroy({ context: false });
+
+        expect(fill.texture).not.toBeNull();
+        expect(fill.transform).not.toBeNull();
+
+        context.destroy(true);
+
+        expect(fill.texture).toBeNull();
+        expect(fill.transform).toBeNull();
+        expect(fill.colorStops).toEqual([]);
+        expect(fill.start).toBeNull();
+        expect(fill.end).toBeNull();
+        expect(fill.center).toBeNull();
+        expect(fill.outerCenter).toBeNull();
     });
 
     it('should destroy its own context', async () =>

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1215,12 +1215,16 @@ export class GraphicsContext extends EventEmitter<{
 
             if (this._fillStyle.texture)
             {
-                this._fillStyle.texture.destroy(destroyTextureSource);
+                this._fillStyle.fill && 'uid' in this._fillStyle.fill
+                    ? this._fillStyle.fill.destroy()
+                    : this._fillStyle.texture.destroy(destroyTextureSource);
             }
 
             if (this._strokeStyle.texture)
             {
-                this._strokeStyle.texture.destroy(destroyTextureSource);
+                this._strokeStyle.fill && 'uid' in this._strokeStyle.fill
+                    ? this._strokeStyle.fill.destroy()
+                    : this._strokeStyle.texture.destroy(destroyTextureSource);
             }
         }
 

--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -524,10 +524,17 @@ export class FillGradient implements CanvasGradient
         return this.uid;
     }
 
+    /** Destroys the gradient, releasing resources. This will also destroy the internal texture. */
     public destroy(): void
     {
         this.texture?.destroy(true);
         this.texture = null;
+        this.transform = null;
+        this.colorStops = [];
+        this.start = null;
+        this.end = null;
+        this.center = null;
+        this.outerCenter = null;
     }
 }
 

--- a/src/scene/graphics/shared/fill/FillPattern.ts
+++ b/src/scene/graphics/shared/fill/FillPattern.ts
@@ -118,4 +118,12 @@ export class FillPattern implements CanvasPattern
 
         return this._styleKey;
     }
+
+    /** Destroys the fill pattern, releasing resources. This will also destroy the internal texture. */
+    public destroy(): void
+    {
+        this.texture.destroy(true);
+        this.texture = null;
+        this._styleKey = null;
+    }
 }


### PR DESCRIPTION
Fixes: #11218

Ensures proper destruction of resources associated with Graphics and fills, preventing memory leaks.

This change introduces `destroy` methods to `FillGradient` and `FillPattern` to release their textures and other resources.

The GraphicsContext now utilizes these destroy methods when cleaning up fills during its own destruction.

A new test case is added to verify the correct destruction behavior.
