### PR TITLE
fix: cast index type to number as it required by setVertexBuffer

### DIFF
--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -156,7 +156,7 @@ export class GpuEncoderSystem implements System
 
         for (const i in buffersToBind)
         {
-            this._setVertexBuffer(i as any as number, geometry.attributes[buffersToBind[i]].buffer);
+            this._setVertexBuffer(parseInt(i, 10), geometry.attributes[buffersToBind[i]].buffer);
         }
 
         if (geometry.indexBuffer)


### PR DESCRIPTION
##### Description of change
`setVertexBuffer` expect to get a number as index but right now it's a string. 
It works fine in browser, but in ReactNative with react-native-wgpu it leads to an error.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
