### PR TITLE
fix: trimmed text rendereing with non default resolution

### DIFF
--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -676,6 +676,34 @@ export class Rectangle implements ShapePrimitive
     }
 
     /**
+     * Scales the rectangle's dimensions and position by the specified factors.
+     * @example
+     * ```ts
+     * const rect = new Rectangle(50, 50, 100, 100);
+     *
+     * // Scale uniformly
+     * rect.scale(0.5, 0.5);
+     * // rect is now: x=25, y=25, width=50, height=50
+     *
+     * // non-uniformly
+     * rect.scale(0.5, 1);
+     * // rect is now: x=25, y=50, width=50, height=100
+     * ```
+     * @param x - The factor by which to scale the horizontal properties (x, width).
+     * @param y - The factor by which to scale the vertical properties (y, height).
+     * @returns Returns itself
+     */
+    public scale(x: number, y: number = x): this
+    {
+        this.x *= x;
+        this.y *= y;
+        this.width *= x;
+        this.height *= y;
+
+        return this;
+    }
+
+    /**
      * Enlarges this rectangle to include the passed rectangle.
      * @example
      * ```ts

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -102,6 +102,11 @@ export class CanvasTextSystem implements System
             // reapply the padding to the frame
             frame.pad(style.padding);
             texture.frame.copyFrom(frame);
+
+            // We initially increased the frame size by a resolution factor
+            // to achieve a crisper display. Now we need to scale down the already
+            // trimmed frame to render the texture in the expected size.
+            texture.frame.scale(1 / resolution);
             texture.updateUvs();
         }
 


### PR DESCRIPTION
Fixes: #11556

##### Description of change
The trimmed frame is now scaled adequately to the expected size.
<img width="553" height="554" alt="image" src="https://github.com/user-attachments/assets/68544c92-3022-4b4a-bca8-69df896be868" />

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
