### PR TITLE
Feat: Adds gl2D file format support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,22 @@ export default tseslint.config(
             },
         },
         rules: {
+            camelcase: [
+                'error',
+                {
+                    ignoreDestructuring: true,
+                    ignoreImports: true,
+                    allow: [
+                        'pixi_container_node',
+                        'pixi_sprite_node',
+                        'pixi_texture_resource',
+                        'pixi_texture_source_resource',
+                        'pixi_video_source_resource',
+                        'v8_0_0',
+                        'v8_3_4'
+                    ],
+                },
+            ],
             'no-mixed-operators': 'off',
             'no-mixed-operators/no-mixed-operators': 1,
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "./lib/spritesheet/init.*",
     "./lib/rendering/renderers/shared/texture/utils/textureFrom.*",
     "./lib/gif/init.*",
+    "./lib/gl2d/init.*",
     "./lib/accessibility/init.*",
     "./lib/advanced-blend-modes/init.*",
     "./lib/app/init.*",
@@ -254,6 +255,16 @@
       "require": {
         "types": "./lib/gif/init.d.ts",
         "default": "./lib/gif/init.js"
+      }
+    },
+    "./gl2d": {
+      "import": {
+        "types": "./lib/gl2d/init.d.ts",
+        "default": "./lib/gl2d/init.mjs"
+      },
+      "require": {
+        "types": "./lib/gl2d/init.d.ts",
+        "default": "./lib/gl2d/init.js"
       }
     },
     "./accessibility": {

--- a/scripts/utils/exports.ts
+++ b/scripts/utils/exports.ts
@@ -77,6 +77,16 @@ const exportFields: Record<string, ExportField> = {
             default: './lib/gif/init.js',
         },
     },
