### PR TITLE
fix: allow canvas source options for gif asset

### DIFF
--- a/src/assets/AssetExtension.ts
+++ b/src/assets/AssetExtension.ts
@@ -90,6 +90,7 @@ interface AssetExtensionAdvanced<
  * @advanced
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface AssetExtension<ASSET = any, META_DATA = any> extends AssetExtensionAdvanced<ASSET, META_DATA>{}
+interface AssetExtension<ASSET = any, META_DATA = any>
+    extends AssetExtensionAdvanced<ASSET, ASSET, ASSET, ASSET, META_DATA>{}
 
 export type { AssetExtension, AssetExtensionAdvanced };

--- a/src/gif/GifAsset.ts
+++ b/src/gif/GifAsset.ts
@@ -12,7 +12,7 @@ import type { AssetExtension } from '../assets/AssetExtension';
  * @category gif
  * @advanced
  */
-const GifAsset = {
+const GifAsset: AssetExtension<GifSource, GifBufferOptions> = {
     extension: ExtensionType.Asset,
     detection: {
         test: async () => true,
@@ -36,6 +36,6 @@ const GifAsset = {
             asset.destroy();
         },
     }
-} as AssetExtension<GifSource, GifBufferOptions>;
+};
 
 export { GifAsset };

--- a/src/gif/GifSource.ts
+++ b/src/gif/GifSource.ts
@@ -1,6 +1,6 @@
 import { decompressFrames, type ParsedFrame, parseGIF } from 'gifuct-js';
 import { DOMAdapter } from '../environment/adapter';
-import { CanvasSource } from '../rendering/renderers/shared/texture/sources/CanvasSource';
+import { CanvasSource, type CanvasSourceOptions } from '../rendering/renderers/shared/texture/sources/CanvasSource';
 import { Texture } from '../rendering/renderers/shared/texture/Texture';
 
 /**
@@ -23,10 +23,10 @@ interface GifFrame
  * @category gif
  * @advanced
  */
-interface GifBufferOptions
+interface GifBufferOptions extends Omit<CanvasSourceOptions, 'resource'>
 {
     /** FPS to use when the GIF animation doesn't define any delay between frames */
-    fps: number;
+    fps?: number;
 }
 
 /**
@@ -153,7 +153,8 @@ class GifSource
         let previousFrame: ImageData | null = null;
 
         // Some GIFs have a non-zero frame delay, so we need to calculate the fallback
-        const defaultDelay = 1000 / (options?.fps ?? 30);
+        const { fps = 30, ...canvasSourceOptions } = options ?? {};
+        const defaultDelay = 1000 / fps;
 
         // Precompute each frame and store as ImageData
         for (let i = 0; i < gifFrames.length; i++)
@@ -206,6 +207,7 @@ class GifSource
                 texture: new Texture({
                     source: new CanvasSource({
                         resource,
+                        ...canvasSourceOptions,
                     }),
                 }),
             });

--- a/src/gif/GifSprite.ts
+++ b/src/gif/GifSprite.ts
@@ -4,8 +4,6 @@ import { UPDATE_PRIORITY } from '../ticker/const';
 import { Ticker } from '../ticker/Ticker';
 import { GifSource } from './GifSource';
 
-import type { SCALE_MODE } from '../rendering/renderers/shared/texture/const';
-
 /**
  * Configuration options for creating a GifSprite instance.
  *
@@ -22,7 +20,6 @@ import type { SCALE_MODE } from '../rendering/renderers/shared/texture/const';
  *     animationSpeed: 1.5,      // 50% faster than normal
  *     loop: true,               // Loop the animation
  *     autoPlay: true,           // Start playing immediately
- *     scaleMode: 'nearest',     // Pixel art style scaling
  *     onComplete: () => {       // Called when non-looping animation ends
  *         console.log('Animation complete!');
  *     }
@@ -56,17 +53,6 @@ interface GifSpriteOptions extends Omit<SpriteOptions, 'texture'>
      * @see {@link GifSprite.play}
      */
     autoPlay?: boolean;
-    /**
-     * Scale Mode to use for the texture
-     * @type {SCALE_MODE}
-     * @default 'linear'
-     * @example
-     * ```ts
-     * const animation = new GifSprite({ source, scaleMode: 'nearest' });
-     * ```
-     * @see {@link SCALE_MODE}
-     */
-    scaleMode?: SCALE_MODE;
     /**
      * Whether to loop the animation.
      * If `false`, the animation will stop after the last frame.
@@ -226,7 +212,6 @@ class GifSprite extends Sprite
      * ```
      */
     public static defaultOptions: Omit<GifSpriteOptions, 'source'> = {
-        scaleMode: 'linear',
         fps: 30,
         loop: true,
         animationSpeed: 1,
@@ -392,7 +377,6 @@ class GifSprite extends Sprite
 
         // Get the options, apply defaults
         const {
-            scaleMode,
             source,
             fps,
             loop,
@@ -876,7 +860,6 @@ class GifSprite extends Sprite
             autoUpdate: this._autoUpdate,
             loop: this.loop,
             autoPlay: this.autoPlay,
-            scaleMode: this.texture.source.scaleMode,
             animationSpeed: this.animationSpeed,
             onComplete: this.onComplete,
             onFrameChange: this.onFrameChange,

--- a/src/gif/__tests__/GifSource.test.ts
+++ b/src/gif/__tests__/GifSource.test.ts
@@ -17,6 +17,8 @@ describe('GifSource', () =>
             expect(data.duration).toBeGreaterThan(0);
             expect(data.frames).toBeDefined();
             expect(data.textures).toBeDefined();
+            expect(data.textures.every((texture) => texture.source.scaleMode === 'linear')).toBe(true);
+            expect(data.textures.every((texture) => texture.source.resolution === 1)).toBe(true);
 
             data.destroy();
 
@@ -34,6 +36,20 @@ describe('GifSource', () =>
             expect(() => (GifSource as any).from()).toThrow();
             // eslint-disable-next-line jest/expect-expect
             expect(() => (GifSource as any).from(new ArrayBuffer(0))).toThrow();
+        });
+
+        it('should support non-default canvas options', () =>
+        {
+            const arrayBuffer = toArrayBuffer('gif/example.gif');
+            const data = GifSource.from(arrayBuffer, {
+                scaleMode: 'nearest',
+                resolution: 2,
+            });
+
+            expect(data.textures.every((texture) => texture.source.scaleMode === 'nearest')).toBe(true);
+            expect(data.textures.every((texture) => texture.source.resolution === 2)).toBe(true);
+
+            data.destroy();
         });
     });
 });


### PR DESCRIPTION
Fixes #11633

### Overview

Currently `scaleMode` is an option for creating GifSprite objects, but is not implemented (looks like it never was). Because normal Sprites don't support `scaleMode` (this is something that lives on the texture source), I have removed this property. The correct way to set source options is through the loader instead.

**Before: (incorrect implementation)**

```ts
import { Assets, GifSprite } from "pixi.js";

const source = await Assets.load("path/to/some.gif");
const sprite = new GifSprite({
  source,
  scaleMode: "nearest"
});
```

**After: (correct implementation)**

```ts
import { Assets, GifSprite } from "pixi.js";

const source = await Assets.load({
  src: "path/to/some.gif",
  data: {
    scaleMode: "nearest"
  }
});
const sprite = new GifSprite(source);
```



### Changes

* Removes `scaleMode` options from GifSpriteOptions 
* Supports CanvasSourceOptions when loading GifAssets
* Fixes incorrect `AssetExtension` type implementation

