### PR TITLE
fix: Fix incompatible `parent` type on `IFederatedContainer`

### DIFF
--- a/src/events/FederatedEventTarget.ts
+++ b/src/events/FederatedEventTarget.ts
@@ -1090,7 +1090,7 @@ export type RemoveListenerOptions = boolean | EventListenerOptions;
 export interface IFederatedContainer extends FederatedOptions
 {
     /** The parent of this event target. */
-    readonly parent?: Container;
+    readonly parent?: Container | null;
 
     /** The children of this event target. */
     readonly children?: ReadonlyArray<Container>;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

When using `strictNullChecks`, TypeScript differentiates between `undefined` and `null`. For codebases using this Pixi in the latest version was producing the following error:
>  Interface '[...].Container<C>' incorrectly extends interface 'PixiMixins.Container<C>'
>   Types of property 'parent' are incompatible
>     Type 'Container<ContainerChild> | null' is not assignable to type 'Container<ContainerChild> | undefined'

This PR widens the `parent` type in `IFederatedContainer` (from which `PixiMixins.Container` extends) in order to fix this issue.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