+    './gl2d': {
+        import: {
+            types: './lib/gl2d/init.d.ts',
+            default: './lib/gl2d/init.mjs',
+        },
+        require: {
+            types: './lib/gl2d/init.d.ts',
+            default: './lib/gl2d/init.js',
+        },
+    },
 };
 const sideEffects = [
     './lib/environment-browser/browserAll.*',
@@ -86,6 +96,7 @@ const sideEffects = [
     './lib/spritesheet/init.*',
     './lib/rendering/renderers/shared/texture/utils/textureFrom.*',
     './lib/gif/init.*',
+    './lib/gl2d/init.*',
 ];
 
 for (const [name, path] of subImports)

--- a/src/assets/loader/parsers/textures/loadTextures.ts
+++ b/src/assets/loader/parsers/textures/loadTextures.ts
@@ -163,6 +163,7 @@ export const loadTextures: LoaderParser<Texture, TextureSourceOptions, LoadTextu
 
         const base = new ImageSource({
             resource: src,
+            uri: asset.src,
             alphaMode: 'premultiply-alpha-on-upload',
             resolution: asset.data?.resolution || getResolutionOfUrl(url),
             ...asset.data,

--- a/src/assets/loader/parsers/textures/loadVideoTextures.ts
+++ b/src/assets/loader/parsers/textures/loadVideoTextures.ts
@@ -256,7 +256,7 @@ export const loadVideoTextures = {
         {
             const onCanPlay = async () =>
             {
-                const base = new VideoSource({ ...options, resource: videoElement });
+                const base = new VideoSource({ ...options, resource: videoElement, uri: asset.src });
 
                 videoElement.removeEventListener('canplay', onCanPlay);
 

--- a/src/gl2d/__docs__/gl2D-spec.md
+++ b/src/gl2d/__docs__/gl2D-spec.md
@@ -1,0 +1,593 @@
+# gl2D File Format Specification
+
+## 1. Introduction
+
+The **gl2D file format** is a JSON-based scene description format designed for 2D rendering engines. It provides a structured way to describe:
+
+- **Scenes** (collections of nodes)
+- **Nodes** (containers, sprites, etc.)
+- **Resources** (textures, images, videos, fonts, etc.)
+- **Extensions** (engine-specific metadata)
+
+gl2D is inspired by **glTF** but tailored for **2D graphics**, focusing on lightweight serialization, hierarchical scene graphs, and efficient resource referencing.
+
+---
+
+## 2. File Structure Overview
+
+A gl2D file is a single JSON object with the following top-level structure:
+
+```json
+{
+  "asset": { ... },
+  "scene": 0,
+  "scenes": [ ... ],
+  "nodes": [ ... ],
+  "resources": [ ... ],
+  "extensionsUsed": [],
+  "extensionsRequired": []
+}
+```
+
+| Name               | Type   | Description                   | Required |
+| ------------------ | ------ | ----------------------------- | -------- |
+| asset              | object | Metadata about the gl2D asset | ✅ Yes   |
+| scene              | number | Index of the default scene    | No       |
+| scenes             | array  | Array of scene definitions    | No       |
+| nodes              | array  | Array of node definitions     | No       |
+| resources          | array  | Array of resource definitions | No       |
+| extensionsUsed     | array  | List of used extensions       | No       |
+| extensionsRequired | array  | List of required extensions   | No       |
+
+---
+
+## 3. Asset Metadata
+
+The `asset` object describes the generator and versioning:
+
+```json
+"asset": {
+  "version": "1.0",
+  "generator": "PixiJS",
+  "minVersion": "1.0"
+}
+```
+
+| Name       | Type   | Description                        | Required |
+| ---------- | ------ | ---------------------------------- | -------- |
+| version    | string | GL2D spec version (e.g., `"1.0"`)  | ✅ Yes   |
+| generator  | string | Tool/library that created the file | No       |
+| minVersion | string | Minimum GL2D version required      | No       |
+
+---
+
+## 4. Scenes
+
+A **scene** is a collection of root nodes. Multiple scenes can exist in one file (e.g., menu, gameplay, credits).
+The default `scene` is the first one defined in the `scenes` array.
+
+```json
+"scenes": [
+  {
+    "name": "MainScene",
+    "nodes": [0, 1]
+  }
+],
+"scene": 0
+```
+
+| Name  | Type     | Description                             | Required |
+| ----- | -------- | --------------------------------------- | -------- |
+| name  | string   | Human-readable name of the scene        | ✅ Yes   |
+| nodes | number[] | Indices into the global `nodes[]` array | ✅ Yes   |
+
+---
+
+## 5. Nodes
+
+Nodes are the **building blocks** of a gl2D scene. They represent containers, sprites, or other visual elements.
+
+### 5.1 Container Node
+
+Groups other nodes, applies hierarchical transforms.
+
+```json
+{
+    "type": "container",
+    "name": "Player",
+    "children": [1],
+    "translation": [200, 150],
+    "rotation": 0.5,
+    "scale": [1, 1],
+    "alpha": 1,
+    "visible": true
+}
+```
+
+| Name        | Type                                             | Description                                 | Required |
+| ----------- | ------------------------------------------------ | ------------------------------------------- | -------- |
+| type        | string                                           | Node type (`"container"`, `"sprite"`, etc.) | ✅ Yes   |
+| uid         | string                                           | Unique identifier                           | No       |
+| name        | string                                           | Human-readable name                         | No       |
+| children    | number[]                                         | Indices of child nodes                      | No       |
+| translation | [number, number]                                 | Position `[x, y]`                           | No       |
+| rotation    | number                                           | Rotation in radians                         | No       |
+| scale       | [number, number]                                 | Scale `[x, y]`                              | No       |
+| matrix      | [number, number, number, number, number, number] | Transformation matrix override              | No       |
+| width       | number                                           | Explicit width override                     | No       |
+| height      | number                                           | Explicit height override                    | No       |
+| blendMode   | enum                                             | Blend mode (normal, multiply, etc.)         | No       |
+| tint        | number                                           | Color tint (0xRRGGBB)                       | No       |
+| alpha       | number                                           | Opacity (0.0–1.0)                           | No       |
+| visible     | boolean                                          | Whether the node is visible                 | No       |
+
+#### PixiJS Container Extension
+
+```json
+{
+    "extensions": {
+        "pixi_container_node": {
+            "skew": [0, 0],
+            "pivot": [0, 0],
+            "origin": [0.5, 0.5],
+            "zIndex": 1,
+            "renderable": true,
+            "sortableChildren": true
+        }
+    }
+}
+```
+
+| Name             | Type             | Description                            | Required |
+| ---------------- | ---------------- | -------------------------------------- | -------- |
+| skew             | [number, number] | Skew in radians `[x, y]`               | No       |
+| pivot            | [number, number] | Pivot point in pixels `[x, y]`         | No       |
+| origin           | [number, number] | Origin point in pixels `[x, y]`        | No       |
+| anchor           | [number, number] | Anchor point (normalized `[0–1, 0–1]`) | No       |
+| zIndex           | number           | Depth sorting order                    | No       |
+| isRenderGroup    | boolean          | Treat as render group                  | No       |
+| renderable       | boolean          | Whether node is rendered               | No       |
+| boundsArea       | number[]         | Cached bounds area                     | No       |
+| sortableChildren | boolean          | Auto-sort children by zIndex           | No       |
+
+### 5.2 Sprite Node
+
+Represents a texture based drawable element.
+
+```json
+{
+    "type": "sprite",
+    "texture": 0
+}
+```
+
+| Name    | Type     | Description                                            | Required |
+| ------- | -------- | ------------------------------------------------------ | -------- |
+| type    | "sprite" | Node type "sprite"                                     | ✅ Yes   |
+| texture | number   | Indices of the texture resource in the resources array | ✅ Yes   |
+
+#### PixiJS Sprite Extension
+
+```json
+{
+    "extensions": {
+        "pixi_sprite_node": {
+            "roundPixels": true
+        }
+    }
+}
+```
+
+| Name        | Type    | Description                                 | Required |
+| ----------- | ------- | ------------------------------------------- | -------- |
+| roundPixels | boolean | Whether to round pixel values for rendering | No       |
+
+---
+
+## 6. Resources
+
+Resources define **textures, images, videos, and other assets**.
+
+### 6.1 Base Resource
+
+```json
+{
+    "type": "texture",
+    "uid": "heroTexture",
+    "name": "Hero",
+    "uri": "/textures/hero.png"
+}
+```
+
+| Name | Type   | Description                                         | Required |
+| ---- | ------ | --------------------------------------------------- | -------- |
+| type | string | Resource type (`"texture"`, `"image_source"`, etc.) | ✅ Yes   |
+| uid  | string | Unique identifier                                   | No       |
+| name | string | Human-readable name                                 | No       |
+| uri  | string | Path/URL/data URI to the resource                   | No       |
+
+### 6.2 Texture
+
+A texture resource is a specialized type of resource that represents a portion of a texture source.
+Therefore all texture resources must have a `source` assigned to them, which can be loaded by the engine.
+
+```json
+{
+    "type": "texture",
+    "source": 0,
+    "frame": [0, 0, 64, 64]
+}
+```
+
+| Name   | Type      | Description                                 | Required |
+| ------ | --------- | ------------------------------------------- | -------- |
+| type   | string    | `"texture"`                                 | ✅ Yes   |
+| source | number    | Index into `resources[]` for texture source | ✅ Yes   |
+| frame  | [x,y,w,h] | Rectangle frame of the texture              | No       |
+
+#### PixiJS Texture Extension
+
+```json
+{
+    "extensions": {
+        "pixi_texture_resource": {
+            "orig": [0, 0, 64, 64],
+            "trim": [0, 0, 64, 64],
+            "defaultAnchor": [0.5, 0.5],
+            "defaultBorders": [0, 0, 0, 0],
+            "rotate": 0,
+            "dynamic": false
+        }
+    }
+}
+```
+
+| Name           | Type                       | Description                                              | Required |
+| -------------- | -------------------------- | -------------------------------------------------------- | -------- |
+| orig           | [x,y,w,h]                  | Original rectangle of the texture                        | No       |
+| trim           | [x,y,w,h]                  | Trimmed rectangle of the texture                         | No       |
+| defaultAnchor  | [x,y]                      | Default anchor point of the texture                      | No       |
+| defaultBorders | [left, top, right, bottom] | Default borders of the texture                           | No       |
+| rotate         | number                     | Indicates how the texture was rotated by texture packer. | No       |
+| dynamic        | boolean                    | Whether the texture is dynamic                           | No       |
+
+### 6.3 Texture Source
+
+There are many types of texture sources, including images, videos, buffers etc.
+
+```json
+{
+    "type": "texture_source",
+    "uid": "unique-id",
+    "name": "Texture Name",
+    "uri": "/textures/hero.png",
+    "width": 256,
+    "height": 256,
+    "resolution": 1,
+    "format": "RGBA",
+    "antialias": true,
+    "alphaMode": "premultiplied",
+    "addressMode": "repeat",
+    "addressModeU": "repeat",
+    "addressModeV": "repeat",
+    "addressModeW": "repeat",
+    "scaleMode": "linear",
+    "magFilter": "linear",
+    "minFilter": "linear",
+    "mipmapFilter": "linear",
+    "lodMinClamp": 0,
+    "lodMaxClamp": 100
+}
+```
+
+| Name         | Type    | Description                                                                     | Required |
+| ------------ | ------- | ------------------------------------------------------------------------------- | -------- |
+| type         | string  | Discriminator for the resource type (e.g., `"image_source"`, `"video_source"`)  | ✅ Yes   |
+| uid          | string  | Unique identifier for the resource                                              | No       |
+| name         | string  | Human-readable name                                                             | No       |
+| uri          | string  | Path/URL/data URI to the resource                                               | No       |
+| width        | number  | Pixel width of the texture source (real pixel size, not resolution-scaled)      | No       |
+| height       | number  | Pixel height of the texture source                                              | No       |
+| resolution   | number  | Resolution scale factor (e.g., `2` for @2x assets)                              | No       |
+| format       | string  | Texture format (from `Texture Formats`)                                         | No       |
+| antialias    | boolean | Whether to use antialiasing (mainly for render textures)                        | No       |
+| alphaMode    | string  | Alpha mode (from `Alpha Modes`)                                                 | No       |
+| addressMode  | string  | Sets wrap mode for U, V, and W simultaneously (from `Wrap Modes`)               | No       |
+| addressModeU | string  | Wrap mode for U (width) coordinate (from `Wrap Modes`)                          | No       |
+| addressModeV | string  | Wrap mode for V (height) coordinate (from `Wrap Modes`)                         | No       |
+| addressModeW | string  | Wrap mode for W (depth) coordinate (from `Wrap Modes`)                          | No       |
+| scaleMode    | string  | Sets magFilter, minFilter, and mipmapFilter simultaneously (from `Scale Modes`) | No       |
+| magFilter    | string  | Sampling behavior when footprint ≤ 1 texel (from `Scale Modes`)                 | No       |
+| minFilter    | string  | Sampling behavior when footprint > 1 texel (from `Scale Modes`)                 | No       |
+| mipmapFilter | string  | Sampling behavior between mipmap levels (from `Scale Modes`)                    | No       |
+| lodMinClamp  | number  | Minimum level of detail clamp                                                   | No       |
+| lodMaxClamp  | number  | Maximum level of detail clamp                                                   | No       |
+
+#### Pixi Texture Source Extension
+
+```json
+{
+    "extensions": {
+        "pixi_texture_source_resource": {
+            "dimensions": "2d",
+            "mipLevelCount": 1,
+            "autoGenerateMipmaps": true,
+            "autoGarbageCollect": false,
+            "compare": "less-equal",
+            "maxAnisotropy": 1
+        }
+    }
+}
+```
+
+| Name                | Type    | Description                                                                   | Required |
+| ------------------- | ------- | ----------------------------------------------------------------------------- | -------- |
+| dimensions          | string  | How many dimensions this texture has (from Texture Dimensions)                | No       |
+| mipLevelCount       | number  | Number of mip levels to generate                                              | No       |
+| autoGenerateMipmaps | boolean | Whether to automatically generate mipmaps                                     | No       |
+| autoGarbageCollect  | boolean | If true, GC may unload this texture when unused                               | No       |
+| compare             | string  | Creates a comparison sampler using the given function (from Compare Function) | No       |
+| maxAnisotropy       | number  | Maximum anisotropy clamp used by the sampler                                  | No       |
+
+#### Texture Dimensions
+
+| Value | Description | Required |
+| ----- | ----------- | -------- |
+| '1d'  | 1D texture  | No       |
+| '2d'  | 2D texture  | No       |
+| '3d'  | 3D texture  | No       |
+
+#### Compare Function
+
+| Value           | Description             | Required |
+| --------------- | ----------------------- | -------- |
+| 'never'         | Comparison always false | No       |
+| 'less'          | Pass if src < dst       | No       |
+| 'equal'         | Pass if src == dst      | No       |
+| 'less-equal'    | Pass if src <= dst      | No       |
+| 'greater'       | Pass if src > dst       | No       |
+| 'not-equal'     | Pass if src != dst      | No       |
+| 'greater-equal' | Pass if src >= dst      | No       |
+| 'always'        | Comparison always true  | No       |
+
+#### Alpha Modes
+
+| Name                          | Description                    | Required |
+| ----------------------------- | ------------------------------ | -------- |
+| 'no-premultiply-alpha'        | No premultiplication on upload | No       |
+| 'premultiply-alpha-on-upload' | Premultiply on upload          | No       |
+| 'premultiplied-alpha'         | Premultiplied alpha            | No       |
+
+#### Wrap Modes
+
+| Name     | Description        | Required |
+| -------- | ------------------ | -------- |
+| 'repeat' | Repeat the texture | No       |
+| 'clamp'  | Clamp the texture  | No       |
+| 'mirror' | Mirror the texture | No       |
+
+#### Scale Modes
+
+| Name      | Description              | Required |
+| --------- | ------------------------ | -------- |
+| 'linear'  | Linear scaling           | No       |
+| 'nearest' | Nearest neighbor scaling | No       |
+
+#### Texture Formats
+
+| Format                | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| r8unorm               | 8-bit unsigned normalized R                           |
+| r8snorm               | 8-bit signed normalized R                             |
+| r8uint                | 8-bit unsigned integer R                              |
+| r8sint                | 8-bit signed integer R                                |
+| r16uint               | 16-bit unsigned integer R                             |
+| r16sint               | 16-bit signed integer R                               |
+| r16float              | 16-bit floating-point R                               |
+| rg8unorm              | 8-bit unsigned normalized RG                          |
+| rg8snorm              | 8-bit signed normalized RG                            |
+| rg8uint               | 8-bit unsigned integer RG                             |
+| rg8sint               | 8-bit signed integer RG                               |
+| r32uint               | 32-bit unsigned integer R                             |
+| r32sint               | 32-bit signed integer R                               |
+| r32float              | 32-bit floating-point R                               |
+| rg16uint              | 16-bit unsigned integer RG                            |
+| rg16sint              | 16-bit signed integer RG                              |
+| rg16float             | 16-bit floating-point RG                              |
+| rgba8unorm            | 8-bit unsigned normalized RGBA                        |
+| rgba8unorm-srgb       | 8-bit unsigned normalized RGBA (sRGB)                 |
+| rgba8snorm            | 8-bit signed normalized RGBA                          |
+| rgba8uint             | 8-bit unsigned integer RGBA                           |
+| rgba8sint             | 8-bit signed integer RGBA                             |
+| bgra8unorm            | 8-bit unsigned normalized BGRA                        |
+| bgra8unorm-srgb       | 8-bit unsigned normalized BGRA (sRGB)                 |
+| rgb9e5ufloat          | Packed RGB with shared 5-bit exponent (HDR)           |
+| rgb10a2unorm          | 10-bit RGB + 2-bit A unsigned normalized              |
+| rg11b10ufloat         | Packed 11-bit R/G + 10-bit B unsigned float (HDR)     |
+| rg32uint              | 32-bit unsigned integer RG                            |
+| rg32sint              | 32-bit signed integer RG                              |
+| rg32float             | 32-bit floating-point RG                              |
+| rgba16uint            | 16-bit unsigned integer RGBA                          |
+| rgba16sint            | 16-bit signed integer RGBA                            |
+| rgba16float           | 16-bit floating-point RGBA                            |
+| rgba32uint            | 32-bit unsigned integer RGBA                          |
+| rgba32sint            | 32-bit signed integer RGBA                            |
+| rgba32float           | 32-bit floating-point RGBA                            |
+| stencil8              | 8-bit stencil                                         |
+| depth16unorm          | 16-bit unsigned normalized depth                      |
+| depth24plus           | 24+ bit depth (implementation-defined)                |
+| depth24plus-stencil8  | 24+ bit depth + 8-bit stencil                         |
+| depth32float          | 32-bit floating-point depth                           |
+| depth32float-stencil8 | 32-bit floating-point depth + 8-bit stencil           |
+| bc1-rgba-unorm        | BC1/DXT1 compressed RGBA unsigned normalized          |
+| bc1-rgba-unorm-srgb   | BC1/DXT1 compressed RGBA (sRGB)                       |
+| bc2-rgba-unorm        | BC2/DXT3 compressed RGBA unsigned normalized          |
+| bc2-rgba-unorm-srgb   | BC2/DXT3 compressed RGBA (sRGB)                       |
+| bc3-rgba-unorm        | BC3/DXT5 compressed RGBA unsigned normalized          |
+| bc3-rgba-unorm-srgb   | BC3/DXT5 compressed RGBA (sRGB)                       |
+| bc4-r-unorm           | BC4 compressed R unsigned normalized                  |
+| bc4-r-snorm           | BC4 compressed R signed normalized                    |
+| bc5-rg-unorm          | BC5 compressed RG unsigned normalized                 |
+| bc5-rg-snorm          | BC5 compressed RG signed normalized                   |
+| bc6h-rgb-ufloat       | BC6H compressed RGB unsigned float (HDR)              |
+| bc6h-rgb-float        | BC6H compressed RGB signed float (HDR)                |
+| bc7-rgba-unorm        | BC7 compressed RGBA unsigned normalized               |
+| bc7-rgba-unorm-srgb   | BC7 compressed RGBA (sRGB)                            |
+| etc2-rgb8unorm        | ETC2 compressed RGB 8-bit unsigned normalized         |
+| etc2-rgb8unorm-srgb   | ETC2 compressed RGB 8-bit (sRGB)                      |
+| etc2-rgb8a1unorm      | ETC2 compressed RGB + 1-bit alpha unsigned normalized |
+| etc2-rgb8a1unorm-srgb | ETC2 compressed RGB + 1-bit alpha (sRGB)              |
+| etc2-rgba8unorm       | ETC2 compressed RGBA 8-bit unsigned normalized        |
+| etc2-rgba8unorm-srgb  | ETC2 compressed RGBA 8-bit (sRGB)                     |
+| eac-r11unorm          | EAC compressed R 11-bit unsigned normalized           |
+| eac-r11snorm          | EAC compressed R 11-bit signed normalized             |
+| eac-rg11unorm         | EAC compressed RG 11-bit unsigned normalized          |
+| eac-rg11snorm         | EAC compressed RG 11-bit signed normalized            |
+| astc-4x4-unorm        | ASTC 4x4 block, unsigned normalized                   |
+| astc-4x4-unorm-srgb   | ASTC 4x4 block (sRGB)                                 |
+| astc-5x4-unorm        | ASTC 5x4 block, unsigned normalized                   |
+| astc-5x4-unorm-srgb   | ASTC 5x4 block (sRGB)                                 |
+| astc-5x5-unorm        | ASTC 5x5 block, unsigned normalized                   |
+| astc-5x5-unorm-srgb   | ASTC 5x5 block (sRGB)                                 |
+| astc-6x5-unorm        | ASTC 6x5 block, unsigned normalized                   |
+| astc-6x5-unorm-srgb   | ASTC 6x5 block (sRGB)                                 |
+| astc-6x6-unorm        | ASTC 6x6 block, unsigned normalized                   |
+| astc-6x6-unorm-srgb   | ASTC 6x6 block (sRGB)                                 |
+| astc-8x5-unorm        | ASTC 8x5 block, unsigned normalized                   |
+| astc-8x5-unorm-srgb   | ASTC 8x5 block (sRGB)                                 |
+| astc-8x6-unorm        | ASTC 8x6 block, unsigned normalized                   |
+| astc-8x6-unorm-srgb   | ASTC 8x6 block (sRGB)                                 |
+| astc-8x8-unorm        | ASTC 8x8 block, unsigned normalized                   |
+| astc-8x8-unorm-srgb   | ASTC 8x8 block (sRGB)                                 |
+| astc-10x5-unorm       | ASTC 10x5 block, unsigned normalized                  |
+| astc-10x5-unorm-srgb  | ASTC 10x5 block (sRGB)                                |
+| astc-10x6-unorm       | ASTC 10x6 block, unsigned normalized                  |
+| astc-10x6-unorm-srgb  | ASTC 10x6 block (sRGB)                                |
+| astc-10x8-unorm       | ASTC 10x8 block, unsigned normalized                  |
+| astc-10x8-unorm-srgb  | ASTC 10x8 block (sRGB)                                |
+| astc-10x10-unorm      | ASTC 10x10 block, unsigned normalized                 |
+| astc-10x10-unorm-srgb | ASTC 10x10 block (sRGB)                               |
+| astc-12x10-unorm      | ASTC 12x10 block, unsigned normalized                 |
+| astc-12x10-unorm-srgb | ASTC 12x10 block (sRGB)                               |
+| astc-12x12-unorm      | ASTC 12x12 block, unsigned normalized                 |
+| astc-12x12-unorm-srgb | ASTC 12x12 block (sRGB)                               |
+
+Note: Availability of compressed formats depends on platform features (e.g., texture-compression-bc/etc2/astc).
+
+### 6.3.1 Image Source
+
+Extends TextureSource
+
+An image source represents a 2D image that can be used as a texture.
+
+```json
+{
+    "type": "image_source",
+    "uri": "/textures/hero.png",
+}
+```
+
+### 6.3.2 Video Source
+
+Extends TextureSource
+
+A video source represents a 2D video that can be used as a texture.
+
+```json
+{
+    "type": "video_source",
+    "uri": "/videos/intro.mp4",
+    "autoPlay": true,
+    "loop": true,
+    "autoLoad": true,
+    "crossorigin": "anonymous",
+    "muted": true,
+    "playsinline": true
+}
+```
+
+| Name        | Type           | Description                | Required |
+| ----------- | -------------- | -------------------------- | -------- |
+| type        | string         | `"video_source"`           | ✅ Yes   |
+| uri         | string         | Path/URL to video          | ✅ Yes   |
+| autoLoad    | boolean        | Whether to preload video   | No       |
+| autoPlay    | boolean        | Whether to autoplay video  | No       |
+| crossorigin | string/boolean | Cross-origin attribute     | No       |
+| loop        | boolean        | Whether video loops        | No       |
+| muted       | boolean        | Whether video is muted     | No       |
+| playsinline | boolean        | Whether video plays inline | No       |
+
+---
+
+## 7. Extensions
+
+Extensions allow engines to add **custom metadata**.
+
+- **extensionsUsed**: List of extensions present
+- **extensionsRequired**: List of extensions required to load
+
+Example:
+
+```json
+"extensionsUsed": ["pixi_container_node", "pixi_sprite_node"],
+"extensionsRequired": ["pixi_texture_resource"]
+```
+
+---
+
+## 8. Example Full File
+
+```json
+{
+    "asset": {
+        "version": "1.0",
+        "generator": "PixiJS"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "name": "MainScene",
+            "nodes": [0]
+        }
+    ],
+    "nodes": [
+        {
+            "type": "container",
+            "name": "Root",
+            "children": [1],
+            "translation": [100, 100]
+        },
+        {
+            "type": "sprite",
+            "name": "Hero",
+            "texture": 0,
+            "translation": [50, 0],
+            "extensions": {
+                "pixi_sprite_node": {
+                    "roundPixels": true
+                }
+            }
+        }
+    ],
+    "resources": [
+        {
+            "type": "texture",
+            "source": 0,
+            "extensions": {
+                "pixi_texture_resource": {
+                    "orig": [0, 0, 64, 64],
+                    "trim": [0, 0, 64, 64],
+                    "defaultAnchor": { "x": 0.5, "y": 0.5 },
+                    "rotate": 0,
+                    "dynamic": false
+                }
+            }
+        },
+        {
+            "type": "image_source",
+            "uri": "/textures/hero.png",
+        }
+    ],
+    "extensionsUsed": ["pixi_sprite_node", "pixi_texture_resource"]
+}
+```

--- a/src/gl2d/extensions/nodes.ts
+++ b/src/gl2d/extensions/nodes.ts
@@ -1,0 +1,73 @@
+import { type Gl2DNode, type Gl2DSprite } from '../node';
+
+/**
+ * Represents a PixiJS container node within a GL2D file through an extension.
+ *
+ * Container nodes are used to group other nodes together, allowing for
+ * hierarchical transformations and organization of the scene graph.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DContainer = Gl2DNode<'container', PixiGl2DContainerExtension>;
+
+/**
+ * Extension properties for PixiJS container nodes.
+ * @category gl2d
+ * @standard
+ */
+export interface PixiGl2DContainerExtension
+{
+    /** Unique identifier for the PixiJS container node */
+    pixi_container_node: {
+        /** Skew transformation in radians as [x, y]. Creates parallelogram distortion. Defaults to [0, 0]. */
+        skew: [number, number];
+        /**
+         * Pivot point for rotations and scaling as [x, y] in pixels.
+         * Relative to the node's local bounds. Defaults to [0, 0] (top-left).
+         */
+        pivot: [number, number];
+        /** Origin point for transformations as [x, y] normalized coordinates */
+        origin: [number, number];
+        /**
+         * Anchor point within the node's content as [x, y] normalized coordinates.
+         * [0, 0] = top-left, [0.5, 0.5] = center, [1, 1] = bottom-right.
+         * Primarily used for sprites and text alignment.
+         */
+        anchor?: [number, number];
+
+        /** Depth sorting order - higher values render on top */
+        zIndex: number;
+
+        /** Whether this node should be treated as a render group for optimization */
+        isRenderGroup: boolean;
+
+        /** Whether the node should be included in rendering */
+        renderable: boolean;
+
+        /** Cached bounds area for optimization purposes */
+        boundsArea: number[];
+
+        /** Whether to automatically sort child nodes by their zIndex values */
+        sortableChildren: boolean;
+    };
+}
+
+/**
+ * Represents a PixiJS sprite node within a GL2D file through an extension.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DSprite = Gl2DSprite<PixiGl2DSpriteExtension>;
+
+/**
+ * Extension properties for PixiJS sprite nodes.
+ * @category gl2d
+ * @standard
+ */
+export interface PixiGl2DSpriteExtension extends PixiGl2DContainerExtension
+{
+    pixi_sprite_node?: {
+        /** Whether to round pixel values for crisp rendering */
+        roundPixels: boolean;
+    };
+}

--- a/src/gl2d/extensions/resources.ts
+++ b/src/gl2d/extensions/resources.ts
@@ -1,0 +1,116 @@
+import { type Gl2DImageSource, type Gl2DTexture, type Gl2DTextureSource, type Gl2DVideoSource } from '../resources';
+
+import type { ALPHA_MODES, COMPARE_FUNCTION, TEXTURE_DIMENSIONS } from '../../rendering/renderers/shared/texture/const';
+
+/**
+ * Represents a PixiJS textureResource node within a GL2D file through an extension.
+ *
+ * TextureResource nodes are used to define and manage textures within the GL2D framework.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DTexture = Gl2DTexture<PixiGl2DTextureExtension>;
+
+/**
+ * Extension properties for PixiJS textureResource nodes.
+ * @category gl2d
+ * @standard
+ */
+export interface PixiGl2DTextureExtension
+{
+    /** Unique identifier for the PixiJS textureResource node */
+    pixi_texture_resource: {
+        /** The area of original texture */
+        orig: [number, number, number, number];
+        /** Trimmed rectangle of original texture */
+        trim: [number, number, number, number];
+        /** Default anchor point used for sprite placement / rotation */
+        defaultAnchor: [number, number];
+        /** Default borders used for 9-slice scaling {@link NineSlicePlane}*/
+        defaultBorders: [number, number, number, number];
+        /** indicates how the texture was rotated by texture packer. See {@link groupD8} */
+        rotate: number;
+        /**
+         * Set to true if you plan on modifying this texture's frame, UVs, or swapping its source at runtime.
+         * This is false by default as it improves performance. Generally, it's recommended to create new
+         * textures and swap those rather than modifying an existing texture's properties unless you are
+         * working with a dynamic frames.
+         * Not setting this to true when modifying the texture can lead to visual artifacts.
+         *
+         * If this is false and you modify the texture, you can manually update the sprite's texture by calling
+         * `sprite.onViewUpdate()`.
+         */
+        dynamic: boolean;
+    };
+}
+
+/**
+ * Represents a PixiJS texture source within a GL2D file through an extension.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DTextureSource<T extends string> = Gl2DTextureSource<T, PixiGl2DTextureSourceExtension>;
+
+/**
+ * Extension properties for PixiJS textureSource nodes.
+ * @category gl2d
+ * @standard
+ */
+export interface PixiGl2DTextureSourceExtension
+{
+    /** Unique identifier for the PixiJS textureResource node */
+    pixi_texture_source_resource: {
+        /** how many dimensions does this texture have? currently v8 only supports 2d */
+        dimensions: TEXTURE_DIMENSIONS;
+        /** The number of mip levels to generate for this texture. this is  overridden if autoGenerateMipmaps is true */
+        mipLevelCount: number;
+        /** Whether to automatically generate mipmaps for this texture. */
+        autoGenerateMipmaps: boolean;
+        /** If true, the Garbage Collector will unload this texture if it is not used after a period of time */
+        autoGarbageCollect: boolean;
+
+        /** When provided the sampler will be a comparison sampler with the specified {@link COMPARE_FUNCTION}. */
+        compare: COMPARE_FUNCTION;
+        /** Specifies the maximum anisotropy value clamp used by the sampler. */
+        maxAnisotropy: number;
+    };
+}
+/**
+ * Represents a PixiJS image source within a GL2D file through an extension.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DImageSource = Gl2DImageSource<PixiGl2DImageSourceExtension>;
+
+/**
+ * Extension properties for PixiJS imageSource nodes.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DImageSourceExtension = PixiGl2DTextureSourceExtension;
+
+/**
+ * Represents a PixiJS video source within a GL2D file through an extension.
+ * @category gl2d
+ * @standard
+ */
+export type PixiGl2DVideoSource = Gl2DVideoSource<PixiGl2DVideoSourceExtension>;
+
+/**
+ * Extension properties for PixiJS videoSource nodes.
+ * @category gl2d
+ * @standard
+ */
+export interface PixiGl2DVideoSourceExtension extends PixiGl2DTextureSourceExtension
+{
+    pixi_video_source_resource: {
+        /** The number of times a second to update the texture from the video. Leave at 0 to update at every render. */
+        updateFPS: number;
+        /** If true, the video will be preloaded. */
+        preload: boolean;
+        /** The time in milliseconds to wait for the video to preload before timing out. */
+        preloadTimeoutMs: number;
+        /** The alpha mode of the video. */
+        alphaMode: ALPHA_MODES;
+    };
+}

--- a/src/gl2d/file.ts
+++ b/src/gl2d/file.ts
@@ -1,0 +1,151 @@
+import { type Gl2DNode } from './node';
+import { type Gl2DResource } from './resources';
+
+/**
+ * Represents the root file structure for a GL2D scene.
+ *
+ * This is the top-level container that defines a complete GL2D scene file,
+ * including metadata, scene definitions, node hierarchy, and all resources
+ * required for rendering.
+ * @example
+ * ```typescript
+ * const sceneFile: Gl2DFile = {
+ *   asset: {
+ *     version: "1.0",
+ *     generator: "gl2d-example-generator"
+ *   },
+ *   scene: 0, // Active scene index
+ *   scenes: [
+ *     {
+ *       name: "MainScene",
+ *       nodes: [0, 1] // References to nodes array
+ *     }
+ *   ],
+ *   nodes: [
+ *     {
+ *       type: "container",
+ *       name: "Player",
+ *       children: [1],
+ *       transform: { position: [200, 150] },
+ *     }
+ *   ],
+ *   resources: [
+ *     { type: "texture", src: "/textures/hero.png" }
+ *   ]
+ * };
+ * ```
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DFile extends Gl2DExtension
+{
+    /** Asset metadata including version and generator information */
+    asset: Gl2DAsset;
+
+    /** The index of the default scene */
+    scene?: number;
+
+    /** Array of scene definitions, each containing references to nodes */
+    scenes?: Gl2DScene[];
+
+    /** Names of gl2D extensions used in this asset. */
+    extensionsUsed?: string[];
+    /** Names of gl2D extensions required to properly load this asset. */
+    extensionsRequired?: string[];
+
+    /** Flat array of all nodes in the file, referenced by index from scenes */
+    nodes: Gl2DNode[];
+
+    /** Array of all resources (textures, audio, fonts, etc.) used by the scene */
+    resources: Gl2DResource[];
+}
+
+/**
+ * Represents a GL2D extension, allowing for custom properties and behaviors.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DExtension<T extends Record<string, any> = Record<string, any>>
+{
+    /** JSON object with extension-specific objects. */
+    extensions?: T
+    /** Application-specific data. */
+    extras?: Record<string, any>;
+}
+
+/**
+ * GL2D Asset Metadata
+ * @example
+ * ```json
+ * {
+ *   "version": "1.0",
+ *   "generator": "gl2d-example-generator",
+ *   "minVersion": "1.0"
+ * }
+ * ```
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DAsset extends Gl2DExtension
+{
+    /** The version of the GL2D file format in the form <major>.<minor> that this asset targets */
+    version: string;
+
+    /** The name of the tool or library that generated this asset */
+    generator?: string;
+
+    /** The minimum version of the GL2D file format that this asset requires */
+    minVersion?: string;
+}
+
+/**
+ * Represents a GL2D scene definition within a GL2D file.
+ *
+ * A scene acts as a container that references specific nodes from the file's
+ * global nodes array. Multiple scenes can exist in a single GL2D file, allowing
+ * for different game states, levels, or UI screens.
+ * @example
+ * ```typescript
+ * const mainScene: Gl2DScene = {
+ *   name: "MainGameplay",
+ *   nodes: [0, 1, 2] // References nodes at indices 0, 1, and 2
+ * };
+ *
+ * const menuScene: Gl2DScene = {
+ *   name: "MainMenu",
+ *   nodes: [3, 4] // References different nodes for menu UI
+ * };
+ *
+ * // In the complete file structure:
+ * const sceneFile: Gl2DFile = {
+ *   scene: 0, // MainGameplay scene is active
+ *   scenes: [mainScene, menuScene],
+ *   nodes: [
+ *     // Index 0-2: gameplay nodes
+ *     { name: "Player" },
+ *     { name: "Enemy" },
+ *     { name: "GameUI" },
+ *     // Index 3-4: menu nodes
+ *     { name: "MenuBackground" },
+ *     { name: "StartButton" }
+ *   ]
+ * };
+ * ```
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DScene extends Gl2DExtension
+{
+    /** human-readable name for the scene (e.g., "MainMenu", "Level1") */
+    name: string;
+
+    /** The indices of each root node. */
+    nodes: number[];
+}
+
+/**
+ * Represents the nodes and resources of a GL2D file for JSON serialization.
+ * @category gl2d
+ * @standard
+ */
+export type ToGl2D = Pick<Gl2DFile, 'resources' | 'nodes' | 'extensionsRequired' | 'extensionsUsed'>;

--- a/src/gl2d/index.ts
+++ b/src/gl2d/index.ts
@@ -1,0 +1,8 @@
+// Auto-generated code, do not edit manually
+export * from './extensions/nodes';
+export * from './extensions/resources';
+export * from './file';
+export * from './node';
+export * from './resources';
+export * from './serialize/serialize';
+export * from './utils/deepRemoveUndefined';

--- a/src/gl2d/init.ts
+++ b/src/gl2d/init.ts
@@ -1,0 +1,6 @@
+export * from './index';
+
+// extensions.handleByList(ExtensionType.Gl2DResourceParser, gl2dResourceParsers);
+// extensions.handleByList(ExtensionType.Gl2DNodeParser, gl2dNodeParsers);
+// extensions.handleByList(ExtensionType.Gl2DTextureSourceParser, gl2dTextureSourceParsers);
+

--- a/src/gl2d/node.ts
+++ b/src/gl2d/node.ts
@@ -1,0 +1,75 @@
+import { type BLEND_MODES } from '../rendering/renderers/shared/state/const';
+import { type Gl2DExtension } from './file';
+
+/**
+ * Represents a GL2D node within a GL2D file.
+ *
+ * Nodes are the basic building blocks of a GL2D scene, representing
+ * individual elements such as sprites, containers, and other visual
+ * components. Each node can have its own transform, children, and
+ * other properties.
+ * @example
+ * ```typescript
+ * const playerNode: Gl2DNode = {
+ *   type: "container",
+ *   name: "Player",
+ *   transform: { position: [100, 200], scale: [1, 1] },
+ *   children: []
+ * };
+ * ```
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DNode<T extends string = string, K extends Record<string, any> = Record<string, any>>
+    extends Gl2DExtension<K>
+{
+    /** The type of the node (e.g., "sprite", "container") */
+    type: T;
+
+    /** Unique identifier for the node */
+    uid?: string;
+
+    /** The user-defined name of this object. */
+    name?: string;
+
+    /** The child nodes of this node */
+    children?: number[];
+
+    /** The nodes rotation in radians */
+    rotation?: number;
+    /** The nodes scale along the x and y axes */
+    scale?: [number, number];
+    /** The nodes translation along the x and y axes */
+    translation?: [number, number];
+    /** A floating-point transformation matrix */
+    matrix?: [number, number, number, number, number, number];
+
+    /** Explicit width override for the node (overrides component-derived width) */
+    width?: number;
+
+    /** Explicit height override for the node (overrides component-derived height) */
+    height?: number;
+
+    /** Blend mode for compositing (e.g., normal, multiply, screen) */
+    blendMode?: BLEND_MODES;
+
+    /** Color tint applied to the node (0xRRGGBB format) */
+    tint?: number;
+
+    /** Opacity/transparency level (0.0 = transparent, 1.0 = opaque) */
+    alpha?: number;
+
+    /** Whether the node and its children are visible */
+    visible?: boolean;
+}
+
+/**
+ * Represents a GL2D sprite node within a GL2D file.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DSprite<K extends Record<string, any> = Record<string, any>> extends Gl2DNode<'sprite', K>
+{
+    /** The index of the texture used by the sprite in the gl2d resource array */
+    texture: number;
+}

