### PR TITLE
docs: Fix missing constructors

### DIFF
--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -215,7 +215,6 @@ export class Application<R extends Renderer = Renderer>
     /** @deprecated since 8.0.0 */
     constructor(options?: Partial<ApplicationOptions>);
 
-    /** @ignore */
     constructor(...args: [Partial<ApplicationOptions>] | [])
     {
         // #if _DEBUG

--- a/src/gif/GifSprite.ts
+++ b/src/gif/GifSprite.ts
@@ -386,7 +386,6 @@ class GifSprite extends Sprite
      */
     constructor(options: GifSpriteOptions);
 
-    /** @ignore */
     constructor(...args: [GifSource] | [GifSpriteOptions])
     {
         const options = args[0] instanceof GifSource ? { source: args[0] } : args[0];

--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -401,7 +401,7 @@ export class AnimatedSprite extends Sprite
      * @param options - The options for the AnimatedSprite.
      */
     constructor(options: AnimatedSpriteOptions);
-    /** @ignore */
+
     constructor(...args: [AnimatedSpriteOptions?] | [AnimatedSpriteFrames?] | [AnimatedSpriteFrames?, boolean?])
     {
         let options = args[0] as AnimatedSpriteOptions;

--- a/src/spritesheet/Spritesheet.ts
+++ b/src/spritesheet/Spritesheet.ts
@@ -293,7 +293,7 @@ export class Spritesheet<S extends SpritesheetData = SpritesheetData>
      * @param {object} data - Spritesheet image data.
      */
     constructor(texture: BindableTexture, data: S);
-    /** @ignore */
+
     constructor(optionsOrTexture: SpritesheetOptions<S> | BindableTexture, arg1?: S)
     {
         let options = optionsOrTexture as SpritesheetOptions<S>;


### PR DESCRIPTION
Issue raised in https://github.com/pixijs/pixijs/pull/11243#issuecomment-3116767491

### Changes

* Constructors for `Application`, `GifSprite`, `AnimatedSprite` and `Spritesheet` were missing from the docs because of the incorrect use of `/** @ignore */`

### Example

* [Before](https://pixijs.download/v8.11.0/docs/scene.AnimatedSprite.html)
* [After](https://pixijs.download/docs/missing-constructors/docs/scene.AnimatedSprite.html)