### PR TITLE
Fix Container.parent type not being nullable and possibly undefined

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -720,7 +720,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @see {@link Container#addChild} For adding to a parent
      * @see {@link Container#removeChild} For removing from parent
      */
-    public parent: Container = null;
+    public parent: Container | null = null;
 
     // used internally for changing up the render order.. mainly for masks and filters
     // TODO setting this should cause a rebuild??


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Update Container.parent type from Container to Container | null to match the actual runtime behavior where parent can be null when a container is not attached to a parent.
Why necessary: The current type forces developers to use non-null assertions (!) or disable ESLint warnings when checking if a container has a parent, even though the runtime value can legitimately be null.
Example:
```
// Current behavior requires non-null assertion or ESLint disable
let current = sprite;
while (current.parent!) { // ESLint: Unnecessary non-null assertion
    current = current.parent!;
}

// With the fix, natural null checking works
let current = sprite;
while (current.parent) { // Clean, no ESLint warnings
    current = current.parent;
}
```
This change aligns the TypeScript types with the actual runtime behavior where parent is initialized as null and can be null when containers are detached from their parent.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [-] Tests passed (`npm run test`) (the current dev branch seems to have many failing tests, I dont think its related)