--- a/src/gl2d/resources.ts
+++ b/src/gl2d/resources.ts
@@ -1,0 +1,126 @@
+import {
+    type ALPHA_MODES,
+    type SCALE_MODE,
+    type TEXTURE_FORMATS,
+    type WRAP_MODE,
+} from '../rendering/renderers/shared/texture/const';
+import { type Gl2DExtension } from './file';
+
+/**
+ * Represents a resource used in a GL2D file, such as textures, fonts, audio, etc.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DResource<T extends string = string, K extends Record<string, any> = Record<string, any>>
+    extends Gl2DExtension<K>
+{
+    /**
+     * Discriminator indicating the kind of resource (e.g., "texture", "font", "audio", "gradient").
+     * This value is used to determine how the resource should be interpreted and loaded.
+     */
+    type: T;
+    /** Unique identifier for the resource. */
+    uid?: string;
+    /** Human‑readable name for the resource. Useful as an identifier when referencing or debugging. */
+    name?: string;
+    /**
+     * Location of the resource data.
+     * Can be an absolute URL, a relative path, or a data URI (e.g., `data:image/png;base64,...`).
+     */
+    uri?: string;
+}
+
+/**
+ * Represents a texture resource in a GL2D file.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DTexture<K extends Record<string, any> = Record<string, any>> extends Gl2DResource<'texture', K>
+{
+    /** The location of the source resource in the gl2D file */
+    source: number;
+    /** The rectangle frame of the texture to show */
+    frame?: [number, number, number, number];
+}
+
+/**
+ * A generic texture source in a GL2D file.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DTextureSource<T extends string = string, K extends Record<string, any> = Record<string, any>>
+    extends Gl2DResource<T, K>
+{
+    /** the pixel width of this texture source. This is the REAL pure number, not accounting resolution */
+    width?: number;
+    /** the pixel height of this texture source. This is the REAL pure number, not accounting resolution */
+    height?: number;
+    /** the resolution of the texture. */
+    resolution?: number;
+    /** the format that the texture data has */
+    format?: TEXTURE_FORMATS;
+    /**
+     * Only really affects RenderTextures.
+     * Should we use antialiasing for this texture. It will look better, but may impact performance as a
+     * Blit operation will be required to resolve the texture.
+     */
+    antialias?: boolean;
+
+    /** the alpha mode of the texture */
+    alphaMode?: ALPHA_MODES;
+
+    /** setting this will set wrapModeU,wrapModeV and wrapModeW all at once! */
+    addressMode?: WRAP_MODE;
+    /** specifies the {{GPUAddressMode|address modes}} for the texture width, height, and depth coordinates, respectively. */
+    addressModeU?: WRAP_MODE;
+    /** specifies the {{GPUAddressMode|address modes}} for the texture width, height, and depth coordinates, respectively. */
+    addressModeV?: WRAP_MODE;
+    /** Specifies the {{GPUAddressMode|address modes}} for the texture width, height, and depth coordinates, respectively. */
+    addressModeW?: WRAP_MODE;
+
+    /** setting this will set magFilter,minFilter and mipmapFilter all at once!  */
+    scaleMode?: SCALE_MODE;
+
+    /** specifies the sampling behavior when the sample footprint is smaller than or equal to one texel. */
+    magFilter?: SCALE_MODE;
+    /** specifies the sampling behavior when the sample footprint is larger than one texel. */
+    minFilter?: SCALE_MODE;
+    /** specifies behavior for sampling between mipmap levels. */
+    mipmapFilter?: SCALE_MODE;
+
+    /** specifies the minimum and maximum levels of detail, respectively, used internally when sampling a texture. */
+    lodMinClamp?: number;
+    /** Specifies the minimum and maximum levels of detail, respectively, used internally when sampling a texture. */
+    lodMaxClamp?: number;
+}
+
+/**
+ * Represents an image source resource in a GL2D file such as a bitmap or a video.
+ * @category gl2d
+ * @standard
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Gl2DImageSource<K extends Record<string, any> = Record<string, any>>
+    extends Gl2DTextureSource<'image_source', K> {}
+
+/**
+ * Represents an video source resource in a GL2D file such as a bitmap or a video.
+ * @category gl2d
+ * @standard
+ */
+export interface Gl2DVideoSource<K extends Record<string, any> = Record<string, any>>
+    extends Gl2DTextureSource<'video_source', K>
+{
+    /** If true, the video will start loading immediately. */
+    autoLoad?: boolean;
+    /** If true, the video will start playing as soon as it is loaded. */
+    autoPlay?: boolean;
+    /** If true, the video will be loaded with the `crossorigin` attribute. */
+    crossorigin?: boolean | string;
+    /** If true, the video will loop when it ends. */
+    loop?: boolean;
+    /** If true, the video will be muted. */
+    muted?: boolean;
+    /** If true, the video will play inline. */
+    playsinline?: boolean;
+}

