### PR TITLE
chore: fix Assets docs typos

### DIFF
--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -143,7 +143,7 @@ function getBrowserSupportedVideoExtensions()
  * A simple plugin to load video textures.
  *
  * You can pass VideoSource options to the loader via the .data property of the asset descriptor
- * when using Asset.load().
+ * when using Assets.load().
  * ```js
  * // Set the data
  * const texture = await Assets.load({

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -115,7 +115,7 @@ export type TextureSourceLike = TextureSource | TextureResourceOrOptions | strin
  * // once Assets has loaded the image it will be available via the from method
  * const sameTexture = Texture.from('assets/image.png');
  * // another way to access the texture once loaded
- * const sameAgainTexture = Asset.get('assets/image.png');
+ * const sameAgainTexture = Assets.get('assets/image.png');
  *
  * const sprite1 = new Sprite(texture);
  *


### PR DESCRIPTION
Fix minor typos with "Assets" vs "Asset" in doc examples.