### PR TITLE
fix: modify conditional to skip draw call when instanceCount < 1

### DIFF
--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -449,7 +449,7 @@ export class GlGeometrySystem implements System
             const byteSize = geometry.indexBuffer.data.BYTES_PER_ELEMENT;
             const glType = byteSize === 2 ? gl.UNSIGNED_SHORT : gl.UNSIGNED_INT;
 
-            if (instanceCount > 1)
+            if (instanceCount !== 1)
             {
                 /* eslint-disable max-len */
                 gl.drawElementsInstanced(glTopology, size || geometry.indexBuffer.data.length, glType, (start || 0) * byteSize, instanceCount);
@@ -460,7 +460,7 @@ export class GlGeometrySystem implements System
                 gl.drawElements(glTopology, size || geometry.indexBuffer.data.length, glType, (start || 0) * byteSize);
             }
         }
-        else if (instanceCount > 1)
+        else if (instanceCount !== 1)
         {
             // TODO need a better way to calculate size..
             gl.drawArraysInstanced(glTopology, start || 0, size || geometry.getSize(), instanceCount);


### PR DESCRIPTION
##### Description of change
<!-- Provide a description of the change below this comment. -->

While working on a project using webgl instanced rendering with varying instance counts, I found one instance of the geometry would always be rendered even when `geometry.instanceCount = 0`, with the same behaviour for negative instance counts.

From a look through the source, it seemed to be due to a conditional in the GlGeometrySystem draw method that would always fall back to a drawElements/drawArrays call for all instanceCount values less than 2. This also led to webgl render errors in cases where instance attribute buffers would be empty when no instances were expected to be drawn.

I'm currently using the following patch in my project which fixes the issue so I think this is on the right track.
```ts
  const app = new Application();
  await app.init({ background: "#011d4c", resizeTo: window, preference: "webgl" });
  const renderer = app.renderer as WebGLRenderer;
  const originalDraw = renderer.geometry.draw.bind(renderer.geometry);
  renderer.geometry.draw = function(topology, size, start, instanceCount) {
    instanceCount ??= this._activeGeometry.instanceCount;  // From original draw method source
    if (instanceCount <= 0) {
      return this;
    }
    return originalDraw(topology, size, start, instanceCount);
  }
```

For this PR I modified the conditionals to explicitly check for `instanceCount === 1` to avoid checking the probably rare case of `instanceCount <= 0` for every draw method call, but the behaviour should be the same as the approach in the above patch.

I've run the tests with and without the modification with no additional errors. Let me know if I should add a test for this or if there's anything else I can add or do.

Apologies if this is too much or not enough information, I'm pretty new to contributing to open source projects. Just hope this could help someone running into similar issues.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