--- a/src/gl2d/serialize/serialize.ts
+++ b/src/gl2d/serialize/serialize.ts
@@ -1,0 +1,48 @@
+import { type Renderer } from '../../rendering/renderers/types';
+import { type Container } from '../../scene/container/Container';
+import { type Gl2DFile, type ToGl2D } from '../file';
+import { deepRemoveUndefined } from '../utils/deepRemoveUndefined';
+
+/**
+ * Options for serializing a PixiJS v8 scene graph into a GL2D scene file.
+ * @category gl2d
+ * @standard
+ */
+export interface ToGl2DOptions
+{
+    gl2D?: ToGl2D;
+    renderer: Renderer;
+}
+
+/**
+ * Serialize a PixiJS v8 scene graph into a GL2D scene file.
+ * @param options - The options for serialization
+ * @param options.root - The root container for the active scene
+ * @param options.renderer - The renderer instance
+ * @returns The serialized GL2D JSON object
+ * @category gl2d
+ * @standard
+ */
+export async function serializeGl2D(options: { root: Container, renderer: Renderer }): Promise<Gl2DFile>
+{
+    const { root, renderer } = options;
+
+    const gl2D: Gl2DFile = {
+        asset: {
+            generator: 'PixiJS',
+            version: '1.0'
+        },
+        extensionsUsed: [],
+        extensionsRequired: [],
+        resources: [],
+        nodes: [],
+    };
+
+    await root.serialize({ gl2D, renderer });
+
+    // Ensure no duplicates if serializers pushed extensions multiple times
+    if (gl2D.extensionsUsed) gl2D.extensionsUsed = Array.from(new Set(gl2D.extensionsUsed));
+    if (gl2D.extensionsRequired) gl2D.extensionsRequired = Array.from(new Set(gl2D.extensionsRequired));
+
+    return deepRemoveUndefined(gl2D);
+}

