### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,50 +1,75 @@
 name: '🐛 Bug Report'
-description: Something is wrong with PixiJS?
-title: 'Bug: '
+description: Create a report to help us improve
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for reporting an issue!
+        **Before Submitting Your Bug Report...**
 
-        Before opening an issue **please** check if a similar issue exists by
-        searching existing issues (<https://github.com/pixijs/pixijs/issues>).
+        This form is specifically for reporting bugs in PixiJS. If you have questions about usage
+        or aren't sure whether you've encountered a bug, please try these resources first:
 
-        Before submitting please read:
+        - Check the [official documentation](https://pixijs.com/)
+        - Join our [Discord community](https://discord.gg/CPTjeb28nH) for help
+        - Browse [GitHub Discussions](https://github.com/pixijs/pixijs/discussions) for Q&A
 
-        Contributors guide: <https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md>
-        Code of Conduct: <https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md>
-  - type: textarea
+        Please search existing issues before submitting - your bug may have already been reported or fixed in the development branch.
+  - type: input
+    id: version
     attributes:
-      label: Current Behavior
+      label: PixiJS version
+    validations:
+      required: true
+  - type: input
+    id: reproduction-link
+    attributes:
+      label: Link to minimal reproduction
+      description: |
+        To help us fix your bug quickly, please provide a minimal code example that demonstrates the issue.
+
+        **Recommended platforms:**
+        - [PixiPlayground](https://www.pixiplayground.com/) - Perfect for most bug reproductions
+        - [StackBlitz](https://stackblitz.com/edit/pixijs-v8) - Use when you need a full build setup
+
+        **Keep it minimal:** Include only the essential code needed to reproduce the bug. Check our [Bug Reproduction Guidelines](https://github.com/pixijs/pixijs/tree/dev/.github/bug-repro-guidelines.md) for best practices.
+
+        ⚠️ **Important:** Issues without a valid reproduction link will be closed. Please don't submit placeholder or unrelated links.
+      placeholder: Reproduction Link
     validations:
       required: true
   - type: textarea
+    id: steps-to-reproduce
     attributes:
-      label: Expected Behavior
+      label: Steps to reproduce
+      description: |
+        Please provide clear, step-by-step instructions on how to trigger the bug after opening your reproduction link.
+
+        Well-written steps help us identify and fix the issue faster. You can use [Markdown](https://guides.github.com/features/mastering-markdown/) to format your instructions with lists and code blocks.
+      placeholder: Steps to reproduce
     validations:
       required: true
   - type: textarea
+    id: expected
     attributes:
-      label: Steps to Reproduce
-      placeholder: |
-        If possible, please provide code that demonstrates the problem.
-        Links to a running example of the problem are best!
+      label: What is expected?
+    validations:
+      required: true
+  - type: textarea
+    id: actually-happening
+    attributes:
+      label: What is actually happening?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Environment
       value: |
-        - **`pixi.js` version**: *e.g. 7.1.0*
         - **Browser & Version**: *e.g. Chrome 108*
         - **OS & Version**: *e.g. Ubuntu 22.04*
-        - **Running Example**: *e.g. <https://pixiplayground.com/>*
     validations:
       required: true
   - type: textarea
+    id: additional-comments
     attributes:
-      label: Possible Solution
-  - type: textarea
-    attributes:
-      label: Additional Information
+      label: Any additional comments?
+      description: e.g. some background/context of how you ran into this bug or possible solutions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: '💬 Discussions'
+  - name: Discord Chat
+    url: https://discord.gg/CPTjeb28nH
+    about: Ask questions and discuss with other PixiJS users in real time.
+  - name: Questions & Discussions
     url: https://github.com/pixijs/pixijs/discussions
-    about: Ask everything about PixiJS.
-  - name: '📦 Strange problems when upgrading PixiJS'
+    about: Use GitHub discussions for message-board style questions and discussions.
+  - name: 'Strange problems when upgrading PixiJS'
     url: https://github.com/pixijs/pixijs/wiki/Upgrading-PixiJS
     about: You may need to reinstall PixiJS when upgrading it.
+  - name: Open Collective
+    url: https://opencollective.com/pixijs/donate
+    about: Love PixiJS? Please consider supporting us via Open Collective.

--- a/.github/bug-repo-guidelines.md
+++ b/.github/bug-repo-guidelines.md
@@ -1,0 +1,34 @@
+## Bug Reproduction Guidelines
+
+A bug reproduction is runnable code that demonstrates exactly how a bug occurs. Think of it as a recipe that helps us recreate and fix the problem you're experiencing.
+
+### Why text descriptions aren't enough
+
+While detailed descriptions are helpful, they can't replace actual code because:
+
+- Technical problems are difficult to describe precisely without missing crucial details
+- The real cause might be something you didn't think to mention
+- Only runnable code gives us the complete context we need to debug effectively
+
+### Make it runnable, not just visual
+
+Screenshots and videos show us *that* a bug exists, but not *why* it happens. We need runnable code to understand the root cause and fix it properly.
+
+**Note:** Videos or GIFs can be helpful supplements for explaining complex interactions that are hard to describe in words.
+
+### Keep it minimal
+
+Please don't link to your entire project and ask us to find the bug. Here's why:
+
+- **Time constraints:** Hunting bugs in large, unfamiliar codebases is extremely time-consuming
+- **Unclear source:** The issue might be in your application code rather than PixiJS itself
+- **Focus:** We need to isolate the exact problem to fix it efficiently
+
+**What "minimal" means:** Include only the essential code needed to trigger the bug. Strip away everything unrelated to the specific issue you're reporting.
+
+### Creating your reproduction
+
+Choose the platform that best fits your needs:
+
+- **[PixiPlayground](https://www.pixiplayground.com/)** - Perfect for most bug reproductions
+- **[StackBlitz](https://stackblitz.com/edit/pixijs-v8)** - Use when you need a full build setup


### PR DESCRIPTION
Updates the bug reporting process by introducing a bug reproduction guideline document and updates the bug report issue template.

This idea here was to better enforce a minimal reproduction when an issue is created.
