### PR TITLE
fix: application destroy for graphics

### DIFF
--- a/src/app/__tests__/Application.test.ts
+++ b/src/app/__tests__/Application.test.ts
@@ -1,3 +1,8 @@
+import { Texture } from '../../rendering/renderers/shared/texture/Texture';
+import { Graphics } from '../../scene/graphics/shared/Graphics';
+import { Sprite } from '../../scene/sprite/Sprite';
+import { Text } from '../../scene/text/Text';
+import { GlobalResourceRegistry } from '../../utils/pool/GlobalResourceRegistry';
 import { Application } from '../Application';
 import { getApp, nextTick } from '@test-utils';
 import { extensions, ExtensionType } from '~/extensions';
@@ -78,6 +83,29 @@ describe('Application', () =>
 
             app.destroy(true, true);
             expect(child.destroyed).toBeTrue();
+        });
+
+        it('should destroy all children when option passed', async () =>
+        {
+            const app = await getApp();
+            const stage = app.stage;
+            const child = new Container();
+            const graphics = new Graphics().rect(0, 0, 10, 10).fill('red');
+            const sprite = new Sprite(Texture.WHITE);
+            const text = new Text({ text: 'Hello, world!' });
+
+            stage.addChild(child, graphics, sprite, text);
+
+            const spy = jest.spyOn(GlobalResourceRegistry, 'release');
+
+            app.render();
+
+            app.destroy(true, true);
+            expect(child.destroyed).toBeTrue();
+            expect(graphics.destroyed).toBeTrue();
+            expect(sprite.destroyed).toBeTrue();
+            expect(text.destroyed).toBeTrue();
+            expect(spy).toHaveBeenCalled();
         });
     });
 

--- a/src/app/__tests__/Application.test.ts
+++ b/src/app/__tests__/Application.test.ts
@@ -1,12 +1,9 @@
-import { Texture } from '../../rendering/renderers/shared/texture/Texture';
-import { Graphics } from '../../scene/graphics/shared/Graphics';
-import { Sprite } from '../../scene/sprite/Sprite';
-import { Text } from '../../scene/text/Text';
-import { GlobalResourceRegistry } from '../../utils/pool/GlobalResourceRegistry';
 import { Application } from '../Application';
-import { getApp, nextTick } from '@test-utils';
+import { basePath, getApp, nextTick } from '@test-utils';
+import { Assets } from '~/assets';
 import { extensions, ExtensionType } from '~/extensions';
-import { Container } from '~/scene';
+import { Container, Graphics, Sprite, Text } from '~/scene';
+import { GlobalResourceRegistry } from '~/utils';
 
 import type { ApplicationOptions } from '../Application';
 
@@ -88,13 +85,19 @@ describe('Application', () =>
         it('should destroy all children when option passed', async () =>
         {
             const app = await getApp();
+
+            await Assets.init({ basePath });
+            const bunny = await Assets.load('textures/bunny.png');
             const stage = app.stage;
             const child = new Container();
             const graphics = new Graphics().rect(0, 0, 10, 10).fill('red');
-            const sprite = new Sprite(Texture.WHITE);
+            const graphics2 = new Graphics().rect(0, 0, 10, 10).fill('red');
+            const sprite = new Sprite(bunny);
             const text = new Text({ text: 'Hello, world!' });
 
-            stage.addChild(child, graphics, sprite, text);
+            graphics.mask = sprite;
+
+            stage.addChild(child, graphics, graphics2, sprite, text);
 
             const spy = jest.spyOn(GlobalResourceRegistry, 'release');
 
@@ -106,6 +109,7 @@ describe('Application', () =>
             expect(sprite.destroyed).toBeTrue();
             expect(text.destroyed).toBeTrue();
             expect(spy).toHaveBeenCalled();
+            Assets.reset();
         });
     });
 

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -139,7 +139,7 @@ export class BindGroup
         {
             const resource = resources[i];
 
-            resource.off?.('change', this.onResourceChange, this);
+            resource?.off?.('change', this.onResourceChange, this);
         }
 
         this.resources = null;

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -113,5 +113,7 @@ export class BatchableGraphics implements DefaultBatchableMeshElement
         this.renderable = null;
         this.texture = null;
         this.geometryData = null;
+        this._batcher = null;
+        this._batch = null;
     }
 }

--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -113,10 +113,5 @@ export class BatchableGraphics implements DefaultBatchableMeshElement
         this.renderable = null;
         this.texture = null;
         this.geometryData = null;
-
-        this._batcher.destroy();
-        this._batcher = null;
-        this._batch.destroy();
-        this._batch = null;
     }
 }


### PR DESCRIPTION
Originally reported on discord: [message](https://discord.com/channels/734147990985375826/1143191340230914068/1413101088680317030)

Fixes issue with graphics double destroying the batcher. The batcher is already getting tidied up as its part of its own pool

Adds a test case to verify that all children, including graphics, sprites, and text, are destroyed when the destroy method is called with the appropriate options.