--- a/src/gl2d/utils/deepRemoveUndefined.ts
+++ b/src/gl2d/utils/deepRemoveUndefined.ts
@@ -1,0 +1,50 @@
+/**
+ * Recursively remove all undefined values from an object or array.
+ * @param value - The value to clean
+ * @returns The cleaned value
+ * @internal
+ */
+export function deepRemoveUndefined<T>(value: T): T
+{
+    if (Array.isArray(value))
+    {
+    // Iterate backwards so we can safely splice while iterating
+        for (let i = value.length - 1; i >= 0; i--)
+        {
+            const item = value[i];
+
+            if (item === undefined)
+            {
+                value.splice(i, 1);
+            }
+            else
+            {
+                deepRemoveUndefined(item);
+            }
+        }
+
+        return value;
+    }
+
+    if (value && typeof value === 'object')
+    {
+        for (const key of Object.keys(value as object))
+        {
+            const val = (value as Record<string, unknown>)[key];
+
+            if (val === undefined)
+            {
+                delete (value as Record<string, unknown>)[key];
+            }
+            else
+            {
+                deepRemoveUndefined(val);
+            }
+        }
+
+        return value;
+    }
+
+    // Primitives are returned as-is
+    return value;
+}

--- a/src/index.docs.ts
+++ b/src/index.docs.ts
@@ -15,6 +15,7 @@
  * @document scene/__docs__/scene-text-overview.md
  * @document ticker/__docs__/ticker-overview.md
  * @document utils/__docs__/utils-overview.md
