### PR TITLE
fix: avoid instanceof

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -11,6 +11,8 @@ import type { Renderer } from '../rendering/renderers/types';
 import type { Container } from '../scene/container/Container';
 import type { isMobileResult } from '../utils/browser/isMobile';
 
+const typeSymbol = Symbol.for('pixijs.AccessibilitySystem');
+
 /** @ignore */
 const KEY_CODE_TAB = 9;
 
@@ -88,6 +90,22 @@ export interface AccessibilityOptions
  */
 export class AccessibilitySystem implements System<AccessibilitySystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of AccessibilitySystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AccessibilitySystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a AccessibilitySystem, false otherwise.
+     */
+    public static isAccessibilitySystem(obj: any): obj is AccessibilitySystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/advanced-blend-modes/ColorBlend.ts
+++ b/src/advanced-blend-modes/ColorBlend.ts
@@ -20,6 +20,7 @@ const typeSymbol = Symbol.for('pixijs.ColorBlend');
  * sprite.blendMode = 'color'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class ColorBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/ColorBlend.ts
+++ b/src/advanced-blend-modes/ColorBlend.ts
@@ -5,6 +5,8 @@ import { hslgpu } from '../filters/blend-modes/hls/GPUhls';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.ColorBlend');
+
 /**
  * The final color has the hue and saturation of the top color, while using the luminosity of the bottom color.
  * The effect preserves gray levels and can be used to colorize the foreground.
@@ -21,6 +23,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class ColorBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of ColorBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorBlend, false otherwise.
+     */
+    public static isColorBlend(obj: any): obj is ColorBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'color',

--- a/src/advanced-blend-modes/ColorBurnBlend.ts
+++ b/src/advanced-blend-modes/ColorBurnBlend.ts
@@ -21,6 +21,7 @@ const typeSymbol = Symbol.for('pixijs.ColorBurnBlend');
  * sprite.blendMode = 'color-burn'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class ColorBurnBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/ColorBurnBlend.ts
+++ b/src/advanced-blend-modes/ColorBurnBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.ColorBurnBlend');
+
 /**
  * The final color is the result of inverting the bottom color, dividing the value by the top color,
  * and inverting that value. A white foreground leads to no change.
@@ -22,6 +24,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class ColorBurnBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of ColorBurnBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorBurnBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorBurnBlend, false otherwise.
+     */
+    public static isColorBurnBlend(obj: any): obj is ColorBurnBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'color-burn',

--- a/src/advanced-blend-modes/ColorDodgeBlend.ts
+++ b/src/advanced-blend-modes/ColorDodgeBlend.ts
@@ -5,6 +5,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.ColorDodgeBlend');
+
 /**
  * The final color is the result of dividing the bottom color by the inverse of the top color.
  * A black foreground leads to no change.
@@ -23,6 +25,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class ColorDodgeBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of ColorDodgeBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorDodgeBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorDodgeBlend, false otherwise.
+     */
+    public static isColorDodgeBlend(obj: any): obj is ColorDodgeBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'color-dodge',

--- a/src/advanced-blend-modes/ColorDodgeBlend.ts
+++ b/src/advanced-blend-modes/ColorDodgeBlend.ts
@@ -22,6 +22,7 @@ const typeSymbol = Symbol.for('pixijs.ColorDodgeBlend');
  * sprite.blendMode = 'color-dodge'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class ColorDodgeBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/DarkenBlend.ts
+++ b/src/advanced-blend-modes/DarkenBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.DarkenBlend');
+
 /**
  * The final color is composed of the darkest values of each color channel.
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class DarkenBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of DarkenBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DarkenBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a DarkenBlend, false otherwise.
+     */
+    public static isDarkenBlend(obj: any): obj is DarkenBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'darken',

--- a/src/advanced-blend-modes/DarkenBlend.ts
+++ b/src/advanced-blend-modes/DarkenBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.DarkenBlend');
  * sprite.blendMode = 'darken'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class DarkenBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/DifferenceBlend.ts
+++ b/src/advanced-blend-modes/DifferenceBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.DifferenceBlend');
+
 /**
  * The final color is the result of subtracting the darker of the two colors from the lighter one.
  * black layer has no effect, while a white layer inverts the other layer's color.
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class DifferenceBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of DifferenceBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DifferenceBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a DifferenceBlend, false otherwise.
+     */
+    public static isDifferenceBlend(obj: any): obj is DifferenceBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'difference',

--- a/src/advanced-blend-modes/DifferenceBlend.ts
+++ b/src/advanced-blend-modes/DifferenceBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.DifferenceBlend');
  * sprite.blendMode = 'difference'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class DifferenceBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/DivideBlend.ts
+++ b/src/advanced-blend-modes/DivideBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.DivideBlend');
+
 /**
  * The Divide blend mode divides the RGB channel values of the bottom layer by those of the top layer.
  * The darker the top layer, the brighter the bottom layer will appear.
@@ -20,6 +22,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class DivideBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of DivideBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DivideBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a DivideBlend, false otherwise.
+     */
+    public static isDivideBlend(obj: any): obj is DivideBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'divide',

--- a/src/advanced-blend-modes/DivideBlend.ts
+++ b/src/advanced-blend-modes/DivideBlend.ts
@@ -19,6 +19,7 @@ const typeSymbol = Symbol.for('pixijs.DivideBlend');
  * sprite.blendMode = 'divide'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class DivideBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/ExclusionBlend.ts
+++ b/src/advanced-blend-modes/ExclusionBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.ExclusionBlend');
+
 /**
  * The final color is similar to difference, but with less contrast.
  * As with difference, a black layer has no effect, while a white layer inverts the other layer's color.
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class ExclusionBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of ExclusionBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ExclusionBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a ExclusionBlend, false otherwise.
+     */
+    public static isExclusionBlend(obj: any): obj is ExclusionBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'exclusion',

--- a/src/advanced-blend-modes/ExclusionBlend.ts
+++ b/src/advanced-blend-modes/ExclusionBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.ExclusionBlend');
  * sprite.blendMode = 'exclusion'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class ExclusionBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/HardLightBlend.ts
+++ b/src/advanced-blend-modes/HardLightBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.HardLightBlend');
+
 /**
  * The final color is the result of multiply if the top color is darker, or screen if the top color is lighter.
  * This blend mode is equivalent to overlay but with the layers swapped.
@@ -20,6 +22,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class HardLightBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of HardLightBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HardLightBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a HardLightBlend, false otherwise.
+     */
+    public static isHardLightBlend(obj: any): obj is HardLightBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'hard-light',

--- a/src/advanced-blend-modes/HardLightBlend.ts
+++ b/src/advanced-blend-modes/HardLightBlend.ts
@@ -19,6 +19,7 @@ const typeSymbol = Symbol.for('pixijs.HardLightBlend');
  * sprite.blendMode = 'hard-light'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class HardLightBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/HardMixBlend.ts
+++ b/src/advanced-blend-modes/HardMixBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.HardMixBlend');
  * sprite.blendMode = 'hard-mix'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class HardMixBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/HardMixBlend.ts
+++ b/src/advanced-blend-modes/HardMixBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.HardMixBlend');
+
 /**
  * Hard defines each of the color channel values of the blend color to the RGB values of the base color.
  * If the sum of a channel is 255, it receives a value of 255; if less than 255, a value of 0.
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class HardMixBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of HardMixBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HardMixBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a HardMixBlend, false otherwise.
+     */
+    public static isHardMixBlend(obj: any): obj is HardMixBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'hard-mix',

--- a/src/advanced-blend-modes/LightenBlend.ts
+++ b/src/advanced-blend-modes/LightenBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.LightenBlend');
+
 /**
  * The final color is composed of the lightest values of each color channel.
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class LightenBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of LightenBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a LightenBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a LightenBlend, false otherwise.
+     */
+    public static isLightenBlend(obj: any): obj is LightenBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'lighten',

--- a/src/advanced-blend-modes/LightenBlend.ts
+++ b/src/advanced-blend-modes/LightenBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.LightenBlend');
  * sprite.blendMode = 'lighten'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class LightenBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/LinearBurnBlend.ts
+++ b/src/advanced-blend-modes/LinearBurnBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.LinearBurnBlend');
  * sprite.blendMode = 'linear-burn'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class LinearBurnBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/LinearBurnBlend.ts
+++ b/src/advanced-blend-modes/LinearBurnBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.LinearBurnBlend');
+
 /**
  * Looks at the color information in each channel and darkens the base color to
  * reflect the blend color by increasing the contrast between the two.
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class LinearBurnBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of LinearBurnBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a LinearBurnBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a LinearBurnBlend, false otherwise.
+     */
+    public static isLinearBurnBlend(obj: any): obj is LinearBurnBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'linear-burn',

--- a/src/advanced-blend-modes/LinearDodgeBlend.ts
+++ b/src/advanced-blend-modes/LinearDodgeBlend.ts
@@ -19,6 +19,7 @@ const typeSymbol = Symbol.for('pixijs.LinearDodgeBlend');
  * sprite.blendMode = 'linear-dodge'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class LinearDodgeBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/LinearDodgeBlend.ts
+++ b/src/advanced-blend-modes/LinearDodgeBlend.ts
@@ -5,6 +5,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.LinearDodgeBlend');
+
 /**
  * Looks at the color information in each channel and brightens the base color to reflect the blend color by decreasing contrast between the two.
  *
@@ -20,6 +22,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class LinearDodgeBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of LinearDodgeBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a LinearDodgeBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a LinearDodgeBlend, false otherwise.
+     */
+    public static isLinearDodgeBlend(obj: any): obj is LinearDodgeBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'linear-dodge',

--- a/src/advanced-blend-modes/LinearLightBlend.ts
+++ b/src/advanced-blend-modes/LinearLightBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.LinearLightBlend');
  * sprite.blendMode = 'linear-light'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class LinearLightBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/LinearLightBlend.ts
+++ b/src/advanced-blend-modes/LinearLightBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.LinearLightBlend');
+
 /**
  * Increase or decrease brightness by burning or dodging color values, based on the blend color
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class LinearLightBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of LinearLightBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a LinearLightBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a LinearLightBlend, false otherwise.
+     */
+    public static isLinearLightBlend(obj: any): obj is LinearLightBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'linear-light',

--- a/src/advanced-blend-modes/LuminosityBlend.ts
+++ b/src/advanced-blend-modes/LuminosityBlend.ts
@@ -20,6 +20,7 @@ const typeSymbol = Symbol.for('pixijs.LuminosityBlend');
  * sprite.blendMode = 'luminosity'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class LuminosityBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/LuminosityBlend.ts
+++ b/src/advanced-blend-modes/LuminosityBlend.ts
@@ -5,6 +5,8 @@ import { hslgpu } from '../filters/blend-modes/hls/GPUhls';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.LuminosityBlend');
+
 /**
  * The final color has the luminosity of the top color, while using the hue and saturation of the bottom color.
  * This blend mode is equivalent to color, but with the layers swapped.
@@ -21,6 +23,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class LuminosityBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of LuminosityBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a LuminosityBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a LuminosityBlend, false otherwise.
+     */
+    public static isLuminosityBlend(obj: any): obj is LuminosityBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'luminosity',

--- a/src/advanced-blend-modes/NegationBlend.ts
+++ b/src/advanced-blend-modes/NegationBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.NegationBlend');
  * sprite.blendMode = 'negation'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class NegationBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/NegationBlend.ts
+++ b/src/advanced-blend-modes/NegationBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.NegationBlend');
+
 /**
  * Implements the Negation blend mode which creates an inverted effect based on the brightness values.
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class NegationBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of NegationBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a NegationBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a NegationBlend, false otherwise.
+     */
+    public static isNegationBlend(obj: any): obj is NegationBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'negation',

--- a/src/advanced-blend-modes/OverlayBlend.ts
+++ b/src/advanced-blend-modes/OverlayBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.OverlayBlend');
+
 /**
  * The final color is the result of multiply if the bottom color is darker, or screen if the bottom color is lighter.
  * This blend mode is equivalent to hard-light but with the layers swapped.
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class OverlayBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of OverlayBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a OverlayBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a OverlayBlend, false otherwise.
+     */
+    public static isOverlayBlend(obj: any): obj is OverlayBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'overlay',

--- a/src/advanced-blend-modes/OverlayBlend.ts
+++ b/src/advanced-blend-modes/OverlayBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.OverlayBlend');
  * sprite.blendMode = 'overlay'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class OverlayBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/PinLightBlend.ts
+++ b/src/advanced-blend-modes/PinLightBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.PinLightBlend');
+
 /**
  * Replaces colors based on the blend color.
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class PinLightBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of PinLightBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PinLightBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a PinLightBlend, false otherwise.
+     */
+    public static isPinLightBlend(obj: any): obj is PinLightBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'pin-light',

--- a/src/advanced-blend-modes/PinLightBlend.ts
+++ b/src/advanced-blend-modes/PinLightBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.PinLightBlend');
  * sprite.blendMode = 'pin-light'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class PinLightBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/SaturationBlend.ts
+++ b/src/advanced-blend-modes/SaturationBlend.ts
@@ -20,6 +20,7 @@ const typeSymbol = Symbol.for('pixijs.SaturationBlend');
  * sprite.blendMode = 'saturation'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class SaturationBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/SaturationBlend.ts
+++ b/src/advanced-blend-modes/SaturationBlend.ts
@@ -5,6 +5,8 @@ import { hslgpu } from '../filters/blend-modes/hls/GPUhls';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.SaturationBlend');
+
 /**
  * The final color has the saturation of the top color, while using the hue and luminosity of the bottom color.
  * A pure gray backdrop, having no saturation, will have no effect.
@@ -21,6 +23,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class SaturationBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of SaturationBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SaturationBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a SaturationBlend, false otherwise.
+     */
+    public static isSaturationBlend(obj: any): obj is SaturationBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'saturation',

--- a/src/advanced-blend-modes/SoftLightBlend.ts
+++ b/src/advanced-blend-modes/SoftLightBlend.ts
@@ -20,6 +20,7 @@ const typeSymbol = Symbol.for('pixijs.SoftLightBlend');
  * sprite.blendMode = 'soft-light'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class SoftLightBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/SoftLightBlend.ts
+++ b/src/advanced-blend-modes/SoftLightBlend.ts
@@ -5,6 +5,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.SoftLightBlend');
+
 /**
  * The final color is similar to hard-light, but softer. This blend mode behaves similar to hard-light.
  * The effect is similar to shining a diffused spotlight on the backdrop.
@@ -21,6 +23,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class SoftLightBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of SoftLightBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SoftLightBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a SoftLightBlend, false otherwise.
+     */
+    public static isSoftLightBlend(obj: any): obj is SoftLightBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'soft-light',

--- a/src/advanced-blend-modes/SubtractBlend.ts
+++ b/src/advanced-blend-modes/SubtractBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.SubtractBlend');
+
 /**
  * Subtracts the blend from the base color using each color channel
  *
@@ -18,6 +20,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class SubtractBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of SubtractBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SubtractBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a SubtractBlend, false otherwise.
+     */
+    public static isSubtractBlend(obj: any): obj is SubtractBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'subtract',

