### PR TITLE
fix: destroy texture during ViewSystem cleanup to prevent resource leaks

### DIFF
--- a/src/rendering/renderers/shared/view/ViewSystem.ts
+++ b/src/rendering/renderers/shared/view/ViewSystem.ts
@@ -217,6 +217,8 @@ export class ViewSystem implements System<ViewSystemOptions, TypeOrBool<ViewSyst
             this.canvas.parentNode.removeChild(this.canvas);
         }
 
+        this.texture.destroy();
+
         // note: don't nullify the element
         //       other systems may need to unbind from it during the destroy iteration (eg. GLContextSystem)
     }


### PR DESCRIPTION
##### Description of change
Fixes: #11592
Texture in ViewSystem retains the detached canvas from being collected by GC.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
