### PR TITLE
chore: conditionally disable StackBlitz publish workflow on non-origin repositories

### DIFF
--- a/.github/workflows/stack-blitz-publish.yaml
+++ b/.github/workflows/stack-blitz-publish.yaml
@@ -8,6 +8,8 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'pixijs/pixijs'
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
##### Description of change
Just a minor fix that prevents publishing to StackBlitz in any fork repository.