--- a/src/advanced-blend-modes/SubtractBlend.ts
+++ b/src/advanced-blend-modes/SubtractBlend.ts
@@ -17,6 +17,7 @@ const typeSymbol = Symbol.for('pixijs.SubtractBlend');
  * sprite.blendMode = 'subtract'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class SubtractBlend extends BlendModeFilter
 {

--- a/src/advanced-blend-modes/VividLightBlend.ts
+++ b/src/advanced-blend-modes/VividLightBlend.ts
@@ -3,6 +3,8 @@ import { BlendModeFilter } from '../filters/blend-modes/BlendModeFilter';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.VividLightBlend');
+
 /**
  * Darkens values darker than 50% gray and lightens those brighter than 50% gray, creating a dramatic effect.
  * It's essentially an extreme version of the Overlay mode, with a significant impact on midtones
@@ -19,6 +21,22 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
  */
 export class VividLightBlend extends BlendModeFilter
 {
+    /**
+     * Type symbol used to identify instances of VividLightBlend.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a VividLightBlend.
+     * @param obj - The object to check.
+     * @returns True if the object is a VividLightBlend, false otherwise.
+     */
+    public static isVividLightBlend(obj: any): obj is VividLightBlend
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'vivid-light',

--- a/src/advanced-blend-modes/VividLightBlend.ts
+++ b/src/advanced-blend-modes/VividLightBlend.ts
@@ -18,6 +18,7 @@ const typeSymbol = Symbol.for('pixijs.VividLightBlend');
  * sprite.blendMode = 'vivid-light'
  * @category filters
  * @noInheritDoc
+ * @standard
  */
 export class VividLightBlend extends BlendModeFilter
 {

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -10,6 +10,8 @@ import type { RendererDestroyOptions } from '../rendering/renderers/shared/syste
 import type { Renderer } from '../rendering/renderers/types';
 import type { DestroyOptions } from '../scene/container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixijs.Application');
+
 /**
  * Interface for creating Application plugins. Any plugin that's usable for Application must implement these methods.
  *
@@ -166,6 +168,22 @@ export interface Application extends PixiMixins.Application { }
  */
 export class Application<R extends Renderer = Renderer>
 {
+    /**
+     * Type symbol used to identify instances of Application.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is an Application.
+     * @param obj - The object to check.
+     * @returns True if the object is an Application, false otherwise.
+     */
+    public static isApplication(obj: any): obj is Application
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Collection of installed plugins.
      * @internal

--- a/src/app/ResizePlugin.ts
+++ b/src/app/ResizePlugin.ts
@@ -3,6 +3,8 @@ import { ExtensionType } from '../extensions/Extensions';
 import type { ExtensionMetadata } from '../extensions/Extensions';
 import type { Renderer } from '../rendering/renderers/types';
 
+const typeSymbol = Symbol.for('pixijs.ResizePlugin');
+
 type ResizeableRenderer = Pick<Renderer, 'resize'>;
 
 /**
@@ -71,6 +73,22 @@ export interface ResizePluginOptions
  */
 export class ResizePlugin
 {
+    /**
+     * Type symbol used to identify instances of ResizePlugin.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ResizePlugin.
+     * @param obj - The object to check.
+     * @returns True if the object is a ResizePlugin, false otherwise.
+     */
+    public static isResizePlugin(obj: any): obj is ResizePlugin
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = ExtensionType.Application;
     /** @internal */

--- a/src/app/TickerPlugin.ts
+++ b/src/app/TickerPlugin.ts
@@ -4,6 +4,8 @@ import { Ticker } from '../ticker/Ticker';
 
 import type { ExtensionMetadata } from '../extensions/Extensions';
 
+const typeSymbol = Symbol.for('pixijs.TickerPlugin');
+
 /**
  * Application options for the {@link TickerPlugin}.
  * These options control the animation loop and update cycle of your PixiJS application.
@@ -138,6 +140,22 @@ export interface TickerPluginOptions
  */
 export class TickerPlugin
 {
+    /**
+     * Type symbol used to identify instances of TickerPlugin.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TickerPlugin.
+     * @param obj - The object to check.
+     * @returns True if the object is a TickerPlugin, false otherwise.
+     */
+    public static isTickerPlugin(obj: any): obj is TickerPlugin
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = ExtensionType.Application;
 

--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -30,6 +30,8 @@ import type { LoadSVGConfig } from './loader/parsers/textures/loadSVG';
 import type { BundleIdentifierOptions } from './resolver/Resolver';
 import type { ArrayOr, AssetsBundle, AssetsManifest, ResolvedAsset, UnresolvedAsset } from './types';
 
+const typeSymbol = Symbol.for('pixijs.AssetsClass');
+
 /**
  * Callback function for tracking asset loading progress. The function is called repeatedly
  * during the loading process with a progress value between 0.0 and 1.0.
@@ -257,6 +259,22 @@ export interface AssetInitOptions
 /** @internal */
 export class AssetsClass
 {
+    /**
+     * Type symbol used to identify instances of AssetsClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AssetsClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a AssetsClass, false otherwise.
+     */
+    public static isAssetsClass(obj: any): obj is AssetsClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The URL resolver for assets. Maps various asset keys and URLs to their final loadable form.
      * @advanced

--- a/src/assets/BackgroundLoader.ts
+++ b/src/assets/BackgroundLoader.ts
@@ -1,6 +1,8 @@
 import type { Loader } from './loader/Loader';
 import type { ResolvedAsset } from './types';
 
+const typeSymbol = Symbol.for('pixijs.BackgroundLoader');
+
 /**
  * The BackgroundLoader handles loading assets passively in the background to prepare them for future use.
  * It loads one asset at a time to minimize impact on application performance.
@@ -45,6 +47,22 @@ import type { ResolvedAsset } from './types';
  */
 export class BackgroundLoader
 {
+    /**
+     * Type symbol used to identify instances of BackgroundLoader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BackgroundLoader.
+     * @param obj - The object to check.
+     * @returns True if the object is a BackgroundLoader, false otherwise.
+     */
+    public static isBackgroundLoader(obj: any): obj is BackgroundLoader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Whether or not the loader should continue loading. */
     private _isActive: boolean;
 

--- a/src/assets/cache/Cache.ts
+++ b/src/assets/cache/Cache.ts
@@ -3,9 +3,27 @@ import { convertToList } from '../utils/convertToList';
 
 import type { CacheParser } from './CacheParser';
 
+const typeSymbol = Symbol.for('pixijs.CacheClass');
+
 /** @internal */
 class CacheClass
 {
+    /**
+     * Type symbol used to identify instances of CacheClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CacheClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a CacheClass, false otherwise.
+     */
+    public static isCacheClass(obj: any): obj is CacheClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private readonly _parsers: CacheParser[] = [];
 
     private readonly _cache: Map<any, any> = new Map();

--- a/src/assets/cache/parsers/cacheTextureArray.ts
+++ b/src/assets/cache/parsers/cacheTextureArray.ts
@@ -14,7 +14,7 @@ export const cacheTextureArray: CacheParser<Texture[]> = {
         name: 'cacheTextureArray',
     },
 
-    test: (asset: any[]) => Array.isArray(asset) && asset.every((t) => t instanceof Texture),
+    test: (asset: any[]) => Array.isArray(asset) && asset.every((t) => Texture.isTexture(t)),
 
     getCacheableAssets: (keys: string[], asset: Texture[]) =>
     {

--- a/src/assets/loader/Loader.ts
+++ b/src/assets/loader/Loader.ts
@@ -7,6 +7,8 @@ import type { ResolvedAsset } from '../types';
 import type { LoaderParser } from './parsers/LoaderParser';
 import type { PromiseAndParser } from './types';
 
+const typeSymbol = Symbol.for('pixijs.Loader');
+
 /**
  * The Loader is responsible for loading all assets, such as images, spritesheets, audio files, etc.
  * It does not do anything clever with URLs - it just loads stuff!
@@ -20,6 +22,22 @@ import type { PromiseAndParser } from './types';
  */
 export class Loader
 {
+    /**
+     * Type symbol used to identify instances of Loader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Loader.
+     * @param obj - The object to check.
+     * @returns True if the object is a Loader, false otherwise.
+     */
+    public static isLoader(obj: any): obj is Loader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private readonly _parsers: LoaderParser[] = [];
     private _parserHash: Record<string, LoaderParser>;
 

--- a/src/assets/loader/workers/WorkerManager.ts
+++ b/src/assets/loader/workers/WorkerManager.ts
@@ -4,6 +4,8 @@ import LoadImageBitmapWorker from 'worker:./loadImageBitmap.worker.ts';
 import type { TextureSourceOptions } from '../../../rendering/renderers/shared/texture/sources/TextureSource';
 import type { ResolvedAsset } from '../../types';
 
+const typeSymbol = Symbol.for('pixijs.WorkerManagerClass');
+
 let UUID = 0;
 let MAX_WORKERS: number;
 
@@ -17,6 +19,22 @@ type LoadImageBitmapResult = {
 /** @internal */
 class WorkerManagerClass
 {
+    /**
+     * Type symbol used to identify instances of WorkerManagerClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a WorkerManagerClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a WorkerManagerClass, false otherwise.
+     */
+    public static isWorkerManagerClass(obj: any): obj is WorkerManagerClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Hash map storing resolve/reject functions for pending worker requests.
      * Keyed by UUID to match responses with their corresponding promises.

--- a/src/assets/resolver/Resolver.ts
+++ b/src/assets/resolver/Resolver.ts
@@ -15,6 +15,8 @@ import type {
 } from '../types';
 import type { PreferOrder, ResolveURLParser } from './types';
 
+const typeSymbol = Symbol.for('pixi.Resolver');
+
 /**
  * Options for how the resolver deals with generating bundle ids
  * @category assets
@@ -77,6 +79,22 @@ export interface BundleIdentifierOptions
  */
 export class Resolver
 {
+    /**
+     * Type symbol used to identify instances of Resolver.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Resolver.
+     * @param obj - The object to check.
+     * @returns True if the object is a Resolver, false otherwise.
+     */
+    public static isResolver(obj: any): obj is Resolver
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The prefix that denotes a URL is for a retina asset.
      * @default /@([0-9\.]+)x/

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -399,7 +399,7 @@ export class Color
     set value(value: ColorSource | null)
     {
         // Support copying from other Color objects
-        if (value instanceof Color)
+        if (Color.isColor(value))
         {
             this._value = this._cloneSource(value._value);
             this._int = value._int;
@@ -1180,7 +1180,7 @@ export class Color
             typeof value === 'number'
             || typeof value === 'string'
             || value instanceof Number
-            || value instanceof Color
+            || Color.isColor(value)
             || Array.isArray(value)
             || value instanceof Uint8Array
             || value instanceof Uint8ClampedArray

--- a/src/color/Color.ts
+++ b/src/color/Color.ts
@@ -5,6 +5,8 @@ import type { AnyColor, HslaColor, HslColor, HsvaColor, HsvColor, RgbaColor, Rgb
 
 extend([namesPlugin]);
 
+const typeSymbol = Symbol.for('pixijs.Color');
+
 /**
  * Array of RGBA color components, where each component is a number between 0 and 1.
  * The array must contain exactly 4 numbers in the order: red, green, blue, alpha.
@@ -163,6 +165,22 @@ type ColorSourceTypedArray = Float32Array | Uint8Array | Uint8ClampedArray;
  */
 export class Color
 {
+    /**
+     * Type symbol used to identify instances of Color.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Color.
+     * @param obj - The object to check.
+     * @returns True if the object is a Color, false otherwise.
+     */
+    public static isColor(obj: any): obj is Color
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Static shared Color instance used for utility operations. This is a singleton color object
      * that can be reused to avoid creating unnecessary Color instances.

--- a/src/culling/Culler.ts
+++ b/src/culling/Culler.ts
@@ -3,6 +3,8 @@ import { getGlobalBounds } from '../scene/container/bounds/getGlobalBounds';
 
 import type { Container } from '../scene/container/Container';
 
+const typeSymbol = Symbol.for('pixijs.Culler');
+
 const tempBounds = new Bounds();
 
 /**
@@ -60,6 +62,22 @@ export type RectangleLike = {x: number, y: number, width: number, height: number
  */
 export class Culler
 {
+    /**
+     * Type symbol used to identify instances of Culler.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Culler.
+     * @param obj - The object to check.
+     * @returns True if the object is a Culler, false otherwise.
+     */
+    public static isCuller(obj: any): obj is Culler
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Culls the children of a specific container based on the given view rectangle.
      * This determines which objects should be rendered and which can be skipped.

--- a/src/culling/CullerPlugin.ts
+++ b/src/culling/CullerPlugin.ts
@@ -5,6 +5,8 @@ import type { ExtensionMetadata } from '../extensions/Extensions';
 import type { Renderer } from '../rendering/renderers/types';
 import type { Container } from '../scene/container/Container';
 
+const typeSymbol = Symbol.for('pixijs.CullerPlugin');
+
 /**
  * Application options for the {@link CullerPlugin}.
  * These options control how your application handles culling of display objects.
@@ -117,6 +119,22 @@ export interface CullerPluginOptions
  */
 export class CullerPlugin
 {
+    /**
+     * Type symbol used to identify instances of CullerPlugin.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CullerPlugin.
+     * @param obj - The object to check.
+     * @returns True if the object is a CullerPlugin, false otherwise.
+     */
+    public static isCullerPlugin(obj: any): obj is CullerPlugin
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         priority: 10,

--- a/src/dom/CanvasObserver.ts
+++ b/src/dom/CanvasObserver.ts
@@ -2,6 +2,8 @@ import { type Renderer } from '../rendering/renderers/types';
 import { UPDATE_PRIORITY } from '../ticker/const';
 import { Ticker } from '../ticker/Ticker';
 
+const typeSymbol = Symbol.for('pixijs.CanvasObserver');
+
 /**
  * CanvasObserver class synchronizes the DOM element's transform with the canvas size and position.
  * It uses ResizeObserver for efficient updates and requestAnimationFrame for fallback.
@@ -10,6 +12,22 @@ import { Ticker } from '../ticker/Ticker';
  */
 export class CanvasObserver
 {
+    /**
+     * Type symbol used to identify instances of CanvasObserver.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasObserver.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasObserver, false otherwise.
+     */
+    public static isCanvasObserver(obj: any): obj is CanvasObserver
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** A cached value of the last transform applied to the DOM element. */
     private _lastTransform = '';
     /** A ResizeObserver instance to observe changes in the canvas size. */

--- a/src/dom/DOMContainer.ts
+++ b/src/dom/DOMContainer.ts
@@ -3,6 +3,8 @@ import { ViewContainer, type ViewContainerOptions } from '../scene/view/ViewCont
 
 import type { PointData } from '../maths/point/PointData';
 
+const typeSymbol = Symbol.for('pixijs.DOMContainer');
+
 /**
  * Options for configuring a {@link DOMContainer}.
  * Controls how DOM elements are integrated into the PixiJS scene graph.
@@ -87,6 +89,22 @@ export interface DOMContainerOptions extends ViewContainerOptions
  */
 export class DOMContainer extends ViewContainer<never>
 {
+    /**
+     * Type symbol used to identify instances of DOMContainer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DOMContainer.
+     * @param obj - The object to check.
+     * @returns True if the object is a DOMContainer, false otherwise.
+     */
+    public static isDOMContainer(obj: any): obj is DOMContainer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'dom';
 

--- a/src/dom/DOMPipe.ts
+++ b/src/dom/DOMPipe.ts
@@ -6,6 +6,8 @@ import type { InstructionSet } from '../rendering/renderers/shared/instructions/
 import type { RenderPipe } from '../rendering/renderers/shared/instructions/RenderPipe';
 import type { Renderer } from '../rendering/renderers/types';
 
+const typeSymbol = Symbol.for('pixijs.DOMPipe');
+
 /**
  * The DOMPipe class is responsible for managing and rendering DOM elements within a PixiJS scene.
  * It maps dom elements to the canvas and ensures they are correctly positioned and visible.
@@ -25,6 +27,22 @@ export class DOMPipe implements RenderPipe<DOMContainer>
         ],
         name: 'dom',
     } as const;
+
+    /**
+     * Type symbol used to identify instances of DOMPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DOMPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a DOMPipe, false otherwise.
+     */
+    public static isDOMPipe(obj: any): obj is DOMPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
 
     private _renderer: Renderer;
 

--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -694,7 +694,7 @@ export class EventBoundary
      */
     protected mapPointerDown(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -734,7 +734,7 @@ export class EventBoundary
      */
     protected mapPointerMove(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -875,7 +875,7 @@ export class EventBoundary
      */
     protected mapPointerOver(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -921,7 +921,7 @@ export class EventBoundary
      */
     protected mapPointerOut(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -980,7 +980,7 @@ export class EventBoundary
      */
     protected mapPointerUp(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -1109,7 +1109,7 @@ export class EventBoundary
      */
     protected mapPointerUpOutside(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent))
+        if (!FederatedPointerEvent.isFederatedPointerEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-pointer event as a pointer event');
@@ -1156,7 +1156,7 @@ export class EventBoundary
      */
     protected mapWheel(from: FederatedEvent): void
     {
-        if (!(from instanceof FederatedWheelEvent))
+        if (!FederatedWheelEvent.isFederatedWheelEvent(from))
         {
             // #if _DEBUG
             warn('EventBoundary cannot map a non-wheel event as a wheel event');
@@ -1323,7 +1323,10 @@ export class EventBoundary
      */
     protected copyPointerData(from: FederatedEvent, to: FederatedEvent): void
     {
-        if (!(from instanceof FederatedPointerEvent && to instanceof FederatedPointerEvent)) return;
+        if (
+            !(FederatedPointerEvent.isFederatedPointerEvent(from)
+            && FederatedPointerEvent.isFederatedPointerEvent(to))
+        ) return;
 
         to.pointerId = from.pointerId;
         to.width = from.width;
@@ -1361,7 +1364,10 @@ export class EventBoundary
      */
     protected copyMouseData(from: FederatedEvent, to: FederatedEvent): void
     {
-        if (!(from instanceof FederatedMouseEvent && to instanceof FederatedMouseEvent)) return;
+        if (
+            !(FederatedMouseEvent.isFederatedMouseEvent(from)
+            && FederatedMouseEvent.isFederatedMouseEvent(to))
+        ) return;
 
         to.altKey = from.altKey;
         to.button = from.button;

--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -14,6 +14,8 @@ import type {
     Cursor, EventMode, FederatedEventHandler,
 } from './FederatedEventTarget';
 
+const typeSymbol = Symbol.for('pixijs.EventBoundary');
+
 // The maximum iterations used in propagation. This prevent infinite loops.
 const PROPAGATION_LIMIT = 2048;
 
@@ -79,6 +81,22 @@ const tempLocalMapping = new Point();
  */
 export class EventBoundary
 {
+    /**
+     * Type symbol used to identify instances of EventBoundary.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a EventBoundary.
+     * @param obj - The object to check.
+     * @returns True if the object is a EventBoundary, false otherwise.
+     */
+    public static isEventBoundary(obj: any): obj is EventBoundary
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The root event-target residing below the event boundary.
      * All events are dispatched trickling down and bubbling up to this `rootTarget`.

--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -12,6 +12,8 @@ import type { PixiTouch } from './FederatedEvent';
 import type { EventMode } from './FederatedEventTarget';
 import type { FederatedMouseEvent } from './FederatedMouseEvent';
 
+const typeSymbol = Symbol.for('pixijs.EventSystem');
+
 const MOUSE_POINTER_ID = 1;
 const TOUCH_TO_POINTER: Record<string, string> = {
     touchstart: 'pointerdown',
@@ -233,6 +235,22 @@ export interface EventSystemFeatures
  */
 export class EventSystem implements System<EventSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of EventSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a EventSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a EventSystem, false otherwise.
+     */
+    public static isEventSystem(obj: any): obj is EventSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = {
         name: 'events',

--- a/src/events/EventTicker.ts
+++ b/src/events/EventTicker.ts
@@ -3,9 +3,27 @@ import { Ticker } from '../ticker/Ticker';
 
 import type { EventSystem } from './EventSystem';
 
+const typeSymbol = Symbol.for('pixijs.EventsTickerClass');
+
 /** @advanced */
 class EventsTickerClass
 {
+    /**
+     * Type symbol used to identify instances of EventsTickerClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a EventsTickerClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a EventsTickerClass, false otherwise.
+     */
+    public static isEventsTickerClass(obj: any): obj is EventsTickerClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The event system. */
     public events: EventSystem;
     /** The DOM element to listen to events on. */

--- a/src/events/FederatedEvent.ts
+++ b/src/events/FederatedEvent.ts
@@ -3,6 +3,8 @@ import { Point } from '../maths/point/Point';
 import type { Container } from '../scene/container/Container';
 import type { EventBoundary } from './EventBoundary';
 
+const typeSymbol = Symbol.for('pixijs.FederatedEvent');
+
 /**
  * A PixiJS compatible touch event interface that extends the standard DOM Touch interface.
  * Provides additional properties to normalize touch input with mouse/pointer events.
@@ -117,6 +119,22 @@ export interface PixiTouch extends Touch
  */
 export class FederatedEvent<N extends UIEvent | PixiTouch = UIEvent | PixiTouch> implements UIEvent
 {
+    /**
+     * Type symbol used to identify instances of FederatedEvent.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FederatedEvent.
+     * @param obj - The object to check.
+     * @returns True if the object is a FederatedEvent, false otherwise.
+     */
+    public static isFederatedEvent(obj: any): obj is FederatedEvent
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Flags whether this event bubbles. This will take effect only if it is set before propagation. */
     public bubbles = true;
 

--- a/src/events/FederatedEventTarget.ts
+++ b/src/events/FederatedEventTarget.ts
@@ -1303,7 +1303,7 @@ export const FederatedContainer: IFederatedContainer = {
     },
     dispatchEvent(e: Event): boolean
     {
-        if (!(e instanceof FederatedEvent))
+        if (!FederatedEvent.isFederatedEvent(e))
         {
             throw new Error('Container cannot propagate events outside of the Federated Events API');
         }

--- a/src/events/FederatedMouseEvent.ts
+++ b/src/events/FederatedMouseEvent.ts
@@ -5,6 +5,8 @@ import type { PointData } from '../maths/point/PointData';
 import type { Container } from '../scene/container/Container';
 import type { PixiTouch } from './FederatedEvent';
 
+const typeSymbol = Symbol.for('pixijs.FederatedMouseEvent');
+
 /**
  * A specialized event class for mouse interactions in PixiJS applications.
  * Extends {@link FederatedEvent} to provide mouse-specific properties and methods
@@ -49,6 +51,22 @@ export class FederatedMouseEvent extends FederatedEvent<
 MouseEvent | PointerEvent | PixiTouch
 > implements MouseEvent
 {
+    /**
+     * Type symbol used to identify instances of FederatedMouseEvent.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FederatedMouseEvent.
+     * @param obj - The object to check.
+     * @returns True if the object is a FederatedMouseEvent, false otherwise.
+     */
+    public static isFederatedMouseEvent(obj: any): obj is FederatedMouseEvent
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Whether the "alt" key was pressed when this mouse event occurred. */
     public altKey: boolean;
 

--- a/src/events/FederatedPointerEvent.ts
+++ b/src/events/FederatedPointerEvent.ts
@@ -1,5 +1,7 @@
 import { FederatedMouseEvent } from './FederatedMouseEvent';
 
+const typeSymbol = Symbol.for('pixijs.FederatedPointerEvent');
+
 /**
  * A specialized event class for pointer interactions in PixiJS applications.
  * Extends {@link FederatedMouseEvent} to provide advanced pointer-specific features
@@ -48,6 +50,22 @@ import { FederatedMouseEvent } from './FederatedMouseEvent';
  */
 export class FederatedPointerEvent extends FederatedMouseEvent implements PointerEvent
 {
+    /**
+     * Type symbol used to identify instances of FederatedPointerEvent.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FederatedPointerEvent.
+     * @param obj - The object to check.
+     * @returns True if the object is a FederatedPointerEvent, false otherwise.
+     */
+    public static isFederatedPointerEvent(obj: any): obj is FederatedPointerEvent
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The unique identifier of the pointer.
      * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pointerId}

--- a/src/events/FederatedWheelEvent.ts
+++ b/src/events/FederatedWheelEvent.ts
@@ -1,5 +1,7 @@
 import { FederatedMouseEvent } from './FederatedMouseEvent';
 
+const typeSymbol = Symbol.for('pixijs.FederatedWheelEvent');
+
 /**
  * A specialized event class for wheel/scroll interactions in PixiJS applications.
  * Extends {@link FederatedMouseEvent} to provide wheel-specific properties while
@@ -49,6 +51,22 @@ import { FederatedMouseEvent } from './FederatedMouseEvent';
  */
 export class FederatedWheelEvent extends FederatedMouseEvent implements WheelEvent
 {
+    /**
+     * Type symbol used to identify instances of FederatedWheelEvent.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FederatedWheelEvent.
+     * @param obj - The object to check.
+     * @returns True if the object is a FederatedWheelEvent, false otherwise.
+     */
+    public static isFederatedWheelEvent(obj: any): obj is FederatedWheelEvent
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The units of `deltaX`, `deltaY`, and `deltaZ`. This is one of `DOM_DELTA_LINE`,
      * `DOM_DELTA_PAGE`, `DOM_DELTA_PIXEL`.

--- a/src/filters/Filter.ts
+++ b/src/filters/Filter.ts
@@ -13,6 +13,8 @@ import type { BLEND_MODES } from '../rendering/renderers/shared/state/const';
 import type { Texture } from '../rendering/renderers/shared/texture/Texture';
 import type { FilterSystem } from './FilterSystem';
 
+const typeSymbol = Symbol.for('pixijs.Filter');
+
 /**
  * The options to use when creating a new filter.
  * @category filters
@@ -130,6 +132,22 @@ export type FilterAntialias = 'on' | 'off' | 'inherit';
  */
 export class Filter extends Shader
 {
+    /**
+     * Type symbol used to identify instances of Filter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Filter.
+     * @param obj - The object to check.
+     * @returns True if the object is a Filter, false otherwise.
+     */
+    public static isFilter(obj: any): obj is Filter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default filter settings */
     public static defaultOptions: FilterOptions = {
         blendMode: 'normal',

--- a/src/filters/FilterEffect.ts
+++ b/src/filters/FilterEffect.ts
@@ -2,6 +2,8 @@ import type { Rectangle } from '../maths/shapes/Rectangle';
 import type { Effect } from '../scene/container/Effect';
 import type { Filter } from './Filter';
 
+const typeSymbol = Symbol.for('pixijs.FilterEffect');
+
 /**
  * A filter effect is an effect that can be applied to a container that involves applying special pixel effects
  * to that container as it is rendered. Used internally when the filters property is modified on a container.
@@ -9,6 +11,22 @@ import type { Filter } from './Filter';
  */
 export class FilterEffect implements Effect
 {
+    /**
+     * Type symbol used to identify instances of FilterEffect.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FilterEffect.
+     * @param obj - The object to check.
+     * @returns True if the object is a FilterEffect, false otherwise.
+     */
+    public static isFilterEffect(obj: any): obj is FilterEffect
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** read only filters array - to modify, set it again! */
     public filters: readonly Filter[];
     /**

--- a/src/filters/FilterPipe.ts
+++ b/src/filters/FilterPipe.ts
@@ -7,9 +7,27 @@ import type { Container } from '../scene/container/Container';
 import type { Effect } from '../scene/container/Effect';
 import type { FilterInstruction } from './FilterSystem';
 
+const typeSymbol = Symbol.for('pixijs.FilterPipe');
+
 /** @internal */
 export class FilterPipe implements InstructionPipe<FilterInstruction>
 {
+    /**
+     * Type symbol used to identify instances of FilterPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FilterPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a FilterPipe, false otherwise.
+     */
+    public static isFilterPipe(obj: any): obj is FilterPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGLPipes,

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -23,6 +23,9 @@ import type { Sprite } from '../scene/sprite/Sprite';
 import type { Filter } from './Filter';
 import type { FilterEffect } from './FilterEffect';
 
+const typeSymbolFilterData = Symbol.for('pixijs.FilterData');
+const typeSymbolFilterSystem = Symbol.for('pixijs.FilterSystem');
+
 const quadGeometry = new Geometry({
     attributes: {
         aPosition: {
@@ -73,6 +76,22 @@ export interface FilterInstruction extends Instruction
  */
 class FilterData
 {
+    /**
+     * Type symbol used to identify instances of FilterData.
+     * @internal
+     */
+    public readonly [typeSymbolFilterData] = true;
+
+    /**
+     * Checks if the given object is a FilterData.
+     * @param obj - The object to check.
+     * @returns True if the object is a FilterData, false otherwise.
+     */
+    public static isFilterData(obj: any): obj is FilterData
+    {
+        return !!obj && !!obj[typeSymbolFilterData];
+    }
+
     /**
      * Indicates whether the filter should be skipped.
      * @type {boolean}
@@ -147,6 +166,22 @@ class FilterData
  */
 export class FilterSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of FilterSystem.
+     * @internal
+     */
+    public readonly [typeSymbolFilterSystem] = true;
+
+    /**
+     * Checks if the given object is a FilterSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a FilterSystem, false otherwise.
+     */
+    public static isFilterSystem(obj: any): obj is FilterSystem
+    {
+        return !!obj && !!obj[typeSymbolFilterSystem];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -747,14 +747,14 @@ export class FilterSystem implements System
         globalFrame[3] = rootTexture.source.height * resolution;
 
         // we are going to overwrite resource we can set it to null!
-        if (output instanceof Texture) output.source.resource = null;
+        if (Texture.isTexture(output)) output.source.resource = null;
 
         // set the output texture - this is where we are going to render to
         const renderTarget = this.renderer.renderTarget.getRenderTarget(output);
 
         this.renderer.renderTarget.bind(output, !!clear);
 
-        if (output instanceof Texture)
+        if (Texture.isTexture(output))
         {
             outputTexture[0] = output.frame.width;
             outputTexture[1] = output.frame.height;

--- a/src/filters/blend-modes/BlendModeFilter.ts
+++ b/src/filters/blend-modes/BlendModeFilter.ts
@@ -7,6 +7,8 @@ import blendTemplateFrag from './blend-template.frag';
 import blendTemplateVert from './blend-template.vert';
 import blendTemplate from './blend-template.wgsl';
 
+const typeSymbol = Symbol.for('pixijs.BlendModeFilter');
+
 /** @internal */
 export interface BlendModeFilterOptions
 {
@@ -24,6 +26,22 @@ export interface BlendModeFilterOptions
 /** @internal */
 export class BlendModeFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of BlendModeFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BlendModeFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a BlendModeFilter, false otherwise.
+     */
+    public static isBlendModeFilter(obj: any): obj is BlendModeFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor(options: BlendModeFilterOptions)
     {
         const gpuOptions = options.gpu;

--- a/src/filters/defaults/alpha/AlphaFilter.ts
+++ b/src/filters/defaults/alpha/AlphaFilter.ts
@@ -8,6 +8,8 @@ import source from './alpha.wgsl';
 
 import type { FilterOptions } from '../../Filter';
 
+const typeSymbol = Symbol.for('pixijs.AlphaFilter');
+
 /**
  * Options for AlphaFilter
  * @category filters
@@ -48,6 +50,22 @@ export interface AlphaFilterOptions extends FilterOptions
  */
 export class AlphaFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of AlphaFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AlphaFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a AlphaFilter, false otherwise.
+     */
+    public static isAlphaFilter(obj: any): obj is AlphaFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default options for the AlphaFilter.
      * @example

--- a/src/filters/defaults/blur/BlurFilter.ts
+++ b/src/filters/defaults/blur/BlurFilter.ts
@@ -9,6 +9,8 @@ import type { Texture } from '../../../rendering/renderers/shared/texture/Textur
 import type { FilterOptions } from '../../Filter';
 import type { FilterSystem } from '../../FilterSystem';
 
+const typeSymbol = Symbol.for('pixijs.BlurFilter');
+
 /**
  * Configuration options for the BlurFilter.
  * Controls how the Gaussian blur effect is applied.
@@ -121,6 +123,22 @@ export interface BlurFilterOptions extends FilterOptions
  */
 export class BlurFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of BlurFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BlurFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a BlurFilter, false otherwise.
+     */
+    public static isBlurFilter(obj: any): obj is BlurFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default blur filter options
      * @example

--- a/src/filters/defaults/blur/BlurFilterPass.ts
+++ b/src/filters/defaults/blur/BlurFilterPass.ts
@@ -9,6 +9,8 @@ import type { Texture } from '../../../rendering/renderers/shared/texture/Textur
 import type { FilterSystem } from '../../FilterSystem';
 import type { BlurFilterOptions } from './BlurFilter';
 
+const typeSymbol = Symbol.for('pixijs.BlurFilterPass');
+
 /**
  * Options for BlurFilterPass
  * @category filters
@@ -35,6 +37,22 @@ export interface BlurFilterPassOptions extends BlurFilterOptions
  */
 export class BlurFilterPass extends Filter
 {
+    /**
+     * Type symbol used to identify instances of BlurFilterPass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BlurFilterPass.
+     * @param obj - The object to check.
+     * @returns True if the object is a BlurFilterPass, false otherwise.
+     */
+    public static isBlurFilterPass(obj: any): obj is BlurFilterPass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Default blur filter pass options */
     public static defaultOptions: Partial<BlurFilterPassOptions> = {
         /** The strength of the blur filter. */

--- a/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
+++ b/src/filters/defaults/color-matrix/ColorMatrixFilter.ts
@@ -11,6 +11,8 @@ import type { ColorSource } from '../../../color/Color';
 import type { ArrayFixed } from '../../../utils/types';
 import type { FilterOptions } from '../../Filter';
 
+const typeSymbol = Symbol.for('pixijs.ColorMatrixFilter');
+
 /**
  * 5x4 matrix for transforming RGBA color and alpha
  * @category filters
@@ -57,6 +59,22 @@ export type ColorMatrix = ArrayFixed<number, 20>;
  */
 export class ColorMatrixFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of ColorMatrixFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorMatrixFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorMatrixFilter, false otherwise.
+     */
+    public static isColorMatrixFilter(obj: any): obj is ColorMatrixFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor(options: FilterOptions = {})
     {
         const colorMatrixUniforms = new UniformGroup({

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -131,7 +131,7 @@ export class DisplacementFilter extends Filter
     {
         let options = args[0];
 
-        if (options instanceof Sprite)
+        if (Sprite.isSprite(options))
         {
             // #if _DEBUG
             if (args[1])

--- a/src/filters/defaults/displacement/DisplacementFilter.ts
+++ b/src/filters/defaults/displacement/DisplacementFilter.ts
@@ -15,6 +15,8 @@ import type { Texture } from '../../../rendering/renderers/shared/texture/Textur
 import type { FilterOptions } from '../../Filter';
 import type { FilterSystem } from '../../FilterSystem';
 
+const typeSymbol = Symbol.for('pixijs.DisplacementFilter');
+
 /**
  * Configuration options for the DisplacementFilter.
  *
@@ -99,6 +101,22 @@ export interface DisplacementFilterOptions extends FilterOptions
  */
 export class DisplacementFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of DisplacementFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DisplacementFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a DisplacementFilter, false otherwise.
+     */
+    public static isDisplacementFilter(obj: any): obj is DisplacementFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private readonly _sprite: Sprite;
 
     /**

--- a/src/filters/defaults/noise/NoiseFilter.ts
+++ b/src/filters/defaults/noise/NoiseFilter.ts
@@ -8,6 +8,8 @@ import source from './noise.wgsl';
 
 import type { FilterOptions } from '../../Filter';
 
+const typeSymbol = Symbol.for('pixijs.NoiseFilter');
+
 /**
  * Configuration options for the NoiseFilter.
  *
@@ -86,6 +88,22 @@ export interface NoiseFilterOptions extends FilterOptions
  */
 export class NoiseFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of NoiseFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a NoiseFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a NoiseFilter, false otherwise.
+     */
+    public static isNoiseFilter(obj: any): obj is NoiseFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The default configuration options for the NoiseFilter.
      *

--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -13,6 +13,8 @@ import type { Sprite } from '../../scene/sprite/Sprite';
 import type { FilterOptions } from '../Filter';
 import type { FilterSystem } from '../FilterSystem';
 
+const typeSymbol = Symbol.for('pixijs.MaskFilter');
+
 /** @internal */
 export interface MaskFilterOptions extends FilterOptions
 {
@@ -24,6 +26,22 @@ export interface MaskFilterOptions extends FilterOptions
 /** @internal */
 export class MaskFilter extends Filter
 {
+    /**
+     * Type symbol used to identify instances of MaskFilter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MaskFilter.
+     * @param obj - The object to check.
+     * @returns True if the object is a MaskFilter, false otherwise.
+     */
+    public static isMaskFilter(obj: any): obj is MaskFilter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public sprite: Sprite;
     private readonly _textureMatrix: TextureMatrix;
 

--- a/src/gif/GifSource.ts
+++ b/src/gif/GifSource.ts
@@ -3,6 +3,8 @@ import { DOMAdapter } from '../environment/adapter';
 import { CanvasSource } from '../rendering/renderers/shared/texture/sources/CanvasSource';
 import { Texture } from '../rendering/renderers/shared/texture/Texture';
 
+const typeSymbol = Symbol.for('pixijs.GifSource');
+
 /**
  * Represents a single frame of a GIF. Includes image and timing data.
  * @category gif
@@ -38,6 +40,22 @@ interface GifBufferOptions
  */
 class GifSource
 {
+    /**
+     * Type symbol used to identify instances of GifSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GifSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a GifSource, false otherwise.
+     */
+    public static isGifSource(obj: any): obj is GifSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Width of the animation */
     public readonly width: number;
 

--- a/src/gif/GifSprite.ts
+++ b/src/gif/GifSprite.ts
@@ -6,6 +6,8 @@ import { GifSource } from './GifSource';
 
 import type { SCALE_MODE } from '../rendering/renderers/shared/texture/const';
 
+const typeSymbol = Symbol.for('pixijs.GifSprite');
+
 /**
  * Configuration options for creating a GifSprite instance.
  *
@@ -212,6 +214,22 @@ interface GifSpriteOptions extends Omit<SpriteOptions, 'texture'>
  */
 class GifSprite extends Sprite
 {
+    /**
+     * Type symbol used to identify instances of GifSprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GifSprite.
+     * @param obj - The object to check.
+     * @returns True if the object is a GifSprite, false otherwise.
+     */
+    public static isGifSprite(obj: any): obj is GifSprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default configuration options for GifSprite instances.
      *

--- a/src/gif/GifSprite.ts
+++ b/src/gif/GifSprite.ts
@@ -406,7 +406,7 @@ class GifSprite extends Sprite
 
     constructor(...args: [GifSource] | [GifSpriteOptions])
     {
-        const options = args[0] instanceof GifSource ? { source: args[0] } : args[0];
+        const options = GifSource.isGifSource(args[0]) ? { source: args[0] } : args[0];
 
         // Get the options, apply defaults
         const {

--- a/src/maths/matrix/Matrix.ts
+++ b/src/maths/matrix/Matrix.ts
@@ -4,6 +4,8 @@ import { Point } from '../point/Point';
 
 import type { PointData } from '../point/PointData';
 
+const typeSymbol = Symbol.for('pixijs.Matrix');
+
 /**
  * The data structure that contains the position, scale, pivot, skew and rotation of an object.
  * This is used by the {@link Matrix} class to decompose the matrix into its components.
@@ -61,6 +63,22 @@ export interface TransformableObject
  */
 export class Matrix
 {
+    /**
+     * Type symbol used to identify instances of Matrix.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Matrix.
+     * @param obj - The object to check.
+     * @returns True if the object is a Matrix, false otherwise.
+     */
+    public static isMatrix(obj: any): obj is Matrix
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Scale on the x axis.
      * @default 1

--- a/src/maths/point/ObservablePoint.ts
+++ b/src/maths/point/ObservablePoint.ts
@@ -1,6 +1,8 @@
 import type { PointData } from './PointData';
 import type { PointLike } from './PointLike';
 
+const typeSymbol = Symbol.for('pixijs.ObservablePoint');
+
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type, requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface ObservablePoint extends PixiMixins.ObservablePoint { }
@@ -72,6 +74,22 @@ export interface Observer<T>
  */
 export class ObservablePoint implements PointLike
 {
+    /**
+     * Type symbol used to identify instances of ObservablePoint.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ObservablePoint.
+     * @param obj - The object to check.
+     * @returns True if the object is a ObservablePoint, false otherwise.
+     */
+    public static isObservablePoint(obj: any): obj is ObservablePoint
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public _x: number;
     /** @ignore */

--- a/src/maths/point/Point.ts
+++ b/src/maths/point/Point.ts
@@ -2,6 +2,8 @@
 import type { PointData } from './PointData';
 import type { PointLike } from './PointLike';
 
+const typeSymbol = Symbol.for('pixijs.Point');
+
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type, requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface Point extends PixiMixins.Point { }
@@ -37,6 +39,22 @@ export interface Point extends PixiMixins.Point { }
  */
 export class Point implements PointLike
 {
+    /**
+     * Type symbol used to identify instances of Point.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Point.
+     * @param obj - The object to check.
+     * @returns True if the object is a Point, false otherwise.
+     */
+    public static isPoint(obj: any): obj is Point
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Position of the point on the x axis
      * @example

--- a/src/maths/shapes/Circle.ts
+++ b/src/maths/shapes/Circle.ts
@@ -3,6 +3,8 @@ import { Rectangle } from './Rectangle';
 import type { SHAPE_PRIMITIVE } from '../misc/const';
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.Circle');
+
 /**
  * The Circle object represents a circle shape in a two-dimensional coordinate system.
  * Used for drawing graphics and specifying hit areas for containers.
@@ -30,6 +32,22 @@ import type { ShapePrimitive } from './ShapePrimitive';
  */
 export class Circle implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of Circle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Circle.
+     * @param obj - The object to check.
+     * @returns True if the object is a Circle, false otherwise.
+     */
+    public static isCircle(obj: any): obj is Circle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The X coordinate of the center of this circle
      * @example

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -2,6 +2,8 @@ import { Rectangle } from './Rectangle';
 
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.Ellipse');
+
 /**
  * The Ellipse object is used to help draw graphics and can also be used to specify a hit area for containers.
  * @example
@@ -29,6 +31,22 @@ import type { ShapePrimitive } from './ShapePrimitive';
  */
 export class Ellipse implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of Ellipse.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is an Ellipse.
+     * @param obj - The object to check.
+     * @returns True if the object is an Ellipse, false otherwise.
+     */
+    public static isEllipse(obj: any): obj is Ellipse
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The X coordinate of the center of this ellipse
      * @example

--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -6,6 +6,8 @@ import type { SHAPE_PRIMITIVE } from '../misc/const';
 import type { PointData } from '../point/PointData';
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.Polygon');
+
 let tempRect: Rectangle;
 let tempRect2: Rectangle;
 
@@ -43,6 +45,22 @@ let tempRect2: Rectangle;
  */
 export class Polygon implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of Polygon.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Polygon.
+     * @param obj - The object to check.
+     * @returns True if the object is a Polygon, false otherwise.
+     */
+    public static isPolygon(obj: any): obj is Polygon
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * An array of the points of this polygon stored as a flat array of numbers.
      * @example

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -6,6 +6,8 @@ import type { Matrix } from '../matrix/Matrix';
 import type { SHAPE_PRIMITIVE } from '../misc/const';
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.Rectangle');
+
 const tempPoints = [new Point(), new Point(), new Point(), new Point()];
 
 // eslint-disable-next-line max-len
@@ -43,6 +45,22 @@ export interface Rectangle extends PixiMixins.Rectangle { }
  */
 export class Rectangle implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of Rectangle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Rectangle.
+     * @param obj - The object to check.
+     * @returns True if the object is a Rectangle, false otherwise.
+     */
+    public static isRectangle(obj: any): obj is Rectangle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The type of the object, mainly used to avoid `instanceof` checks
      * @example

--- a/src/maths/shapes/RoundedRectangle.ts
+++ b/src/maths/shapes/RoundedRectangle.ts
@@ -3,6 +3,8 @@ import { Rectangle } from './Rectangle';
 
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.RoundedRectangle');
+
 const isCornerWithinStroke = (
     pX: number,
     pY: number,
@@ -44,6 +46,22 @@ const isCornerWithinStroke = (
  */
 export class RoundedRectangle implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of RoundedRectangle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RoundedRectangle.
+     * @param obj - The object to check.
+     * @returns True if the object is a RoundedRectangle, false otherwise.
+     */
+    public static isRoundedRectangle(obj: any): obj is RoundedRectangle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The X coordinate of the upper-left corner of the rounded rectangle
      * @example

--- a/src/maths/shapes/Triangle.ts
+++ b/src/maths/shapes/Triangle.ts
@@ -4,6 +4,8 @@ import { Rectangle } from './Rectangle';
 import type { SHAPE_PRIMITIVE } from '../misc/const';
 import type { ShapePrimitive } from './ShapePrimitive';
 
+const typeSymbol = Symbol.for('pixijs.Triangle');
+
 /**
  * A class to define a shape of a triangle via user defined coordinates.
  *
@@ -28,6 +30,22 @@ import type { ShapePrimitive } from './ShapePrimitive';
  */
 export class Triangle implements ShapePrimitive
 {
+    /**
+     * Type symbol used to identify instances of Triangle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Triangle.
+     * @param obj - The object to check.
+     * @returns True if the object is a Triangle, false otherwise.
+     */
+    public static isTriangle(obj: any): obj is Triangle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The type of the object, mainly used to avoid `instanceof` checks
      * @example

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -8,6 +8,8 @@ import type { Renderer } from '../rendering/renderers/types';
 import type { GraphicsContext } from '../scene/graphics/shared/GraphicsContext';
 import type { Text } from '../scene/text/Text';
 
+const typeSymbol = Symbol.for('pixijs.PrepareBase');
+
 /**
  * The accepted types to pass to the prepare system
  * @category rendering
@@ -30,6 +32,22 @@ export type PrepareQueueItem = TextureSource | Text | GraphicsContext;
  */
 export abstract class PrepareBase
 {
+    /**
+     * Type symbol used to identify instances of PrepareBase.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PrepareBase.
+     * @param obj - The object to check.
+     * @returns True if the object is a PrepareBase, false otherwise.
+     */
+    public static isPrepareBase(obj: any): obj is PrepareBase
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The number of uploads to process per frame */
     public static uploadsPerFrame = 4;
 

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -97,7 +97,7 @@ export abstract class PrepareBase
         for (const resourceItem of resourceArray)
         {
             // handle containers and their children
-            if (resourceItem instanceof Container)
+            if (Container.isContainer(resourceItem))
             {
                 this._addContainer(resourceItem);
             }

--- a/src/prepare/PrepareQueue.ts
+++ b/src/prepare/PrepareQueue.ts
@@ -47,15 +47,15 @@ export abstract class PrepareQueue extends PrepareBase
      */
     protected resolveQueueItem(source: PrepareSourceItem, queue: PrepareQueueItem[]): void
     {
-        if (source instanceof Container)
+        if (Container.isContainer(source))
         {
             this.resolveContainerQueueItem(source, queue);
         }
-        else if (source instanceof TextureSource || source instanceof Texture)
+        else if (TextureSource.isTextureSource(source) || Texture.isTexture(source))
         {
             queue.push(source.source);
         }
-        else if (source instanceof GraphicsContext)
+        else if (GraphicsContext.isGraphicsContext(source))
         {
             queue.push(source);
         }
@@ -74,19 +74,19 @@ export abstract class PrepareQueue extends PrepareBase
         // Note: we are just concerned with the given view.
         // Children are handled by the recursive call of the base class
 
-        if (container instanceof Sprite || container instanceof TilingSprite || container instanceof Mesh)
+        if (Sprite.isSprite(container) || TilingSprite.isTilingSprite(container) || Mesh.isMesh(container))
         {
             queue.push(container.texture.source);
         }
-        else if (container instanceof Text)
+        else if (Text.isText(container))
         {
             queue.push(container);
         }
-        else if (container instanceof Graphics)
+        else if (Graphics.isGraphics(container))
         {
             queue.push(container.context);
         }
-        else if (container instanceof AnimatedSprite)
+        else if (AnimatedSprite.isAnimatedSprite(container))
         {
             container.textures.forEach((textureOrFrame) =>
             {

--- a/src/prepare/PrepareQueue.ts
+++ b/src/prepare/PrepareQueue.ts
@@ -14,6 +14,8 @@ import type { FillInstruction, TextureInstruction } from '../scene/graphics/shar
 import type { FrameObject } from '../scene/sprite-animated/AnimatedSprite';
 import type { PrepareQueueItem, PrepareSourceItem } from './PrepareBase';
 
+const typeSymbol = Symbol.for('pixijs.PrepareQueue');
+
 /**
  * Part of the prepare system. Responsible for uploading all the items to the GPU.
  * This class extends the base functionality and resolves given resource items ready for the queue.
@@ -22,6 +24,22 @@ import type { PrepareQueueItem, PrepareSourceItem } from './PrepareBase';
  */
 export abstract class PrepareQueue extends PrepareBase
 {
+    /**
+     * Type symbol used to identify instances of PrepareQueue.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PrepareQueue.
+     * @param obj - The object to check.
+     * @returns True if the object is a PrepareQueue, false otherwise.
+     */
+    public static isPrepareQueue(obj: any): obj is PrepareQueue
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Resolve the given resource type and return an item for the queue
      * @param source

--- a/src/prepare/PrepareSystem.ts
+++ b/src/prepare/PrepareSystem.ts
@@ -3,6 +3,8 @@ import { PrepareUpload } from './PrepareUpload';
 
 import type { System } from '../rendering/renderers/shared/system/System';
 
+const typeSymbol = Symbol.for('pixijs.PrepareSystem');
+
 /**
  * The prepare system provides renderer-specific plugins for pre-rendering DisplayObjects. This is useful for
  * asynchronously preparing and uploading to the GPU assets, textures, graphics waiting to be displayed.
@@ -37,6 +39,22 @@ import type { System } from '../rendering/renderers/shared/system/System';
  */
 export class PrepareSystem extends PrepareUpload implements System
 {
+    /**
+     * Type symbol used to identify instances of PrepareSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PrepareSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a PrepareSystem, false otherwise.
+     */
+    public static isPrepareSystem(obj: any): obj is PrepareSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/prepare/PrepareUpload.ts
+++ b/src/prepare/PrepareUpload.ts
@@ -40,23 +40,23 @@ export abstract class PrepareUpload extends PrepareQueue
      */
     protected uploadQueueItem(item: PrepareQueueItem): void
     {
-        if (item instanceof TextureSource)
+        if (TextureSource.isTextureSource(item))
         {
             this.uploadTextureSource(item);
         }
-        else if (item instanceof Text)
+        else if (Text.isText(item))
         {
             this.uploadText(item);
         }
-        else if (item instanceof HTMLText)
+        else if (HTMLText.isHTMLText(item))
         {
             this.uploadHTMLText(item);
         }
-        else if (item instanceof BitmapText)
+        else if (BitmapText.isBitmapText(item))
         {
             this.uploadBitmapText(item);
         }
-        else if (item instanceof GraphicsContext)
+        else if (GraphicsContext.isGraphicsContext(item))
         {
             this.uploadGraphicsContext(item);
         }

--- a/src/prepare/PrepareUpload.ts
+++ b/src/prepare/PrepareUpload.ts
@@ -8,6 +8,8 @@ import { PrepareQueue } from './PrepareQueue';
 import type { FillInstruction, TextureInstruction } from '../scene/graphics/shared/GraphicsContext';
 import type { PrepareQueueItem } from './PrepareBase';
 
+const typeSymbol = Symbol.for('pixijs.PrepareUpload');
+
 /**
  * @advanced
  * Part of the prepare system. Responsible for uploading all the items to the GPU.
@@ -16,6 +18,22 @@ import type { PrepareQueueItem } from './PrepareBase';
  */
 export abstract class PrepareUpload extends PrepareQueue
 {
+    /**
+     * Type symbol used to identify instances of PrepareUpload.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PrepareUpload.
+     * @param obj - The object to check.
+     * @returns True if the object is a PrepareUpload, false otherwise.
+     */
+    public static isPrepareUpload(obj: any): obj is PrepareUpload
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Upload the given queue item
      * @param item

--- a/src/rendering/batcher/gl/GlBatchAdaptor.ts
+++ b/src/rendering/batcher/gl/GlBatchAdaptor.ts
@@ -7,6 +7,8 @@ import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { Batch } from '../shared/Batcher';
 import type { BatcherAdaptor, BatcherPipe } from '../shared/BatcherPipe';
 
+const typeSymbol = Symbol.for('pixijs.GlBatchAdaptor');
+
 /**
  * A BatcherAdaptor that uses WebGL to render batches.
  * @category rendering
@@ -14,6 +16,22 @@ import type { BatcherAdaptor, BatcherPipe } from '../shared/BatcherPipe';
  */
 export class GlBatchAdaptor implements BatcherAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GlBatchAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlBatchAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlBatchAdaptor, false otherwise.
+     */
+    public static isGlBatchAdaptor(obj: any): obj is GlBatchAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
+++ b/src/rendering/batcher/gpu/GpuBatchAdaptor.ts
@@ -9,6 +9,8 @@ import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { Batch } from '../shared/Batcher';
 import type { BatcherAdaptor, BatcherPipe } from '../shared/BatcherPipe';
 
+const typeSymbol = Symbol.for('pixijs.GpuBatchAdaptor');
+
 const tempState = State.for2d();
 
 /**
@@ -18,6 +20,22 @@ const tempState = State.for2d();
  */
 export class GpuBatchAdaptor implements BatcherAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GpuBatchAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuBatchAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuBatchAdaptor, false otherwise.
+     */
+    public static isGpuBatchAdaptor(obj: any): obj is GpuBatchAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/batcher/shared/BatchGeometry.ts
+++ b/src/rendering/batcher/shared/BatchGeometry.ts
@@ -5,6 +5,8 @@ import { Geometry } from '../../renderers/shared/geometry/Geometry';
 const placeHolderBufferData = new Float32Array(1);
 const placeHolderIndexData = new Uint32Array(1);
 
+const typeSymbol = Symbol.for('pixijs.BatchGeometry');
+
 /**
  * This class represents a geometry used for batching in the rendering system.
  * It defines the structure of vertex attributes and index buffers for batched rendering.
@@ -13,6 +15,22 @@ const placeHolderIndexData = new Uint32Array(1);
  */
 export class BatchGeometry extends Geometry
 {
+    /**
+     * Type symbol used to identify instances of BatchGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchGeometry, false otherwise.
+     */
+    public static isBatchGeometry(obj: any): obj is BatchGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor()
     {
         const vertexSize = 6;

--- a/src/rendering/batcher/shared/BatchTextureArray.ts
+++ b/src/rendering/batcher/shared/BatchTextureArray.ts
@@ -1,5 +1,7 @@
 import type { TextureSource } from '../../renderers/shared/texture/sources/TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.BatchTextureArray');
+
 /**
  * Used by the batcher to build texture batches. Holds list of textures and their respective locations.
  * @category rendering
@@ -7,6 +9,22 @@ import type { TextureSource } from '../../renderers/shared/texture/sources/Textu
  */
 export class BatchTextureArray
 {
+    /**
+     * Type symbol used to identify instances of BatchTextureArray.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchTextureArray.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchTextureArray, false otherwise.
+     */
+    public static isBatchTextureArray(obj: any): obj is BatchTextureArray
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Inside textures array. */
     public textures: TextureSource[];
 

--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -16,6 +16,9 @@ import type { InstructionSet } from '../../renderers/shared/instructions/Instruc
 import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { Texture } from '../../renderers/shared/texture/Texture';
 
+const typeSymbolBatch = Symbol.for('pixijs.Batch');
+const typeSymbolBatcher = Symbol.for('pixijs.Batcher');
+
 /**
  * The action types for a batch.
  * @category rendering
@@ -30,6 +33,22 @@ export type BatchAction = 'startBatch' | 'renderBatch';
  */
 export class Batch implements Instruction
 {
+    /**
+     * Type symbol used to identify instances of Batch.
+     * @internal
+     */
+    public readonly [typeSymbolBatch] = true;
+
+    /**
+     * Checks if the given object is a Batch.
+     * @param obj - The object to check.
+     * @returns True if the object is a Batch, false otherwise.
+     */
+    public static isBatch(obj: any): obj is Batch
+    {
+        return !!obj && !!obj[typeSymbolBatch];
+    }
+
     public renderPipeId = 'batch';
     public action: BatchAction = 'startBatch';
 
@@ -275,6 +294,22 @@ export interface BatcherOptions
  */
 export abstract class Batcher
 {
+    /**
+     * Type symbol used to identify instances of Batcher.
+     * @internal
+     */
+    public readonly [typeSymbolBatcher] = true;
+
+    /**
+     * Checks if the given object is a Batcher.
+     * @param obj - The object to check.
+     * @returns True if the object is a Batcher, false otherwise.
+     */
+    public static isBatcher(obj: any): obj is Batcher
+    {
+        return !!obj && !!obj[typeSymbolBatcher];
+    }
+
     public static defaultOptions: Partial<BatcherOptions> = {
         maxTextures: null,
         attributesInitialSize: 4,

--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -9,6 +9,8 @@ import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { Renderer } from '../../renderers/types';
 import type { Batch, BatchableElement, Batcher } from './Batcher';
 
+const typeSymbol = Symbol.for('pixijs.BatcherPipe');
+
 /** @internal */
 export interface BatcherAdaptor
 {
@@ -28,6 +30,22 @@ export interface BatcherAdaptor
  */
 export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
 {
+    /**
+     * Type symbol used to identify instances of BatcherPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatcherPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatcherPipe, false otherwise.
+     */
+    public static isBatcherPipe(obj: any): obj is BatcherPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -4,12 +4,11 @@ import { BatchGeometry } from './BatchGeometry';
 import { DefaultShader } from './DefaultShader';
 
 import type { Matrix } from '../../../maths/matrix/Matrix';
-import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { BatchableMeshElement, BatchableQuadElement, BatcherOptions } from './Batcher';
 
 const typeSymbol = Symbol.for('pixijs.DefaultBatcher');
 
-let defaultShader: Shader = null;
+let defaultShader: DefaultShader = null;
 
 /**
  * Represents the common elements for default batch rendering.

--- a/src/rendering/batcher/shared/DefaultBatcher.ts
+++ b/src/rendering/batcher/shared/DefaultBatcher.ts
@@ -7,6 +7,8 @@ import type { Matrix } from '../../../maths/matrix/Matrix';
 import type { Shader } from '../../renderers/shared/shader/Shader';
 import type { BatchableMeshElement, BatchableQuadElement, BatcherOptions } from './Batcher';
 
+const typeSymbol = Symbol.for('pixijs.DefaultBatcher');
+
 let defaultShader: Shader = null;
 
 /**
@@ -64,6 +66,22 @@ export interface DefaultBatchableMeshElement extends BatchableMeshElement, Defau
  */
 export class DefaultBatcher extends Batcher
 {
+    /**
+     * Type symbol used to identify instances of DefaultBatcher.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DefaultBatcher.
+     * @param obj - The object to check.
+     * @returns True if the object is a DefaultBatcher, false otherwise.
+     */
+    public static isDefaultBatcher(obj: any): obj is DefaultBatcher
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/batcher/shared/DefaultShader.ts
+++ b/src/rendering/batcher/shared/DefaultShader.ts
@@ -5,6 +5,8 @@ import { roundPixelsBit, roundPixelsBitGl } from '../../high-shader/shader-bits/
 import { getBatchSamplersUniformGroup } from '../../renderers/gl/shader/getBatchSamplersUniformGroup';
 import { Shader } from '../../renderers/shared/shader/Shader';
 
+const typeSymbol = Symbol.for('pixijs.DefaultShader');
+
 /**
  * DefaultShader is a specialized shader class designed for batch rendering.
  * It extends the base Shader class and provides functionality for handling
@@ -17,6 +19,22 @@ import { Shader } from '../../renderers/shared/shader/Shader';
  */
 export class DefaultShader extends Shader
 {
+    /**
+     * Type symbol used to identify instances of DefaultShader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DefaultShader.
+     * @param obj - The object to check.
+     * @returns True if the object is a DefaultShader, false otherwise.
+     */
+    public static isDefaultShader(obj: any): obj is DefaultShader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor(maxTextures: number)
     {
         const glProgram = compileHighShaderGlProgram({

--- a/src/rendering/mask/MaskEffectManager.ts
+++ b/src/rendering/mask/MaskEffectManager.ts
@@ -4,6 +4,8 @@ import { BigPool } from '../../utils/pool/PoolGroup';
 import type { Effect, EffectConstructor } from '../../scene/container/Effect';
 import type { PoolItem, PoolItemConstructor } from '../../utils/pool/Pool';
 
+const typeSymbol = Symbol.for('pixijs.MaskEffectManagerClass');
+
 interface MaskConversionTest
 {
     test: (item: any) => boolean;
@@ -24,6 +26,22 @@ export type MaskEffect = {mask: unknown} & Effect;
  */
 export class MaskEffectManagerClass
 {
+    /**
+     * Type symbol used to identify instances of MaskEffectManagerClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MaskEffectManagerClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a MaskEffectManagerClass, false otherwise.
+     */
+    public static isMaskEffectManagerClass(obj: any): obj is MaskEffectManagerClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @private */
     public readonly _effectClasses: EffectConstructor[] = [];
     private readonly _tests: MaskConversionTest[] = [];

--- a/src/rendering/mask/alpha/AlphaMask.ts
+++ b/src/rendering/mask/alpha/AlphaMask.ts
@@ -10,6 +10,8 @@ import type { Container } from '../../../scene/container/Container';
 import type { Effect } from '../../../scene/container/Effect';
 import type { PoolItem } from '../../../utils/pool/Pool';
 
+const typeSymbol = Symbol.for('pixijs.AlphaMask');
+
 /**
  * AlphaMask is an effect that applies a mask to a container using the alpha channel of a sprite.
  * It can be used to create complex masking effects by using a sprite as the mask.
@@ -19,6 +21,22 @@ import type { PoolItem } from '../../../utils/pool/Pool';
  */
 export class AlphaMask implements Effect, PoolItem
 {
+    /**
+     * Type symbol used to identify instances of AlphaMask.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AlphaMask.
+     * @param obj - The object to check.
+     * @returns True if the object is a AlphaMask, false otherwise.
+     */
+    public static isAlphaMask(obj: any): obj is AlphaMask
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.MaskEffect;
 
     public priority = 0;

--- a/src/rendering/mask/alpha/AlphaMask.ts
+++ b/src/rendering/mask/alpha/AlphaMask.ts
@@ -59,7 +59,7 @@ export class AlphaMask implements Effect, PoolItem
 
         // TODO - might want to change this to adjust on the fly
         // user may add children to the sprite..
-        this.renderMaskToTexture = !(mask instanceof Sprite);
+        this.renderMaskToTexture = !Sprite.isSprite(mask);
 
         this.mask.renderable = this.renderMaskToTexture;
         this.mask.includeInBuild = !this.renderMaskToTexture;
@@ -101,6 +101,6 @@ export class AlphaMask implements Effect, PoolItem
 
     public static test(mask: any): boolean
     {
-        return mask instanceof Sprite;
+        return Sprite.isSprite(mask);
     }
 }

--- a/src/rendering/mask/alpha/AlphaMaskPipe.ts
+++ b/src/rendering/mask/alpha/AlphaMaskPipe.ts
@@ -19,6 +19,9 @@ import type { RenderTarget } from '../../renderers/shared/renderTarget/RenderTar
 import type { Renderer } from '../../renderers/types';
 import type { AlphaMask } from './AlphaMask';
 
+const typeSymbolAlphaMaskEffect = Symbol.for('pixijs.AlphaMaskEffect');
+const typeSymbolAlphaMaskPipe = Symbol.for('pixijs.AlphaMaskPipe');
+
 type MaskMode = 'pushMaskBegin' | 'pushMaskEnd' | 'popMaskBegin' | 'popMaskEnd';
 
 const tempBounds = new Bounds();
@@ -26,6 +29,22 @@ const tempBounds = new Bounds();
 /** @internal */
 class AlphaMaskEffect extends FilterEffect implements PoolItem
 {
+    /**
+     * Type symbol used to identify instances of AlphaMaskEffect.
+     * @internal
+     */
+    public readonly [typeSymbolAlphaMaskEffect] = true;
+
+    /**
+     * Checks if the given object is a AlphaMaskEffect.
+     * @param obj - The object to check.
+     * @returns True if the object is a AlphaMaskEffect, false otherwise.
+     */
+    public static isAlphaMaskEffect(obj: any): obj is AlphaMaskEffect
+    {
+        return !!obj && !!obj[typeSymbolAlphaMaskEffect];
+    }
+
     constructor()
     {
         super();
@@ -84,6 +103,22 @@ export interface AlphaMaskData
 /** @internal */
 export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
 {
+    /**
+     * Type symbol used to identify instances of AlphaMaskPipe.
+     * @internal
+     */
+    public readonly [typeSymbolAlphaMaskPipe] = true;
+
+    /**
+     * Checks if the given object is a AlphaMaskPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a AlphaMaskPipe, false otherwise.
+     */
+    public static isAlphaMaskPipe(obj: any): obj is AlphaMaskPipe
+    {
+        return !!obj && !!obj[typeSymbolAlphaMaskPipe];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/mask/color/ColorMask.ts
+++ b/src/rendering/mask/color/ColorMask.ts
@@ -4,6 +4,8 @@ import type { ExtensionMetadata } from '../../../extensions/Extensions';
 import type { Effect } from '../../../scene/container/Effect';
 import type { PoolItem } from '../../../utils/pool/Pool';
 
+const typeSymbol = Symbol.for('pixijs.ColorMask');
+
 /**
  * The ColorMask effect allows you to apply a color mask to the rendering process.
  * This can be useful for selectively rendering certain colors or for creating
@@ -13,6 +15,22 @@ import type { PoolItem } from '../../../utils/pool/Pool';
  */
 export class ColorMask implements Effect, PoolItem
 {
+    /**
+     * Type symbol used to identify instances of ColorMask.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorMask.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorMask, false otherwise.
+     */
+    public static isColorMask(obj: any): obj is ColorMask
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.MaskEffect;
 
     public priority = 0;

--- a/src/rendering/mask/color/ColorMaskPipe.ts
+++ b/src/rendering/mask/color/ColorMaskPipe.ts
@@ -8,6 +8,8 @@ import type { InstructionPipe } from '../../renderers/shared/instructions/Render
 import type { Renderer } from '../../renderers/types';
 import type { ColorMask } from './ColorMask';
 
+const typeSymbol = Symbol.for('pixijs.ColorMaskPipe');
+
 /** @internal */
 export interface ColorMaskInstruction extends Instruction
 {
@@ -18,6 +20,22 @@ export interface ColorMaskInstruction extends Instruction
 /** @internal */
 export class ColorMaskPipe implements InstructionPipe<ColorMaskInstruction>
 {
+    /**
+     * Type symbol used to identify instances of ColorMaskPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ColorMaskPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a ColorMaskPipe, false otherwise.
+     */
+    public static isColorMaskPipe(obj: any): obj is ColorMaskPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/mask/scissor/ScissorMask.ts
+++ b/src/rendering/mask/scissor/ScissorMask.ts
@@ -6,6 +6,8 @@ import type { Bounds } from '../../../scene/container/bounds/Bounds';
 import type { Container } from '../../../scene/container/Container';
 import type { Effect } from '../../../scene/container/Effect';
 
+const typeSymbol = Symbol.for('pixijs.ScissorMask');
+
 /**
  * ScissorMask is an effect that applies a scissor mask to a container.
  * It restricts rendering to the area defined by the mask.
@@ -17,6 +19,22 @@ import type { Effect } from '../../../scene/container/Effect';
  */
 export class ScissorMask implements Effect
 {
+    /**
+     * Type symbol used to identify instances of ScissorMask.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ScissorMask.
+     * @param obj - The object to check.
+     * @returns True if the object is a ScissorMask, false otherwise.
+     */
+    public static isScissorMask(obj: any): obj is ScissorMask
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public priority = 0;
     public mask: Container;
     public pipe = 'scissorMask';

--- a/src/rendering/mask/stencil/StencilMask.ts
+++ b/src/rendering/mask/stencil/StencilMask.ts
@@ -90,6 +90,6 @@ export class StencilMask implements Effect, PoolItem
 
     public static test(mask: any): boolean
     {
-        return mask instanceof Container;
+        return Container.isContainer(mask);
     }
 }

--- a/src/rendering/mask/stencil/StencilMask.ts
+++ b/src/rendering/mask/stencil/StencilMask.ts
@@ -9,6 +9,8 @@ import type { Bounds } from '../../../scene/container/bounds/Bounds';
 import type { Effect } from '../../../scene/container/Effect';
 import type { PoolItem } from '../../../utils/pool/Pool';
 
+const typeSymbol = Symbol.for('pixijs.StencilMask');
+
 /**
  * A mask that uses the stencil buffer to clip the rendering of a container.
  * This is useful for complex masks that cannot be achieved with simple shapes.
@@ -19,6 +21,22 @@ import type { PoolItem } from '../../../utils/pool/Pool';
  */
 export class StencilMask implements Effect, PoolItem
 {
+    /**
+     * Type symbol used to identify instances of StencilMask.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a StencilMask.
+     * @param obj - The object to check.
+     * @returns True if the object is a StencilMask, false otherwise.
+     */
+    public static isStencilMask(obj: any): obj is StencilMask
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.MaskEffect;
 
     public priority = 0;

--- a/src/rendering/mask/stencil/StencilMaskPipe.ts
+++ b/src/rendering/mask/stencil/StencilMaskPipe.ts
@@ -11,6 +11,8 @@ import type { Renderable } from '../../renderers/shared/Renderable';
 import type { Renderer } from '../../renderers/types';
 import type { StencilMask } from './StencilMask';
 
+const typeSymbol = Symbol.for('pixijs.StencilMaskPipe');
+
 /** @internal */
 type MaskMode = 'pushMaskBegin' | 'pushMaskEnd' | 'popMaskBegin' | 'popMaskEnd';
 
@@ -26,6 +28,22 @@ export interface StencilMaskInstruction extends Instruction
 /** @internal */
 export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
 {
+    /**
+     * Type symbol used to identify instances of StencilMaskPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a StencilMaskPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a StencilMaskPipe, false otherwise.
+     */
+    public static isStencilMaskPipe(obj: any): obj is StencilMaskPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGLPipes,

--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -11,6 +11,8 @@ import type { RenderOptions } from '../shared/system/AbstractRenderer';
 import type { System } from '../shared/system/System';
 import type { WebGLRenderer } from './WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlBackBufferSystem');
+
 const bigTriangleGeometry = new Geometry({
     attributes: {
         aPosition: [
@@ -57,6 +59,22 @@ export interface GlBackBufferOptions
  */
 export class GlBackBufferSystem implements System<GlBackBufferOptions>
 {
+    /**
+     * Type symbol used to identify instances of GlBackBufferSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlBackBufferSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlBackBufferSystem, false otherwise.
+     */
+    public static isGlBackBufferSystem(obj: any): obj is GlBackBufferSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/GlColorMaskSystem.ts
+++ b/src/rendering/renderers/gl/GlColorMaskSystem.ts
@@ -3,6 +3,8 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import type { System } from '../shared/system/System';
 import type { WebGLRenderer } from './WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlColorMaskSystem');
+
 /**
  * The system that handles color masking for the WebGL.
  * @category rendering
@@ -10,6 +12,22 @@ import type { WebGLRenderer } from './WebGLRenderer';
  */
 export class GlColorMaskSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlColorMaskSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlColorMaskSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlColorMaskSystem, false otherwise.
+     */
+    public static isGlColorMaskSystem(obj: any): obj is GlColorMaskSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/GlEncoderSystem.ts
+++ b/src/rendering/renderers/gl/GlEncoderSystem.ts
@@ -7,6 +7,8 @@ import type { State } from '../shared/state/State';
 import type { System } from '../shared/system/System';
 import type { WebGLRenderer } from './WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlEncoderSystem');
+
 /**
  * The system that handles encoding commands for the WebGL.
  * @category rendering
@@ -14,6 +16,22 @@ import type { WebGLRenderer } from './WebGLRenderer';
  */
 export class GlEncoderSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlEncoderSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlEncoderSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlEncoderSystem, false otherwise.
+     */
+    public static isGlEncoderSystem(obj: any): obj is GlEncoderSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/GlLimitsSystem.ts
+++ b/src/rendering/renderers/gl/GlLimitsSystem.ts
@@ -3,6 +3,9 @@ import { checkMaxIfStatementsInShader } from '../../batcher/gl/utils/checkMaxIfS
 import { type System } from '../shared/system/System';
 
 import type { WebGLRenderer } from './WebGLRenderer';
+
+const typeSymbol = Symbol.for('pixijs.GlLimitsSystem');
+
 /**
  * The GpuLimitsSystem provides information about the capabilities and limitations of the underlying GPU.
  * These limits, such as the maximum number of textures that can be used in a shader
@@ -28,6 +31,22 @@ import type { WebGLRenderer } from './WebGLRenderer';
  */
 export class GlLimitsSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlLimitsSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlLimitsSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlLimitsSystem, false otherwise.
+     */
+    public static isGlLimitsSystem(obj: any): obj is GlLimitsSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/GlRenderTarget.ts
+++ b/src/rendering/renderers/gl/GlRenderTarget.ts
@@ -1,3 +1,5 @@
+const typeSymbol = Symbol.for('pixijs.GlRenderTarget');
+
 /**
  * Represents a render target.
  * @category rendering
@@ -5,6 +7,22 @@
  */
 export class GlRenderTarget
 {
+    /**
+     * Type symbol used to identify instances of GlRenderTarget.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlRenderTarget.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlRenderTarget, false otherwise.
+     */
+    public static isGlRenderTarget(obj: any): obj is GlRenderTarget
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public width = -1;
     public height = -1;
     public msaa = false;

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -6,6 +6,8 @@ import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import type { System } from '../shared/system/System';
 import type { WebGLRenderer } from './WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlStencilSystem');
+
 /**
  * This manages the stencil buffer. Used primarily for masking
  * @category rendering
@@ -13,6 +15,22 @@ import type { WebGLRenderer } from './WebGLRenderer';
  */
 export class GlStencilSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlStencilSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlStencilSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlStencilSystem, false otherwise.
+     */
+    public static isGlStencilSystem(obj: any): obj is GlStencilSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/GlUboSystem.ts
+++ b/src/rendering/renderers/gl/GlUboSystem.ts
@@ -3,6 +3,8 @@ import { UboSystem } from '../shared/shader/UboSystem';
 import { createUboElementsSTD40 } from './shader/utils/createUboElementsSTD40';
 import { createUboSyncFunctionSTD40 } from './shader/utils/createUboSyncSTD40';
 
+const typeSymbol = Symbol.for('pixijs.GlUboSystem');
+
 /**
  * System plugin to the renderer to manage uniform buffers. But with an WGSL adaptor.
  * @category rendering
@@ -10,6 +12,22 @@ import { createUboSyncFunctionSTD40 } from './shader/utils/createUboSyncSTD40';
  */
 export class GlUboSystem extends UboSystem
 {
+    /**
+     * Type symbol used to identify instances of GlUboSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlUboSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlUboSystem, false otherwise.
+     */
+    public static isGlUboSystem(obj: any): obj is GlUboSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGLSystem],

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -27,6 +27,8 @@ import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
 import type { GlRenderingContext } from './context/GlRenderingContext';
 
+const typeSymbol = Symbol.for('pixijs.WebGLRenderer');
+
 const DefaultWebGLSystems = [
     ...SharedSystems,
     GlUboSystem,
@@ -161,6 +163,22 @@ export class WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
     extends AbstractRenderer<WebGLPipes, WebGLOptions, T>
     implements WebGLSystems
 {
+    /**
+     * Type symbol used to identify instances of WebGLRenderer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a WebGLRenderer.
+     * @param obj - The object to check.
+     * @returns True if the object is a WebGLRenderer, false otherwise.
+     */
+    public static isWebGLRenderer(obj: any): obj is WebGLRenderer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public gl: GlRenderingContext;
 
     constructor()

--- a/src/rendering/renderers/gl/buffer/GlBuffer.ts
+++ b/src/rendering/renderers/gl/buffer/GlBuffer.ts
@@ -1,8 +1,26 @@
 import type { BUFFER_TYPE } from './const';
 
+const typeSymbol = Symbol.for('pixijs.GlBuffer');
+
 /** @internal */
 export class GlBuffer
 {
+    /**
+     * Type symbol used to identify instances of GlBuffer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlBuffer.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlBuffer, false otherwise.
+     */
+    public static isGlBuffer(obj: any): obj is GlBuffer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public buffer: WebGLBuffer;
     public updateID: number;
     public byteLength: number;

--- a/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
+++ b/src/rendering/renderers/gl/buffer/GlBufferSystem.ts
@@ -8,6 +8,8 @@ import type { System } from '../../shared/system/System';
 import type { GlRenderingContext } from '../context/GlRenderingContext';
 import type { WebGLRenderer } from '../WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlBufferSystem');
+
 /**
  * System plugin to the renderer to manage buffers.
  *
@@ -28,6 +30,22 @@ import type { WebGLRenderer } from '../WebGLRenderer';
  */
 export class GlBufferSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlBufferSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlBufferSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlBufferSystem, false otherwise.
+     */
+    public static isGlBufferSystem(obj: any): obj is GlBufferSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -8,6 +8,8 @@ import type { System } from '../../shared/system/System';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { WebGLExtensions } from './WebGLExtensions';
 
+const typeSymbol = Symbol.for('pixijs.GlContextSystem');
+
 /**
  * Options for the context system.
  * @category rendering
@@ -76,6 +78,22 @@ export interface ContextSystemOptions
  */
 export class GlContextSystem implements System<ContextSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of GlContextSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlContextSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlContextSystem, false otherwise.
+     */
+    public static isGlContextSystem(obj: any): obj is GlContextSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -10,6 +10,8 @@ import type { GlRenderingContext } from '../context/GlRenderingContext';
 import type { GlProgram } from '../shader/GlProgram';
 import type { WebGLRenderer } from '../WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlGeometrySystem');
+
 const topologyToGlMap = {
     'point-list': 0x0000,
     'line-list': 0x0001,
@@ -25,6 +27,22 @@ const topologyToGlMap = {
  */
 export class GlGeometrySystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlGeometrySystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlGeometrySystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlGeometrySystem, false otherwise.
+     */
+    public static isGlGeometrySystem(obj: any): obj is GlGeometrySystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -183,7 +183,7 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
         // we are rendering to the main canvas..
         const colorTexture = renderTarget.colorTexture;
 
-        if (colorTexture instanceof CanvasSource)
+        if (CanvasSource.isCanvasSource(colorTexture))
         {
             this._renderer.context.ensureCanvasSize(renderTarget.colorTexture.resource);
 

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -11,6 +11,8 @@ import type { Texture } from '../../shared/texture/Texture';
 import type { CLEAR_OR_BOOL } from '../const';
 import type { WebGLRenderer } from '../WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlRenderTargetAdaptor');
+
 /**
  * The WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGL renderer
  * @category rendering
@@ -18,6 +20,22 @@ import type { WebGLRenderer } from '../WebGLRenderer';
  */
 export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget>
 {
+    /**
+     * Type symbol used to identify instances of GlRenderTargetAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlRenderTargetAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlRenderTargetAdaptor, false otherwise.
+     */
+    public static isGlRenderTargetAdaptor(obj: any): obj is GlRenderTargetAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private _renderTargetSystem: RenderTargetSystem<GlRenderTarget>;
     private _renderer: WebGLRenderer<HTMLCanvasElement>;
     private _clearColorCache: RgbaArray = [0, 0, 0, 0];

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetSystem.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetSystem.ts
@@ -5,6 +5,8 @@ import { GlRenderTargetAdaptor } from './GlRenderTargetAdaptor';
 import type { GlRenderTarget } from '../GlRenderTarget';
 import type { WebGLRenderer } from '../WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlRenderTargetSystem');
+
 /**
  * The WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGl renderer
  * @category rendering
@@ -12,6 +14,22 @@ import type { WebGLRenderer } from '../WebGLRenderer';
  */
 export class GlRenderTargetSystem extends RenderTargetSystem<GlRenderTarget>
 {
+    /**
+     * Type symbol used to identify instances of GlRenderTargetSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlRenderTargetSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlRenderTargetSystem, false otherwise.
+     */
+    public static isGlRenderTargetSystem(obj: any): obj is GlRenderTargetSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGLSystem],

--- a/src/rendering/renderers/gl/shader/GenerateShaderSyncCode.ts
+++ b/src/rendering/renderers/gl/shader/GenerateShaderSyncCode.ts
@@ -49,7 +49,7 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
         {
             const resource = group.resources[j];
 
-            if (resource instanceof UniformGroup)
+            if (UniformGroup.isUniformGroup(resource))
             {
                 if (resource.ubo)
                 {
@@ -70,7 +70,7 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
                     `);
                 }
             }
-            else if (resource instanceof BufferResource)
+            else if (BufferResource.isBufferResource(resource))
             {
                 const resName = shader._uniformBindMap[i][Number(j)];
 
@@ -82,7 +82,7 @@ export function generateShaderSyncCode(shader: Shader, shaderSystem: GlShaderSys
                     );
                 `);
             }
-            else if (resource instanceof TextureSource)
+            else if (TextureSource.isTextureSource(resource))
             {
                 const uniformName = shader._uniformBindMap[i as unknown as number][j as unknown as number];
 

--- a/src/rendering/renderers/gl/shader/GlProgram.ts
+++ b/src/rendering/renderers/gl/shader/GlProgram.ts
@@ -9,6 +9,8 @@ import { stripVersion } from './program/preprocessors/stripVersion';
 import type { TypedArray } from '../../shared/buffer/Buffer';
 import type { ExtractedAttributeData } from './program/extractAttributesFromGlProgram';
 
+const typeSymbol = Symbol.for('pixijs.GlProgram');
+
 /** @internal */
 export interface GlUniformData
 {
@@ -98,6 +100,22 @@ const programCache: Record<string, GlProgram> = Object.create(null);
  */
 export class GlProgram
 {
+    /**
+     * Type symbol used to identify instances of GlProgram.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlProgram.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlProgram, false otherwise.
+     */
+    public static isGlProgram(obj: any): obj is GlProgram
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options used by the program. */
     public static defaultOptions: Partial<GlProgramOptions> = {
         preferredVertexPrecision: 'highp',

--- a/src/rendering/renderers/gl/shader/GlProgramData.ts
+++ b/src/rendering/renderers/gl/shader/GlProgramData.ts
@@ -1,27 +1,10 @@
-const typeSymbolIGLUniformData = Symbol.for('pixijs.IGLUniformData');
-const typeSymbolGlProgramData = Symbol.for('pixijs.GlProgramData');
+const typeSymbol = Symbol.for('pixijs.GlProgramData');
 
 /** @private */
-export class IGLUniformData
+export interface IGLUniformData
 {
-    /**
-     * Type symbol used to identify instances of IGLUniformData.
-     * @internal
-     */
-    public readonly [typeSymbolIGLUniformData] = true;
-
-    /**
-     * Checks if the given object is a IGLUniformData.
-     * @param obj - The object to check.
-     * @returns True if the object is a IGLUniformData, false otherwise.
-     */
-    public static isIGLUniformData(obj: any): obj is IGLUniformData
-    {
-        return !!obj && !!obj[typeSymbolIGLUniformData];
-    }
-
-    public location: WebGLUniformLocation;
-    public value: number | boolean | Float32Array | Int32Array | Uint32Array | boolean[];
+    location: WebGLUniformLocation;
+    value: number | boolean | Float32Array | Int32Array | Uint32Array | boolean[];
 }
 
 /**
@@ -34,7 +17,7 @@ export class GlProgramData
      * Type symbol used to identify instances of GlProgramData.
      * @internal
      */
-    public readonly [typeSymbolGlProgramData] = true;
+    public readonly [typeSymbol] = true;
 
     /**
      * Checks if the given object is a GlProgramData.
@@ -43,7 +26,7 @@ export class GlProgramData
      */
     public static isGlProgramData(obj: any): obj is GlProgramData
     {
-        return !!obj && !!obj[typeSymbolGlProgramData];
+        return !!obj && !!obj[typeSymbol];
     }
 
     /** The shader program. */

--- a/src/rendering/renderers/gl/shader/GlProgramData.ts
+++ b/src/rendering/renderers/gl/shader/GlProgramData.ts
@@ -1,6 +1,25 @@
+const typeSymbolIGLUniformData = Symbol.for('pixijs.IGLUniformData');
+const typeSymbolGlProgramData = Symbol.for('pixijs.GlProgramData');
+
 /** @private */
 export class IGLUniformData
 {
+    /**
+     * Type symbol used to identify instances of IGLUniformData.
+     * @internal
+     */
+    public readonly [typeSymbolIGLUniformData] = true;
+
+    /**
+     * Checks if the given object is a IGLUniformData.
+     * @param obj - The object to check.
+     * @returns True if the object is a IGLUniformData, false otherwise.
+     */
+    public static isIGLUniformData(obj: any): obj is IGLUniformData
+    {
+        return !!obj && !!obj[typeSymbolIGLUniformData];
+    }
+
     public location: WebGLUniformLocation;
     public value: number | boolean | Float32Array | Int32Array | Uint32Array | boolean[];
 }
@@ -11,6 +30,22 @@ export class IGLUniformData
  */
 export class GlProgramData
 {
+    /**
+     * Type symbol used to identify instances of GlProgramData.
+     * @internal
+     */
+    public readonly [typeSymbolGlProgramData] = true;
+
+    /**
+     * Checks if the given object is a GlProgramData.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlProgramData, false otherwise.
+     */
+    public static isGlProgramData(obj: any): obj is GlProgramData
+    {
+        return !!obj && !!obj[typeSymbolGlProgramData];
+    }
+
     /** The shader program. */
     public program: WebGLProgram;
 

--- a/src/rendering/renderers/gl/shader/GlShaderSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlShaderSystem.ts
@@ -10,6 +10,8 @@ import type { WebGLRenderer } from '../WebGLRenderer';
 import type { GlProgram } from './GlProgram';
 import type { GlProgramData } from './GlProgramData';
 
+const typeSymbol = Symbol.for('pixijs.GlShaderSystem');
+
 /** @internal */
 export interface ShaderSyncData
 {
@@ -33,6 +35,22 @@ const defaultSyncData: ShaderSyncData = {
  */
 export class GlShaderSystem
 {
+    /**
+     * Type symbol used to identify instances of GlShaderSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlShaderSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlShaderSystem, false otherwise.
+     */
+    public static isGlShaderSystem(obj: any): obj is GlShaderSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/shader/GlUniformGroupSystem.ts
+++ b/src/rendering/renderers/gl/shader/GlUniformGroupSystem.ts
@@ -8,6 +8,8 @@ import type { GlRenderingContext } from '../context/GlRenderingContext';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { GlProgram, GlUniformData } from './GlProgram';
 
+const typeSymbol = Symbol.for('pixijs.GlUniformGroupSystem');
+
 /**
  * System plugin to the renderer to manage shaders.
  * @category rendering
@@ -15,6 +17,22 @@ import type { GlProgram, GlUniformData } from './GlProgram';
  */
 export class GlUniformGroupSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlUniformGroupSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlUniformGroupSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlUniformGroupSystem, false otherwise.
+     */
+    public static isGlUniformGroupSystem(obj: any): obj is GlUniformGroupSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/shader/utils/generateUniformsSync.ts
+++ b/src/rendering/renderers/gl/shader/utils/generateUniformsSync.ts
@@ -31,7 +31,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Record<st
     {
         if (!uniformData[i])
         {
-            if (group.uniforms[i] instanceof UniformGroup)
+            if (UniformGroup.isUniformGroup(group.uniforms[i]))
             {
                 if ((group.uniforms[i] as UniformGroup).ubo)
                 {
@@ -46,7 +46,7 @@ export function generateUniformsSync(group: UniformGroup, uniformData: Record<st
                     `);
                 }
             }
-            else if (group.uniforms[i] instanceof BufferResource)
+            else if (BufferResource.isBufferResource(group.uniforms[i]))
             {
                 funcFragments.push(`
                         renderer.shader.bindBufferResource(uv.${i}, "${i}");

--- a/src/rendering/renderers/gl/state/GlStateSystem.ts
+++ b/src/rendering/renderers/gl/state/GlStateSystem.ts
@@ -8,6 +8,8 @@ import type { BLEND_MODES } from '../../shared/state/const';
 import type { System } from '../../shared/system/System';
 import type { GlRenderingContext } from '../context/GlRenderingContext';
 
+const typeSymbol = Symbol.for('pixijs.GlStateSystem');
+
 const BLEND = 0;
 const OFFSET = 1;
 const CULLING = 2;
@@ -22,6 +24,22 @@ const DEPTH_MASK = 5;
  */
 export class GlStateSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlStateSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlStateSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlStateSystem, false otherwise.
+     */
+    public static isGlStateSystem(obj: any): obj is GlStateSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gl/texture/GlTexture.ts
+++ b/src/rendering/renderers/gl/texture/GlTexture.ts
@@ -1,5 +1,7 @@
 import { GL_FORMATS, GL_TARGETS, GL_TYPES } from './const';
 
+const typeSymbol = Symbol.for('pixijs.GlTexture');
+
 /**
  * Internal texture for WebGL context
  * @category rendering
@@ -7,6 +9,22 @@ import { GL_FORMATS, GL_TARGETS, GL_TYPES } from './const';
  */
 export class GlTexture
 {
+    /**
+     * Type symbol used to identify instances of GlTexture.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlTexture.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlTexture, false otherwise.
+     */
+    public static isGlTexture(obj: any): obj is GlTexture
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public target: GL_TARGETS = GL_TARGETS.TEXTURE_2D;
 
     /** The WebGL texture. */

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -22,6 +22,8 @@ import type { GlRenderingContext } from '../context/GlRenderingContext';
 import type { WebGLRenderer } from '../WebGLRenderer';
 import type { GLTextureUploader } from './uploaders/GLTextureUploader';
 
+const typeSymbol = Symbol.for('pixijs.GlTextureSystem');
+
 const BYTES_PER_PIXEL = 4;
 
 /**
@@ -31,6 +33,22 @@ const BYTES_PER_PIXEL = 4;
  */
 export class GlTextureSystem implements System, CanvasGenerator
 {
+    /**
+     * Type symbol used to identify instances of GlTextureSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlTextureSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlTextureSystem, false otherwise.
+     */
+    public static isGlTextureSystem(obj: any): obj is GlTextureSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -12,6 +12,8 @@ import type { BindResource } from './shader/BindResource';
 import type { GpuProgram } from './shader/GpuProgram';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.BindGroupSystem');
+
 /**
  * This manages the WebGPU bind groups. this is how data is bound to a shader when rendering
  * @category rendering
@@ -20,6 +22,22 @@ import type { WebGPURenderer } from './WebGPURenderer';
 export class BindGroupSystem implements System
 {
     /** @ignore */
+    /**
+     * Type symbol used to identify instances of BindGroupSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BindGroupSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a BindGroupSystem, false otherwise.
+     */
+    public static isBindGroupSystem(obj: any): obj is BindGroupSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGPUSystem,

--- a/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
+++ b/src/rendering/renderers/gpu/GpuColorMaskSystem.ts
@@ -3,6 +3,8 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuColorMaskSystem');
+
 /**
  * The system that handles color masking for the GPU.
  * @category rendering
@@ -10,6 +12,22 @@ import type { WebGPURenderer } from './WebGPURenderer';
  */
 export class GpuColorMaskSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuColorMaskSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuColorMaskSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuColorMaskSystem, false otherwise.
+     */
+    public static isGpuColorMaskSystem(obj: any): obj is GpuColorMaskSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -5,6 +5,8 @@ import type { System } from '../shared/system/System';
 import type { GpuPowerPreference } from '../types';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuDeviceSystem');
+
 /**
  * The GPU object.
  * Contains the GPU adapter and device.
@@ -56,6 +58,22 @@ export interface GpuContextOptions
  */
 export class GpuDeviceSystem implements System<GpuContextOptions>
 {
+    /**
+     * Type symbol used to identify instances of GpuDeviceSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuDeviceSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuDeviceSystem, false otherwise.
+     */
+    public static isGpuDeviceSystem(obj: any): obj is GpuDeviceSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -15,6 +15,8 @@ import type { BindGroup } from './shader/BindGroup';
 import type { GpuProgram } from './shader/GpuProgram';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuEncoderSystem');
+
 /**
  * The system that handles encoding commands for the GPU.
  * @category rendering
@@ -22,6 +24,22 @@ import type { WebGPURenderer } from './WebGPURenderer';
  */
 export class GpuEncoderSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuEncoderSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuEncoderSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuEncoderSystem, false otherwise.
+     */
+    public static isGpuEncoderSystem(obj: any): obj is GpuEncoderSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGPUSystem],

--- a/src/rendering/renderers/gpu/GpuLimitsSystem.ts
+++ b/src/rendering/renderers/gpu/GpuLimitsSystem.ts
@@ -2,6 +2,8 @@ import { ExtensionType } from '../../../extensions/Extensions';
 import { type System } from '../shared/system/System';
 import { type WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuLimitsSystem');
+
 /**
  * The GpuLimitsSystem provides information about the capabilities and limitations of the underlying GPU.
  * These limits, such as the maximum number of textures that can be used in a shader
@@ -28,6 +30,22 @@ import { type WebGPURenderer } from './WebGPURenderer';
  */
 export class GpuLimitsSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuLimitsSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuLimitsSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuLimitsSystem, false otherwise.
+     */
+    public static isGpuLimitsSystem(obj: any): obj is GpuLimitsSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/GpuStencilSystem.ts
+++ b/src/rendering/renderers/gpu/GpuStencilSystem.ts
@@ -5,6 +5,8 @@ import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import type { System } from '../shared/system/System';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuStencilSystem');
+
 /**
  * This manages the stencil buffer. Used primarily for masking
  * @category rendering
@@ -12,6 +14,22 @@ import type { WebGPURenderer } from './WebGPURenderer';
  */
 export class GpuStencilSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuStencilSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuStencilSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuStencilSystem, false otherwise.
+     */
+    public static isGpuStencilSystem(obj: any): obj is GpuStencilSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/GpuUboSystem.ts
+++ b/src/rendering/renderers/gpu/GpuUboSystem.ts
@@ -3,6 +3,8 @@ import { UboSystem } from '../shared/shader/UboSystem';
 import { createUboElementsWGSL } from './shader/utils/createUboElementsWGSL';
 import { createUboSyncFunctionWGSL } from './shader/utils/createUboSyncFunctionWGSL';
 
+const typeSymbol = Symbol.for('pixijs.GpuUboSystem');
+
 /**
  * System plugin to the renderer to manage uniform buffers. With a WGSL twist!
  * @category rendering
@@ -10,6 +12,22 @@ import { createUboSyncFunctionWGSL } from './shader/utils/createUboSyncFunctionW
  */
 export class GpuUboSystem extends UboSystem
 {
+    /**
+     * Type symbol used to identify instances of GpuUboSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuUboSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuUboSystem, false otherwise.
+     */
+    public static isGpuUboSystem(obj: any): obj is GpuUboSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGPUSystem],

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -8,11 +8,29 @@ import { BindGroup } from './shader/BindGroup';
 import type { UniformGroup } from '../shared/shader/UniformGroup';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuUniformBatchPipe');
+
 const minUniformOffsetAlignment = 128;// 256 / 2;
 
 /** @internal */
 export class GpuUniformBatchPipe
 {
+    /**
+     * Type symbol used to identify instances of GpuUniformBatchPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuUniformBatchPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuUniformBatchPipe, false otherwise.
+     */
+    public static isGpuUniformBatchPipe(obj: any): obj is GpuUniformBatchPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -26,6 +26,8 @@ import type { SharedRendererOptions } from '../shared/system/SharedSystems';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
 
+const typeSymbol = Symbol.for('pixijs.WebGPURenderer');
+
 const DefaultWebGPUSystems = [
     ...SharedSystems,
     GpuUboSystem,
@@ -156,6 +158,22 @@ export class WebGPURenderer<T extends ICanvas = HTMLCanvasElement>
     extends AbstractRenderer<WebGPUPipes, WebGPUOptions, T>
     implements WebGPUSystems
 {
+    /**
+     * Type symbol used to identify instances of WebGPURenderer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a WebGPURenderer.
+     * @param obj - The object to check.
+     * @returns True if the object is a WebGPURenderer, false otherwise.
+     */
+    public static isWebGPURenderer(obj: any): obj is WebGPURenderer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The WebGPU Device. */
     public gpu: GPU;
 

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -6,6 +6,8 @@ import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuBufferSystem');
+
 /**
  * System plugin to the renderer to manage buffers.
  * @category rendering
@@ -13,6 +15,22 @@ import type { WebGPURenderer } from '../WebGPURenderer';
  */
 export class GpuBufferSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuBufferSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuBufferSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuBufferSystem, false otherwise.
+     */
+    public static isGpuBufferSystem(obj: any): obj is GpuBufferSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/buffer/UboBatch.ts
+++ b/src/rendering/renderers/gpu/buffer/UboBatch.ts
@@ -1,6 +1,24 @@
+const typeSymbol = Symbol.for('pixijs.UboBatch');
+
 /** @internal */
 export class UboBatch
 {
+    /**
+     * Type symbol used to identify instances of UboBatch.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a UboBatch.
+     * @param obj - The object to check.
+     * @returns True if the object is a UboBatch, false otherwise.
+     */
+    public static isUboBatch(obj: any): obj is UboBatch
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public data: Float32Array;
     private readonly _minUniformOffsetAlignment: number = 256;
 

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -15,6 +15,8 @@ import type { GpuProgram } from '../shader/GpuProgram';
 import type { StencilState } from '../state/GpuStencilModesToPixi';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.PipelineSystem');
+
 const topologyStringToId = {
     'point-list': 0,
     'line-list': 1,
@@ -82,6 +84,22 @@ type PipeHash = Record<number, GPURenderPipeline>;
  */
 export class PipelineSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of PipelineSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PipelineSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a PipelineSystem, false otherwise.
+     */
+    public static isPipelineSystem(obj: any): obj is PipelineSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGPUSystem],

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
@@ -1,5 +1,7 @@
 import type { TextureSource } from '../../shared/texture/sources/TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.GpuRenderTarget');
+
 /**
  * A class which holds the canvas contexts and textures for a render target.
  * @category rendering
@@ -7,6 +9,22 @@ import type { TextureSource } from '../../shared/texture/sources/TextureSource';
  */
 export class GpuRenderTarget
 {
+    /**
+     * Type symbol used to identify instances of GpuRenderTarget.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuRenderTarget.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuRenderTarget, false otherwise.
+     */
+    public static isGpuRenderTarget(obj: any): obj is GpuRenderTarget
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public contexts: GPUCanvasContext[] = [];
     public msaaTextures: TextureSource[] = [];
     public msaa: boolean;

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -263,7 +263,7 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
         // is a canvas...
         renderTarget.colorTextures.forEach((colorTexture, i) =>
         {
-            if (colorTexture instanceof CanvasSource)
+            if (CanvasSource.isCanvasSource(colorTexture))
             {
                 const context = colorTexture.resource.getContext(
                     'webgpu'

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -11,6 +11,8 @@ import type { RenderTargetAdaptor, RenderTargetSystem } from '../../shared/rende
 import type { Texture } from '../../shared/texture/Texture';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuRenderTargetAdaptor');
+
 /**
  * The WebGPU adaptor for the render target system. Allows the Render Target System to
  * be used with the WebGPU renderer
@@ -19,6 +21,22 @@ import type { WebGPURenderer } from '../WebGPURenderer';
  */
 export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarget>
 {
+    /**
+     * Type symbol used to identify instances of GpuRenderTargetAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuRenderTargetAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuRenderTargetAdaptor, false otherwise.
+     */
+    public static isGpuRenderTargetAdaptor(obj: any): obj is GpuRenderTargetAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private _renderTargetSystem: RenderTargetSystem<GpuRenderTarget>;
     private _renderer: WebGPURenderer<HTMLCanvasElement>;
 

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetSystem.ts
@@ -5,6 +5,8 @@ import { GpuRenderTargetAdaptor } from './GpuRenderTargetAdaptor';
 import type { WebGPURenderer } from '../WebGPURenderer';
 import type { GpuRenderTarget } from './GpuRenderTarget';
 
+const typeSymbol = Symbol.for('pixijs.GpuRenderTargetSystem');
+
 /**
  * The WebGL adaptor for the render target system. Allows the Render Target System to be used with the WebGl renderer
  * @category rendering
@@ -12,6 +14,22 @@ import type { GpuRenderTarget } from './GpuRenderTarget';
  */
 export class GpuRenderTargetSystem extends RenderTargetSystem<GpuRenderTarget>
 {
+    /**
+     * Type symbol used to identify instances of GpuRenderTargetSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuRenderTargetSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuRenderTargetSystem, false otherwise.
+     */
+    public static isGpuRenderTargetSystem(obj: any): obj is GpuRenderTargetSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [ExtensionType.WebGPUSystem],

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -1,5 +1,7 @@
 import type { BindResource } from './BindResource';
 
+const typeSymbol = Symbol.for('pixijs.BindGroup');
+
 /**
  * A bind group is a collection of resources that are bound together for use by a shader.
  * They are essentially a wrapper for the WebGPU BindGroup class. But with the added bonus
@@ -29,6 +31,22 @@ import type { BindResource } from './BindResource';
  */
 export class BindGroup
 {
+    /**
+     * Type symbol used to identify instances of BindGroup.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BindGroup.
+     * @param obj - The object to check.
+     * @returns True if the object is a BindGroup, false otherwise.
+     */
+    public static isBindGroup(obj: any): obj is BindGroup
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The resources that are bound together for use by a shader. */
     public resources: Record<string, BindResource> = Object.create(null);
     /**

--- a/src/rendering/renderers/gpu/shader/GpuProgram.ts
+++ b/src/rendering/renderers/gpu/shader/GpuProgram.ts
@@ -8,6 +8,8 @@ import { removeStructAndGroupDuplicates } from './utils/removeStructAndGroupDupl
 import type { ExtractedAttributeData } from '../../gl/shader/program/extractAttributesFromGlProgram';
 import type { StructsAndGroups } from './utils/extractStructAndGroups';
 
+const typeSymbol = Symbol.for('pixijs.GpuProgram');
+
 /**
  * a WebGPU descriptions of how the program is laid out
  * @see https://gpuweb.github.io/gpuweb/#gpupipelinelayout
@@ -97,6 +99,22 @@ const programCache: Record<string, GpuProgram> = Object.create(null);
  */
 export class GpuProgram
 {
+    /**
+     * Type symbol used to identify instances of GpuProgram.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuProgram.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuProgram, false otherwise.
+     */
+    public static isGpuProgram(obj: any): obj is GpuProgram
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The fragment glsl shader source. */
     public readonly fragment?: ProgramSource;
     /** The vertex glsl shader source */

--- a/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
+++ b/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
@@ -3,6 +3,8 @@ import { ExtensionType } from '../../../../extensions/Extensions';
 import type { GPU } from '../GpuDeviceSystem';
 import type { GpuProgram } from './GpuProgram';
 
+const typeSymbol = Symbol.for('pixijs.GpuShaderSystem');
+
 /**
  * Data structure for GPU program layout.
  * Contains bind group layouts and pipeline layout.
@@ -22,6 +24,22 @@ export interface GPUProgramData
  */
 export class GpuShaderSystem
 {
+    /**
+     * Type symbol used to identify instances of GpuShaderSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuShaderSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuShaderSystem, false otherwise.
+     */
+    public static isGpuShaderSystem(obj: any): obj is GpuShaderSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/state/GpuStateSystem.ts
+++ b/src/rendering/renderers/gpu/state/GpuStateSystem.ts
@@ -6,6 +6,8 @@ import type { BLEND_MODES } from '../../shared/state/const';
 import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 
+const typeSymbol = Symbol.for('pixijs.GpuStateSystem');
+
 /**
  * System plugin to the renderer to manage WebGL state machines.
  * @category rendering
@@ -13,6 +15,22 @@ import type { GPU } from '../GpuDeviceSystem';
  */
 export class GpuStateSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GpuStateSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuStateSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuStateSystem, false otherwise.
+     */
+    public static isGpuStateSystem(obj: any): obj is GpuStateSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -19,6 +19,8 @@ import type { GPU } from '../GpuDeviceSystem';
 import type { WebGPURenderer } from '../WebGPURenderer';
 import type { GpuTextureUploader } from './uploaders/GpuTextureUploader';
 
+const typeSymbol = Symbol.for('pixijs.GpuTextureSystem');
+
 /**
  * The system that handles textures for the GPU.
  * @category rendering
@@ -26,6 +28,22 @@ import type { GpuTextureUploader } from './uploaders/GpuTextureUploader';
  */
 export class GpuTextureSystem implements System, CanvasGenerator
 {
+    /**
+     * Type symbol used to identify instances of GpuTextureSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuTextureSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuTextureSystem, false otherwise.
+     */
+    public static isGpuTextureSystem(obj: any): obj is GpuTextureSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/gpu/texture/utils/GpuMipmapGenerator.ts
+++ b/src/rendering/renderers/gpu/texture/utils/GpuMipmapGenerator.ts
@@ -1,3 +1,5 @@
+const typeSymbol = Symbol.for('pixijs.GpuMipmapGenerator');
+
 /**
  * A class which generates mipmaps for a GPUTexture.
  * Thanks to toji for the original implementation
@@ -7,6 +9,22 @@
  */
 export class GpuMipmapGenerator
 {
+    /**
+     * Type symbol used to identify instances of GpuMipmapGenerator.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuMipmapGenerator.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuMipmapGenerator, false otherwise.
+     */
+    public static isGpuMipmapGenerator(obj: any): obj is GpuMipmapGenerator
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public device: GPUDevice;
     public sampler: GPUSampler;
     public pipelines: Record<string, GPURenderPipeline>;

--- a/src/rendering/renderers/shared/SchedulerSystem.ts
+++ b/src/rendering/renderers/shared/SchedulerSystem.ts
@@ -3,6 +3,8 @@ import { Ticker } from '../../../ticker/Ticker';
 
 import type { System } from './system/System';
 
+const typeSymbol = Symbol.for('pixijs.SchedulerSystem');
+
 // start at one too keep it positive!
 let uid = 1;
 
@@ -13,6 +15,22 @@ let uid = 1;
  */
 export class SchedulerSystem implements System<null>
 {
+    /**
+     * Type symbol used to identify instances of SchedulerSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SchedulerSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a SchedulerSystem, false otherwise.
+     */
+    public static isSchedulerSystem(obj: any): obj is SchedulerSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/background/BackgroundSystem.ts
+++ b/src/rendering/renderers/shared/background/BackgroundSystem.ts
@@ -4,6 +4,9 @@ import { warn } from '../../../../utils/logging/warn';
 
 import type { ColorSource, RgbaArray } from '../../../../color/Color';
 import type { System } from '../system/System';
+
+const typeSymbol = Symbol.for('pixijs.BackgroundSystem');
+
 /**
  * Options for the background system.
  * @category rendering
@@ -40,6 +43,22 @@ export interface BackgroundSystemOptions
  */
 export class BackgroundSystem implements System<BackgroundSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of BackgroundSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BackgroundSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a BackgroundSystem, false otherwise.
+     */
+    public static isBackgroundSystem(obj: any): obj is BackgroundSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/blendModes/BlendModePipe.ts
+++ b/src/rendering/renderers/shared/blendModes/BlendModePipe.ts
@@ -11,6 +11,8 @@ import type { InstructionPipe } from '../instructions/RenderPipe';
 import type { Renderable } from '../Renderable';
 import type { BLEND_MODES } from '../state/const';
 
+const typeSymbol = Symbol.for('pixijs.BlendModePipe');
+
 interface AdvancedBlendInstruction extends Instruction
 {
     renderPipeId: 'blendMode',
@@ -48,6 +50,22 @@ extensions.handle(ExtensionType.BlendMode, (value) =>
  */
 export class BlendModePipe implements InstructionPipe<AdvancedBlendInstruction>
 {
+    /**
+     * Type symbol used to identify instances of BlendModePipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BlendModePipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a BlendModePipe, false otherwise.
+     */
+    public static isBlendModePipe(obj: any): obj is BlendModePipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -4,6 +4,8 @@ import { BufferUsage } from './const';
 
 import type { BindResource } from '../../gpu/shader/BindResource';
 
+const typeSymbol = Symbol.for('pixijs.Buffer');
+
 /**
  * All the various typed arrays that exist in js
  * @category rendering
@@ -93,6 +95,22 @@ export class Buffer extends EventEmitter<{
     destroy: Buffer,
 }> implements BindResource
 {
+    /**
+     * Type symbol used to identify instances of Buffer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Buffer.
+     * @param obj - The object to check.
+     * @returns True if the object is a Buffer, false otherwise.
+     */
+    public static isBuffer(obj: any): obj is Buffer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * emits when the underlying buffer has changed shape (i.e. resized)
      * letting the renderer know that it needs to discard the old buffer on the GPU and create a new one

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -4,6 +4,8 @@ import { uid } from '../../../../utils/data/uid';
 import type { BindResource } from '../../gpu/shader/BindResource';
 import type { Buffer } from './Buffer';
 
+const typeSymbol = Symbol.for('pixijs.BufferResource');
+
 /**
  * A resource that can be bound to a bind group and used in a shader.
  * Whilst a buffer can be used as a resource, this class allows you to specify an offset and size of the buffer to use.
@@ -29,6 +31,22 @@ export class BufferResource extends EventEmitter<{
     change: BindResource,
 }> implements BindResource
 {
+    /**
+     * Type symbol used to identify instances of BufferResource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BufferResource.
+     * @param obj - The object to check.
+     * @returns True if the object is a BufferResource, false otherwise.
+     */
+    public static isBufferResource(obj: any): obj is BufferResource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * emits when the underlying buffer has changed shape (i.e. resized)
      * letting the renderer know that it needs to discard the old buffer on the GPU and create a new one

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -487,7 +487,7 @@ export class ExtractSystem implements System
         defaults: Partial<T> = {},
     ): T
     {
-        if (options instanceof Container || options instanceof Texture)
+        if (Container.isContainer(options) || Texture.isTexture(options))
         {
             return {
                 target: options,
@@ -676,7 +676,7 @@ export class ExtractSystem implements System
 
         const renderer = this._renderer;
 
-        if (target instanceof Texture)
+        if (Texture.isTexture(target))
         {
             return renderer.texture.generateCanvas(target);
         }
@@ -727,13 +727,13 @@ export class ExtractSystem implements System
         const target = options.target;
 
         const renderer = this._renderer;
-        const texture = target instanceof Texture
+        const texture = Texture.isTexture(target)
             ? target
             : renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
 
         const pixelInfo = renderer.texture.getPixels(texture);
 
-        if (target instanceof Container)
+        if (Container.isContainer(target))
         {
             // destroy generated texture
             texture.destroy(true);
@@ -789,7 +789,7 @@ export class ExtractSystem implements System
     {
         options = this._normalizeOptions(options);
 
-        if (options.target instanceof Texture) return options.target;
+        if (Texture.isTexture(options.target)) return options.target;
 
         return this._renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);
     }

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -12,6 +12,8 @@ import type { System } from '../system/System';
 import type { GetPixelsOutput } from '../texture/GenerateCanvas';
 import type { GenerateTextureOptions } from './GenerateTextureSystem';
 
+const typeSymbol = Symbol.for('pixijs.ExtractSystem');
+
 const imageTypes = {
     png: 'image/png',
     jpg: 'image/jpeg',
@@ -430,6 +432,22 @@ export type ExtractOptions = BaseExtractOptions | ExtractImageOptions | ExtractD
  */
 export class ExtractSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of ExtractSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ExtractSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a ExtractSystem, false otherwise.
+     */
+    public static isExtractSystem(obj: any): obj is ExtractSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -289,7 +289,7 @@ export class GenerateTextureSystem implements System
      */
     public generateTexture(options: GenerateTextureOptions | Container): RenderTexture
     {
-        if (options instanceof Container)
+        if (Container.isContainer(options))
         {
             options = {
                 target: options,

--- a/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
+++ b/src/rendering/renderers/shared/extract/GenerateTextureSystem.ts
@@ -11,6 +11,8 @@ import type { Renderer } from '../../types';
 import type { System } from '../system/System';
 import type { TextureSourceOptions } from '../texture/sources/TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.GenerateTextureSystem');
+
 /**
  * Options for generating a texture source.
  * @category rendering
@@ -217,6 +219,22 @@ const noColor: ColorSource = [0, 0, 0, 0];
  */
 export class GenerateTextureSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GenerateTextureSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GenerateTextureSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GenerateTextureSystem, false otherwise.
+     */
+    public static isGenerateTextureSystem(obj: any): obj is GenerateTextureSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -8,6 +8,8 @@ import { getGeometryBounds } from './utils/getGeometryBounds';
 import type { TypedArray } from '../buffer/Buffer';
 import type { Topology, VertexFormat } from './const';
 
+const typeSymbol = Symbol.for('pixijs.Geometry');
+
 /**
  * The index buffer array type used in geometries.
  * @category rendering
@@ -133,6 +135,22 @@ export class Geometry extends EventEmitter<{
     destroy: Geometry,
 }>
 {
+    /**
+     * Type symbol used to identify instances of Geometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Geometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a Geometry, false otherwise.
+     */
+    public static isGeometry(obj: any): obj is Geometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The topology of the geometry. */
     public topology: Topology;
     /** The unique id of the geometry. */

--- a/src/rendering/renderers/shared/instructions/InstructionSet.ts
+++ b/src/rendering/renderers/shared/instructions/InstructionSet.ts
@@ -3,6 +3,8 @@ import { uid } from '../../../../utils/data/uid';
 import type { Renderable } from '../Renderable';
 import type { Instruction } from './Instruction';
 
+const typeSymbol = Symbol.for('pixijs.InstructionSet');
+
 /**
  * A set of instructions that can be executed by the renderer.
  * Basically wraps an array, but with some extra properties that help the renderer
@@ -16,6 +18,22 @@ import type { Instruction } from './Instruction';
  */
 export class InstructionSet
 {
+    /**
+     * Type symbol used to identify instances of InstructionSet.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a InstructionSet.
+     * @param obj - The object to check.
+     * @returns True if the object is a InstructionSet, false otherwise.
+     */
+    public static isInstructionSet(obj: any): obj is InstructionSet
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** a unique id for this instruction set used through the renderer */
     public readonly uid: number = uid('instructionSet');
     /** the array of instructions */

--- a/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/GlobalUniformSystem.ts
@@ -13,6 +13,8 @@ import type { WebGPURenderer } from '../../gpu/WebGPURenderer';
 import type { UboSystem } from '../shader/UboSystem';
 import type { System } from '../system/System';
 
+const typeSymbol = Symbol.for('pixijs.GlobalUniformSystem');
+
 /**
  * Type definition for the global uniforms used in the renderer.
  * This includes projection matrix, world transform matrix, world color, and resolution.
@@ -73,6 +75,22 @@ export interface GlobalUniformRenderer
  */
 export class GlobalUniformSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of GlobalUniformSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlobalUniformSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlobalUniformSystem, false otherwise.
+     */
+    public static isGlobalUniformSystem(obj: any): obj is GlobalUniformSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -148,8 +148,8 @@ export class RenderTarget
         if (descriptor.depthStencilTexture || this.stencil)
         {
             // TODO add a test
-            if (descriptor.depthStencilTexture instanceof Texture
-                || descriptor.depthStencilTexture instanceof TextureSource)
+            if (Texture.isTexture(descriptor.depthStencilTexture)
+                || TextureSource.isTextureSource(descriptor.depthStencilTexture))
             {
                 this.depthStencilTexture = descriptor.depthStencilTexture.source;
             }

--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -6,6 +6,8 @@ import { Texture } from '../texture/Texture';
 
 import type { BindableTexture } from '../texture/Texture';
 
+const typeSymbol = Symbol.for('pixijs.RenderTarget');
+
 /**
  * Options for creating a render target.
  * @category rendering
@@ -45,6 +47,22 @@ export interface RenderTargetOptions
  */
 export class RenderTarget
 {
+    /**
+     * Type symbol used to identify instances of RenderTarget.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderTarget.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderTarget, false otherwise.
+     */
+    public static isRenderTarget(obj: any): obj is RenderTarget
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options for a render target */
     public static defaultOptions: RenderTargetOptions = {
         /** the width of the RenderTarget */

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -19,6 +19,8 @@ import type { Renderer } from '../../types';
 import type { System } from '../system/System';
 import type { BindableTexture } from '../texture/Texture';
 
+const typeSymbol = Symbol.for('pixijs.RenderTargetSystem');
+
 /**
  * A render surface is a texture, canvas, or render target
  * @category rendering
@@ -152,6 +154,22 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends GlRenderTarget | GpuR
  */
 export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRenderTarget> implements System
 {
+    /**
+     * Type symbol used to identify instances of RenderTargetSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderTargetSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderTargetSystem, false otherwise.
+     */
+    public static isRenderTargetSystem(obj: any): obj is RenderTargetSystem<GlRenderTarget | GpuRenderTarget>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** When rendering of a scene begins, this is where the root render surface is stored */
     public rootRenderTarget: RenderTarget;
     /** This is the root viewport for the render pass*/

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -307,7 +307,7 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
         const pixelWidth = source.pixelWidth;
         const pixelHeight = source.pixelHeight;
 
-        if (!frame && renderSurface instanceof Texture)
+        if (!frame && Texture.isTexture(renderSurface))
         {
             frame = renderSurface.frame;
         }
@@ -543,17 +543,17 @@ export class RenderTargetSystem<RENDER_TARGET extends GlRenderTarget | GpuRender
             renderSurface = getCanvasTexture(renderSurface as ICanvas).source;
         }
 
-        if (renderSurface instanceof RenderTarget)
+        if (RenderTarget.isRenderTarget(renderSurface))
         {
             renderTarget = renderSurface;
         }
-        else if (renderSurface instanceof TextureSource)
+        else if (TextureSource.isTextureSource(renderSurface))
         {
             renderTarget = new RenderTarget({
                 colorTextures: [renderSurface],
             });
 
-            if (renderSurface.source instanceof CanvasSource)
+            if (CanvasSource.isCanvasSource(renderSurface.source))
             {
                 renderTarget.isRoot = true;
             }

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -10,6 +10,8 @@ import type { GlProgramOptions } from '../../gl/shader/GlProgram';
 import type { BindResource } from '../../gpu/shader/BindResource';
 import type { GpuProgramOptions } from '../../gpu/shader/GpuProgram';
 
+const typeSymbol = Symbol.for('pixijs.Shader');
+
 /**
  * A record of {@link BindGroup}'s used by the shader.
  *
@@ -193,6 +195,22 @@ export type ShaderFromResources = (GlShaderFromWith | GpuShaderFromWith)
  */
 export class Shader extends EventEmitter<{'destroy': Shader}>
 {
+    /**
+     * Type symbol used to identify instances of Shader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Shader.
+     * @param obj - The object to check.
+     * @returns True if the object is a Shader, false otherwise.
+     */
+    public static isShader(obj: any): obj is Shader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** A unique identifier for the shader */
     public readonly uid: number = uid('shader');
     /** An instance of the GPU program used by the WebGPU renderer */

--- a/src/rendering/renderers/shared/shader/UboSystem.ts
+++ b/src/rendering/renderers/shared/shader/UboSystem.ts
@@ -6,6 +6,8 @@ import type { System } from '../system/System';
 import type { UboElement, UboLayout, UniformData, UniformsSyncCallback } from './types';
 import type { UniformGroup } from './UniformGroup';
 
+const typeSymbol = Symbol.for('pixijs.UboSystem');
+
 /** @internal */
 export interface UboAdaptor
 {
@@ -20,6 +22,22 @@ export interface UboAdaptor
  */
 export class UboSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of UboSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a UboSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a UboSystem, false otherwise.
+     */
+    public static isUboSystem(obj: any): obj is UboSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Cache of uniform buffer layouts and sync functions, so we don't have to re-create them */
     private _syncFunctionHash: Record<string, {
         layout: UboLayout,

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -6,6 +6,8 @@ import { getDefaultUniformValue } from './utils/getDefaultUniformValue';
 import type { BindResource } from '../../gpu/shader/BindResource';
 import type { Buffer } from '../buffer/Buffer';
 
+const typeSymbol = Symbol.for('pixijs.UniformGroup');
+
 type FLOPS<T = UniformData> = T extends { value: infer V } ? V : never;
 
 /**
@@ -87,6 +89,22 @@ export type UniformGroupOptions = {
  */
 export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any> implements BindResource
 {
+    /**
+     * Type symbol used to identify instances of UniformGroup.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a UniformGroup.
+     * @param obj - The object to check.
+     * @returns True if the object is a UniformGroup, false otherwise.
+     */
+    public static isUniformGroup(obj: any): obj is UniformGroup
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options used by the uniform group. */
     public static defaultOptions: UniformGroupOptions = {
         /** if true the UniformGroup is handled as an Uniform buffer object. */

--- a/src/rendering/renderers/shared/startup/HelloSystem.ts
+++ b/src/rendering/renderers/shared/startup/HelloSystem.ts
@@ -5,6 +5,8 @@ import { type Renderer, RendererType } from '../../types';
 import type { WebGLRenderer } from '../../gl/WebGLRenderer';
 import type { System } from '../system/System';
 
+const typeSymbol = Symbol.for('pixijs.HelloSystem');
+
 /**
  * Options for the startup system.
  * @property {boolean} [hello=false] - Whether to log the version and type information of renderer to console.
@@ -27,6 +29,22 @@ export interface HelloSystemOptions
  */
 export class HelloSystem implements System<HelloSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of HelloSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HelloSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a HelloSystem, false otherwise.
+     */
+    public static isHelloSystem(obj: any): obj is HelloSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/state/State.ts
+++ b/src/rendering/renderers/shared/state/State.ts
@@ -1,5 +1,7 @@
 import type { BLEND_MODES, CULL_MODES } from './const';
 
+const typeSymbol = Symbol.for('pixijs.State');
+
 const blendModeIds = {
     normal: 0,
     add: 1,
@@ -30,6 +32,22 @@ const DEPTH_MASK = 5;
  */
 export class State
 {
+    /**
+     * Type symbol used to identify instances of State.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a State.
+     * @param obj - The object to check.
+     * @returns True if the object is a State, false otherwise.
+     */
+    public static isState(obj: any): obj is State
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The data is a unique number based on the states settings.
      * This lets us quickly compare states with a single number rather than looking

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -300,7 +300,7 @@ export class AbstractRenderer<
     {
         let options = args;
 
-        if (options instanceof Container)
+        if (Container.isContainer(options))
         {
             options = { container: options };
 

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -162,7 +162,7 @@ export class AbstractRenderer<
      * @param obj - The object to check.
      * @returns True if the object is a AbstractRenderer, false otherwise.
      */
-    public static isAbstractRenderer(obj: any): obj is AbstractRenderer
+    public static isAbstractRenderer(obj: any): obj is AbstractRenderer<any, any, any>
     {
         return !!obj && !!obj[typeSymbol];
     }

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -24,6 +24,8 @@ import type { ViewSystem, ViewSystemDestroyOptions } from '../view/ViewSystem';
 import type { SharedRendererOptions } from './SharedSystems';
 import type { System, SystemConstructor } from './System';
 
+const typeSymbol = Symbol.for('pixijs.AbstractRenderer');
+
 /**
  * The configuration for the renderer.
  * This is used to define the systems and render pipes that will be used by the renderer.
@@ -149,6 +151,22 @@ export class AbstractRenderer<
     PIPES, OPTIONS extends SharedRendererOptions, CANVAS extends ICanvas = HTMLCanvasElement
 > extends EventEmitter<{resize: [screenWidth: number, screenHeight: number, resolution: number]}>
 {
+    /**
+     * Type symbol used to identify instances of AbstractRenderer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AbstractRenderer.
+     * @param obj - The object to check.
+     * @returns True if the object is a AbstractRenderer, false otherwise.
+     */
+    public static isAbstractRenderer(obj: any): obj is AbstractRenderer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options for the renderer. */
     public static defaultOptions = {
         /**

--- a/src/rendering/renderers/shared/system/SystemRunner.ts
+++ b/src/rendering/renderers/shared/system/SystemRunner.ts
@@ -1,3 +1,5 @@
+const typeSymbol = Symbol.for('pixijs.SystemRunner');
+
 /**
  * SystemRunner is used internally by the renderers as an efficient way for systems to
  * be notified about what the renderer is up to during the rendering phase.
@@ -43,6 +45,22 @@
  */
 export class SystemRunner
 {
+    /**
+     * Type symbol used to identify instances of SystemRunner.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SystemRunner.
+     * @param obj - The object to check.
+     * @returns True if the object is a SystemRunner, false otherwise.
+     */
+    public static isSystemRunner(obj: any): obj is SystemRunner
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public items: any[];
     private _name: string;
 

--- a/src/rendering/renderers/shared/texture/CanvasPool.ts
+++ b/src/rendering/renderers/shared/texture/CanvasPool.ts
@@ -4,6 +4,8 @@ import { nextPow2 } from '../../../../maths/misc/pow2';
 import type { ICanvas, ICanvasRenderingContext2DSettings } from '../../../../environment/canvas/ICanvas';
 import type { ICanvasRenderingContext2D } from '../../../../environment/canvas/ICanvasRenderingContext2D';
 
+const typeSymbol = Symbol.for('pixijs.CanvasPoolClass');
+
 /**
  * A utility type that represents a canvas and its rendering context.
  * @category rendering
@@ -34,6 +36,22 @@ export class CanvasPoolClass
      */
     public enableFullScreen: boolean;
     private _canvasPool: {[x in string | number]: CanvasAndContext[]};
+
+    /**
+     * Type symbol used to identify instances of CanvasPoolClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasPoolClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasPoolClass, false otherwise.
+     */
+    public static isCanvasPoolClass(obj: any): obj is CanvasPoolClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
 
     constructor(canvasOptions?: ICanvasRenderingContext2DSettings)
     {

--- a/src/rendering/renderers/shared/texture/RenderTexture.ts
+++ b/src/rendering/renderers/shared/texture/RenderTexture.ts
@@ -3,6 +3,8 @@ import { Texture } from './Texture';
 
 import type { TextureSourceOptions } from './sources/TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.RenderTexture');
+
 /**
  * A render texture, extends `Texture`.
  * @see {@link Texture}
@@ -11,6 +13,22 @@ import type { TextureSourceOptions } from './sources/TextureSource';
  */
 export class RenderTexture extends Texture
 {
+    /**
+     * Type symbol used to identify instances of RenderTexture.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderTexture.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderTexture, false otherwise.
+     */
+    public static isRenderTexture(obj: any): obj is RenderTexture
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static create(options: TextureSourceOptions): RenderTexture
     {
         return new RenderTexture({

--- a/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/RenderableGCSystem.ts
@@ -9,6 +9,8 @@ import type { RenderPipe } from '../instructions/RenderPipe';
 import type { Renderable } from '../Renderable';
 import type { System } from '../system/System';
 
+const typeSymbol = Symbol.for('pixijs.RenderableGCSystem');
+
 let renderableGCTick = 0;
 
 /**
@@ -76,6 +78,22 @@ export interface RenderableGCSystemOptions
  */
 export class RenderableGCSystem implements System<RenderableGCSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of RenderableGCSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderableGCSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderableGCSystem, false otherwise.
+     */
+    public static isRenderableGCSystem(obj: any): obj is RenderableGCSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Extension metadata for registering this system with the renderer.
      * @ignore

--- a/src/rendering/renderers/shared/texture/Texture.ts
+++ b/src/rendering/renderers/shared/texture/Texture.ts
@@ -10,6 +10,8 @@ import { TextureMatrix } from './TextureMatrix';
 
 import type { TextureResourceOrOptions } from './utils/textureFrom';
 
+const typeSymbol = Symbol.for('pixijs.Texture');
+
 /**
  * Stores the width of the non-scalable borders, for example when used with {@link NineSlicePlane} texture.
  * @category rendering
@@ -145,6 +147,22 @@ export class Texture<TextureSourceType extends TextureSource = TextureSource> ex
     destroy: Texture
 }> implements BindableTexture
 {
+    /**
+     * Type symbol used to identify instances of Texture.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Texture.
+     * @param obj - The object to check.
+     * @returns True if the object is a Texture, false otherwise.
+     */
+    public static isTexture(obj: any): obj is Texture
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Helper function that creates a returns Texture based on the source you provide.
      * The source should be loaded and ready to go. If not its best to grab the asset using Assets.

--- a/src/rendering/renderers/shared/texture/TextureGCSystem.ts
+++ b/src/rendering/renderers/shared/texture/TextureGCSystem.ts
@@ -3,6 +3,8 @@ import { ExtensionType } from '../../../../extensions/Extensions';
 import type { Renderer } from '../../types';
 import type { System } from '../system/System';
 
+const typeSymbol = Symbol.for('pixijs.TextureGCSystem');
+
 /**
  * Options for the {@link TextureGCSystem}.
  * @category rendering
@@ -39,6 +41,22 @@ export interface TextureGCSystemOptions
  */
 export class TextureGCSystem implements System<TextureGCSystemOptions>
 {
+    /**
+     * Type symbol used to identify instances of TextureGCSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextureGCSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextureGCSystem, false otherwise.
+     */
+    public static isTextureGCSystem(obj: any): obj is TextureGCSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/rendering/renderers/shared/texture/TextureMatrix.ts
+++ b/src/rendering/renderers/shared/texture/TextureMatrix.ts
@@ -2,6 +2,7 @@ import { Matrix } from '../../../../maths/matrix/Matrix';
 
 import type { Texture } from './Texture';
 
+const typeSymbol = Symbol.for('pixijs.TextureMatrix');
 const tempMat = new Matrix();
 
 /**
@@ -22,6 +23,22 @@ const tempMat = new Matrix();
  */
 export class TextureMatrix
 {
+    /**
+     * Type symbol used to identify instances of TextureMatrix.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextureMatrix.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextureMatrix, false otherwise.
+     */
+    public static isTextureMatrix(obj: any): obj is TextureMatrix
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Matrix operation that converts texture region coords to texture coords
      * @readonly

--- a/src/rendering/renderers/shared/texture/TexturePool.ts
+++ b/src/rendering/renderers/shared/texture/TexturePool.ts
@@ -5,6 +5,8 @@ import { TextureStyle } from './TextureStyle';
 
 import type { TextureSourceOptions } from './sources/TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.TexturePoolClass');
+
 let count = 0;
 
 /**
@@ -19,6 +21,22 @@ let count = 0;
  */
 export class TexturePoolClass
 {
+    /**
+     * Type symbol used to identify instances of TexturePoolClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TexturePoolClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a TexturePoolClass, false otherwise.
+     */
+    public static isTexturePoolClass(obj: any): obj is TexturePoolClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options for texture pool */
     public textureOptions: TextureSourceOptions;
 

--- a/src/rendering/renderers/shared/texture/TextureStyle.ts
+++ b/src/rendering/renderers/shared/texture/TextureStyle.ts
@@ -5,6 +5,8 @@ import { deprecation, v8_0_0 } from '../../../../utils/logging/deprecation';
 import type { BindResource } from '../../gpu/shader/BindResource';
 import type { COMPARE_FUNCTION, SCALE_MODE, WRAP_MODE } from './const';
 
+const typeSymbol = Symbol.for('pixijs.TextureStyle');
+
 const idHash: Record<string, number> = Object.create(null);
 
 /**
@@ -84,6 +86,22 @@ export class TextureStyle extends EventEmitter<{
     destroy: TextureStyle,
 }> implements BindResource
 {
+    /**
+     * Type symbol used to identify instances of TextureStyle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextureStyle.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextureStyle, false otherwise.
+     */
+    public static isTextureStyle(obj: any): obj is TextureStyle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public _resourceType = 'textureSampler';
     /** @internal */

--- a/src/rendering/renderers/shared/texture/TextureUvs.ts
+++ b/src/rendering/renderers/shared/texture/TextureUvs.ts
@@ -3,6 +3,8 @@ import { groupD8 } from '../../../../maths/matrix/groupD8';
 import type { Size } from '../../../../maths/misc/Size';
 import type { Rectangle } from '../../../../maths/shapes/Rectangle';
 
+const typeSymbol = Symbol.for('pixijs.TextureUvs');
+
 /**
  * Stores a texture's frame in UV coordinates, in
  * which everything lies in the rectangle `[(0,0), (1,0),
@@ -20,6 +22,22 @@ import type { Rectangle } from '../../../../maths/shapes/Rectangle';
  */
 export class TextureUvs
 {
+    /**
+     * Type symbol used to identify instances of TextureUvs.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextureUvs.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextureUvs, false otherwise.
+     */
+    public static isTextureUvs(obj: any): obj is TextureUvs
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** X-component of top-left corner `(x0,y0)`. */
     public x0: number;
 

--- a/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/BufferImageSource.ts
@@ -5,6 +5,8 @@ import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { TypedArray } from '../../buffer/Buffer';
 import type { TextureSourceOptions } from './TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.BufferImageSource');
+
 /**
  * Options for creating a BufferImageSource.
  * @category rendering
@@ -24,6 +26,22 @@ export interface BufferSourceOptions extends TextureSourceOptions<TypedArray | A
  */
 export class BufferImageSource extends TextureSource<TypedArray | ArrayBuffer>
 {
+    /**
+     * Type symbol used to identify instances of BufferImageSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BufferImageSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a BufferImageSource, false otherwise.
+     */
+    public static isBufferImageSource(obj: any): obj is BufferImageSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.TextureSource;
 
     public uploadMethodId = 'buffer';

--- a/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CanvasSource.ts
@@ -6,6 +6,8 @@ import type { ICanvas } from '../../../../../environment/canvas/ICanvas';
 import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { TextureSourceOptions } from './TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.CanvasSource');
+
 /**
  * Options for creating a CanvasSource.
  * @category rendering
@@ -32,6 +34,22 @@ export interface CanvasSourceOptions extends TextureSourceOptions<ICanvas>
  */
 export class CanvasSource extends TextureSource<ICanvas>
 {
+    /**
+     * Type symbol used to identify instances of CanvasSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasSource, false otherwise.
+     */
+    public static isCanvasSource(obj: any): obj is CanvasSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.TextureSource;
 
     public uploadMethodId = 'image';

--- a/src/rendering/renderers/shared/texture/sources/CompressedSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/CompressedSource.ts
@@ -2,6 +2,8 @@ import { TextureSource } from './TextureSource';
 
 import type { TextureSourceOptions } from './TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.CompressedSource');
+
 /**
  * A texture source that uses a compressed resource, such as an array of Uint8Arrays.
  * It is used for compressed textures that can be uploaded to the GPU.
@@ -10,6 +12,22 @@ import type { TextureSourceOptions } from './TextureSource';
  */
 export class CompressedSource extends TextureSource<Uint8Array[]>
 {
+    /**
+     * Type symbol used to identify instances of CompressedSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CompressedSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a CompressedSource, false otherwise.
+     */
+    public static isCompressedSource(obj: any): obj is CompressedSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public readonly uploadMethodId = 'compressed';
 
     constructor(options: TextureSourceOptions)

--- a/src/rendering/renderers/shared/texture/sources/ImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/ImageSource.ts
@@ -5,6 +5,8 @@ import type { ICanvas } from '../../../../../environment/canvas/ICanvas';
 import type { ExtensionMetadata } from '../../../../../extensions/Extensions';
 import type { TextureSourceOptions } from './TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.ImageSource');
+
 /**
  * The type of image-like resource that can be used as a texture source.
  *
@@ -35,6 +37,22 @@ ImageBitmap
  */
 export class ImageSource extends TextureSource<ImageResource>
 {
+    /**
+     * Type symbol used to identify instances of ImageSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ImageSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a ImageSource, false otherwise.
+     */
+    public static isImageSource(obj: any): obj is ImageSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.TextureSource;
     public uploadMethodId = 'image';
 

--- a/src/rendering/renderers/shared/texture/sources/TextureSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/TextureSource.ts
@@ -9,6 +9,8 @@ import type { ALPHA_MODES, SCALE_MODE, TEXTURE_DIMENSIONS, TEXTURE_FORMATS, WRAP
 import type { TextureStyleOptions } from '../TextureStyle';
 import type { TextureResourceOrOptions } from '../utils/textureFrom';
 
+const typeSymbol = Symbol.for('pixijs.TextureSource');
+
 /**
  * options for creating a new TextureSource
  * @category rendering
@@ -82,6 +84,22 @@ export class TextureSource<T extends Record<string, any> = any> extends EventEmi
     error: Error;
 }> implements BindResource
 {
+    /**
+     * Type symbol used to identify instances of TextureSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextureSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextureSource, false otherwise.
+     */
+    public static isTextureSource(obj: any): obj is TextureSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options used when creating a new TextureSource. override these to add your own defaults */
     public static defaultOptions: TextureSourceOptions = {
         resolution: 1,

--- a/src/rendering/renderers/shared/texture/sources/VideoSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/VideoSource.ts
@@ -10,6 +10,8 @@ import type { Dict } from '../../../../../utils/types';
 import type { ALPHA_MODES } from '../const';
 import type { TextureSourceOptions } from './TextureSource';
 
+const typeSymbol = Symbol.for('pixijs.VideoSource');
+
 /**
  * The type of resource used for video textures.
  * This is typically an HTMLVideoElement.
@@ -58,6 +60,22 @@ export interface VideoSourceOptions extends TextureSourceOptions<VideoResource>
  */
 export class VideoSource extends TextureSource<VideoResource>
 {
+    /**
+     * Type symbol used to identify instances of VideoSource.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a VideoSource.
+     * @param obj - The object to check.
+     * @returns True if the object is a VideoSource, false otherwise.
+     */
+    public static isVideoSource(obj: any): obj is VideoSource
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension: ExtensionMetadata = ExtensionType.TextureSource;
 
     /** The default options for video sources. */

--- a/src/rendering/renderers/shared/texture/utils/textureFrom.ts
+++ b/src/rendering/renderers/shared/texture/utils/textureFrom.ts
@@ -120,7 +120,7 @@ export function textureFrom(id: TextureSourceLike, skipCache = false): Texture
     {
         return Cache.get(id);
     }
-    else if (id instanceof TextureSource)
+    else if (TextureSource.isTextureSource(id))
     {
         return new Texture({ source: id });
     }

--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -12,6 +12,8 @@ import type { System } from '../system/System';
 import type { CanvasSource } from '../texture/sources/CanvasSource';
 import type { Texture } from '../texture/Texture';
 
+const typeSymbol = Symbol.for('pixijs.ViewSystem');
+
 /**
  * Options passed to the ViewSystem
  * @category rendering
@@ -70,6 +72,22 @@ export interface ViewSystemDestroyOptions
  */
 export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSystemDestroyOptions> >
 {
+    /**
+     * Type symbol used to identify instances of ViewSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ViewSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a ViewSystem, false otherwise.
+     */
+    public static isViewSystem(obj: any): obj is ViewSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -32,6 +32,8 @@ import type { Dict } from '../../utils/types';
 import type { Optional } from './container-mixins/measureMixin';
 import type { DestroyOptions } from './destroyTypes';
 
+const typeSymbol = Symbol.for('pixijs.Container');
+
 /**
  * The type of child that can be added to a {@link Container}.
  * This is a generic type that extends the {@link Container} class.
@@ -640,6 +642,22 @@ export interface Container<C extends ContainerChild>
  */
 export class Container<C extends ContainerChild = ContainerChild> extends EventEmitter<ContainerEvents<C> & AnyEvent>
 {
+    /**
+     * Type symbol used to identify instances of Container.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Container.
+     * @param obj - The object to check.
+     * @returns True if the object is a Container, false otherwise.
+     */
+    public static isContainer(obj: any): obj is Container
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Mixes all enumerable properties and methods from a source object to Container.
      * @param source - The source of properties and methods to mix in.

--- a/src/scene/container/CustomRenderPipe.ts
+++ b/src/scene/container/CustomRenderPipe.ts
@@ -5,6 +5,8 @@ import type { InstructionPipe, RenderPipe } from '../../rendering/renderers/shar
 import type { Renderer } from '../../rendering/renderers/types';
 import type { RenderContainer } from './RenderContainer';
 
+const typeSymbol = Symbol.for('pixijs.CustomRenderPipe');
+
 /**
  * The CustomRenderPipe is a render pipe that allows for custom rendering logic for your renderable objects.
  * @example
@@ -21,6 +23,22 @@ import type { RenderContainer } from './RenderContainer';
  */
 export class CustomRenderPipe implements InstructionPipe<RenderContainer>, RenderPipe<RenderContainer>
 {
+    /**
+     * Type symbol used to identify instances of CustomRenderPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CustomRenderPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a CustomRenderPipe, false otherwise.
+     */
+    public static isCustomRenderPipe(obj: any): obj is CustomRenderPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGLPipes,

--- a/src/scene/container/RenderContainer.ts
+++ b/src/scene/container/RenderContainer.ts
@@ -6,6 +6,8 @@ import type { Renderer } from '../../rendering/renderers/types';
 import type { Bounds, BoundsData } from './bounds/Bounds';
 import type { ContainerOptions } from './Container';
 
+const typeSymbol = Symbol.for('pixijs.RenderContainer');
+
 /**
  * A function that takes a renderer and does the custom rendering logic.
  * This is the function that will be called each frame.
@@ -78,6 +80,22 @@ export interface RenderContainerOptions extends ContainerOptions
  */
 export class RenderContainer extends ViewContainer implements Instruction
 {
+    /**
+     * Type symbol used to identify instances of RenderContainer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderContainer.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderContainer, false otherwise.
+     */
+    public static isRenderContainer(obj: any): obj is RenderContainer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'customRender';
     /** @internal */

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -11,6 +11,8 @@ import type { ViewContainer } from '../view/ViewContainer';
 import type { Bounds } from './bounds/Bounds';
 import type { Container } from './Container';
 
+const typeSymbol = Symbol.for('pixijs.RenderGroup');
+
 /**
  * Options for caching a container as a texture.
  * @category rendering
@@ -51,6 +53,22 @@ export interface CacheAsTextureOptions
  */
 export class RenderGroup implements Instruction
 {
+    /**
+     * Type symbol used to identify instances of RenderGroup.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderGroup.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderGroup, false otherwise.
+     */
+    public static isRenderGroup(obj: any): obj is RenderGroup
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public renderPipeId = 'renderGroup';
     public root: Container = null;
 

--- a/src/scene/container/RenderGroupPipe.ts
+++ b/src/scene/container/RenderGroupPipe.ts
@@ -9,6 +9,8 @@ import type { InstructionPipe } from '../../rendering/renderers/shared/instructi
 import type { Renderer } from '../../rendering/renderers/types';
 import type { RenderGroup } from './RenderGroup';
 
+const typeSymbol = Symbol.for('pixijs.RenderGroupPipe');
+
 const tempMatrix = new Matrix();
 
 /**
@@ -17,6 +19,22 @@ const tempMatrix = new Matrix();
  */
 export class RenderGroupPipe implements InstructionPipe<RenderGroup>
 {
+    /**
+     * Type symbol used to identify instances of RenderGroupPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderGroupPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderGroupPipe, false otherwise.
+     */
+    public static isRenderGroupPipe(obj: any): obj is RenderGroupPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGLPipes,

--- a/src/scene/container/RenderGroupSystem.ts
+++ b/src/scene/container/RenderGroupSystem.ts
@@ -15,6 +15,8 @@ import type { ViewContainer } from '../view/ViewContainer';
 import type { Container } from './Container';
 import type { RenderGroup } from './RenderGroup';
 
+const typeSymbol = Symbol.for('pixijs.RenderGroupSystem');
+
 const tempMatrix = new Matrix();
 
 /**
@@ -25,6 +27,22 @@ const tempMatrix = new Matrix();
  */
 export class RenderGroupSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of RenderGroupSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderGroupSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderGroupSystem, false otherwise.
+     */
+    public static isRenderGroupSystem(obj: any): obj is RenderGroupSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -1,6 +1,7 @@
 import { RenderLayer } from '../../layers/RenderLayer';
 import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
+import { Point } from '~/maths';
 import { Matrix } from '~/maths/matrix/Matrix';
 
 describe('Container', () =>
@@ -112,7 +113,7 @@ describe('Container', () =>
         container.position.set(10, 10);
         child.position.set(10, 10);
 
-        expect(child.toGlobal({ x: 0, y: 0 })).toEqual({ x: 20, y: 20 });
+        expect(child.toGlobal({ x: 0, y: 0 })).toEqual(new Point(20, 20));
         //   expect(container.getBounds()).toEqual({ x: 10, y: 10, width: 0, height: 0 });
     });
 
@@ -139,12 +140,12 @@ describe('Container', () =>
         child.position.set(10, 10);
 
         // wrong!
-        expect(child.toGlobal({ x: 0, y: 0 }, null, true)).toEqual({ x: 0, y: 0 });
+        expect(child.toGlobal({ x: 0, y: 0 }, null, true)).toEqual(new Point(0, 0));
 
         updateRenderGroupTransforms(container.parentRenderGroup, true);
 
         // right!!
-        expect(child.toGlobal({ x: 0, y: 0 }, null, true)).toEqual({ x: 20, y: 20 });
+        expect(child.toGlobal({ x: 0, y: 0 }, null, true)).toEqual(new Point(20, 20));
     });
 
     it('should a local position correctly', async () =>
@@ -155,7 +156,7 @@ describe('Container', () =>
 
         child.position.set(10, 10);
 
-        expect(child.toLocal({ x: 0, y: 0 })).toEqual({ x: -10, y: -10 });
+        expect(child.toLocal({ x: 0, y: 0 })).toEqual(new Point(-10, -10));
     });
 
     it('should a local position correctly when nested', async () =>
@@ -185,7 +186,7 @@ describe('Container', () =>
         container.position.set(10, 10);
         child.position.set(10, 10);
 
-        expect(child.toLocal({ x: 0, y: 0 }, otherContainer)).toEqual({ x: -20, y: -20 });
+        expect(child.toLocal({ x: 0, y: 0 }, otherContainer)).toEqual(new Point(-20, -20));
 
         //   expect(container.getBounds()).toEqual({ x: 10, y: 10, width: 0, height: 0 });
     });
@@ -217,12 +218,12 @@ describe('Container', () =>
         child.position.set(10, 10);
 
         // wrong!
-        expect(child.toLocal({ x: 0, y: 0 }, otherContainer, null, true)).toEqual({ x: 0, y: 0 });
+        expect(child.toLocal({ x: 0, y: 0 }, otherContainer, null, true)).toEqual(new Point(0, 0));
 
         updateRenderGroupTransforms(container.parentRenderGroup, true);
 
         // right!
-        expect(child.toLocal({ x: 0, y: 0 }, otherContainer, null, true)).toEqual({ x: -20, y: -20 });
+        expect(child.toLocal({ x: 0, y: 0 }, otherContainer, null, true)).toEqual(new Point(-20, -20));
         //   expect(container.getBounds()).toEqual({ x: 10, y: 10, width: 0, height: 0 });
     });
 

--- a/src/scene/container/bounds/Bounds.ts
+++ b/src/scene/container/bounds/Bounds.ts
@@ -1,6 +1,8 @@
 import { Matrix } from '../../../maths/matrix/Matrix';
 import { Rectangle } from '../../../maths/shapes/Rectangle';
 
+const typeSymbol = Symbol.for('pixijs.Bounds');
+
 /**
  * A simple axis-aligned bounding box (AABB) data structure used to define rectangular boundaries.
  * Provides a clearer alternative to array-based bounds representation [minX, minY, maxX, maxY].
@@ -74,6 +76,22 @@ const defaultMatrix = new Matrix();
  */
 export class Bounds
 {
+    /**
+     * Type symbol used to identify instances of Bounds.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Bounds.
+     * @param obj - The object to check.
+     * @returns True if the object is a Bounds, false otherwise.
+     */
+    public static isBounds(obj: any): obj is Bounds
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The minimum X coordinate of the bounds.
      * Represents the leftmost edge of the bounding box.

--- a/src/scene/graphics/gl/GlGraphicsAdaptor.ts
+++ b/src/scene/graphics/gl/GlGraphicsAdaptor.ts
@@ -15,6 +15,8 @@ import type { WebGLRenderer } from '../../../rendering/renderers/gl/WebGLRendere
 import type { Graphics } from '../shared/Graphics';
 import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
 
+const typeSymbol = Symbol.for('pixijs.GlGraphicsAdaptor');
+
 /**
  * A GraphicsAdaptor that uses WebGL to render graphics.
  * @category rendering
@@ -22,6 +24,22 @@ import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
  */
 export class GlGraphicsAdaptor implements GraphicsAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GlGraphicsAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlGraphicsAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlGraphicsAdaptor, false otherwise.
+     */
+    public static isGlGraphicsAdaptor(obj: any): obj is GlGraphicsAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/graphics/gpu/GpuGraphicsAdaptor.ts
+++ b/src/scene/graphics/gpu/GpuGraphicsAdaptor.ts
@@ -17,6 +17,8 @@ import type { Topology } from '../../../rendering/renderers/shared/geometry/cons
 import type { Graphics } from '../shared/Graphics';
 import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
 
+const typeSymbol = Symbol.for('pixijs.GpuGraphicsAdaptor');
+
 /**
  * A GraphicsAdaptor that uses the GPU to render graphics.
  * @category rendering
@@ -24,6 +26,22 @@ import type { GraphicsAdaptor, GraphicsPipe } from '../shared/GraphicsPipe';
  */
 export class GpuGraphicsAdaptor implements GraphicsAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GpuGraphicsAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuGraphicsAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuGraphicsAdaptor, false otherwise.
+     */
+    public static isGpuGraphicsAdaptor(obj: any): obj is GpuGraphicsAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -7,6 +7,7 @@ import type { Topology } from '../../../rendering/renderers/shared/geometry/cons
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { Graphics } from './Graphics';
 
+const typeSymbol = Symbol.for('pixijs.BatchableGraphics');
 const identityMatrix = new Matrix();
 
 /**
@@ -15,6 +16,22 @@ const identityMatrix = new Matrix();
  */
 export class BatchableGraphics implements DefaultBatchableMeshElement
 {
+    /**
+     * Type symbol used to identify instances of BatchableGraphics.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchableGraphics.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchableGraphics, false otherwise.
+     */
+    public static isBatchableGraphics(obj: any): obj is BatchableGraphics
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public readonly packAsQuad = false;
     public batcherName = 'default';
 

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -14,6 +14,8 @@ import type { FillInput, FillStyle, StrokeStyle } from './FillTypes';
 import type { GraphicsPath } from './path/GraphicsPath';
 import type { RoundedPoint } from './path/roundShape';
 
+const typeSymbol = Symbol.for('pixijs.Graphics');
+
 /**
  * Constructor options used for Graphics instances.
  * Configures the initial state and behavior of a Graphics object.
@@ -93,6 +95,22 @@ export interface Graphics extends PixiMixins.Graphics, ViewContainer<GraphicsGpu
  */
 export class Graphics extends ViewContainer<GraphicsGpuData> implements Instruction
 {
+    /**
+     * Type symbol used to identify instances of Graphics.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Graphics.
+     * @param obj - The object to check.
+     * @returns True if the object is a Graphics, false otherwise.
+     */
+    public static isGraphics(obj: any): obj is Graphics
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'graphics';
     /** @internal */

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -125,7 +125,7 @@ export class Graphics extends ViewContainer<GraphicsGpuData> implements Instruct
      */
     constructor(options?: GraphicsOptions | GraphicsContext)
     {
-        if (options instanceof GraphicsContext)
+        if (GraphicsContext.isGraphicsContext(options))
         {
             options = { context: options };
         }

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -17,6 +17,8 @@ import type { TextureDestroyOptions, TypeOrBool } from '../../container/destroyT
 import type { ConvertedFillStyle, ConvertedStrokeStyle, FillInput, StrokeInput } from './FillTypes';
 import type { RoundedPoint } from './path/roundShape';
 
+const typeSymbol = Symbol.for('pixijs.GraphicsContext');
+
 const tmpPoint = new Point();
 
 /**
@@ -83,6 +85,22 @@ export class GraphicsContext extends EventEmitter<{
     destroy: GraphicsContext
 }>
 {
+    /**
+     * Type symbol used to identify instances of GraphicsContext.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GraphicsContext.
+     * @param obj - The object to check.
+     * @returns True if the object is a GraphicsContext, false otherwise.
+     */
+    public static isGraphicsContext(obj: any): obj is GraphicsContext
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default fill style to use when none is provided. */
     public static defaultFillStyle: ConvertedFillStyle = {
         /** The color to use for the fill. */

--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1001,7 +1001,7 @@ export class GraphicsContext extends EventEmitter<{
     public setTransform(a: number, b: number, c: number, d: number, dx: number, dy: number): this;
     public setTransform(a: number | Matrix, b?: number, c?: number, d?: number, dx?: number, dy?: number): this
     {
-        if (a instanceof Matrix)
+        if (Matrix.isMatrix(a))
         {
             this._transform.set(a.a, a.b, a.c, a.d, a.tx, a.ty);
 
@@ -1034,7 +1034,7 @@ export class GraphicsContext extends EventEmitter<{
     public transform(a: number, b: number, c: number, d: number, dx: number, dy: number): this;
     public transform(a: number | Matrix, b?: number, c?: number, d?: number, dx?: number, dy?: number): this
     {
-        if (a instanceof Matrix)
+        if (Matrix.isMatrix(a))
         {
             this._transform.append(a);
 

--- a/src/scene/graphics/shared/GraphicsContextSystem.ts
+++ b/src/scene/graphics/shared/GraphicsContextSystem.ts
@@ -12,6 +12,9 @@ import type { PoolItem } from '../../../utils/pool/Pool';
 import type { BatchableGraphics } from './BatchableGraphics';
 import type { GraphicsContext } from './GraphicsContext';
 
+const typeSymbolGpuGraphicsContext = Symbol.for('pixijs.GpuGraphicsContext');
+const typeSymbolGraphicsContextRenderData = Symbol.for('pixijs.GraphicsContextRenderData');
+
 interface GeometryData
 {
     vertices: number[];
@@ -26,6 +29,22 @@ interface GeometryData
  */
 export class GpuGraphicsContext
 {
+    /**
+     * Type symbol used to identify instances of GpuGraphicsContext.
+     * @internal
+     */
+    public readonly [typeSymbolGpuGraphicsContext] = true;
+
+    /**
+     * Checks if the given object is a GpuGraphicsContext.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuGraphicsContext, false otherwise.
+     */
+    public static isGpuGraphicsContext(obj: any): obj is GpuGraphicsContext
+    {
+        return !!obj && !!obj[typeSymbolGpuGraphicsContext];
+    }
+
     public isBatchable: boolean;
     public context: GraphicsContext;
 
@@ -45,6 +64,22 @@ export class GpuGraphicsContext
  */
 export class GraphicsContextRenderData
 {
+    /**
+     * Type symbol used to identify instances of GraphicsContextRenderData.
+     * @internal
+     */
+    public readonly [typeSymbolGraphicsContextRenderData] = true;
+
+    /**
+     * Checks if the given object is a GraphicsContextRenderData.
+     * @param obj - The object to check.
+     * @returns True if the object is a GraphicsContextRenderData, false otherwise.
+     */
+    public static isGraphicsContextRenderData(obj: any): obj is GraphicsContextRenderData
+    {
+        return !!obj && !!obj[typeSymbolGraphicsContextRenderData];
+    }
+
     public batcher: DefaultBatcher;
     public instructions = new InstructionSet();
 

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -12,6 +12,9 @@ import type { PoolItem } from '../../../utils/pool/Pool';
 import type { Graphics } from './Graphics';
 import type { GpuGraphicsContext } from './GraphicsContextSystem';
 
+const typeSymbolGraphicsGpuData = Symbol.for('pixijs.GraphicsGpuData');
+const typeSymbolGraphicsPipe = Symbol.for('pixijs.GraphicsPipe');
+
 /** @internal */
 export interface GraphicsAdaptor
 {
@@ -24,6 +27,22 @@ export interface GraphicsAdaptor
 /** @internal */
 export class GraphicsGpuData
 {
+    /**
+     * Type symbol used to identify instances of GraphicsGpuData.
+     * @internal
+     */
+    public readonly [typeSymbolGraphicsGpuData] = true;
+
+    /**
+     * Checks if the given object is a GraphicsGpuData.
+     * @param obj - The object to check.
+     * @returns True if the object is a GraphicsGpuData, false otherwise.
+     */
+    public static isGraphicsGpuData(obj: any): obj is GraphicsGpuData
+    {
+        return !!obj && !!obj[typeSymbolGraphicsGpuData];
+    }
+
     public batches: BatchableGraphics[] = [];
     public batched = false;
     public destroy()
@@ -40,6 +59,22 @@ export class GraphicsGpuData
 /** @internal */
 export class GraphicsPipe implements RenderPipe<Graphics>
 {
+    /**
+     * Type symbol used to identify instances of GraphicsPipe.
+     * @internal
+     */
+    public readonly [typeSymbolGraphicsPipe] = true;
+
+    /**
+     * Checks if the given object is a GraphicsPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a GraphicsPipe, false otherwise.
+     */
+    public static isGraphicsPipe(obj: any): obj is GraphicsPipe
+    {
+        return !!obj && !!obj[typeSymbolGraphicsPipe];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/graphics/shared/fill/FillGradient.ts
+++ b/src/scene/graphics/shared/fill/FillGradient.ts
@@ -13,6 +13,8 @@ import type { PointData } from '../../../../maths/point/PointData';
 import type { CanvasAndContext } from '../../../../rendering/renderers/shared/texture/CanvasPool';
 import type { TextureSpace } from '../FillTypes';
 
+const typeSymbol = Symbol.for('pixijs.FillGradient');
+
 /**
  * Defines the type of gradient to create.
  *
@@ -206,6 +208,22 @@ const emptyColorStops: { offset: number, color: string }[] = [{ offset: 0, color
  */
 export class FillGradient implements CanvasGradient
 {
+    /**
+     * Type symbol used to identify instances of FillGradient.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FillGradient.
+     * @param obj - The object to check.
+     * @returns True if the object is a FillGradient, false otherwise.
+     */
+    public static isFillGradient(obj: any): obj is FillGradient
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Default options for creating a gradient fill */
     public static readonly defaultLinearOptions: LinearGradientOptions = {
         start: { x: 0, y: 0 },

--- a/src/scene/graphics/shared/fill/FillPattern.ts
+++ b/src/scene/graphics/shared/fill/FillPattern.ts
@@ -4,6 +4,8 @@ import { uid } from '../../../../utils/data/uid';
 import type { WRAP_MODE } from '../../../../rendering/renderers/shared/texture/const';
 import type { Texture } from '../../../../rendering/renderers/shared/texture/Texture';
 
+const typeSymbol = Symbol.for('pixijs.FillPattern');
+
 /**
  * Defines the repetition modes for fill patterns.
  *
@@ -57,6 +59,22 @@ const repetitionMap = {
  */
 export class FillPattern implements CanvasPattern
 {
+    /**
+     * Type symbol used to identify instances of FillPattern.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a FillPattern.
+     * @param obj - The object to check.
+     * @returns True if the object is a FillPattern, false otherwise.
+     */
+    public static isFillPattern(obj: any): obj is FillPattern
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * unique id for this fill pattern
      * @internal

--- a/src/scene/graphics/shared/path/GraphicsPath.ts
+++ b/src/scene/graphics/shared/path/GraphicsPath.ts
@@ -9,6 +9,8 @@ import type { PointData } from '../../../../maths/point/PointData';
 import type { Bounds } from '../../../container/bounds/Bounds';
 import type { RoundedPoint } from './roundShape';
 
+const typeSymbol = Symbol.for('pixijs.GraphicsPath');
+
 /**
  * Represents a single drawing instruction in a `GraphicsPath`.
  * Each instruction consists of an action type and associated data.
@@ -36,6 +38,22 @@ export interface PathInstruction
  */
 export class GraphicsPath
 {
+    /**
+     * Type symbol used to identify instances of GraphicsPath.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GraphicsPath.
+     * @param obj - The object to check.
+     * @returns True if the object is a GraphicsPath, false otherwise.
+     */
+    public static isGraphicsPath(obj: any): obj is GraphicsPath
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public instructions: PathInstruction[] = [];
 
     /** unique id for this graphics path */

--- a/src/scene/graphics/shared/path/ShapePath.ts
+++ b/src/scene/graphics/shared/path/ShapePath.ts
@@ -19,6 +19,8 @@ import type { ShapePrimitive } from '../../../../maths/shapes/ShapePrimitive';
 import type { GraphicsPath } from './GraphicsPath';
 import type { RoundedPoint } from './roundShape';
 
+const typeSymbol = Symbol.for('pixijs.ShapePath');
+
 const tempRectangle = new Rectangle();
 
 /**
@@ -45,6 +47,22 @@ export type ShapePrimitiveWithHoles = {
  */
 export class ShapePath
 {
+    /**
+     * Type symbol used to identify instances of ShapePath.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ShapePath.
+     * @param obj - The object to check.
+     * @returns True if the object is a ShapePath, false otherwise.
+     */
+    public static isShapePath(obj: any): obj is ShapePath
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The list of shape primitives that make up the path. */
     public shapePrimitives: ShapePrimitiveWithHoles[] = [];
     private _currentPoly: Polygon | null = null;

--- a/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
+++ b/src/scene/graphics/shared/utils/convertFillInputToFillStyle.ts
@@ -19,17 +19,17 @@ function isColorLike(value: unknown): value is ColorSource
 
 function isFillPattern(value: unknown): value is FillPattern
 {
-    return value instanceof FillPattern;
+    return FillPattern.isFillPattern(value);
 }
 
 function isFillGradient(value: unknown): value is FillGradient
 {
-    return value instanceof FillGradient;
+    return FillGradient.isFillGradient(value);
 }
 
 function isTexture(value: unknown): value is Texture
 {
-    return value instanceof Texture;
+    return Texture.isTexture(value);
 }
 
 /**

--- a/src/scene/graphics/shared/utils/generateTextureFillMatrix.ts
+++ b/src/scene/graphics/shared/utils/generateTextureFillMatrix.ts
@@ -83,7 +83,7 @@ export function generateTextureMatrix(out: Matrix, style: FillStyle | StrokeStyl
     const sourceStyle = style.texture.source.style;
 
     // we don't want to set the address mode if the fill is a gradient as this handles its own address mode
-    if (!(style.fill instanceof FillGradient) && sourceStyle.addressMode === 'clamp-to-edge')
+    if (!FillGradient.isFillGradient(style.fill) && sourceStyle.addressMode === 'clamp-to-edge')
     {
         sourceStyle.addressMode = 'repeat';
         sourceStyle.update();

--- a/src/scene/layers/RenderLayer.ts
+++ b/src/scene/layers/RenderLayer.ts
@@ -5,6 +5,9 @@ import { type Bounds } from '../container/bounds/Bounds';
 import { Container } from '../container/Container';
 
 import type EventEmitter from 'eventemitter3';
+
+const typeSymbol = Symbol.for('pixijs.RenderLayer');
+
 // TODO make it clear render layer cannot have 'filters'
 
 /**
@@ -97,6 +100,22 @@ export type IRenderLayer = Omit<RenderLayerClass, PartialContainerKeys>;
 /** @standard */
 class RenderLayerClass extends Container
 {
+    /**
+     * Type symbol used to identify instances of RenderLayer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RenderLayer.
+     * @param obj - The object to check.
+     * @returns True if the object is a RenderLayer, false otherwise.
+     */
+    public static isRenderLayer(obj: any): obj is RenderLayerClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default options for RenderLayer instances. These options control the sorting behavior
      * of objects within the render layer.

--- a/src/scene/mesh-perspective/PerspectiveMesh.ts
+++ b/src/scene/mesh-perspective/PerspectiveMesh.ts
@@ -5,6 +5,8 @@ import { PerspectivePlaneGeometry } from './PerspectivePlaneGeometry';
 
 import type { MeshPlaneOptions } from '../mesh-plane/MeshPlane';
 
+const typeSymbol = Symbol.for('pixijs.PerspectiveMesh');
+
 /**
  * Constructor options used for `PerspectiveMesh` instances. Defines the geometry and appearance
  * of a 2D mesh with perspective projection.
@@ -89,6 +91,22 @@ export interface PerspectivePlaneOptions extends MeshPlaneOptions
  */
 export class PerspectiveMesh extends Mesh<PerspectivePlaneGeometry>
 {
+    /**
+     * Type symbol used to identify instances of PerspectiveMesh.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PerspectiveMesh.
+     * @param obj - The object to check.
+     * @returns True if the object is a PerspectiveMesh, false otherwise.
+     */
+    public static isPerspectiveMesh(obj: any): obj is PerspectiveMesh
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default options for creating a PerspectiveMesh instance.
      *

--- a/src/scene/mesh-perspective/PerspectivePlaneGeometry.ts
+++ b/src/scene/mesh-perspective/PerspectivePlaneGeometry.ts
@@ -5,6 +5,8 @@ import { compute2DProjection } from './utils/compute2DProjections';
 import type { ArrayFixed } from '../../utils/types';
 import type { PlaneGeometryOptions } from '../mesh-plane/PlaneGeometry';
 
+const typeSymbol = Symbol.for('pixi.PerspectivePlaneGeometry');
+
 /**
  * Constructor options used for `PerspectivePlaneGeometry` instances.
  * @category scene
@@ -38,6 +40,22 @@ export interface PerspectivePlaneGeometryOptions extends PlaneGeometryOptions
  */
 export class PerspectivePlaneGeometry extends PlaneGeometry
 {
+    /**
+     * Type symbol used to identify instances of PerspectivePlaneGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PerspectivePlaneGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a PerspectivePlaneGeometry, false otherwise.
+     */
+    public static isPerspectivePlaneGeometry(obj: any): obj is PerspectivePlaneGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The corner points of the quad you can modify these directly, if you do make sure to call `updateProjection` */
     public corners: [number, number, number, number, number, number, number, number];
     private readonly _projectionMatrix: ArrayFixed<number, 9> = [0, 0, 0, 0, 0, 0, 0, 0, 0];

--- a/src/scene/mesh-plane/MeshPlane.ts
+++ b/src/scene/mesh-plane/MeshPlane.ts
@@ -6,6 +6,8 @@ import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { DestroyOptions } from '../container/destroyTypes';
 import type { MeshOptions } from '../mesh/shared/Mesh';
 
+const typeSymbol = Symbol.for('pixijs.MeshPlane');
+
 /**
  * Constructor options used for `MeshPlane` instances. Defines how a texture is mapped
  * onto a plane with configurable vertex density.
@@ -82,6 +84,22 @@ export interface MeshPlaneOptions extends Omit<MeshOptions, 'geometry'>
  */
 export class MeshPlane extends Mesh
 {
+    /**
+     * Type symbol used to identify instances of MeshPlane.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MeshPlane.
+     * @param obj - The object to check.
+     * @returns True if the object is a MeshPlane, false otherwise.
+     */
+    public static isMeshPlane(obj: any): obj is MeshPlane
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Controls whether the mesh geometry automatically updates when the texture dimensions change.
      * When true, the mesh will resize to match any texture updates. When false, the mesh maintains

--- a/src/scene/mesh-plane/PlaneGeometry.ts
+++ b/src/scene/mesh-plane/PlaneGeometry.ts
@@ -3,6 +3,8 @@ import { MeshGeometry } from '../mesh/shared/MeshGeometry';
 
 import type { MeshGeometryOptions } from '../mesh/shared/MeshGeometry';
 
+const typeSymbol = Symbol.for('pixijs.PlaneGeometry');
+
 /**
  * Constructor options used for `PlaneGeometry` instances.
  * ```js
@@ -36,6 +38,22 @@ export interface PlaneGeometryOptions
  */
 export class PlaneGeometry extends MeshGeometry
 {
+    /**
+     * Type symbol used to identify instances of PlaneGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PlaneGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a PlaneGeometry, false otherwise.
+     */
+    public static isPlaneGeometry(obj: any): obj is PlaneGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static defaultOptions: PlaneGeometryOptions & MeshGeometryOptions = {
         width: 100,
         height: 100,

--- a/src/scene/mesh-simple/MeshRope.ts
+++ b/src/scene/mesh-simple/MeshRope.ts
@@ -6,6 +6,8 @@ import type { PointData } from '../../maths/point/PointData';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { MeshOptions } from '../mesh/shared/Mesh';
 
+const typeSymbol = Symbol.for('pixijs.MeshRope');
+
 /**
  * Constructor options used for `MeshRope` instances. Allows configuration of a rope-like mesh
  * that follows a series of points with a texture applied.
@@ -91,6 +93,22 @@ export interface MeshRopeOptions extends Omit<MeshOptions, 'geometry'>
  */
 export class MeshRope extends Mesh
 {
+    /**
+     * Type symbol used to identify instances of MeshRope.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MeshRope.
+     * @param obj - The object to check.
+     * @returns True if the object is a MeshRope, false otherwise.
+     */
+    public static isMeshRope(obj: any): obj is MeshRope
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default options for creating a MeshRope instance. These values are used when specific
      * options aren't provided in the constructor.

--- a/src/scene/mesh-simple/MeshSimple.ts
+++ b/src/scene/mesh-simple/MeshSimple.ts
@@ -7,6 +7,8 @@ import type { Topology } from '../../rendering/renderers/shared/geometry/const';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { MeshOptions } from '../mesh/shared/Mesh';
 
+const typeSymbol = Symbol.for('pixi.MeshSimple');
+
 /**
  * Options for creating a SimpleMesh instance. Defines the texture, geometry data, and rendering topology
  * for a basic mesh with direct vertex manipulation capabilities.
@@ -135,6 +137,22 @@ export interface SimpleMeshOptions extends Omit<MeshOptions, 'geometry'>
  */
 export class MeshSimple extends Mesh
 {
+    /**
+     * Type symbol used to identify instances of MeshSimple.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MeshSimple.
+     * @param obj - The object to check.
+     * @returns True if the object is a MeshSimple, false otherwise.
+     */
+    public static isMeshSimple(obj: any): obj is MeshSimple
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Controls whether the mesh's vertex buffer is automatically updated each frame.
      * When true, vertex changes will be reflected immediately. When false, manual updates are required.

--- a/src/scene/mesh-simple/RopeGeometry.ts
+++ b/src/scene/mesh-simple/RopeGeometry.ts
@@ -3,6 +3,8 @@ import { MeshGeometry } from '../mesh/shared/MeshGeometry';
 import type { PointData } from '../../maths/point/PointData';
 import type { MeshGeometryOptions } from '../mesh/shared/MeshGeometry';
 
+const typeSymbol = Symbol.for('pixi.RopeGeometry');
+
 /**
  * Constructor options used for `RopeGeometry` instances.
  * ```js
@@ -49,6 +51,22 @@ export interface RopeGeometryOptions
  */
 export class RopeGeometry extends MeshGeometry
 {
+    /**
+     * Type symbol used to identify instances of RopeGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a RopeGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a RopeGeometry, false otherwise.
+     */
+    public static isRopeGeometry(obj: any): obj is RopeGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** Default options for RopeGeometry constructor. */
     public static defaultOptions: RopeGeometryOptions & MeshGeometryOptions = {
         /** The width (i.e., thickness) of the rope. */

--- a/src/scene/mesh/gl/GlMeshAdaptor.ts
+++ b/src/scene/mesh/gl/GlMeshAdaptor.ts
@@ -11,6 +11,8 @@ import { warn } from '../../../utils/logging/warn';
 import type { Mesh } from '../shared/Mesh';
 import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
 
+const typeSymbol = Symbol.for('pixijs.GlMeshAdaptor');
+
 /**
  * A MeshAdaptor that uses the WebGL to render meshes.
  * @category rendering
@@ -18,6 +20,22 @@ import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
  */
 export class GlMeshAdaptor implements MeshAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GlMeshAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlMeshAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlMeshAdaptor, false otherwise.
+     */
+    public static isGlMeshAdaptor(obj: any): obj is GlMeshAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static extension = {
         type: [
             ExtensionType.WebGLPipesAdaptor,

--- a/src/scene/mesh/gpu/GpuMeshAdapter.ts
+++ b/src/scene/mesh/gpu/GpuMeshAdapter.ts
@@ -12,6 +12,8 @@ import type { WebGPURenderer } from '../../../rendering/renderers/gpu/WebGPURend
 import type { Mesh } from '../shared/Mesh';
 import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
 
+const typeSymbol = Symbol.for('pixi.GpuMeshAdapter');
+
 /**
  * The WebGL adaptor for the mesh system. Allows the Mesh System to be used with the WebGl renderer
  * @category rendering
@@ -19,6 +21,22 @@ import type { MeshAdaptor, MeshPipe } from '../shared/MeshPipe';
  */
 export class GpuMeshAdapter implements MeshAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GpuMeshAdapter.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuMeshAdapter.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuMeshAdapter, false otherwise.
+     */
+    public static isGpuMeshAdapter(obj: any): obj is GpuMeshAdapter
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/mesh/shared/BatchableMesh.ts
+++ b/src/scene/mesh/shared/BatchableMesh.ts
@@ -6,12 +6,30 @@ import type { Texture } from '../../../rendering/renderers/shared/texture/Textur
 import type { ViewContainer } from '../../view/ViewContainer';
 import type { MeshGeometry } from './MeshGeometry';
 
+const typeSymbol = Symbol.for('pixijs.BatchableMesh');
+
 /**
  * A batchable mesh object.
  * @ignore
  */
 export class BatchableMesh implements DefaultBatchableMeshElement
 {
+    /**
+     * Type symbol used to identify instances of BatchableMesh.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchableMesh.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchableMesh, false otherwise.
+     */
+    public static isBatchableMesh(obj: any): obj is BatchableMesh
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public batcherName = 'default';
 
     public _topology: Topology;

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -108,7 +108,7 @@ export class Mesh<
      * @param obj - The object to check.
      * @returns True if the object is a Mesh, false otherwise.
      */
-    public static isMesh(obj: any): obj is Mesh<GEOMETRY, SHADER>
+    public static isMesh(obj: any): obj is Mesh<any, any>
     {
         return !!obj && !!obj[typeSymbol];
     }

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -15,6 +15,8 @@ import type { View } from '../../../rendering/renderers/shared/view/View';
 import type { ContainerOptions } from '../../container/Container';
 import type { DestroyOptions } from '../../container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixi.Mesh');
+
 /**
  * Shader that uses a texture.
  * This is the default shader used by `Mesh` when no shader is provided.
@@ -95,6 +97,22 @@ export class Mesh<
     SHADER extends Shader = TextureShader
 > extends ViewContainer<MeshGpuData> implements View, Instruction
 {
+    /**
+     * Type symbol used to identify instances of Mesh.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Mesh.
+     * @param obj - The object to check.
+     * @returns True if the object is a Mesh, false otherwise.
+     */
+    public static isMesh(obj: any): obj is Mesh<GEOMETRY, SHADER>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'mesh';
     public state: State;

--- a/src/scene/mesh/shared/Mesh.ts
+++ b/src/scene/mesh/shared/Mesh.ts
@@ -133,7 +133,7 @@ export class Mesh<
     {
         let options = args[0];
 
-        if (options instanceof Geometry)
+        if (Geometry.isGeometry(options))
         {
             // #if _DEBUG
             deprecation(v8_0_0, 'Mesh: use new Mesh({ geometry, shader }) instead');
@@ -255,7 +255,7 @@ export class Mesh<
         // It isn't compatible if depth test or culling is enabled.
         if ((this.state.data & 0b001100) !== 0) return false;
 
-        if (this._geometry instanceof MeshGeometry)
+        if (MeshGeometry.isMeshGeometry(this._geometry))
         {
             if (this._geometry.batchMode === 'auto')
             {

--- a/src/scene/mesh/shared/MeshGeometry.ts
+++ b/src/scene/mesh/shared/MeshGeometry.ts
@@ -6,6 +6,8 @@ import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 import type { Topology } from '../../../rendering/renderers/shared/geometry/const';
 import type { BatchMode } from '../../graphics/shared/GraphicsContext';
 
+const typeSymbol = Symbol.for('pixi.MeshGeometry');
+
 /**
  * Options for the mesh geometry.
  * @category scene
@@ -32,6 +34,22 @@ export interface MeshGeometryOptions
  */
 export class MeshGeometry extends Geometry
 {
+    /**
+     * Type symbol used to identify instances of MeshGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MeshGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a MeshGeometry, false otherwise.
+     */
+    public static isMeshGeometry(obj: any): obj is MeshGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static defaultOptions: MeshGeometryOptions = {
         topology: 'triangle-list',
         shrinkBuffersToFit: false,

--- a/src/scene/mesh/shared/MeshPipe.ts
+++ b/src/scene/mesh/shared/MeshPipe.ts
@@ -15,6 +15,8 @@ import type {
 import type { Renderer } from '../../../rendering/renderers/types';
 import type { Mesh } from './Mesh';
 
+const typeSymbol = Symbol.for('pixi.MeshPipe');
+
 // TODO Record mode is a P2, will get back to this as it's not a priority
 // const recordMode = true;
 
@@ -64,6 +66,22 @@ export interface MeshAdaptor
  */
 export class MeshPipe implements RenderPipe<Mesh>, InstructionPipe<Mesh>
 {
+    /**
+     * Type symbol used to identify instances of MeshPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a MeshPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a MeshPipe, false otherwise.
+     */
+    public static isMeshPipe(obj: any): obj is MeshPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/particle-container/gl/GlParticleContainerAdaptor.ts
+++ b/src/scene/particle-container/gl/GlParticleContainerAdaptor.ts
@@ -2,9 +2,27 @@ import type { WebGLRenderer } from '../../../rendering/renderers/gl/WebGLRendere
 import type { ParticleContainer } from '../shared/ParticleContainer';
 import type { ParticleContainerAdaptor, ParticleContainerPipe } from '../shared/ParticleContainerPipe';
 
+const typeSymbol = Symbol.for('GlParticleContainerAdaptor');
+
 /** @internal */
 export class GlParticleContainerAdaptor implements ParticleContainerAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GlParticleContainerAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlParticleContainerAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlParticleContainerAdaptor, false otherwise.
+     */
+    public static isGlParticleContainerAdaptor(obj: any): obj is GlParticleContainerAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public execute(particleContainerPipe: ParticleContainerPipe, container: ParticleContainer)
     {
         const state = particleContainerPipe.state;

--- a/src/scene/particle-container/gpu/GpuParticleContainerAdaptor.ts
+++ b/src/scene/particle-container/gpu/GpuParticleContainerAdaptor.ts
@@ -2,9 +2,27 @@ import type { WebGPURenderer } from '../../../rendering/renderers/gpu/WebGPURend
 import type { ParticleContainer } from '../shared/ParticleContainer';
 import type { ParticleContainerAdaptor, ParticleContainerPipe } from '../shared/ParticleContainerPipe';
 
+const typeSymbol = Symbol.for('pixijs.GpuParticleContainerAdaptor');
+
 /** @internal */
 export class GpuParticleContainerAdaptor implements ParticleContainerAdaptor
 {
+    /**
+     * Type symbol used to identify instances of GpuParticleContainerAdaptor.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuParticleContainerAdaptor.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuParticleContainerAdaptor, false otherwise.
+     */
+    public static isGpuParticleContainerAdaptor(obj: any): obj is GpuParticleContainerAdaptor
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public execute(particleContainerPipe: ParticleContainerPipe, container: ParticleContainer)
     {
         const renderer = particleContainerPipe.renderer as WebGPURenderer;

--- a/src/scene/particle-container/shared/GlParticleContainerPipe.ts
+++ b/src/scene/particle-container/shared/GlParticleContainerPipe.ts
@@ -4,6 +4,8 @@ import { ParticleContainerPipe } from './ParticleContainerPipe';
 
 import type { WebGLRenderer } from '../../../rendering/renderers/gl/WebGLRenderer';
 
+const typeSymbol = Symbol.for('pixijs.GlParticleContainerPipe');
+
 /**
  * WebGL renderer for Particles that is designed for speed over feature set.
  * @category scene
@@ -11,6 +13,22 @@ import type { WebGLRenderer } from '../../../rendering/renderers/gl/WebGLRendere
  */
 export class GlParticleContainerPipe extends ParticleContainerPipe
 {
+    /**
+     * Type symbol used to identify instances of GlParticleContainerPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GlParticleContainerPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a GlParticleContainerPipe, false otherwise.
+     */
+    public static isGlParticleContainerPipe(obj: any): obj is GlParticleContainerPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/particle-container/shared/GpuParticleContainerPipe.ts
+++ b/src/scene/particle-container/shared/GpuParticleContainerPipe.ts
@@ -4,6 +4,8 @@ import { ParticleContainerPipe } from './ParticleContainerPipe';
 
 import type { WebGPURenderer } from '../../../rendering/renderers/gpu/WebGPURenderer';
 
+const typeSymbol = Symbol.for('pixijs.GpuParticleContainerPipe');
+
 /**
  * WebGPU renderer for Particles that is designed for speed over feature set.
  * @category scene
@@ -11,6 +13,22 @@ import type { WebGPURenderer } from '../../../rendering/renderers/gpu/WebGPURend
  */
 export class GpuParticleContainerPipe extends ParticleContainerPipe
 {
+    /**
+     * Type symbol used to identify instances of GpuParticleContainerPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a GpuParticleContainerPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a GpuParticleContainerPipe, false otherwise.
+     */
+    public static isGpuParticleContainerPipe(obj: any): obj is GpuParticleContainerPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/particle-container/shared/Particle.ts
+++ b/src/scene/particle-container/shared/Particle.ts
@@ -5,6 +5,8 @@ import { assignWithIgnore } from '../../container/utils/assignWithIgnore';
 
 import type { ColorSource } from '../../../color/Color';
 
+const typeSymbol = Symbol.for('pixi.Particle');
+
 /**
  * Represents a particle with properties for position, scale, rotation, color, and texture.
  * Particles are lightweight alternatives to sprites, optimized for use in particle systems.
@@ -154,6 +156,22 @@ export type ParticleOptions = Omit<Partial<IParticle>, 'color'> & {
  */
 export class Particle implements IParticle
 {
+    /**
+     * Type symbol used to identify instances of Particle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Particle.
+     * @param obj - The object to check.
+     * @returns True if the object is a Particle, false otherwise.
+     */
+    public static isParticle(obj: any): obj is Particle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default options used when creating new particles. These values are applied when specific
      * options aren't provided in the constructor.

--- a/src/scene/particle-container/shared/Particle.ts
+++ b/src/scene/particle-container/shared/Particle.ts
@@ -313,7 +313,7 @@ export class Particle implements IParticle
 
     constructor(options: Texture | ParticleOptions)
     {
-        if (options instanceof Texture)
+        if (Texture.isTexture(options))
         {
             this.texture = options;
             assignWithIgnore(this, Particle.defaultOptions, {});

--- a/src/scene/particle-container/shared/ParticleBuffer.ts
+++ b/src/scene/particle-container/shared/ParticleBuffer.ts
@@ -11,6 +11,8 @@ import type { IParticle } from './Particle';
 import type { ParticleRendererProperty } from './particleData';
 import type { ParticleUpdateFunction } from './utils/generateParticleUpdateFunction';
 
+const typeSymbol = Symbol.for('pixijs.ParticleBuffer');
+
 /**
  * Options for creating a ParticleBuffer.
  * @internal
@@ -30,6 +32,22 @@ export interface ParticleBufferOptions
  */
 export class ParticleBuffer
 {
+    /**
+     * Type symbol used to identify instances of ParticleBuffer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ParticleBuffer.
+     * @param obj - The object to check.
+     * @returns True if the object is a ParticleBuffer, false otherwise.
+     */
+    public static isParticleBuffer(obj: any): obj is ParticleBuffer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The buffer containing static attribute data for all elements in the batch. */
     public staticAttributeBuffer: ViewableBuffer;
     /** The buffer containing dynamic attribute data for all elements in the batch. */

--- a/src/scene/particle-container/shared/ParticleContainer.ts
+++ b/src/scene/particle-container/shared/ParticleContainer.ts
@@ -12,6 +12,8 @@ import type { DestroyOptions } from '../../container/destroyTypes';
 import type { IParticle } from './Particle';
 import type { ParticleRendererProperty } from './particleData';
 
+const typeSymbol = Symbol.for('pixijs.ParticleContainer');
+
 const emptyBounds = new Bounds(0, 0, 0, 0);
 
 /**
@@ -197,6 +199,22 @@ export interface ParticleContainer extends PixiMixins.ParticleContainer, ViewCon
  */
 export class ParticleContainer extends ViewContainer<ParticleBuffer> implements Instruction
 {
+    /**
+     * Type symbol used to identify instances of ParticleContainer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ParticleContainer.
+     * @param obj - The object to check.
+     * @returns True if the object is a ParticleContainer, false otherwise.
+     */
+    public static isParticleContainer(obj: any): obj is ParticleContainer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Defines the default options for creating a ParticleContainer.
      * @example

--- a/src/scene/particle-container/shared/ParticleContainerPipe.ts
+++ b/src/scene/particle-container/shared/ParticleContainerPipe.ts
@@ -12,6 +12,8 @@ import type { Shader } from '../../../rendering/renderers/shared/shader/Shader';
 import type { Renderer } from '../../../rendering/renderers/types';
 import type { ParticleContainer } from './ParticleContainer';
 
+const typeSymbol = Symbol.for('pixijs.ParticleContainerPipe');
+
 /** @internal */
 export interface ParticleContainerAdaptor
 {
@@ -25,6 +27,22 @@ export interface ParticleContainerAdaptor
  */
 export class ParticleContainerPipe implements RenderPipe<ParticleContainer>
 {
+    /**
+     * Type symbol used to identify instances of ParticleContainerPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ParticleContainerPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a ParticleContainerPipe, false otherwise.
+     */
+    public static isParticleContainerPipe(obj: any): obj is ParticleContainerPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default shader that is used if a sprite doesn't have a more specific one. */
     public defaultShader: Shader;
 

--- a/src/scene/particle-container/shared/shader/ParticleShader.ts
+++ b/src/scene/particle-container/shared/shader/ParticleShader.ts
@@ -9,9 +9,27 @@ import fragment from './particles.frag';
 import vertex from './particles.vert';
 import wgsl from './particles.wgsl';
 
+const typeSymbol = Symbol.for('pixijs.ParticleShader');
+
 /** @internal */
 export class ParticleShader extends Shader
 {
+    /**
+     * Type symbol used to identify instances of ParticleShader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ParticleShader.
+     * @param obj - The object to check.
+     * @returns True if the object is a ParticleShader, false otherwise.
+     */
+    public static isParticleShader(obj: any): obj is ParticleShader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor()
     {
         const glProgram = GlProgram.from({

--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -6,6 +6,8 @@ import { Sprite } from '../sprite/Sprite';
 
 import type { SpriteOptions } from '../sprite/Sprite';
 
+const typeSymbol = Symbol.for('pixi.AnimatedSprite');
+
 /**
  * A collection of textures or frame objects that can be used to create an `AnimatedSprite`.
  * @see {@link AnimatedSprite}
@@ -260,6 +262,22 @@ export interface AnimatedSprite extends PixiMixins.AnimatedSprite, Sprite {}
  */
 export class AnimatedSprite extends Sprite
 {
+    /**
+     * Type symbol used to identify instances of AnimatedSprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is an AnimatedSprite.
+     * @param obj - The object to check.
+     * @returns True if the object is an AnimatedSprite, false otherwise.
+     */
+    public static isAnimatedSprite(obj: any): obj is AnimatedSprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The speed that the AnimatedSprite will play at. Higher is faster, lower is slower.
      * @example

--- a/src/scene/sprite-animated/AnimatedSprite.ts
+++ b/src/scene/sprite-animated/AnimatedSprite.ts
@@ -448,7 +448,7 @@ export class AnimatedSprite extends Sprite
 
         super({
             ...rest,
-            texture: firstFrame instanceof Texture ? firstFrame : firstFrame.texture,
+            texture: Texture.isTexture(firstFrame) ? firstFrame : firstFrame.texture,
         });
 
         this._textures = null;
@@ -933,7 +933,7 @@ export class AnimatedSprite extends Sprite
 
     set textures(value: AnimatedSpriteFrames)
     {
-        if (value[0] instanceof Texture)
+        if (Texture.isTexture(value[0]))
         {
             this._textures = value as Texture[];
             this._durations = null;

--- a/src/scene/sprite-nine-slice/NineSliceGeometry.ts
+++ b/src/scene/sprite-nine-slice/NineSliceGeometry.ts
@@ -1,6 +1,8 @@
 import { type PointData } from '../../maths/point/PointData';
 import { PlaneGeometry } from '../mesh-plane/PlaneGeometry';
 
+const typeSymbol = Symbol.for('pixi.NineSliceGeometry');
+
 /**
  * Options for the NineSliceGeometry.
  * @category scene
@@ -37,6 +39,22 @@ export interface NineSliceGeometryOptions
  */
 export class NineSliceGeometry extends PlaneGeometry
 {
+    /**
+     * Type symbol used to identify instances of NineSliceGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a NineSliceGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a NineSliceGeometry, false otherwise.
+     */
+    public static isNineSliceGeometry(obj: any): obj is NineSliceGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The default options for the NineSliceGeometry. */
     public static defaultOptions: NineSliceGeometryOptions = {
         /** The width of the NineSlicePlane, setting this will actually modify the vertices and UV's of this plane. */

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -11,6 +11,8 @@ import type { View } from '../../rendering/renderers/shared/view/View';
 import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixijs.NineSliceSprite');
+
 /**
  * Constructor options used for `NineSliceSprite` instances.
  * Defines how the sprite's texture is divided and scaled in nine sections.
@@ -212,6 +214,22 @@ export interface NineSliceSprite extends PixiMixins.NineSliceSprite, ViewContain
  */
 export class NineSliceSprite extends ViewContainer<NineSliceSpriteGpuData> implements View
 {
+    /**
+     * Type symbol used to identify instances of NineSliceSprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a NineSliceSprite.
+     * @param obj - The object to check.
+     * @returns True if the object is a NineSliceSprite, false otherwise.
+     */
+    public static isNineSliceSprite(obj: any): obj is NineSliceSprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The default options used to override initial values of any options passed in the constructor.
      * These values are used as fallbacks when specific options are not provided.

--- a/src/scene/sprite-nine-slice/NineSliceSprite.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSprite.ts
@@ -270,7 +270,7 @@ export class NineSliceSprite extends ViewContainer<NineSliceSpriteGpuData> imple
 
     constructor(options: NineSliceSpriteOptions | Texture)
     {
-        if ((options instanceof Texture))
+        if (Texture.isTexture(options))
         {
             options = { texture: options };
         }
@@ -723,7 +723,7 @@ export class NineSlicePlane extends NineSliceSprite
     {
         let options = args[0];
 
-        if (options instanceof Texture)
+        if (Texture.isTexture(options))
         {
             // #if _DEBUG
             // eslint-disable-next-line max-len

--- a/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
+++ b/src/scene/sprite-nine-slice/NineSliceSpritePipe.ts
@@ -7,6 +7,8 @@ import type { RenderPipe } from '../../rendering/renderers/shared/instructions/R
 import type { Renderer } from '../../rendering/renderers/types';
 import type { NineSliceSprite } from './NineSliceSprite';
 
+const typeSymbol = Symbol.for('pixijs.NineSliceSpritePipe');
+
 /**
  * GPU data for NineSliceSprite.
  * @internal
@@ -31,6 +33,22 @@ export class NineSliceSpriteGpuData extends BatchableMesh
  */
 export class NineSliceSpritePipe implements RenderPipe<NineSliceSprite>
 {
+    /**
+     * Type symbol used to identify instances of NineSliceSpritePipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a NineSliceSpritePipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a NineSliceSpritePipe, false otherwise.
+     */
+    public static isNineSliceSpritePipe(obj: any): obj is NineSliceSpritePipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -14,6 +14,8 @@ import type { View } from '../../rendering/renderers/shared/view/View';
 import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixijs.TilingSprite');
+
 /**
  * Constructor options used for creating a TilingSprite instance.
  * Defines the texture, tiling behavior, and rendering properties of the sprite.
@@ -204,6 +206,22 @@ export interface TilingSprite extends PixiMixins.TilingSprite, ViewContainer<Til
  */
 export class TilingSprite extends ViewContainer<TilingSpriteGpuData> implements View, Instruction
 {
+    /**
+     * Type symbol used to identify instances of TilingSprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TilingSprite.
+     * @param obj - The object to check.
+     * @returns True if the object is a TilingSprite, false otherwise.
+     */
+    public static isTilingSprite(obj: any): obj is TilingSprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Creates a new tiling sprite based on a source texture or image path.
      * This is a convenience method that automatically creates and manages textures.

--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -359,7 +359,7 @@ export class TilingSprite extends ViewContainer<TilingSpriteGpuData> implements 
     {
         let options = args[0] || {};
 
-        if (options instanceof Texture)
+        if (Texture.isTexture(options))
         {
             options = { texture: options };
         }

--- a/src/scene/sprite-tiling/TilingSpritePipe.ts
+++ b/src/scene/sprite-tiling/TilingSpritePipe.ts
@@ -15,11 +15,30 @@ import type { InstructionSet } from '../../rendering/renderers/shared/instructio
 import type { RenderPipe } from '../../rendering/renderers/shared/instructions/RenderPipe';
 import type { TilingSprite } from './TilingSprite';
 
+const typeSymbolTilingSpriteGpuData = Symbol.for('pixi.TilingSpriteGpuData');
+const typeSymbolTilingSpritePipe = Symbol.for('pixi.TilingSpritePipe');
+
 const sharedQuad = new QuadGeometry();
 
 /** @internal */
 export class TilingSpriteGpuData
 {
+    /**
+     * Type symbol used to identify instances of TilingSpriteGpuData.
+     * @internal
+     */
+    public readonly [typeSymbolTilingSpriteGpuData] = true;
+
+    /**
+     * Checks if the given object is a TilingSpriteGpuData.
+     * @param obj - The object to check.
+     * @returns True if the object is a TilingSpriteGpuData, false otherwise.
+     */
+    public static isTilingSpriteGpuData(obj: any): obj is TilingSpriteGpuData
+    {
+        return !!obj && !!obj[typeSymbolTilingSpriteGpuData];
+    }
+
     public canBatch: boolean = true;
     public renderable: TilingSprite;
     public batchableMesh?: BatchableMesh;
@@ -49,6 +68,22 @@ export class TilingSpriteGpuData
  */
 export class TilingSpritePipe implements RenderPipe<TilingSprite>
 {
+    /**
+     * Type symbol used to identify instances of TilingSpritePipe.
+     * @internal
+     */
+    public readonly [typeSymbolTilingSpritePipe] = true;
+
+    /**
+     * Checks if the given object is a TilingSpritePipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a TilingSpritePipe, false otherwise.
+     */
+    public static isTilingSpritePipe(obj: any): obj is TilingSpritePipe
+    {
+        return !!obj && !!obj[typeSymbolTilingSpritePipe];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/sprite-tiling/shader/TilingSpriteShader.ts
+++ b/src/scene/sprite-tiling/shader/TilingSpriteShader.ts
@@ -13,6 +13,8 @@ import { tilingBit, tilingBitGl } from './tilingBit';
 import type { GlProgram } from '../../../rendering/renderers/gl/shader/GlProgram';
 import type { GpuProgram } from '../../../rendering/renderers/gpu/shader/GpuProgram';
 
+const typeSymbol = Symbol.for('pixi.TilingSpriteShader');
+
 let gpuProgram: GpuProgram;
 let glProgram: GlProgram;
 
@@ -22,6 +24,22 @@ let glProgram: GlProgram;
  */
 export class TilingSpriteShader extends Shader
 {
+    /**
+     * Type symbol used to identify instances of TilingSpriteShader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TilingSpriteShader.
+     * @param obj - The object to check.
+     * @returns True if the object is a TilingSpriteShader, false otherwise.
+     */
+    public static isTilingSpriteShader(obj: any): obj is TilingSpriteShader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor()
     {
         gpuProgram ??= compileHighShaderGpuProgram({

--- a/src/scene/sprite-tiling/utils/QuadGeometry.ts
+++ b/src/scene/sprite-tiling/utils/QuadGeometry.ts
@@ -1,8 +1,26 @@
 import { MeshGeometry } from '../../mesh/shared/MeshGeometry';
 
+const typeSymbol = Symbol.for('QuadGeometry');
+
 /** @internal */
 export class QuadGeometry extends MeshGeometry
 {
+    /**
+     * Type symbol used to identify instances of QuadGeometry.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a QuadGeometry.
+     * @param obj - The object to check.
+     * @returns True if the object is a QuadGeometry, false otherwise.
+     */
+    public static isQuadGeometry(obj: any): obj is QuadGeometry
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor()
     {
         super({

--- a/src/scene/sprite/BatchableSprite.ts
+++ b/src/scene/sprite/BatchableSprite.ts
@@ -6,12 +6,30 @@ import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { BoundsData } from '../container/bounds/Bounds';
 import type { Container } from '../container/Container';
 
+const typeSymbol = Symbol.for('pixijs.BatchableSprite');
+
 /**
  * A batchable sprite object.
  * @internal
  */
 export class BatchableSprite implements DefaultBatchableQuadElement
 {
+    /**
+     * Type symbol used to identify instances of BatchableSprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchableSprite.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchableSprite, false otherwise.
+     */
+    public static isBatchableSprite(obj: any): obj is BatchableSprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public batcherName = 'default';
     public topology: Topology = 'triangle-list';
 

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -12,6 +12,8 @@ import type { BoundsData } from '../container/bounds/Bounds';
 import type { Optional } from '../container/container-mixins/measureMixin';
 import type { DestroyOptions } from '../container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixijs.Sprite');
+
 /**
  * Options for configuring a Sprite instance. Defines the texture, anchor point, and rendering behavior.
  * @example
@@ -133,6 +135,22 @@ export interface Sprite extends PixiMixins.Sprite, ViewContainer<BatchableSprite
  */
 export class Sprite extends ViewContainer<BatchableSprite>
 {
+    /**
+     * Type symbol used to identify instances of Sprite.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Sprite.
+     * @param obj - The object to check.
+     * @returns True if the object is a Sprite, false otherwise.
+     */
+    public static isSprite(obj: any): obj is Sprite
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Creates a new sprite based on a source texture, image, video, or canvas element.
      * This is a convenience method that automatically creates and manages textures.

--- a/src/scene/sprite/Sprite.ts
+++ b/src/scene/sprite/Sprite.ts
@@ -175,7 +175,7 @@ export class Sprite extends ViewContainer<BatchableSprite>
      */
     public static from(source: Texture | TextureSourceLike, skipCache = false): Sprite
     {
-        if (source instanceof Texture)
+        if (Texture.isTexture(source))
         {
             return new Sprite(source);
         }
@@ -204,7 +204,7 @@ export class Sprite extends ViewContainer<BatchableSprite>
      */
     constructor(options: SpriteOptions | Texture = Texture.EMPTY)
     {
-        if (options instanceof Texture)
+        if (Texture.isTexture(options))
         {
             options = { texture: options };
         }

--- a/src/scene/sprite/SpritePipe.ts
+++ b/src/scene/sprite/SpritePipe.ts
@@ -6,9 +6,27 @@ import type { RenderPipe } from '../../rendering/renderers/shared/instructions/R
 import type { Renderer } from '../../rendering/renderers/types';
 import type { Sprite } from './Sprite';
 
+const typeSymbol = Symbol.for('pixijs.SpritePipe');
+
 /** @internal */
 export class SpritePipe implements RenderPipe<Sprite>
 {
+    /**
+     * Type symbol used to identify instances of SpritePipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SpritePipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a SpritePipe, false otherwise.
+     */
+    public static isSpritePipe(obj: any): obj is SpritePipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text-bitmap/AbstractBitmapFont.ts
+++ b/src/scene/text-bitmap/AbstractBitmapFont.ts
@@ -4,6 +4,8 @@ import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { FontMetrics } from '../text/canvas/CanvasTextMetrics';
 
+const typeSymbol = Symbol.for('pixijs.AbstractBitmapFont');
+
 /**
  * @category text
  * @advanced
@@ -92,6 +94,22 @@ export abstract class AbstractBitmapFont<FontType>
     extends EventEmitter<BitmapFontEvents<FontType>>
     implements Omit<BitmapFontData, 'chars' | 'pages' | 'fontSize'>
 {
+    /**
+     * Type symbol used to identify instances of AbstractBitmapFont.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AbstractBitmapFont.
+     * @param obj - The object to check.
+     * @returns True if the object is a AbstractBitmapFont, false otherwise.
+     */
+    public static isAbstractBitmapFont(obj: any): obj is AbstractBitmapFont<any>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The map of characters by character code. */
     public readonly chars: Record<string, CharData> = Object.create(null);
 

--- a/src/scene/text-bitmap/BitmapFont.ts
+++ b/src/scene/text-bitmap/BitmapFont.ts
@@ -8,6 +8,8 @@ import type { FontMetrics } from '../text/canvas/CanvasTextMetrics';
 import type { BitmapFontData } from './AbstractBitmapFont';
 import type { BitmapFontInstallOptions } from './BitmapFontManager';
 
+const typeSymbol = Symbol.for('pixi.BitmapFont');
+
 /**
  * Options for creating a BitmapFont. Used when loading or creating bitmap fonts from existing textures and data.
  * @example
@@ -126,6 +128,22 @@ export interface BitmapFontOptions
  */
 export class BitmapFont extends AbstractBitmapFont<BitmapFont>
 {
+    /**
+     * Type symbol used to identify instances of BitmapFont.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BitmapFont.
+     * @param obj - The object to check.
+     * @returns True if the object is a BitmapFont, false otherwise.
+     */
+    public static isBitmapFont(obj: any): obj is BitmapFont
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The URL from which the font was loaded, if applicable.
      * This is useful for tracking font sources and reloading.

--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -455,7 +455,7 @@ class BitmapFontManagerClass
 
         const textStyle = options.style;
 
-        const style = textStyle instanceof TextStyle ? textStyle : new TextStyle(textStyle);
+        const style = TextStyle.isTextStyle(textStyle) ? textStyle : new TextStyle(textStyle);
         const overrideFill = options.dynamicFill ?? this._canUseTintForStyle(style);
         const font = new DynamicBitmapFont({
             style,

--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -418,11 +418,12 @@ class BitmapFontManagerClass
      *
      * const title = new BitmapText({ text: 'This is the title', fontFamily: 'TitleFont' });
      */
-    public install(options: BitmapFontInstallOptions): BitmapFont;
+    public install(options: BitmapFontInstallOptions): DynamicBitmapFont;
     /** @deprecated since 7.0.0 */
-    public install(name: string, style?: TextStyle | TextStyleOptions, options?: BitmapFontInstallOptions): BitmapFont;
     // eslint-disable-next-line max-len
-    public install(...args: [string | BitmapFontInstallOptions, (TextStyle | TextStyleOptions)?, BitmapFontInstallOptions?]): BitmapFont
+    public install(name: string, style?: TextStyle | TextStyleOptions, options?: BitmapFontInstallOptions): DynamicBitmapFont;
+    // eslint-disable-next-line max-len
+    public install(...args: [string | BitmapFontInstallOptions, (TextStyle | TextStyleOptions)?, BitmapFontInstallOptions?]): DynamicBitmapFont
     {
         let options = args[0] as BitmapFontInstallOptions;
 
@@ -484,7 +485,7 @@ class BitmapFontManagerClass
     public uninstall(name: string)
     {
         const cacheKey = `${name}-bitmap`;
-        const font = Cache.get<BitmapFont>(cacheKey);
+        const font = Cache.get<DynamicBitmapFont>(cacheKey);
 
         if (font)
         {

--- a/src/scene/text-bitmap/BitmapText.ts
+++ b/src/scene/text-bitmap/BitmapText.ts
@@ -8,6 +8,8 @@ import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from '../text/AbstractText';
 import type { TextStyleOptions } from '../text/TextStyle';
 
+const typeSymbol = Symbol.for('pixijs.BitmapText');
+
 // eslint-disable-next-line requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface BitmapText extends PixiMixins.BitmapText, AbstractText<
     TextStyle,
@@ -126,6 +128,22 @@ export class BitmapText extends AbstractText<
     BitmapTextGraphics
 > implements View
 {
+    /**
+     * Type symbol used to identify instances of BitmapText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BitmapText.
+     * @param obj - The object to check.
+     * @returns True if the object is a BitmapText, false otherwise.
+     */
+    public static isBitmapText(obj: any): obj is BitmapText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'bitmapText';
 

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -12,9 +12,28 @@ import type { Renderable } from '../../rendering/renderers/shared/Renderable';
 import type { Renderer } from '../../rendering/renderers/types';
 import type { BitmapText } from './BitmapText';
 
+const typeSymbolBitmapTextGraphics = Symbol.for('pixijs.BitmapTextGraphics');
+const typeSymbolBitmapTextPipe = Symbol.for('pixijs.BitmapTextPipe');
+
 /** @internal */
 export class BitmapTextGraphics extends Graphics
 {
+    /**
+     * Type symbol used to identify instances of BitmapTextGraphics.
+     * @internal
+     */
+    public readonly [typeSymbolBitmapTextGraphics] = true;
+
+    /**
+     * Checks if the given object is a BitmapTextGraphics.
+     * @param obj - The object to check.
+     * @returns True if the object is a BitmapTextGraphics, false otherwise.
+     */
+    public static isBitmapTextGraphics(obj: any): obj is BitmapTextGraphics
+    {
+        return !!obj && !!obj[typeSymbolBitmapTextGraphics];
+    }
+
     public destroy()
     {
         if (this.context.customShader)
@@ -29,6 +48,22 @@ export class BitmapTextGraphics extends Graphics
 /** @internal */
 export class BitmapTextPipe implements RenderPipe<BitmapText>
 {
+    /**
+     * Type symbol used to identify instances of BitmapTextPipe.
+     * @internal
+     */
+    public readonly [typeSymbolBitmapTextPipe] = true;
+
+    /**
+     * Checks if the given object is a BitmapTextPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a BitmapTextPipe, false otherwise.
+     */
+    public static isBitmapTextPipe(obj: any): obj is BitmapTextPipe
+    {
+        return !!obj && !!obj[typeSymbolBitmapTextPipe];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -134,7 +134,7 @@ export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
 
         if (dynamicOptions.textureStyle)
         {
-            this._textureStyle = dynamicOptions.textureStyle instanceof TextureStyle
+            this._textureStyle = TextureStyle.isTextureStyle(dynamicOptions.textureStyle)
                 ? dynamicOptions.textureStyle
                 : new TextureStyle(dynamicOptions.textureStyle);
         }

--- a/src/scene/text-bitmap/DynamicBitmapFont.ts
+++ b/src/scene/text-bitmap/DynamicBitmapFont.ts
@@ -15,6 +15,8 @@ import type { ICanvasRenderingContext2D } from '../../environment/canvas/ICanvas
 import type { CanvasAndContext } from '../../rendering/renderers/shared/texture/CanvasPool';
 import type { FontMetrics } from '../text/canvas/CanvasTextMetrics';
 
+const typeSymbol = Symbol.for('pixijs.DynamicBitmapFont');
+
 /** @internal */
 export interface DynamicBitmapFontOptions
 {
@@ -36,6 +38,22 @@ export interface DynamicBitmapFontOptions
  */
 export class DynamicBitmapFont extends AbstractBitmapFont<DynamicBitmapFont>
 {
+    /**
+     * Type symbol used to identify instances of DynamicBitmapFont.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a DynamicBitmapFont.
+     * @param obj - The object to check.
+     * @returns True if the object is a DynamicBitmapFont, false otherwise.
+     */
+    public static isDynamicBitmapFont(obj: any): obj is DynamicBitmapFont
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public static defaultOptions: DynamicBitmapFontOptions = {
         textureSize: 512,
         style: new TextStyle(),

--- a/src/scene/text-bitmap/asset/loadBitmapFont.ts
+++ b/src/scene/text-bitmap/asset/loadBitmapFont.ts
@@ -25,7 +25,7 @@ export const bitmapFontCachePlugin = {
         type: ExtensionType.CacheParser,
         name: 'cacheBitmapFont',
     },
-    test: (asset: BitmapFont) => asset instanceof BitmapFont,
+    test: (asset: BitmapFont) => BitmapFont.isBitmapFont(asset),
     getCacheableAssets(keys: string[], asset: BitmapFont)
     {
         const out: Record<string, BitmapFont> = {};

--- a/src/scene/text-html/BatchableHTMLText.ts
+++ b/src/scene/text-html/BatchableHTMLText.ts
@@ -4,6 +4,8 @@ import { BatchableSprite } from '../sprite/BatchableSprite';
 import type { Renderer } from '../../rendering/renderers/types';
 import type { HTMLText } from './HTMLText';
 
+const typeSymbol = Symbol.for('pixijs.BatchableHTMLText');
+
 /**
  * The BatchableHTMLText class extends the BatchableSprite class and is used to handle HTML text rendering.
  * It includes a promise for the texture as generating the HTML texture takes some time.
@@ -11,6 +13,22 @@ import type { HTMLText } from './HTMLText';
  */
 export class BatchableHTMLText extends BatchableSprite
 {
+    /**
+     * Type symbol used to identify instances of BatchableHTMLText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchableHTMLText.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchableHTMLText, false otherwise.
+     */
+    public static isBatchableHTMLText(obj: any): obj is BatchableHTMLText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private readonly _renderer: Renderer;
     public texturePromise: Promise<Texture>;
     public generatingTexture = false;

--- a/src/scene/text-html/HTMLText.ts
+++ b/src/scene/text-html/HTMLText.ts
@@ -8,6 +8,8 @@ import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from '../text/AbstractText';
 import type { HTMLTextStyleOptions } from './HTMLTextStyle';
 
+const typeSymbol = Symbol.for('pixijs.HTMLText');
+
 /**
  * Constructor options used for `HTMLText` instances. Extends the base text options
  * with HTML-specific features and texture styling capabilities.
@@ -160,6 +162,22 @@ export class HTMLText extends AbstractText<
     BatchableHTMLText
 > implements View
 {
+    /**
+     * Type symbol used to identify instances of HTMLText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HTMLText.
+     * @param obj - The object to check.
+     * @returns True if the object is a HTMLText, false otherwise.
+     */
+    public static isHTMLText(obj: any): obj is HTMLText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'htmlText';
 

--- a/src/scene/text-html/HTMLText.ts
+++ b/src/scene/text-html/HTMLText.ts
@@ -203,7 +203,7 @@ export class HTMLText extends AbstractText<
 
         if (options.textureStyle)
         {
-            this.textureStyle = options.textureStyle instanceof TextureStyle
+            this.textureStyle = TextureStyle.isTextureStyle(options.textureStyle)
                 ? options.textureStyle
                 : new TextureStyle(options.textureStyle);
         }

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -8,12 +8,30 @@ import type { RenderPipe } from '../../rendering/renderers/shared/instructions/R
 import type { Renderer } from '../../rendering/renderers/types';
 import type { HTMLText } from './HTMLText';
 
+const typeSymbol = Symbol.for('pixi.HTMLTextPipe');
+
 /**
  * The HTMLTextPipe class is responsible for rendering HTML text.
  * @internal
  */
 export class HTMLTextPipe implements RenderPipe<HTMLText>
 {
+    /**
+     * Type symbol used to identify instances of HTMLTextPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HTMLTextPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a HTMLTextPipe, false otherwise.
+     */
+    public static isHTMLTextPipe(obj: any): obj is HTMLTextPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text-html/HTMLTextRenderData.ts
+++ b/src/scene/text-html/HTMLTextRenderData.ts
@@ -3,6 +3,8 @@ import { type ImageLike } from '../../environment/ImageLike';
 
 import type { CanvasAndContext } from '../../rendering/renderers/shared/texture/CanvasPool';
 
+const typeSymbol = Symbol.for('pixijs.HTMLTextRenderData');
+
 /** @internal */
 const nssvg = 'http://www.w3.org/2000/svg';
 /** @internal */
@@ -11,6 +13,22 @@ const nsxhtml = 'http://www.w3.org/1999/xhtml';
 /** @internal */
 export class HTMLTextRenderData
 {
+    /**
+     * Type symbol used to identify instances of HTMLTextRenderData.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HTMLTextRenderData.
+     * @param obj - The object to check.
+     * @returns True if the object is a HTMLTextRenderData, false otherwise.
+     */
+    public static isHTMLTextRenderData(obj: any): obj is HTMLTextRenderData
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     public svgRoot = document.createElementNS(nssvg, 'svg');
     public foreignObject = document.createElementNS(nssvg, 'foreignObject');
     public domElement = document.createElementNS(nsxhtml, 'div');

--- a/src/scene/text-html/HTMLTextStyle.ts
+++ b/src/scene/text-html/HTMLTextStyle.ts
@@ -6,6 +6,8 @@ import { textStyleToCSS } from './utils/textStyleToCSS';
 import type { FillInput, StrokeInput } from '../graphics/shared/FillTypes';
 import type { TextStyleOptions } from '../text/TextStyle';
 
+const typeSymbol = Symbol.for('pixijs.HTMLTextStyle');
+
 /**
  * Options for HTML text style, extends standard text styling with HTML-specific capabilities.
  * Omits certain base text properties that don't apply to HTML rendering.
@@ -86,6 +88,22 @@ export interface HTMLTextStyleOptions extends Omit<TextStyleOptions, 'leading' |
  */
 export class HTMLTextStyle extends TextStyle
 {
+    /**
+     * Type symbol used to identify instances of HTMLTextStyle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HTMLTextStyle.
+     * @param obj - The object to check.
+     * @returns True if the object is a HTMLTextStyle, false otherwise.
+     */
+    public static isHTMLTextStyle(obj: any): obj is HTMLTextStyle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private _cssOverrides: string[] = [];
     private _cssStyle: string;
     /**

--- a/src/scene/text-html/HTMLTextStyle.ts
+++ b/src/scene/text-html/HTMLTextStyle.ts
@@ -85,6 +85,7 @@ export interface HTMLTextStyleOptions extends Omit<TextStyleOptions, 'leading' |
 /**
  * A TextStyle object rendered by the HTMLTextSystem.
  * @category text
+ * @standard
  */
 export class HTMLTextStyle extends TextStyle
 {

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -22,6 +22,8 @@ import type { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import type { PoolItem } from '../../utils/pool/Pool';
 import type { HTMLTextOptions } from './HTMLText';
 
+const typeSymbol = Symbol.for('pixi.HTMLTextSystem');
+
 /**
  * System plugin to the renderer to manage HTMLText
  * @category rendering
@@ -29,6 +31,22 @@ import type { HTMLTextOptions } from './HTMLText';
  */
 export class HTMLTextSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of HTMLTextSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a HTMLTextSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a HTMLTextSystem, false otherwise.
+     */
+    public static isHTMLTextSystem(obj: any): obj is HTMLTextSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text-split/AbstractSplitText.ts
+++ b/src/scene/text-split/AbstractSplitText.ts
@@ -4,6 +4,8 @@ import { type DestroyOptions } from '../container/destroyTypes';
 import { TextStyle, type TextStyleOptions } from '../text/TextStyle';
 import { type SplitableTextObject, type TextSplitOutput } from './types';
 
+const typeSymbol = Symbol.for('pixi.AbstractSplitText');
+
 /**
  * Configuration options for text splitting.
  * @category text
@@ -180,6 +182,22 @@ export interface AbstractSplitTextOptions extends ContainerOptions, AbstractSpli
  */
 export abstract class AbstractSplitText<T extends SplitableTextObject> extends Container
 {
+    /**
+     * Type symbol used to identify instances of AbstractSplitText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a AbstractSplitText.
+     * @param obj - The object to check.
+     * @returns True if the object is a AbstractSplitText, false otherwise.
+     */
+    public static isAbstractSplitText(obj: any): obj is AbstractSplitText<any>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Individual character segments of the text.
      * @example

--- a/src/scene/text-split/SplitBitmapText.ts
+++ b/src/scene/text-split/SplitBitmapText.ts
@@ -8,6 +8,8 @@ import {
 } from './AbstractSplitText';
 import { type TextSplitOutput } from './types';
 
+const typeSymbol = Symbol.for('pixijs.SplitBitmapText');
+
 /**
  * Configuration options for BitmapText splitting.
  * @category text
@@ -143,6 +145,22 @@ export interface SplitBitmapTextOptions
  */
 export class SplitBitmapText extends AbstractSplitText<BitmapText>
 {
+    /**
+     * Type symbol used to identify instances of SplitBitmapText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SplitBitmapText.
+     * @param obj - The object to check.
+     * @returns True if the object is a SplitBitmapText, false otherwise.
+     */
+    public static isSplitBitmapText(obj: any): obj is SplitBitmapText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default configuration options for SplitBitmapText instances.
      * @example

--- a/src/scene/text-split/SplitText.ts
+++ b/src/scene/text-split/SplitText.ts
@@ -5,6 +5,8 @@ import { canvasTextSplit } from '../text/utils/canvasTextSplit';
 import { type AbstractSplitOptions, AbstractSplitText } from './AbstractSplitText';
 import { type TextSplitOutput } from './types';
 
+const typeSymbol = Symbol.for('pixijs.SplitText');
+
 /**
  * Configuration options for Text splitting.
  * @category text
@@ -137,6 +139,22 @@ export interface SplitTextOptions extends PixiMixins.SplitText, ContainerOptions
  */
 export class SplitText extends AbstractSplitText<Text>
 {
+    /**
+     * Type symbol used to identify instances of SplitText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SplitText.
+     * @param obj - The object to check.
+     * @returns True if the object is a SplitText, false otherwise.
+     */
+    public static isSplitText(obj: any): obj is SplitText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default configuration options for SplitText instances.
      * @example

--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -10,6 +10,8 @@ import type { DestroyOptions } from '../container/destroyTypes';
 import type { HTMLTextStyle, HTMLTextStyleOptions } from '../text-html/HTMLTextStyle';
 import type { TextStyle, TextStyleOptions } from './TextStyle';
 
+const typeSymbol = Symbol.for('pixijs.AbstractText');
+
 /**
  * A string or number that can be used as text.
  * @example
@@ -246,6 +248,22 @@ export abstract class AbstractText<
     GPU_DATA extends { destroy: () => void } = any
 > extends ViewContainer<GPU_DATA> implements View
 {
+    /**
+     * Type symbol used to identify instances of AbstractText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is an AbstractText.
+     * @param obj - The object to check.
+     * @returns True if the object is an AbstractText, false otherwise.
+     */
+    public static isAbstractText(obj: any): obj is AbstractText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public batched = true;
     /** @internal */

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -9,6 +9,8 @@ import type { View } from '../../rendering/renderers/shared/view/View';
 import type { TextOptions, TextString } from './AbstractText';
 import type { TextStyleOptions } from './TextStyle';
 
+const typeSymbol = Symbol.for('pixi.Text');
+
 // eslint-disable-next-line requireExport/require-export-jsdoc, requireMemberAPI/require-member-api-doc
 export interface Text extends PixiMixins.Text, AbstractText<
     TextStyle,
@@ -155,6 +157,22 @@ export class Text
     extends AbstractText<TextStyle, TextStyleOptions, CanvasTextOptions, BatchableText>
     implements View
 {
+    /**
+     * Type symbol used to identify instances of Text.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Text.
+     * @param obj - The object to check.
+     * @returns True if the object is a Text, false otherwise.
+     */
+    public static isText(obj: any): obj is Text
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string = 'text';
 

--- a/src/scene/text/Text.ts
+++ b/src/scene/text/Text.ts
@@ -198,7 +198,7 @@ export class Text
 
         if (options.textureStyle)
         {
-            this.textureStyle = options.textureStyle instanceof TextureStyle
+            this.textureStyle = TextureStyle.isTextureStyle(options.textureStyle)
                 ? options.textureStyle
                 : new TextureStyle(options.textureStyle);
         }

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -22,6 +22,8 @@ import type {
     StrokeStyle
 } from '../graphics/shared/FillTypes';
 
+const typeSymbol = Symbol.for('pixi.TextStyle');
+
 /**
  * The alignment of the text.
  *
@@ -704,6 +706,22 @@ export class TextStyle extends EventEmitter<{
     update: TextDropShadow
 }>
 {
+    /**
+     * Type symbol used to identify instances of TextStyle.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TextStyle.
+     * @param obj - The object to check.
+     * @returns True if the object is a TextStyle, false otherwise.
+     */
+    public static isTextStyle(obj: any): obj is TextStyle
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Default drop shadow settings used when enabling drop shadows on text.
      * These values are used as the base configuration when drop shadows are enabled without specific settings.

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -1174,7 +1174,7 @@ export class TextStyle extends EventEmitter<{
     private _isFillStyle(value: FillInput): value is FillStyle
     {
         return ((value ?? null) !== null
-            && !(Color.isColorLike(value) || value instanceof FillGradient || value instanceof FillPattern));
+            && !(Color.isColorLike(value) || FillGradient.isFillGradient(value) || FillPattern.isFillPattern(value)));
     }
 }
 
@@ -1218,7 +1218,7 @@ function convertV7Tov8Style(style: TextStyleOptions)
             obj.color = color as ColorSource;
         }
         // handles stroke: new FillGradient()
-        else if (color instanceof FillGradient || color instanceof FillPattern)
+        else if (FillGradient.isFillGradient(color) || FillPattern.isFillPattern(color))
         {
             obj.fill = color as FillGradient | FillPattern;
         }

--- a/src/scene/text/canvas/BatchableText.ts
+++ b/src/scene/text/canvas/BatchableText.ts
@@ -3,9 +3,27 @@ import { BatchableSprite } from '../../sprite/BatchableSprite';
 import type { Renderer } from '../../../rendering/renderers/types';
 import type { Text } from '../Text';
 
+const typeSymbol = Symbol.for('pixijs.BatchableText');
+
 /** @internal */
 export class BatchableText extends BatchableSprite
 {
+    /**
+     * Type symbol used to identify instances of BatchableText.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a BatchableText.
+     * @param obj - The object to check.
+     * @returns True if the object is a BatchableText, false otherwise.
+     */
+    public static isBatchableText(obj: any): obj is BatchableText
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     private readonly _renderer: Renderer;
 
     constructor(renderer: Renderer)

--- a/src/scene/text/canvas/CanvasTextGenerator.ts
+++ b/src/scene/text/canvas/CanvasTextGenerator.ts
@@ -7,6 +7,8 @@ import { CanvasTextMetrics } from './CanvasTextMetrics';
 import { fontStringFromTextStyle } from './utils/fontStringFromTextStyle';
 import { getCanvasFillStyle } from './utils/getCanvasFillStyle';
 
+const typeSymbol = Symbol.for('pixijs.CanvasTextGenerator');
+
 /**
  * Temporary rectangle for getting the bounding box of the text.
  * @internal
@@ -51,6 +53,22 @@ const tempRect = new Rectangle();
  */
 class CanvasTextGeneratorClass
 {
+    /**
+     * Type symbol used to identify instances of CanvasTextGenerator.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasTextGenerator.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasTextGenerator, false otherwise.
+     */
+    public static isCanvasTextGenerator(obj: any): obj is CanvasTextGeneratorClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Creates a canvas with the specified text rendered to it.
      *

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -5,6 +5,8 @@ import type { ICanvas, ICanvasRenderingContext2DSettings } from '../../../enviro
 import type { ICanvasRenderingContext2D } from '../../../environment/canvas/ICanvasRenderingContext2D';
 import type { TextStyle, TextStyleWhiteSpace } from '../TextStyle';
 
+const typeSymbol = Symbol.for('pixijs.CanvasTextMetrics');
+
 // The type for Intl.Segmenter is only available since TypeScript 4.7.2, so let's make a polyfill for it.
 interface ISegmentData
 {
@@ -71,6 +73,22 @@ const contextSettings: ICanvasRenderingContext2DSettings = {
  */
 export class CanvasTextMetrics
 {
+    /**
+     * Type symbol used to identify instances of CanvasTextMetrics.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasTextMetrics.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasTextMetrics, false otherwise.
+     */
+    public static isCanvasTextMetrics(obj: any): obj is CanvasTextMetrics
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The text that was measured. */
     public text: string;
 

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -7,9 +7,27 @@ import type { RenderPipe } from '../../../rendering/renderers/shared/instruction
 import type { Renderer } from '../../../rendering/renderers/types';
 import type { Text } from '../Text';
 
+const typeSymbol = Symbol.for('pixijs.CanvasTextPipe');
+
 /** @internal */
 export class CanvasTextPipe implements RenderPipe<Text>
 {
+    /**
+     * Type symbol used to identify instances of CanvasTextPipe.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasTextPipe.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasTextPipe, false otherwise.
+     */
+    public static isCanvasTextPipe(obj: any): obj is CanvasTextPipe
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -86,12 +86,12 @@ export class CanvasTextSystem implements System
             };
         }
 
-        if (!(options.style instanceof TextStyle))
+        if (!TextStyle.isTextStyle(options.style))
         {
             options.style = new TextStyle(options.style);
         }
 
-        if (!(options.textureStyle instanceof TextureStyle))
+        if (!TextureStyle.isTextureStyle(options.textureStyle))
         {
             options.textureStyle = new TextureStyle(options.textureStyle);
         }

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -12,6 +12,8 @@ import type { System } from '../../../rendering/renderers/shared/system/System';
 import type { Texture } from '../../../rendering/renderers/shared/texture/Texture';
 import type { Renderer } from '../../../rendering/renderers/types';
 
+const typeSymbol = Symbol.for('pixijs.CanvasTextSystem');
+
 /**
  * System plugin to the renderer to manage canvas text.
  * @category rendering
@@ -19,6 +21,22 @@ import type { Renderer } from '../../../rendering/renderers/types';
  */
 export class CanvasTextSystem implements System
 {
+    /**
+     * Type symbol used to identify instances of CanvasTextSystem.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a CanvasTextSystem.
+     * @param obj - The object to check.
+     * @returns True if the object is a CanvasTextSystem, false otherwise.
+     */
+    public static isCanvasTextSystem(obj: any): obj is CanvasTextSystem
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/scene/text/canvas/utils/getCanvasFillStyle.ts
+++ b/src/scene/text/canvas/utils/getCanvasFillStyle.ts
@@ -46,7 +46,7 @@ export function getCanvasFillStyle(
         return pattern;
     }
     // Pattern fill
-    else if (fillStyle.fill instanceof FillPattern)
+    else if (FillPattern.isFillPattern(fillStyle.fill))
     {
         const fillPattern = fillStyle.fill;
         const pattern = context.createPattern(fillPattern.texture.source.resource, 'repeat');
@@ -62,7 +62,7 @@ export function getCanvasFillStyle(
         return pattern;
     }
     // Gradient fill
-    else if (fillStyle.fill instanceof FillGradient)
+    else if (FillGradient.isFillGradient(fillStyle.fill))
     {
         const fillGradient = fillStyle.fill;
 

--- a/src/scene/text/sdfShader/SdfShader.ts
+++ b/src/scene/text/sdfShader/SdfShader.ts
@@ -18,12 +18,30 @@ import { mSDFBit, mSDFBitGl } from './shader-bits/mSDFBit';
 import type { GlProgram } from '../../../rendering/renderers/gl/shader/GlProgram';
 import type { GpuProgram } from '../../../rendering/renderers/gpu/shader/GpuProgram';
 
+const typeSymbol = Symbol.for('pixijs.SdfShader');
+
 let gpuProgram: GpuProgram;
 let glProgram: GlProgram;
 
 /** @internal */
 export class SdfShader extends Shader
 {
+    /**
+     * Type symbol used to identify instances of SdfShader.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a SdfShader.
+     * @param obj - The object to check.
+     * @returns True if the object is a SdfShader, false otherwise.
+     */
+    public static isSdfShader(obj: any): obj is SdfShader
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     constructor(maxTextures: number)
     {
         const uniforms = new UniformGroup({

--- a/src/scene/text/utils/generateTextStyleKey.ts
+++ b/src/scene/text/utils/generateTextStyleKey.ts
@@ -5,7 +5,7 @@ import type { ConvertedFillStyle, ConvertedStrokeStyle } from '../../graphics/sh
 import type { HTMLTextStyle } from '../../text-html/HTMLTextStyle';
 import type { TextStyle } from '../TextStyle';
 
-const valuesToIterateForKeys: Partial<keyof TextStyle | keyof HTMLTextStyle>[] = [
+const valuesToIterateForKeys = [
     'align',
     'breakWords',
     'cssOverrides',
@@ -23,7 +23,7 @@ const valuesToIterateForKeys: Partial<keyof TextStyle | keyof HTMLTextStyle>[] =
     'fontFamily',
     'fontStyle',
     'fontSize',
-] as const;
+] as const satisfies Partial<keyof TextStyle | keyof HTMLTextStyle>[];
 
 /**
  * Generates a unique key for the text style.

--- a/src/scene/view/ViewContainer.ts
+++ b/src/scene/view/ViewContainer.ts
@@ -9,6 +9,8 @@ import type { PointData } from '../../maths/point/PointData';
 import type { View } from '../../rendering/renderers/shared/view/View';
 import type { DestroyOptions } from '../container/destroyTypes';
 
+const typeSymbol = Symbol.for('pixi.ViewContainer');
+
 /** @internal */
 export interface GPUData
 {
@@ -37,6 +39,22 @@ export interface ViewContainer<GPU_DATA extends GPUData = any> extends PixiMixin
  */
 export abstract class ViewContainer<GPU_DATA extends GPUData = any> extends Container implements View
 {
+    /**
+     * Type symbol used to identify instances of ViewContainer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ViewContainer.
+     * @param obj - The object to check.
+     * @returns True if the object is a ViewContainer, false otherwise.
+     */
+    public static isViewContainer(obj: any): obj is ViewContainer<any>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public override readonly renderPipeId: string;
     /** @internal */

--- a/src/spritesheet/Spritesheet.ts
+++ b/src/spritesheet/Spritesheet.ts
@@ -6,6 +6,8 @@ import type { PointData } from '../maths/point/PointData';
 import type { BindableTexture, TextureBorders } from '../rendering/renderers/shared/texture/Texture';
 import type { Dict } from '../utils/types';
 
+const typeSymbol = Symbol.for('pixi.Spritesheet');
+
 /**
  * Represents the JSON data for a spritesheet atlas.
  * @category assets
@@ -214,6 +216,22 @@ export interface SpritesheetOptions<S extends SpritesheetData = SpritesheetData>
  */
 export class Spritesheet<S extends SpritesheetData = SpritesheetData>
 {
+    /**
+     * Type symbol used to identify instances of Spritesheet.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Spritesheet.
+     * @param obj - The object to check.
+     * @returns True if the object is a Spritesheet, false otherwise.
+     */
+    public static isSpritesheet(obj: any): obj is Spritesheet<S>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The maximum number of Textures to build per process.
      * @advanced

--- a/src/spritesheet/Spritesheet.ts
+++ b/src/spritesheet/Spritesheet.ts
@@ -227,7 +227,7 @@ export class Spritesheet<S extends SpritesheetData = SpritesheetData>
      * @param obj - The object to check.
      * @returns True if the object is a Spritesheet, false otherwise.
      */
-    public static isSpritesheet(obj: any): obj is Spritesheet<S>
+    public static isSpritesheet(obj: any): obj is Spritesheet<any>
     {
         return !!obj && !!obj[typeSymbol];
     }

--- a/src/spritesheet/Spritesheet.ts
+++ b/src/spritesheet/Spritesheet.ts
@@ -316,7 +316,7 @@ export class Spritesheet<S extends SpritesheetData = SpritesheetData>
     {
         let options = optionsOrTexture as SpritesheetOptions<S>;
 
-        if ((optionsOrTexture as BindableTexture)?.source instanceof TextureSource)
+        if (TextureSource.isTextureSource((optionsOrTexture as BindableTexture)?.source))
         {
             options = {
                 texture: optionsOrTexture as BindableTexture,
@@ -326,7 +326,7 @@ export class Spritesheet<S extends SpritesheetData = SpritesheetData>
         const { texture, data, cachePrefix = '' } = options;
 
         this.cachePrefix = cachePrefix;
-        this._texture = texture instanceof Texture ? texture : null;
+        this._texture = Texture.isTexture(texture) ? texture : null;
         this.textureSource = texture.source;
         this.textures = {} as Record<keyof S['frames'], Texture>;
         this.animations = {} as Record<keyof NonNullable<S['animations']>, Texture[]>;

--- a/src/spritesheet/spritesheetAsset.ts
+++ b/src/spritesheet/spritesheetAsset.ts
@@ -85,7 +85,7 @@ export const spritesheetAsset = {
     extension: ExtensionType.Asset,
     /** Handle the caching of the related Spritesheet Textures */
     cache: {
-        test: (asset: Spritesheet) => asset instanceof Spritesheet,
+        test: (asset: Spritesheet) => Spritesheet.isSpritesheet(asset),
         getCacheableAssets: (keys: string[], asset: Spritesheet) => getCacheableAssets(keys, asset, false),
     },
     /** Resolve the resolution of the asset. */
@@ -164,7 +164,7 @@ export const spritesheetAsset = {
 
             let texture: Texture;
 
-            if (imageTexture instanceof Texture)
+            if (Texture.isTexture(imageTexture))
             {
                 texture = imageTexture;
             }

--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -1,6 +1,8 @@
 import { UPDATE_PRIORITY } from './const';
 import { TickerListener } from './TickerListener';
 
+const typeSymbol = Symbol.for('pixijs.Ticker');
+
 /**
  * A callback which can be added to a ticker.
  * ```js
@@ -55,6 +57,22 @@ export type TickerCallback<T> = (this: T, ticker: Ticker) => any;
  */
 export class Ticker
 {
+    /**
+     * Type symbol used to identify instances of Ticker.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Ticker.
+     * @param obj - The object to check.
+     * @returns True if the object is a Ticker, false otherwise.
+     */
+    public static isTicker(obj: any): obj is Ticker
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * Target frame rate in frames per millisecond.
      * Used for converting deltaTime to a scalar time delta.

--- a/src/ticker/TickerListener.ts
+++ b/src/ticker/TickerListener.ts
@@ -1,5 +1,7 @@
 import type { Ticker, TickerCallback } from './Ticker';
 
+const typeSymbol = Symbol.for('TickerListener');
+
 /**
  * Internal class for handling the priority sorting of ticker handlers.
  * @private
@@ -7,6 +9,22 @@ import type { Ticker, TickerCallback } from './Ticker';
  */
 export class TickerListener<T = any>
 {
+    /**
+     * Type symbol used to identify instances of TickerListener.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a TickerListener.
+     * @param obj - The object to check.
+     * @returns True if the object is a TickerListener, false otherwise.
+     */
+    public static isTickerListener(obj: any): obj is TickerListener
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The current priority. */
     public priority: number;
     /** The next item in chain. */

--- a/src/unsafe-eval/shader/generateShaderSyncPolyfill.ts
+++ b/src/unsafe-eval/shader/generateShaderSyncPolyfill.ts
@@ -28,7 +28,7 @@ function syncShader(renderer: WebGLRenderer, shader: Shader, syncData: ShaderSyn
         {
             const resource = bindGroup.resources[j];
 
-            if (resource instanceof UniformGroup)
+            if (UniformGroup.isUniformGroup(resource))
             {
                 if (resource.ubo)
                 {
@@ -43,7 +43,7 @@ function syncShader(renderer: WebGLRenderer, shader: Shader, syncData: ShaderSyn
                     shaderSystem.updateUniformGroup(resource);
                 }
             }
-            else if (resource instanceof BufferResource)
+            else if (BufferResource.isBufferResource(resource))
             {
                 shaderSystem.bindUniformBlock(
                     resource,
@@ -51,7 +51,7 @@ function syncShader(renderer: WebGLRenderer, shader: Shader, syncData: ShaderSyn
                     syncData.blockIndex++
                 );
             }
-            else if (resource instanceof TextureSource)
+            else if (TextureSource.isTextureSource(resource))
             {
                 // TODO really we should not be binding the sampler here too
                 renderer.texture.bind(resource, syncData.textureCount);
@@ -70,7 +70,7 @@ function syncShader(renderer: WebGLRenderer, shader: Shader, syncData: ShaderSyn
                     syncData.textureCount++;
                 }
             }
-            else if (resource instanceof TextureStyle)
+            else if (TextureStyle.isTextureStyle(resource))
             {
                 // TODO not doing anything here works is assuming that textures are bound with the style they own.
                 // this.renderer.texture.bindSampler(resource, syncData.textureCount);

--- a/src/utils/data/ViewableBuffer.ts
+++ b/src/utils/data/ViewableBuffer.ts
@@ -1,5 +1,7 @@
 import { type TypedArray } from '../../rendering/renderers/shared/buffer/Buffer';
 
+const typeSymbol = Symbol.for('pixijs.ViewableBuffer');
+
 /**
  * Flexible wrapper around `ArrayBuffer` that also provides typed array views on demand.
  * @category utils
@@ -7,6 +9,22 @@ import { type TypedArray } from '../../rendering/renderers/shared/buffer/Buffer'
  */
 export class ViewableBuffer
 {
+    /**
+     * Type symbol used to identify instances of ViewableBuffer.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a ViewableBuffer.
+     * @param obj - The object to check.
+     * @returns True if the object is a ViewableBuffer, false otherwise.
+     */
+    public static isViewableBuffer(obj: any): obj is ViewableBuffer
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** The size of the buffer in bytes. */
     public size: number;
 

--- a/src/utils/global/globalHooks.ts
+++ b/src/utils/global/globalHooks.ts
@@ -5,6 +5,9 @@ import type { Application } from '../../app/Application';
 import type { System } from '../../rendering/renderers/shared/system/System';
 import type { Renderer } from '../../rendering/renderers/types';
 
+const typeSymbolApplicationInitHook = Symbol.for('pixijs.ApplicationInitHook');
+const typeSymbolRendererInitHook = Symbol.for('pixijs.RendererInitHook');
+
 declare global
 {
     /* eslint-disable no-var */
@@ -20,6 +23,22 @@ declare global
  */
 export class ApplicationInitHook
 {
+    /**
+     * Type symbol used to identify instances of ApplicationInitHook.
+     * @internal
+     */
+    public readonly [typeSymbolApplicationInitHook] = true;
+
+    /**
+     * Checks if the given object is a ApplicationInitHook.
+     * @param obj - The object to check.
+     * @returns True if the object is a ApplicationInitHook, false otherwise.
+     */
+    public static isApplicationInitHook(obj: any): obj is ApplicationInitHook
+    {
+        return !!obj && !!obj[typeSymbolApplicationInitHook];
+    }
+
     /** @ignore */
     public static extension: ExtensionMetadata = ExtensionType.Application;
     public static init(): void
@@ -39,6 +58,22 @@ export class ApplicationInitHook
  */
 export class RendererInitHook implements System
 {
+    /**
+     * Type symbol used to identify instances of RendererInitHook.
+     * @internal
+     */
+    public readonly [typeSymbolRendererInitHook] = true;
+
+    /**
+     * Checks if the given object is a RendererInitHook.
+     * @param obj - The object to check.
+     * @returns True if the object is a RendererInitHook, false otherwise.
+     */
+    public static isRendererInitHook(obj: any): obj is RendererInitHook
+    {
+        return !!obj && !!obj[typeSymbolRendererInitHook];
+    }
+
     /** @ignore */
     public static extension = {
         type: [

--- a/src/utils/logging/logScene.ts
+++ b/src/utils/logging/logScene.ts
@@ -44,7 +44,7 @@ export function logScene(container: Container, depth = 0, data: {color?: string}
 
     let label = container.label;
 
-    if (!label && container instanceof Sprite)
+    if (!label && Sprite.isSprite(container))
     {
         label = `sprite:${container.texture.label}`;
     }

--- a/src/utils/misc/Transform.ts
+++ b/src/utils/misc/Transform.ts
@@ -3,6 +3,8 @@ import { ObservablePoint } from '../../maths/point/ObservablePoint';
 
 import type { Observer } from '../../maths/point/ObservablePoint';
 
+const typeSymbol = Symbol.for('pixijs.Transform');
+
 /**
  * Options for the {@link Transform} constructor.
  * @category utils
@@ -51,6 +53,22 @@ export interface TransformOptions
  */
 export class Transform
 {
+    /**
+     * Type symbol used to identify instances of Transform.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Transform.
+     * @param obj - The object to check.
+     * @returns True if the object is a Transform, false otherwise.
+     */
+    public static isTransform(obj: any): obj is Transform
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * The local transformation matrix.
      * @internal

--- a/src/utils/pool/Pool.ts
+++ b/src/utils/pool/Pool.ts
@@ -1,3 +1,5 @@
+const typeSymbol = Symbol.for('Pool');
+
 /**
  * A generic class for managing a pool of items.
  * @template T The type of items in the pool. Must implement {@link PoolItem}.
@@ -6,6 +8,22 @@
  */
 export class Pool<T extends PoolItem>
 {
+    /**
+     * Type symbol used to identify instances of Pool.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a Pool.
+     * @param obj - The object to check.
+     * @returns True if the object is a Pool, false otherwise.
+     */
+    public static isPool(obj: any): obj is Pool<any>
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /** @internal */
     public readonly _classType: PoolItemConstructor<T>;
     private readonly _pool: T[] = [];

--- a/src/utils/pool/PoolGroup.ts
+++ b/src/utils/pool/PoolGroup.ts
@@ -2,6 +2,8 @@ import { Pool } from './Pool';
 
 import type { PoolItem, PoolItemConstructor } from './Pool';
 
+const typeSymbol = Symbol.for('PoolGroupClass');
+
 /**
  * A type alias for a constructor of a Pool.
  * @template T The type of items in the pool. Must extend PoolItem.
@@ -17,6 +19,22 @@ export type PoolConstructor<T extends PoolItem> = new () => Pool<T>;
  */
 export class PoolGroupClass
 {
+    /**
+     * Type symbol used to identify instances of PoolGroupClass.
+     * @internal
+     */
+    public readonly [typeSymbol] = true;
+
+    /**
+     * Checks if the given object is a PoolGroupClass.
+     * @param obj - The object to check.
+     * @returns True if the object is a PoolGroupClass, false otherwise.
+     */
+    public static isPoolGroupClass(obj: any): obj is PoolGroupClass
+    {
+        return !!obj && !!obj[typeSymbol];
+    }
+
     /**
      * A map to store the pools by their class type.
      * @private


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Originated from https://github.com/pixijs/pixi-react/pull/621

The `instanceof` operator does not work across JS realms (aka a pop-out window). I have based my changes on https://jakearchibald.com/2017/arrays-symbols-realms/.

This involves a lot of repetitive code, so I was hoping I could do this using a TypeScript decorator or a build plugin, but both would cause the `is<Class>` method to not appear in the type definition from what I could tell.

##### TODO
- [x] Replace all `instanceof` usages for pixi.js classes
- [ ] Replace all `instanceof` usages for built-in classes
- [ ] Create a test that fails on the `main` branch and ensure it passes for this PR

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
