### PR TITLE
fix: Add missing createCanvas calls

### DIFF
--- a/src/assets/loader/parsers/textures/loadSVG.ts
+++ b/src/assets/loader/parsers/textures/loadSVG.ts
@@ -108,16 +108,11 @@ async function loadAsTexture(
     URL.revokeObjectURL(blobUrl);
 
     // convert to canvas...
-    const canvas = document.createElement('canvas');
-    const context = canvas.getContext('2d');
-
-    const resolution = asset.data?.resolution || getResolutionOfUrl(url);
-
     const width = asset.data?.width ?? image.width;
     const height = asset.data?.height ?? image.height;
-
-    canvas.width = width * resolution;
-    canvas.height = height * resolution;
+    const resolution = asset.data?.resolution || getResolutionOfUrl(url);
+    const canvas = DOMAdapter.get().createCanvas(width * resolution, height * resolution);
+    const context = canvas.getContext('2d');
 
     context.drawImage(image, 0, 0, width * resolution, height * resolution);
 

--- a/src/rendering/renderers/gl/texture/utils/getSupportedGlCompressedTextureFormats.ts
+++ b/src/rendering/renderers/gl/texture/utils/getSupportedGlCompressedTextureFormats.ts
@@ -1,4 +1,5 @@
 import { DOMAdapter } from '../../../../../environment/adapter';
+
 import type { TEXTURE_FORMATS } from '../../../shared/texture/const';
 
 let supportedGLCompressedTextureFormats: TEXTURE_FORMATS[];

--- a/src/rendering/renderers/gl/texture/utils/getSupportedGlCompressedTextureFormats.ts
+++ b/src/rendering/renderers/gl/texture/utils/getSupportedGlCompressedTextureFormats.ts
@@ -1,3 +1,4 @@
+import { DOMAdapter } from '../../../../../environment/adapter';
 import type { TEXTURE_FORMATS } from '../../../shared/texture/const';
 
 let supportedGLCompressedTextureFormats: TEXTURE_FORMATS[];
@@ -8,7 +9,7 @@ export function getSupportedGlCompressedTextureFormats(): TEXTURE_FORMATS[]
     if (supportedGLCompressedTextureFormats) return supportedGLCompressedTextureFormats;
 
     // TODO: can we use already created context (webgl or webgl2)?
-    const canvas = document.createElement('canvas');
+    const canvas = DOMAdapter.get().createCanvas(1, 1);
     const gl = canvas.getContext('webgl');
 
     if (!gl)

--- a/src/utils/browser/detectVideoAlphaMode.ts
+++ b/src/utils/browser/detectVideoAlphaMode.ts
@@ -1,4 +1,5 @@
 import { DOMAdapter } from '../../environment/adapter';
+
 import type { ALPHA_MODES } from '../../rendering/renderers/shared/texture/const';
 
 let promise: Promise<ALPHA_MODES> | undefined;

--- a/src/utils/browser/detectVideoAlphaMode.ts
+++ b/src/utils/browser/detectVideoAlphaMode.ts
@@ -1,3 +1,4 @@
+import { DOMAdapter } from '../../environment/adapter';
 import type { ALPHA_MODES } from '../../rendering/renderers/shared/texture/const';
 
 let promise: Promise<ALPHA_MODES> | undefined;
@@ -19,7 +20,7 @@ export async function detectVideoAlphaMode(): Promise<ALPHA_MODES>
 {
     promise ??= (async () =>
     {
-        const canvas = document.createElement('canvas');
+        const canvas = DOMAdapter.get().createCanvas(1, 1);
         const gl = canvas.getContext('webgl');
 
         if (!gl)


### PR DESCRIPTION
Addresses: https://github.com/pixijs/pixijs/issues/11545#issuecomment-3077774625


### Changes

* Replaces `document.createElement('canvas')` with `DOMAdapter.get().createCanvas()`


cc @UlyssesZh

