### PR TITLE
fix: unsafe-eval particle update polyfill

### DIFF
--- a/src/unsafe-eval/particle/generateParticleUpdatePolyfill.ts
+++ b/src/unsafe-eval/particle/generateParticleUpdatePolyfill.ts
@@ -11,10 +11,11 @@ type ParticleUpdateFunction = (ps: IParticle[], f32v: Float32Array, u32v: Uint32
  * @param properties
  * @internal
  */
-export function generateParticleUpdatePolyfill(properties: ParticleRendererProperty[])
+export function generateParticleUpdatePolyfill(properties: Record<string, ParticleRendererProperty>)
 {
-    const dynamicProperties = properties.filter((p) => p.dynamic);
-    const staticProperties = properties.filter((p) => !p.dynamic);
+    const allProperties = Object.values(properties);
+    const dynamicProperties = allProperties.filter((p) => p.dynamic);
+    const staticProperties = allProperties.filter((p) => !p.dynamic);
 
     return {
         dynamicUpdate: generateUpdateFunction(dynamicProperties),


### PR DESCRIPTION
##### Description of change
Fix unsafe-eval `generateParticleUpdatePolyfill` for updated function signature.
The polyfill did not match the original function signature and thus caused `filter is not a function` errors.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
