### PR TITLE
fix: Boost classes in the docs search results

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -87,5 +87,8 @@
         "rewrittenLink": true,
         "notDocumented": false,
         "unusedMergeModuleWith": true
-    }
+    },
+    "searchGroupBoosts": {
+        "Classes": 1.5,
+    },
 }


### PR DESCRIPTION
Fixes #11535

Thanks for pointing out this option @UlyssesZh

### Before

<img width="545" height="483" alt="Screenshot 2025-07-17 at 1 03 56 AM" src="https://github.com/user-attachments/assets/bdd7b1fa-441f-4a34-809f-5afe43ba9c3d" />


### After

<img width="541" height="480" alt="Screenshot 2025-07-17 at 1 04 09 AM" src="https://github.com/user-attachments/assets/8f78bfa9-413f-481b-8cca-d7881633c691" />
