### PR TITLE
fix: supports husky to run without PATH

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,3 @@
+# This loads nvm.sh and sets the correct PATH before running hook
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
I occasionally use GitHub Desktop to manage commits, but it was complaining about husky:

> .husky/pre-commit: line 4: npx: command not found husky - pre-commit hook exited with code 127 (error) husky - command not found in PATH=/Applications/GitHub Desktop.app/Contents/Resources/app/git/libexec/git-core:/usr/bin:/bin:/usr/sbin:/sbin

Solution found here: 
https://github.com/typicode/husky/issues/912