### PR TITLE
fix: AnimatedSprite destroy method

### DIFF
--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -1,6 +1,7 @@
 import { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import { UPDATE_PRIORITY } from '../../ticker/const';
 import { Ticker } from '../../ticker/Ticker';
+import { type DestroyOptions } from '../container/destroyTypes';
 import { Sprite } from '../sprite/Sprite';
 
 import type { SpriteOptions } from '../sprite/Sprite';
@@ -748,16 +749,39 @@ export class AnimatedSprite extends Sprite
 
     /**
      * Stops the AnimatedSprite and destroys it.
+     * This method stops the animation playback, removes it from the ticker,
+     * and cleans up any resources associated with the sprite.
+     * @param options - Options for destroying the sprite, such as whether to remove from parent
      * @example
      * ```ts
      * // Destroy the sprite when done
      * sprite.destroy();
+     * // Or with options
+     * sprite.destroy({ children: true, texture: true, textureSource: true });
      * ```
      */
-    public destroy(): void
+    public destroy(options: DestroyOptions = false): void
     {
+        const destroyTexture = typeof options === 'boolean' ? options : options?.texture;
+
+        if (destroyTexture)
+        {
+            const destroyTextureSource = typeof options === 'boolean' ? options : options?.textureSource;
+
+            this._textures.forEach((texture) =>
+            {
+                // the current texture will be destroyed by the base sprite class
+                if (this.texture !== texture)
+                {
+                    texture.destroy(destroyTextureSource);
+                }
+            });
+        }
+        this._textures = [];
+        this._durations = null;
+
         this.stop();
-        super.destroy();
+        super.destroy(options);
 
         this.onComplete = null;
         this.onFrameChange = null;

--- a/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
+++ b/src/scene/sprite-animated/__tests__/AnimatedSprite.test.ts
@@ -563,4 +563,37 @@ describe('AnimatedSprite', () =>
             expect(count).toBe(2);
         });
     });
+
+    describe('.destroy()', () =>
+    {
+        it('should destroy all textures', () =>
+        {
+            const sprite = new AnimatedSprite([new Texture(), new Texture()]);
+            const textures = sprite['_textures'];
+            const texture1 = textures[0];
+            const texture2 = textures[1];
+
+            expect(texture1.destroyed).toBe(false);
+            expect(texture2.destroyed).toBe(false);
+
+            sprite.destroy(true);
+
+            expect(texture1.destroyed).toBe(true);
+            expect(texture2.destroyed).toBe(true);
+        });
+
+        it('should destroy the current texture', () =>
+        {
+            const sprite = new AnimatedSprite([new Texture(), new Texture()]);
+
+            sprite.gotoAndPlay(0);
+            const texture = sprite.texture;
+
+            expect(texture.destroyed).toBe(false);
+
+            sprite.destroy(true);
+
+            expect(texture.destroyed).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
Fixes: #11407

Ensures that all textures associated with the AnimatedSprite are properly destroyed.

This prevents memory leaks when the sprite is no longer needed.

Addresses an issue where textures were not being disposed when the AnimatedSprite was destroyed with the `texture` option.
