### PR TITLE
fix: reset bounds dirty flag in GraphicsContext to prevent recalculations on each access

### DIFF
--- a/src/scene/graphics/shared/GraphicsContext.ts
+++ b/src/scene/graphics/shared/GraphicsContext.ts
@@ -1072,6 +1072,8 @@ export class GraphicsContext extends EventEmitter<{
     {
         if (!this._boundsDirty) return this._bounds;
 
+        this._boundsDirty = false;
+
         // TODO switch to idy dirty with tick..
         const bounds = this._bounds;
 


### PR DESCRIPTION
##### Description of change
Currently, every attempt to access the Graphics(GraphicsContext) boundaries causes them to be recalculated, regardless of whether the content has changed.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
