### PR TITLE
fix: text baseline measurement for BitmapText so it renders accurately within its bounds

### DIFF
--- a/src/scene/text-bitmap/BitmapFont.ts
+++ b/src/scene/text-bitmap/BitmapFont.ts
@@ -189,8 +189,8 @@ export class BitmapFont extends AbstractBitmapFont<BitmapFont>
 
         (this.baseMeasurementFontSize as number) = data.fontSize;
         (this.fontMetrics as FontMetrics) = {
-            ascent: 0,
-            descent: 0,
+            ascent: data.lineHeight - data.baseLineOffset,
+            descent: data.baseLineOffset,
             fontSize: data.fontSize,
         };
         (this.baseLineOffset as number) = data.baseLineOffset;

--- a/src/scene/text-bitmap/BitmapText.ts
+++ b/src/scene/text-bitmap/BitmapText.ts
@@ -158,7 +158,6 @@ export class BitmapText extends AbstractText<
 
         const bitmapMeasurement = BitmapFontManager.measureText(this.text, this._style);
         const scale = bitmapMeasurement.scale;
-        const offset = bitmapMeasurement.offsetY * scale;
 
         let width = bitmapMeasurement.width * scale;
         let height = bitmapMeasurement.height * scale;
@@ -173,7 +172,7 @@ export class BitmapText extends AbstractText<
 
         bounds.minX = (-anchor._x * width);
         bounds.maxX = bounds.minX + width;
-        bounds.minY = (-anchor._y * (height + offset));
+        bounds.minY = (-anchor._y * height);
         bounds.maxY = bounds.minY + height;
     }
 

--- a/src/scene/text-bitmap/BitmapTextPipe.ts
+++ b/src/scene/text-bitmap/BitmapTextPipe.ts
@@ -44,6 +44,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+        this._renderer.renderableGC.addManagedHash(this, '_gpuBitmapText');
     }
 
     public validateRenderable(bitmapText: BitmapText): boolean
@@ -114,7 +115,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
         const chars = CanvasTextMetrics.graphemeSegmenter(bitmapText.text);
         const style = bitmapText._style;
 
-        let currentY = bitmapFont.baseLineOffset;
+        let currentY = 0;
 
         // measure our text...
         const bitmapTextLayout = getBitmapTextLayout(chars, style, bitmapFont, true);
@@ -146,14 +147,7 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
             lineHeight = style.lineHeight / scale;
         }
 
-        let linePositionYShift = (lineHeight - fontSize) / 2;
-
-        // if `currentY` is no longer starts from `baseLineOffset`
-        // the `baseLineOffset` below may also need to be removed
-        if (linePositionYShift - bitmapFont.baseLineOffset < 0)
-        {
-            linePositionYShift = 0;
-        }
+        const linePositionYShift = Math.max(0, (lineHeight - fontSize) / 2);
 
         for (let i = 0; i < bitmapTextLayout.lines.length; i++)
         {
@@ -171,8 +165,8 @@ export class BitmapTextPipe implements RenderPipe<BitmapText>
                     context.texture(
                         texture,
                         tint ? tint : 'black',
-                        Math.round(line.charPositions[j] + charData.xOffset),
-                        Math.round(currentY + charData.yOffset + linePositionYShift),
+                        (line.charPositions[j] + charData.xOffset),
+                        (currentY + charData.yOffset + linePositionYShift),
                         texture.orig.width,
                         texture.orig.height,
                     );

--- a/src/scene/text-bitmap/utils/getBaselineOffset.ts
+++ b/src/scene/text-bitmap/utils/getBaselineOffset.ts
@@ -1,0 +1,57 @@
+import type { TextStyle } from '../../text/TextStyle';
+
+/**
+ * Compute baseline position from the top of a line box, based on the style's textBaseline.
+ * Returns a y-offset (in line box units) to add to the line top to reach the desired baseline.
+ *
+ * Mapping notes:
+ * - alphabetic: ascent (top to alphabetic baseline)
+ * - top: 0
+ * - bottom: lineHeight
+ * - middle: lineHeight / 2
+ * - ideographic: lineHeight - descent
+ * - hanging: approximated as ~0.2 * lineHeight
+ *
+ * If ascent/descent are missing, falls back to centering using lineHeight/2.
+ * @param style
+ * @param lineHeight
+ * @param ascent
+ * @param descent
+ * @category text
+ * @returns The baseline offset in line box units.
+ * @internal
+ */
+export function getBaselineOffset(
+    style: TextStyle,
+    lineHeight: number,
+    ascent: number | undefined,
+    descent: number | undefined
+): number
+{
+    const baseline = style.textBaseline || 'alphabetic';
+
+    const hasMetrics = typeof ascent === 'number' && typeof descent === 'number'
+        && !Number.isNaN(ascent) && !Number.isNaN(descent);
+
+    const safeAscent = hasMetrics ? ascent! : lineHeight / 2;
+    const safeDescent = hasMetrics ? descent! : lineHeight / 2;
+
+    switch (baseline)
+    {
+        case 'top':
+            return 0;
+        case 'bottom':
+            return lineHeight;
+        case 'middle':
+            return lineHeight / 2;
+        case 'ideographic':
+            return lineHeight - safeDescent;
+        case 'hanging':
+            // No direct metric; approximate at ~20% of line height from top
+            return Math.max(0, Math.min(lineHeight, lineHeight * 0.2));
+        case 'alphabetic':
+        default:
+            return safeAscent;
+    }
+}
+


### PR DESCRIPTION
##### Description of change
BitmapText now renders properly within its bounds. This enables proper vertical centering of the text.
Additionally, textBaseline argument is now taken into consideration and influences text rendering.

<img width="2074" height="868" alt="image" src="https://github.com/user-attachments/assets/5b513636-67a0-4642-a18d-92bba39d2147" />

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Fixes #10791 