### PR TITLE
feat: add LRU cache for text measuring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "eventemitter3": "^5.0.1",
         "gifuct-js": "^2.1.2",
         "ismobilejs": "^1.1.1",
-        "parse-svg-path": "^0.1.2"
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.5"
       },
       "devDependencies": {
         "@babel/core": "7.22",
@@ -16517,6 +16518,15 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
+      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -29854,6 +29864,11 @@
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
       }
+    },
+    "tiny-lru": {
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.5.tgz",
+      "integrity": "sha512-hkcz3FjNJfKXjV4mjQ1OrXSLAehg8Hw+cEZclOVT+5c/cWQWImQ9wolzTjth+dmmDe++p3bme3fTxz6Q4Etsqw=="
     },
     "tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "eventemitter3": "^5.0.1",
     "gifuct-js": "^2.1.2",
     "ismobilejs": "^1.1.1",
-    "parse-svg-path": "^0.1.2"
+    "parse-svg-path": "^0.1.2",
+    "tiny-lru": "^11.4.5"
   },
   "devDependencies": {
     "@babel/core": "7.22",

--- a/src/scene/text-bitmap/BitmapFontManager.ts
+++ b/src/scene/text-bitmap/BitmapFontManager.ts
@@ -1,3 +1,4 @@
+import { lru } from 'tiny-lru';
 import { Cache } from '../../assets/cache/Cache';
 import { type TextureStyle, type TextureStyleOptions } from '../../rendering/renderers/shared/texture/TextureStyle';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
@@ -299,6 +300,9 @@ class BitmapFontManagerClass
         textureStyle: null,
     };
 
+    /** Cache for measured text layouts to avoid recalculating them multiple times. */
+    public readonly measureCache = lru<BitmapTextLayoutData>(1000);
+
     /**
      * Get a font for the specified text and style.
      * @param text - The text to get the font for
@@ -382,9 +386,22 @@ class BitmapFontManagerClass
     {
         const bitmapFont = this.getFont(text, style);
 
+        const id = `${text}-${style.styleKey}-${trimEnd}`;
+
+        // Check if we have a cached layout
+        if (this.measureCache.has(id))
+        {
+            return this.measureCache.get(id);
+        }
+
         const segments = CanvasTextMetrics.graphemeSegmenter(text);
 
-        return getBitmapTextLayout(segments, style, bitmapFont, trimEnd);
+        // Generate the layout data
+        const layoutData = getBitmapTextLayout(segments, style, bitmapFont, trimEnd);
+
+        this.measureCache.set(id, layoutData);
+
+        return layoutData;
     }
 
     /**

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -1,3 +1,4 @@
+import { lru } from 'tiny-lru';
 import { DOMAdapter } from '../../../environment/adapter';
 import { fontStringFromTextStyle } from './utils/fontStringFromTextStyle';
 
@@ -215,6 +216,9 @@ export class CanvasTextMetrics
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private static __context: ICanvasRenderingContext2D;
 
+    /** Cache for measured text metrics */
+    private static readonly _measurementCache = lru<CanvasTextMetrics>(1000);
+
     /**
      * @param text - the text that was measured
      * @param style - the style that was measured
@@ -255,6 +259,14 @@ export class CanvasTextMetrics
         wordWrap: boolean = style.wordWrap,
     ): CanvasTextMetrics
     {
+        const textKey = `${text}-${style.styleKey}`;
+
+        // check if we have already measured this text with the same style
+        if (CanvasTextMetrics._measurementCache.has(textKey))
+        {
+            return CanvasTextMetrics._measurementCache.get(textKey);
+        }
+
         const font = fontStringFromTextStyle(style);
         const fontProperties = CanvasTextMetrics.measureFont(font);
 
@@ -312,6 +324,9 @@ export class CanvasTextMetrics
             maxLineWidth,
             fontProperties
         );
+
+        // cache the measurements
+        CanvasTextMetrics._measurementCache.set(textKey, measurements);
 
         return measurements;
     }

--- a/src/scene/text/canvas/CanvasTextMetrics.ts
+++ b/src/scene/text/canvas/CanvasTextMetrics.ts
@@ -259,7 +259,7 @@ export class CanvasTextMetrics
         wordWrap: boolean = style.wordWrap,
     ): CanvasTextMetrics
     {
-        const textKey = `${text}-${style.styleKey}`;
+        const textKey = `${text}-${style.styleKey}-wordWrap-${wordWrap}`;
 
         // check if we have already measured this text with the same style
         if (CanvasTextMetrics._measurementCache.has(textKey))


### PR DESCRIPTION
Introduces caching mechanisms for bitmap font layouts and canvas text metrics to reduce redundant calculations.

This code was from the original cache text PR: #11505, split out to make reviewing easier 