### PR TITLE
fix: blur filter strength and deprecate old behavior

### DIFF
--- a/src/filters/defaults/blur/const.ts
+++ b/src/filters/defaults/blur/const.ts
@@ -12,3 +12,23 @@ export const GAUSSIAN_VALUES: IGAUSSIAN_VALUES = {
     13: [0.002406, 0.009255, 0.027867, 0.065666, 0.121117, 0.174868, 0.197641],
     15: [0.000489, 0.002403, 0.009246, 0.02784, 0.065602, 0.120999, 0.174697, 0.197448],
 };
+
+/** @internal */
+export const GAUSSIAN_VALUES_FIX: IGAUSSIAN_VALUES = {};
+
+for (const kernelSize of [5, 7, 9, 11, 13, 15])
+{
+    const a: number[] = GAUSSIAN_VALUES_FIX[kernelSize] = [];
+
+    for (let i = 0; (2 * i) + 1 <= kernelSize; i++)
+    {
+        // recurrence relation for binomial coefficients
+        a[i] = i === 0 ? 1 : a[i - 1] * (kernelSize - i) / i;
+    }
+    const normalization = 2 ** (1 - kernelSize);
+
+    for (let i = 0; i < a.length; i++)
+    {
+        a[i] *= normalization;
+    }
+}

--- a/src/filters/defaults/blur/gl/generateBlurFragSource.ts
+++ b/src/filters/defaults/blur/gl/generateBlurFragSource.ts
@@ -1,4 +1,4 @@
-import { GAUSSIAN_VALUES } from '../const';
+import { GAUSSIAN_VALUES, GAUSSIAN_VALUES_FIX } from '../const';
 
 const fragTemplate = [
     'in vec2 vBlurTexCoords[%size%];',
@@ -16,10 +16,11 @@ const fragTemplate = [
 /**
  * @internal
  * @param kernelSize - The size of the kernel.
+ * @param fix - Whether to use the new Gaussian values.
  */
-export function generateBlurFragSource(kernelSize: number): string
+export function generateBlurFragSource(kernelSize: number, fix: boolean): string
 {
-    const kernel = GAUSSIAN_VALUES[kernelSize];
+    const kernel = (fix ? GAUSSIAN_VALUES_FIX : GAUSSIAN_VALUES)[kernelSize];
     const halfLength = kernel.length;
 
     let fragSource = fragTemplate;

--- a/src/filters/defaults/blur/gl/generateBlurGlProgram.ts
+++ b/src/filters/defaults/blur/gl/generateBlurGlProgram.ts
@@ -6,11 +6,12 @@ import { generateBlurVertSource } from './generateBlurVertSource';
  * @internal
  * @param horizontal - Whether to generate a horizontal or vertical blur program.
  * @param kernelSize - The size of the kernel.
+ * @param fix - Whether to use the new Gaussian values.
  */
-export function generateBlurGlProgram(horizontal: boolean, kernelSize: number)
+export function generateBlurGlProgram(horizontal: boolean, kernelSize: number, fix: boolean)
 {
     const vertex = generateBlurVertSource(kernelSize, horizontal);
-    const fragment = generateBlurFragSource(kernelSize);
+    const fragment = generateBlurFragSource(kernelSize, fix);
 
     return GlProgram.from({
         vertex,

--- a/src/filters/defaults/blur/gpu/generateBlurProgram.ts
+++ b/src/filters/defaults/blur/gpu/generateBlurProgram.ts
@@ -1,15 +1,16 @@
 import { GpuProgram } from '../../../../rendering/renderers/gpu/shader/GpuProgram';
-import { GAUSSIAN_VALUES } from '../const';
+import { GAUSSIAN_VALUES, GAUSSIAN_VALUES_FIX } from '../const';
 import source from './blur-template.wgsl';
 
 /**
  * @internal
  * @param horizontal - Whether to generate a horizontal or vertical blur program.
  * @param kernelSize - The size of the kernel.
+ * @param fix - Whether to use the new Gaussian values.
  */
-export function generateBlurProgram(horizontal: boolean, kernelSize: number)
+export function generateBlurProgram(horizontal: boolean, kernelSize: number, fix: boolean)
 {
-    const kernel = GAUSSIAN_VALUES[kernelSize];
+    const kernel = (fix ? GAUSSIAN_VALUES_FIX : GAUSSIAN_VALUES)[kernelSize];
     const halfLength = kernel.length;
 
     const blurStructSource: string[] = [];

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -13,6 +13,11 @@ export const v8_0_0 = '8.0.0';
  * @ignore
  */
 export const v8_3_4 = '8.3.4';
+/**
+ * deprecation name for version 8.12.0
+ * @ignore
+ */
+export const v8_12_0 = '8.12.0';
 
 /**
  * Helper for warning developers about deprecated features & settings.


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

Closes #11554.

##### Description of change
Fix blur filter strength and deprecate old behavior. The old behavior is still the default, and the new behavior is enabled by setting the static property `BlurFilterPass.sqrtScaledStrength = true`. Creating an instance of `BlurFilterPass` without this flag emits a deprecation warning.

Core change:

```diff
-this._uniforms.uStrength = this.strength / this.passes;
+this._uniforms.uStrength = this.strength / Math.sqrt(this.passes * (this._kernelSize - 1));
```

Now the standard deviation of the blurring effect is independent of the quality (number of passes) and the kernel size. The distribution defined in constant `GAUSSIAN_VALUES_FIX` has standard deviation `sqrt(kernelSize - 1)`.

Not sure if a visual scene test should be included.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
