### PR TITLE
feat: suppression and colorization options for deprecation message

### DIFF
--- a/src/scene/sprite-tiling/TilingSprite.ts
+++ b/src/scene/sprite-tiling/TilingSprite.ts
@@ -2,7 +2,6 @@ import { Cache } from '../../assets/cache/Cache';
 import { ObservablePoint } from '../../maths/point/ObservablePoint';
 import { Texture } from '../../rendering/renderers/shared/texture/Texture';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
-import { warn } from '../../utils/logging/warn';
 import { Transform } from '../../utils/misc/Transform';
 import { ViewContainer, type ViewContainerOptions } from '../view/ViewContainer';
 import { type TilingSpriteGpuData } from './TilingSpritePipe';
@@ -310,14 +309,14 @@ export class TilingSprite extends ViewContainer<TilingSpriteGpuData> implements 
      */
     public get uvRespectAnchor(): boolean
     {
-        warn('uvRespectAnchor is deprecated, please use applyAnchorToTexture instead');
+        deprecation(v8_0_0, 'uvRespectAnchor is deprecated, please use applyAnchorToTexture instead');
 
         return this.applyAnchorToTexture;
     }
     /** @advanced */
     public set uvRespectAnchor(value: boolean)
     {
-        warn('uvRespectAnchor is deprecated, please use applyAnchorToTexture instead');
+        deprecation(v8_0_0, 'uvRespectAnchor is deprecated, please use applyAnchorToTexture instead');
         this.applyAnchorToTexture = value;
     }
 

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -32,7 +32,7 @@ interface DeprecationOptions
      * @default true
      * @standard
      */
-    colorful: boolean;
+    noColor: boolean;
 }
 
 /** @internal */