+ * @document gl2d/__docs__/gl2D-spec.md
  */
 
 export * from './accessibility';

--- a/src/rendering/renderers/shared/extract/ExtractSystem.ts
+++ b/src/rendering/renderers/shared/extract/ExtractSystem.ts
@@ -469,7 +469,7 @@ export class ExtractSystem implements System
         defaults: Partial<T> = {},
     ): T
     {
-        if (options instanceof Container || options instanceof Texture)
+        if (options instanceof Container || (options as Texture).isTexture)
         {
             return {
                 target: options,
@@ -658,9 +658,9 @@ export class ExtractSystem implements System
 
         const renderer = this._renderer;
 
-        if (target instanceof Texture)
+        if ((target as Texture).isTexture)
         {
-            return renderer.texture.generateCanvas(target);
+            return renderer.texture.generateCanvas(target as Texture);
         }
 
         const texture = renderer.textureGenerator.generateTexture(options as GenerateTextureOptions);

--- a/src/rendering/renderers/shared/texture/sources/ImageSource.ts
+++ b/src/rendering/renderers/shared/texture/sources/ImageSource.ts
@@ -1,4 +1,6 @@
 import { ExtensionType } from '../../../../../extensions/Extensions';
+import { type PixiGl2DImageSource } from '../../../../../gl2d/extensions/resources';
+import { type ToGl2DOptions } from '../../../../../gl2d/serialize/serialize';
 import { TextureSource } from './TextureSource';
 
 import type { ICanvas } from '../../../../../environment/canvas/ICanvas';
@@ -50,5 +52,29 @@ export class ImageSource extends TextureSource<ImageResource>
         return (globalThis.HTMLImageElement && resource instanceof HTMLImageElement)
         || (typeof ImageBitmap !== 'undefined' && resource instanceof ImageBitmap)
         || (globalThis.VideoFrame && resource instanceof VideoFrame);
+    }
+
+    /**
+     * Serializes the texture source to a format suitable for the GL2D renderer.
+     * @param options - The options to use for serialization.
+     * @returns The serialized texture source.
+     */
+    public override async serialize(options: ToGl2DOptions): Promise<ToGl2DOptions>
+    {
+        await super.serialize(options);
+        const { gl2D } = options;
+
+        // find the resource
+        const source = gl2D.resources.find(
+            (texture) => texture.uid === `texture_source_${this.uid}`) as PixiGl2DImageSource;
+
+        if (!source)
+        {
+            throw new Error(`ImageSource: Texture source with uid ${this.uid} not found.`);
+        }
+
+        source.type = 'image_source';
+
+        return options;
     }
 }

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -2,6 +2,8 @@ import EventEmitter from 'eventemitter3';
 import { Color, type ColorSource } from '../../color/Color';
 import { cullingMixin } from '../../culling/cullingMixin';
 import { extensions } from '../../extensions/Extensions';
+import { type PixiGl2DContainer } from '../../gl2d/extensions/nodes';
+import { type ToGl2DOptions } from '../../gl2d/serialize/serialize';
 import { Matrix } from '../../maths/matrix/Matrix';
 import { DEG_TO_RAD, RAD_TO_DEG } from '../../maths/misc/const';
 import { ObservablePoint } from '../../maths/point/ObservablePoint';
@@ -2106,6 +2108,66 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
 
         this.renderGroup?.destroy();
         this.renderGroup = null;
+    }
+
+    /**
+     * Serializes the container and its children into a gl2D-compatible format.
+     * @param gl2DOptions - The gl2D serialization context and options.
+     * @returns The updated gl2D serialization context.
+     */
+    public async serialize(gl2DOptions: ToGl2DOptions): Promise<ToGl2DOptions>
+    {
+        const node: PixiGl2DContainer = {
+            name: this.label ?? undefined,
+            type: 'container',
+            uid: `container_${this.uid}`,
+            children: [],
+            alpha: this.alpha,
+            visible: this.visible,
+            tint: this.tint,
+            blendMode: this.blendMode,
+            extensions: {
+                pixi_container_node: {
+                    skew: [this.skew.x, this.skew.y],
+                    pivot: [this.pivot.x, this.pivot.y],
+                    origin: [this.origin.x, this.origin.y],
+                    boundsArea: this.boundsArea
+                        ? [this.boundsArea.x, this.boundsArea.y, this.boundsArea.width, this.boundsArea.height]
+                        : undefined,
+                    isRenderGroup: this.isRenderGroup,
+                    zIndex: this.zIndex,
+                    sortableChildren: this.sortableChildren,
+                    renderable: this.renderable
+                }
+            }
+        };
+
+        const { gl2D } = gl2DOptions;
+
+        gl2D.nodes.push(node);
+        gl2D.extensionsRequired.push('pixi_container_node');
+        gl2D.extensionsUsed.push('pixi_container_node');
+
+        // loop through children and serialize them
+        for (const child of this.children)
+        {
+            // check if child already exists in gl2d
+            const existingChildIndex = gl2D.nodes.findIndex((node) => node.uid === `container_${child.uid}`);
+
+            if (existingChildIndex === -1)
+            {
+                await child.serialize(gl2DOptions);
+                const childIndex = gl2D.nodes.findIndex((node) => node.uid === `container_${child.uid}`);
+
+                node.children.push(childIndex);
+            }
+            else
+            {
+                node.children.push(existingChildIndex);
+            }
+        }
+
+        return gl2DOptions;
     }
 }
 


