### PR TITLE
fix: fillGradientStop logic in TextStyle

### DIFF
--- a/src/scene/text/__tests__/TextStyle.test.ts
+++ b/src/scene/text/__tests__/TextStyle.test.ts
@@ -231,7 +231,8 @@ describe('TextStyle', () =>
     it('should convert fillGradientStops array to FillGradient', () =>
     {
         const style = {
-            fillGradientStops: [0x000000, 0xff0000, 0xFFFFFF],
+            fill: [0x000000, 0xff0000, 0xFFFFFF],
+            fillGradientStops: [0, 0.5, 1],
         };
 
         const textStyle = new TextStyle(style as TextStyleOptions);


### PR DESCRIPTION
Fixes: #10595

Corrects the fillGradientStops implementation in TextStyle when converting from v7 to v8 styles.

One thing to note is that unlike v7, v8 needs to have the number of fills match the number of stops. I don''t think we should be back porting the v7 implementation here, so I have added a warning for when they don't match