@@ -40,7 +40,7 @@ export type DeprecationFn = ((version: string, message: string, ignoreDepth?: nu
 
 const deprecationState: DeprecationOptions = {
     quiet: false,
-    colorful: true
+    noColor: true
 };
 
 /**
@@ -73,7 +73,7 @@ export const deprecation: DeprecationFn = ((version: string, message: string, ig
     let stack = new Error().stack;
 
     const deprecationMessage = `${message}\nDeprecated since v${version}`;
-    const useGroup = typeof console.groupCollapsed === 'function' && deprecationState.colorful;
+    const useGroup = typeof console.groupCollapsed === 'function' && deprecationState.noColor;
 
     // Handle IE < 10 and Safari < 6
     if (typeof stack === 'undefined')
@@ -117,13 +117,13 @@ Object.defineProperties(deprecation, {
         enumerable: true,
         configurable: false
     },
-    colorful: {
-        get: () => deprecationState.colorful,
+    noColor: {
+        get: () => deprecationState.noColor,
         set: (value: boolean) =>
         {
-            deprecationState.colorful = value;
+            deprecationState.noColor = value;
         },
         enumerable: true,
         configurable: false
     }
-});
+} satisfies {[key in keyof DeprecationOptions]: PropertyDescriptor});

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -22,14 +22,16 @@ export const v8_3_4 = '8.3.4';
 interface DeprecationOptions
 {
     /**
-     * Indicates whether deprecation messages must be suppressed.
+     * When set to true, all deprecation warning messages will be hidden.
+     * Use this if you want to silence deprecation notifications.
      * @default false
      * @standard
      */
     quiet: boolean;
     /**
-     * Indicates whether deprecation messages should be formatted with colors or as plain text.
-     * @default true
+     * When set to true, deprecation messages will be displayed as plain text without color formatting.
+     * Use this if you want to disable colored console output for deprecation warnings.
+     * @default false
      * @standard
      */
     noColor: boolean;

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -56,7 +56,7 @@ const deprecationState: DeprecationOptions = {
  * deprecation.quiet = true;
  *
  * // Put plain text to console instead of colorful messages
- * deprecation.colorful = false;
+ * deprecation.noColor = true;
  * ```
  * @category utils
  * @ignore

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -1,7 +1,5 @@
-import type { Dict } from '../types';
-
-// A map of warning messages already fired
-const warnings: Dict<boolean> = {};
+// A set of warning messages already fired
+const warnings: Set<string> = new Set();
 
 /**
  * deprecation name for version 8.0.0
@@ -17,9 +15,47 @@ export const v8_0_0 = '8.0.0';
 export const v8_3_4 = '8.3.4';
 
 /**
+ * Options for managing deprecation messages behavior globally
+ * @category utils
+ * @standard
+ */
+interface DeprecationOptions
+{
+    /**
+     * Indicates whether deprecation messages must be suppressed.
+     * @default false
+     * @standard
+     */
+    quiet: boolean;
+    /**
+     * Indicates whether deprecation messages should be formatted with colors or as plain text.
+     * @default true
+     * @standard
+     */
+    colorful: boolean;
+}
+
+/** @internal */
+export type DeprecationFn = ((version: string, message: string, ignoreDepth?: number) => void) & DeprecationOptions;
+
+const deprecationState: DeprecationOptions = {
+    quiet: false,
+    colorful: true
+};
+
+/**
  * Helper for warning developers about deprecated features & settings.
  * A stack track for warnings is given; useful for tracking-down where
  * deprecated methods/properties/classes are being used within the code.
+ *
+ * Deprecation messages can be configured globally:
+ * ```ts
+ * // Suppress all deprecation messages
+ * deprecation.quiet = true;
+ *
+ * // Put plain text to console instead of colorful messages
+ * deprecation.colorful = false;
+ * ```
  * @category utils
  * @ignore
  * @function deprecation
@@ -28,45 +64,66 @@ export const v8_3_4 = '8.3.4';
  * @param {number} [ignoreDepth=3] - The number of steps to ignore at the top of the error stack
  *        this is mostly to ignore internal deprecation calls.
  */
-export function deprecation(version: string, message: string, ignoreDepth = 3): void
+export const deprecation: DeprecationFn = ((version: string, message: string, ignoreDepth: number = 3) =>
 {
-    // Ignore duplicate
-    if (warnings[message])
-    {
-        return;
-    }
+    // Suppress if is in quiet mode and ignore duplicate
+    if (deprecationState.quiet || warnings.has(message)) return;
 
     /* eslint-disable no-console */
     let stack = new Error().stack;
 
+    const deprecationMessage = `${message}\nDeprecated since v${version}`;
+    const useGroup = typeof console.groupCollapsed === 'function' && deprecationState.colorful;
+
     // Handle IE < 10 and Safari < 6
     if (typeof stack === 'undefined')
     {
-        console.warn('PixiJS Deprecation Warning: ', `${message}\nDeprecated since v${version}`);
+        console.warn('PixiJS Deprecation Warning: ', deprecationMessage);
     }
     else
     {
         // chop off the stack trace which includes PixiJS internal calls
         stack = stack.split('\n').splice(ignoreDepth).join('\n');
 
-        if (console.groupCollapsed)
+        if (useGroup)
         {
             console.groupCollapsed(
                 '%cPixiJS Deprecation Warning: %c%s',
                 'color:#614108;background:#fffbe6',
                 'font-weight:normal;color:#614108;background:#fffbe6',
-                `${message}\nDeprecated since v${version}`
+                deprecationMessage
             );
             console.warn(stack);
             console.groupEnd();
         }
         else
         {
-            console.warn('PixiJS Deprecation Warning: ', `${message}\nDeprecated since v${version}`);
+            console.warn('PixiJS Deprecation Warning: ', deprecationMessage);
             console.warn(stack);
         }
     }
     /* eslint-enable no-console */
 
-    warnings[message] = true;
-}
+    warnings.add(message);
+}) as DeprecationFn;
+
+Object.defineProperties(deprecation, {
+    quiet: {
+        get: () => deprecationState.quiet,
+        set: (value: boolean) =>
+        {
+            deprecationState.quiet = value;
+        },
+        enumerable: true,
+        configurable: false
+    },
+    colorful: {
+        get: () => deprecationState.colorful,
+        set: (value: boolean) =>
+        {
+            deprecationState.colorful = value;
+        },
+        enumerable: true,
+        configurable: false
+    }
+});

--- a/src/utils/logging/deprecation.ts
+++ b/src/utils/logging/deprecation.ts
@@ -42,7 +42,7 @@ export type DeprecationFn = ((version: string, message: string, ignoreDepth?: nu
 
 const deprecationState: DeprecationOptions = {
     quiet: false,
-    noColor: true
+    noColor: false
 };
 
 /**
@@ -75,7 +75,7 @@ export const deprecation: DeprecationFn = ((version: string, message: string, ig
     let stack = new Error().stack;
 
     const deprecationMessage = `${message}\nDeprecated since v${version}`;
-    const useGroup = typeof console.groupCollapsed === 'function' && deprecationState.noColor;
+    const useGroup = typeof console.groupCollapsed === 'function' && !deprecationState.noColor;
 
     // Handle IE < 10 and Safari < 6
     if (typeof stack === 'undefined')


### PR DESCRIPTION
##### Description of change
Fixes: #9491, #10216

- Added `quiet` and `noColor` options to control global deprecation message behavior for more flexible usage.
- Replaced `warn` method with `deprecation` in `TilingSprite`.

I chose names `quiet` and `noColor` instead of `silence` and `simple` (suggested in the issue), just because they are pretty common in software development (especially in CLI).  

Introduced API:
```ts
import { deprecation } from 'pixi.js';
// Supresses deprecation warnings
deprecation.quiet = true;
// Removes color formatting from deprecation messages
deprecation.noColor = true;
```

##### Pre-Merge Checklist
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)