### PR TITLE
fix: allow for culler plugin to update transforms

### DIFF
--- a/src/culling/CullerPlugin.ts
+++ b/src/culling/CullerPlugin.ts
@@ -6,6 +6,58 @@ import type { Renderer } from '../rendering/renderers/types';
 import type { Container } from '../scene/container/Container';
 
 /**
+ * Application options for the {@link CullerPlugin}.
+ * These options control how your application handles culling of display objects.
+ * @example
+ * ```ts
+ * import { Application } from 'pixi.js';
+ *
+ * // Create application
+ * const app = new Application();
+ * await app.init({
+ *     culler: {
+ *         skipUpdateTransform: true // Skip updating transforms for culled objects
+ *     }
+ * });
+ * ```
+ * @category app
+ * @standard
+ */
+export interface CullerPluginOptions
+{
+    /**
+     * Options for the culler behavior.
+     * @example
+     * ```ts
+     * // Basic culling options
+     * const app = new Application();
+     * await app.init({
+     *     culler: {...}
+     * });
+     * ```
+     */
+    culler?: {
+        /**
+         * Skip updating the transform of culled objects.
+         *
+         * > [!IMPORTANT] Keeping this as `true` can improve performance by avoiding unnecessary calculations,
+         * > however, the transform used for culling may not be up-to-date if the object has moved since the last render.
+         * @default true
+         * @example
+         * ```ts
+         * const app = new Application();
+         * await app.init({
+         *     culler: {
+         *         skipUpdateTransform: true // Skip updating transforms for culled objects
+         *     }
+         * });
+         * ```
+         */
+        skipUpdateTransform?: boolean;
+    };
+}
+
+/**
  * An {@link Application} plugin that automatically culls (hides) display objects that are outside
  * the visible screen area. This improves performance by not rendering objects that aren't visible.
  *
@@ -80,14 +132,18 @@ export class CullerPlugin
     public static render: () => void;
     private static _renderRef: () => void;
 
-    /** @internal */
-    public static init(): void
+    /**
+     * Initialize the plugin with scope of application instance
+     * @private
+     * @param {object} [options] - See application options
+     */
+    public static init(options?: PixiMixins.ApplicationOptions): void
     {
         this._renderRef = this.render.bind(this);
 
         this.render = (): void =>
         {
-            Culler.shared.cull(this.stage, this.renderer.screen);
+            Culler.shared.cull(this.stage, this.renderer.screen, options?.culler?.skipUpdateTransform ?? true);
             this.renderer.render({ container: this.stage });
         };
     }

--- a/src/culling/CullingMixins.d.ts
+++ b/src/culling/CullingMixins.d.ts
@@ -8,6 +8,9 @@ declare global
 
         // eslint-disable-next-line @typescript-eslint/no-empty-object-type
         interface ContainerOptions extends Partial<import('./cullingMixin').CullingMixinConstructor> {}
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+        interface ApplicationOptions extends Partial<import('./CullerPlugin').CullerPluginOptions> {}
     }
 }
 

--- a/src/culling/__tests__/Culler.test.ts
+++ b/src/culling/__tests__/Culler.test.ts
@@ -1,4 +1,6 @@
+import { Application } from '../../app/Application';
 import { Culler } from '../Culler';
+import { CullerPlugin } from '../CullerPlugin';
 import { basePath } from '@test-utils';
 import { Assets, loadTextures } from '~/assets';
 import { extensions } from '~/extensions';
@@ -211,5 +213,51 @@ describe('Culler', () =>
 
         expect(container.culled).toBe(true);
         expect(graphics.culled).toBe(false);
+    });
+});
+
+describe('CullerPlugin', () =>
+{
+    it('should use the correct default options', async () =>
+    {
+        const spyCull = jest.spyOn(Culler.shared, 'cull');
+
+        extensions.add(CullerPlugin);
+        const app = new Application();
+
+        await app.init();
+
+        app.render();
+
+        expect(spyCull).toHaveBeenCalledWith(app.stage, app.renderer.screen, true);
+        app.destroy();
+        extensions.remove(CullerPlugin);
+    });
+
+    it('should use the correct options', async () =>
+    {
+        const spyInit = jest.spyOn(CullerPlugin, 'init');
+        const spyCull = jest.spyOn(Culler.shared, 'cull');
+
+        extensions.add(CullerPlugin);
+        const app = new Application();
+
+        await app.init({
+            culler: {
+                skipUpdateTransform: false,
+            },
+        });
+
+        expect(spyInit).toHaveBeenCalledWith({
+            culler: {
+                skipUpdateTransform: false,
+            },
+        });
+
+        app.render();
+
+        expect(spyCull).toHaveBeenCalledWith(app.stage, app.renderer.screen, false);
+        app.destroy();
+        extensions.remove(CullerPlugin);
     });
 });


### PR DESCRIPTION
Fixes: #10735

This allows users to configure culling behavior through application options, including skipping transform updates for culled objects.

We keep it true by default to keep the performance as optimal as possible.
