### PR TITLE
fix: check if object exists before call destroy on it

### DIFF
--- a/src/scene/graphics/shared/BatchableGraphics.ts
+++ b/src/scene/graphics/shared/BatchableGraphics.ts
@@ -114,9 +114,15 @@ export class BatchableGraphics implements DefaultBatchableMeshElement
         this.texture = null;
         this.geometryData = null;
 
-        this._batcher.destroy();
-        this._batcher = null;
-        this._batch.destroy();
-        this._batch = null;
+        if (this._batcher)
+        {
+            this._batcher.destroy();
+            this._batcher = null;
+        }
+        if (this._batch)
+        {
+            this._batch.destroy();
+            this._batch = null;
+        }
     }
 }


### PR DESCRIPTION
##### Description of change
If Graphics cannot be batched, there is will be an error on destroy, because `_batcher ` or `_batch` will be null.

I did review [PR](https://github.com/pixijs/pixijs/pull/11581/files) where it was introduced and look like it's only the place where error can happened.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [] Tests passed (`npm run test`)
