### PR TITLE
fix: make text filters immutable

### DIFF
--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -637,7 +637,7 @@ export interface TextStyleOptions
      * compared to applying the filter directly to the text object (which would be applied at run time).
      * @default undefined
      */
-    filters?: Filter[];
+    filters?: Filter[] | readonly Filter[];
 }
 
 /**

--- a/src/scene/text/TextStyle.ts
+++ b/src/scene/text/TextStyle.ts
@@ -783,7 +783,7 @@ export class TextStyle extends EventEmitter<{
     private _whiteSpace: TextStyleWhiteSpace;
     private _wordWrap: boolean;
     private _wordWrapWidth: number;
-    private _filters: Filter[];
+    private _filters: readonly Filter[];
 
     private _padding: number;
 
@@ -894,8 +894,8 @@ export class TextStyle extends EventEmitter<{
      * compared to applying the filter directly to the text object (which would be applied at run time).
      * @default null
      */
-    get filters(): Filter[] { return this._filters; }
-    set filters(value: Filter[]) { this._filters = value; this.update(); }
+    get filters(): readonly Filter[] { return this._filters; }
+    set filters(value: Filter[]) { this._filters = Object.freeze(value); this.update(); }
 
     /**
      * Trim transparent borders from the text texture.

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -114,7 +114,7 @@ export class CanvasTextSystem implements System
         {
             // apply the filters to the texture if required..
             // this returns a new texture with the filters applied
-            const filteredTexture = this._applyFilters(texture, style.filters);
+            const filteredTexture = this._applyFilters(texture, style.filters as Filter[]);
 
             // return the original texture to the pool so we can reuse the next frame
             this.returnTexture(texture);

--- a/src/scene/text/utils/generateTextStyleKey.ts
+++ b/src/scene/text/utils/generateTextStyleKey.ts
@@ -47,7 +47,7 @@ export function generateTextStyleKey(style: TextStyle): string
     index = addFillStyleKey(style._fill, key as string[], index);
     index = addStokeStyleKey(style._stroke, key as string[], index);
     index = addDropShadowKey(style.dropShadow, key as string[], index);
-    index = addFiltersKey(style.filters, key as string[], index);
+    index = addFiltersKey(style.filters as Filter[], key as string[], index);
 
     return key.join('-');
 }


### PR DESCRIPTION
Ensures that filter arrays are treated as read-only within the text style, preventing unintended external
modifications.

This code was from the original cache text PR: #11505, split out to make reviewing easier 
