### PR TITLE
fix: ensure `updateTextBounds` is called regardless of style and resolution change

### DIFF
--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -51,7 +51,10 @@ export class CanvasTextPipe implements RenderPipe<Text>
                 // If the text has changed, we need to update the GPU text
                 this._updateGpuText(text);
             }
+
             text._didTextUpdate = false;
+
+            updateTextBounds(batchableText, text);
         }
 
         this._renderer.renderPipes.batch.addToBatch(batchableText, instructionSet);
@@ -77,8 +80,6 @@ export class CanvasTextPipe implements RenderPipe<Text>
 
         batchableText.texture = this._renderer.canvasText.getManagedTexture(text);
         batchableText.currentKey = text.styleKey;
-
-        updateTextBounds(batchableText, text);
     }
 
     private _getGpuText(text: Text)


### PR DESCRIPTION
##### Description of change
Fixes: #11675 

- Text bounds may be influenced by several factors unrelated to direct text/style changes, so we must update them accordingly. The same approach is already in place for `HTMLTextPipe`.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
