### PR TITLE
fix: progress tracking for asset bundles

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -746,8 +746,10 @@ export class AssetsClass
         const promises = keys.map((bundleId) =>
         {
             const resolveResult = resolveResults[bundleId];
+            const values = Object.values(resolveResult);
+            const totalAssetsToLoad = [...new Set(values.flat())] as ResolvedAsset[];
 
-            total += Object.keys(resolveResult).length;
+            total += totalAssetsToLoad.length;
 
             return this._mapLoadToResolve(resolveResult, _onProgress)
                 .then((resolveResult) =>

--- a/src/assets/__tests__/Assets.test.ts
+++ b/src/assets/__tests__/Assets.test.ts
@@ -28,6 +28,32 @@ describe('Assets', () =>
         expect(bunny2).toBeInstanceOf(Texture);
     });
 
+    it('should load assets with the correct progress', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        let progress = 0;
+        const progressMock = jest.fn((p) => { progress = p; });
+
+        const assets = [
+            {
+                src: 'textures/texture.{webp,png}',
+                alias: ['bunny-array', 'bunny-array2'],
+            },
+            'textures/bunny.png'
+        ];
+        const res = await Assets.load(assets, progressMock);
+
+        expect(progressMock).toHaveBeenCalledTimes(2);
+        expect(progress).toBe(1);
+
+        expect(res['bunny-array']).toBeInstanceOf(Texture);
+        expect(res['bunny-array2']).toBeInstanceOf(Texture);
+        expect(res['textures/bunny.png']).toBeInstanceOf(Texture);
+    });
+
     it('should load assets with resolver', async () =>
     {
         await Assets.init({

--- a/src/assets/__tests__/bundle.test.ts
+++ b/src/assets/__tests__/bundle.test.ts
@@ -37,6 +37,28 @@ describe('Assets bundles', () =>
         expect(assets.spritesheet).toBeInstanceOf(Spritesheet);
     });
 
+    it('should give a correct progress update', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        Assets.addBundle('testBundle', [
+            { alias: ['bunny', 'b'], src: 'textures/bunny.{png,webp}' },
+            { alias: 'spritesheet', src: 'spritesheet/spritesheet.json' },
+        ]);
+
+        let progress = 0;
+        const progressMock = jest.fn((p) => { progress = p; });
+        const assets = await Assets.loadBundle('testBundle', progressMock);
+
+        expect(progressMock).toHaveBeenCalledTimes(2);
+        expect(progress).toBe(1);
+
+        expect(assets.bunny).toBeInstanceOf(Texture);
+        expect(assets.spritesheet).toBeInstanceOf(Spritesheet);
+    });
+
     it('should add and load bundle object', async () =>
     {
         await Assets.init({


### PR DESCRIPTION
Fixes: #10981

The progress is now correctly reported for both individual assets and asset bundles.
