### PR TITLE
fix: applying nextLine to BitmapTextLayout so it renders newlines properly

### DIFF
--- a/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
+++ b/src/scene/text-bitmap/utils/getBitmapTextLayout.ts
@@ -183,10 +183,7 @@ export function getBitmapTextLayout(
 
             if (char === '\r' || char === '\n')
             {
-                if (currentLine.width !== 0)
-                {
-                    nextLine();
-                }
+                nextLine();
             }
             else if (!isEnd)
             {


### PR DESCRIPTION
##### Description of change
BitmapText now renders empty lines of text as it is supposed to. You can see attached images of before and after.
<img width="606" height="430" alt="image" src="https://github.com/user-attachments/assets/30707221-a3f3-4ed2-b2a2-52e22d77d258" />

<img width="588" height="469" alt="image" src="https://github.com/user-attachments/assets/3a5ce63a-260e-4490-b7d9-4a0541a9e67c" />


##### Pre-Merge Checklist
- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Fixes https://github.com/pixijs/pixijs/issues/10463