### PR DESCRIPTION

### Summary

This PR introduces initial support for the gl2D file format, which enables serialization of PixiJS scenes into a JSON-based structure. The goal is to provide a standardized way to save, load, and share any 2D scenes, while ensuring resources can be efficiently reused across nodes and scenes.

### Design

A scene is represented as two main components:
- Resources – reusable assets such as textures, web fonts, spritesheets, images, and videos.
- Nodes – scene graph elements that reference resources.

For textures specifically:
- All textures are stored within the resources section.
- Each texture defines a source (e.g., ImageSource, Spritesheet, VideoSource) to describe how it was created.

Additionally, all nodes and resources can be extended via extensions, allowing custom metadata and features to be attached.

### Example API

```ts
// Serialize a PixiJS scene into gl2D
const serialized = await serializeGl2D({ root, renderer });
// Deserialize without reloading (if resources are still present)
const cloned = await deserializeGl2D(serialized);

// Or load it directly via Assets
const cloned = await Assets.load('path/to/scene.gl2d');
```

### gl2D Spec
<details>
<summary>gl2D Spec & Example</summary>


	•	gl2D spec

Example JSON

{
  "asset": {
    "generator": "PixiJS",
    "version": "1.0"
  },
  "extensionsUsed": [
    "pixi_container_node",
    "pixi_texture_source_resource",
    "pixi_texture_resource",
    "pixi_sprite_node"
  ],
  "extensionsRequired": ["pixi_container_node"],
  "resources": [
    {
      "uid": "texture_source_3",
      "type": "image_source",
      "uri": "/assets/bunny.1.webp",
      "width": 26,
      "height": 37,
      "resolution": 1,
      "format": "bgra8unorm",
      "antialias": false,
      "alphaMode": "premultiply-alpha-on-upload",
      "addressModeU": "clamp-to-edge",
      "addressModeV": "clamp-to-edge",
      "addressModeW": "clamp-to-edge",
      "magFilter": "linear",
      "minFilter": "linear",
      "mipmapFilter": "linear",
      "extensions": {
        "pixi_texture_source_resource": {
          "autoGarbageCollect": true,
          "mipLevelCount": 1,
          "maxAnisotropy": 1,
          "dimensions": "2d",
          "autoGenerateMipmaps": false
        }
      }
    },
    {
      "type": "texture",
      "uid": "texture_3",
      "name": "http://localhost:8081/assets/bunny.1.webp",
      "frame": [0, 0, 26, 37],
      "source": 0,
      "extensions": {
        "pixi_texture_resource": {
          "orig": [0, 0, 26, 37],
          "rotate": 0,
          "dynamic": false
        }
      }
    }
  ],
  "nodes": [
    {
      "type": "container",
      "uid": "container_2",
      "children": [1],
      "alpha": 1,
      "visible": true,
      "tint": 16777215,
      "blendMode": "inherit",
      "extensions": {
        "pixi_container_node": {
          "skew": [0, 0],
          "pivot": [0, 0],
          "origin": [0, 0],
          "isRenderGroup": false,
          "zIndex": 0,
          "sortableChildren": false,
          "renderable": true
        }
      }
    },
    {
      "name": "Sprite",
      "type": "sprite",
      "uid": "container_4",
      "children": [],
      "matrix": [1, 0, 24, 0, 1, 24, 0, 0, 1],
      "alpha": 1,
      "visible": true,
      "tint": 16777215,
      "blendMode": "inherit",
      "extensions": {
        "pixi_container_node": {
          "skew": [0, 0],
          "pivot": [0, 0],
          "origin": [0, 0],
          "isRenderGroup": false,
          "zIndex": 0,
          "sortableChildren": false,
          "renderable": true,
          "anchor": [0, 0]
        },
        "pixi_sprite_node": {
          "roundPixels": false
        }
      },
      "texture": 1
    }
  ]
}

</details>

### NOTE
This is the first of several PR that will add all the different resources and node types, along with the deserialisation methods. Just splitting everything up to be more manageable.