### PR TITLE
fix: destroy of prepared but not rendered text should not throw an error

### DIFF
--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -170,7 +170,7 @@ export abstract class PrepareBase
     /** called per frame by the ticker, defer processing to next tick */
     private readonly _tick = () =>
     {
-        if (!this._destroyed) return;
+        if (this._destroyed) return;
 
         this.timeout = setTimeout(this._processQueue, 0) as unknown as number;
     };
@@ -178,7 +178,7 @@ export abstract class PrepareBase
     /** process the queue up to max item limit per frame */
     private readonly _processQueue = () =>
     {
-        if (!this._destroyed) return;
+        if (this._destroyed) return;
 
         const { queue } = this;
         let itemsProcessed = 0;

--- a/src/prepare/PrepareBase.ts
+++ b/src/prepare/PrepareBase.ts
@@ -45,6 +45,8 @@ export abstract class PrepareBase
     /** Timeout id for next processing call */
     protected timeout?: number;
 
+    private _destroyed: boolean;
+
     /**
      * @param {Renderer} renderer - A reference to the current renderer
      */
@@ -159,15 +161,25 @@ export abstract class PrepareBase
         this.queue.length = nextUnique;
     }
 
+    public destroy(): void
+    {
+        this._destroyed = true;
+        clearTimeout(this.timeout);
+    }
+
     /** called per frame by the ticker, defer processing to next tick */
     private readonly _tick = () =>
     {
+        if (!this._destroyed) return;
+
         this.timeout = setTimeout(this._processQueue, 0) as unknown as number;
     };
 
     /** process the queue up to max item limit per frame */
     private readonly _processQueue = () =>
     {
+        if (!this._destroyed) return;
+
         const { queue } = this;
         let itemsProcessed = 0;
 

--- a/src/prepare/PrepareSystem.ts
+++ b/src/prepare/PrepareSystem.ts
@@ -49,6 +49,8 @@ export class PrepareSystem extends PrepareUpload implements System
     /** Destroys the plugin, don't use after this. */
     public destroy(): void
     {
+        super.destroy();
+
         clearTimeout(this.timeout);
         this.renderer = null;
         this.queue = null;

--- a/src/prepare/__tests__/PrepareSystem.test.ts
+++ b/src/prepare/__tests__/PrepareSystem.test.ts
@@ -3,33 +3,38 @@ import '~/scene/text-bitmap/init';
 import '~/scene/text-html/init';
 import { PrepareSystem } from '../PrepareSystem';
 import { getWebGLRenderer } from '@test-utils';
-import { Texture, TextureSource } from '~/rendering';
+import { type Renderer, Texture, TextureSource } from '~/rendering';
 import { Container, Graphics, Sprite, Text } from '~/scene';
+
+let renderer: Renderer;
+let prepare: PrepareSystem;
+
+beforeEach(async () =>
+{
+    renderer = await getWebGLRenderer();
+    prepare = new PrepareSystem(renderer);
+});
+
+afterEach(() =>
+{
+    prepare.destroy();
+    renderer.destroy();
+});
 
 describe('PrepareSystem', () =>
 {
-    const setup = async () =>
-    {
-        const renderer = await getWebGLRenderer();
-        const prepare = new PrepareSystem(renderer);
-
-        return { renderer, prepare };
-    };
-
     describe('Adding to the queue', () =>
     {
-        it('should add a texture source to the queue', async () =>
+        it('should add a texture source to the queue', () =>
         {
-            const { prepare } = await setup();
             const textureSource = new TextureSource();
 
             prepare.add(textureSource);
             expect(prepare.getQueue()).toEqual([textureSource]);
         });
 
-        it('should add a container to the queue', async () =>
+        it('should add a container to the queue', () =>
         {
-            const { prepare } = await setup();
             const container = new Graphics();
 
             prepare.add(container);
@@ -37,9 +42,8 @@ describe('PrepareSystem', () =>
             expect(prepare.getQueue()).toEqual([container.context]);
         });
 
-        it('should add a container and all its children to the queue', async () =>
+        it('should add a container and all its children to the queue', () =>
         {
-            const { prepare } = await setup();
             const container = new Container();
             const child1 = new Sprite();
             const child2 = new Graphics();
@@ -50,18 +54,16 @@ describe('PrepareSystem', () =>
             expect(prepare.getQueue()).toEqual([child1.texture.source, child2.context]);
         });
 
-        it('should add a texture to the queue', async () =>
+        it('should add a texture to the queue', () =>
         {
-            const { prepare } = await setup();
             const texture = new Texture();
 
             prepare.add(texture);
             expect(prepare.getQueue()).toEqual([texture.source]);
         });
 
-        it('should add a graphics context to the queue', async () =>
+        it('should add a graphics context to the queue', () =>
         {
-            const { prepare } = await setup();
             const graphics = new Graphics();
 
             prepare.add(graphics);
@@ -71,9 +73,8 @@ describe('PrepareSystem', () =>
 
     describe('Uploading the queue', () =>
     {
-        it('should dedupe the queue', async () =>
+        it('should dedupe the queue', () =>
         {
-            const { prepare } = await setup();
             const textureSource = new TextureSource();
 
             prepare.add(textureSource);
@@ -88,8 +89,6 @@ describe('PrepareSystem', () =>
 
         it('should upload a graphics correctly', async () =>
         {
-            const { prepare } = await setup();
-
             const graphics = new Graphics();
             const spy = jest.spyOn(prepare as any, 'uploadGraphicsContext');
 
@@ -101,7 +100,6 @@ describe('PrepareSystem', () =>
 
         it('should upload a texture source', async () =>
         {
-            const { prepare } = await setup();
             const textureSource = new TextureSource();
 
             const spy = jest.spyOn(prepare as any, 'uploadTextureSource');
@@ -114,7 +112,6 @@ describe('PrepareSystem', () =>
 
         it('should upload a text view', async () =>
         {
-            const { prepare } = await setup();
             const text = new Text({
                 text: 'foo'
             });
@@ -129,8 +126,6 @@ describe('PrepareSystem', () =>
 
         it('should respected maximum number of uploads per frame', async () =>
         {
-            const { prepare } = await setup();
-
             const uploadSpy = jest.spyOn(prepare as any, 'uploadTextureSource');
             const tickSpy = jest.spyOn(prepare as any, '_tick');
 
@@ -152,8 +147,6 @@ describe('PrepareSystem', () =>
 
         it('should resolve when all uploads done', async () =>
         {
-            const { prepare } = await setup();
-
             const uploadSpy = jest.spyOn(prepare as any, 'uploadTextureSource');
 
             const batches = 3;
@@ -177,8 +170,6 @@ describe('PrepareSystem', () =>
 
         it('should resolve when all uploads done even if more added', async () =>
         {
-            const { prepare } = await setup();
-
             const uploadCount = 10;
             const promises = [];
 
@@ -191,7 +182,7 @@ describe('PrepareSystem', () =>
 
             expect(prepare.getQueue()).toHaveLength(uploadCount);
 
-            void Promise.all(promises).then(() =>
+            await Promise.all(promises).then(() =>
             {
                 expect(prepare.getQueue()).toHaveLength(0);
             });

--- a/src/prepare/__tests__/PrepareSystem.test.ts
+++ b/src/prepare/__tests__/PrepareSystem.test.ts
@@ -188,4 +188,13 @@ describe('PrepareSystem', () =>
             });
         });
     });
+
+    it('should not throw when destroying prepared but not rendered text', async () =>
+    {
+        const text = new Text({ text: 'text' });
+
+        await prepare.upload(text);
+
+        expect(() => text.destroy()).not.toThrow();
+    });
 });

--- a/src/scene/text/canvas/BatchableText.ts
+++ b/src/scene/text/canvas/BatchableText.ts
@@ -33,10 +33,17 @@ export class BatchableText extends BatchableSprite
     public destroy()
     {
         const { canvasText } = this._renderer;
+        const refCount = canvasText.getReferenceCount(this.currentKey);
 
-        canvasText.getReferenceCount(this.currentKey) === null
-            ? canvasText.returnTexture(this.texture)
-            : canvasText.decreaseReferenceCount(this.currentKey);
+        if (refCount > 0)
+        {
+            canvasText.decreaseReferenceCount(this.currentKey);
+        }
+        else if (this.texture)
+        {
+            canvasText.returnTexture(this.texture);
+        }
+
         this._renderer.runners.resolutionChange.remove(this);
         (this._renderer as null) = null;
     }

--- a/src/scene/text/canvas/CanvasTextSystem.ts
+++ b/src/scene/text/canvas/CanvasTextSystem.ts
@@ -233,7 +233,7 @@ export class CanvasTextSystem implements System
      */
     public getReferenceCount(textKey: string)
     {
-        return this._activeTextures[textKey]?.usageCount ?? null;
+        return this._activeTextures[textKey]?.usageCount ?? 0;
     }
 
     private _increaseReferenceCount(textKey: string)


### PR DESCRIPTION
##### Description of change
Fixes: #11613

- BatchableText now verifies that the texture exists before trying to return it.
- PrepareSystem now does not throw an error if it's destroyed before all items from the queue are uploaded.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
