### PR TITLE
fix: Allow IRenderLayer as part of the ContainerOptions children array

### DIFF
--- a/src/events/FederatedEventTarget.ts
+++ b/src/events/FederatedEventTarget.ts
@@ -1,4 +1,3 @@
-import { type IRenderLayer } from '../scene/layers/RenderLayer.js';
 import { EventSystem } from './EventSystem';
 import { FederatedEvent } from './FederatedEvent';
 
@@ -1094,7 +1093,7 @@ export interface IFederatedContainer extends FederatedOptions
     readonly parent?: Container | null;
 
     /** The children of this event target. */
-    readonly children?: ReadonlyArray<Container | IRenderLayer>;
+    readonly children?: ReadonlyArray<Container>;
 
     /** @private */
     _internalEventMode: EventMode;

--- a/src/events/FederatedEventTarget.ts
+++ b/src/events/FederatedEventTarget.ts
@@ -1,3 +1,4 @@
+import { type IRenderLayer } from '../scene/layers/RenderLayer.js';
 import { EventSystem } from './EventSystem';
 import { FederatedEvent } from './FederatedEvent';
 
@@ -1093,7 +1094,7 @@ export interface IFederatedContainer extends FederatedOptions
     readonly parent?: Container | null;
 
     /** The children of this event target. */
-    readonly children?: ReadonlyArray<Container>;
+    readonly children?: ReadonlyArray<Container | IRenderLayer>;
 
     /** @private */
     _internalEventMode: EventMode;

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -301,7 +301,7 @@ export interface ContainerOptions<C extends ContainerChild = ContainerChild> ext
      * @see {@link Container#addChild} For adding children
      * @see {@link Container#removeChild} For removing children
      */
-    children?: C[];
+    children?: (C | IRenderLayer)[];
     /**
      * The display object container that contains this display object.
      * This represents the parent-child relationship in the display tree.
@@ -700,7 +700,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @see {@link Container#addChild} For adding children
      * @see {@link Container#removeChild} For removing children
      */
-    public children: C[] = [];
+    public children: (C | IRenderLayer)[] = [];
     /**
      * The display object container that contains this display object.
      * This represents the parent-child relationship in the display tree.

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -9,7 +9,7 @@ import { uid } from '../../utils/data/uid';
 import { deprecation, v8_0_0 } from '../../utils/logging/deprecation';
 import { warn } from '../../utils/logging/warn';
 import { BigPool } from '../../utils/pool/PoolGroup';
-import { type IRenderLayer } from '../layers/RenderLayer';
+import { type RenderLayer } from '../layers/RenderLayer';
 import { cacheAsTextureMixin } from './container-mixins/cacheAsTextureMixin';
 import { childrenHelperMixin } from './container-mixins/childrenHelperMixin';
 import { collectRenderablesMixin } from './container-mixins/collectRenderablesMixin';
@@ -301,7 +301,7 @@ export interface ContainerOptions<C extends ContainerChild = ContainerChild> ext
      * @see {@link Container#addChild} For adding children
      * @see {@link Container#removeChild} For removing children
      */
-    children?: (C | IRenderLayer)[];
+    children?: C[];
     /**
      * The display object container that contains this display object.
      * This represents the parent-child relationship in the display tree.
@@ -737,7 +737,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @readonly
      * @advanced
      */
-    public parentRenderLayer: IRenderLayer;
+    public parentRenderLayer: RenderLayer | null = null;
 
     // / /////////////Transform related props//////////////
 
@@ -990,7 +990,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @see {@link Container#removeChild} For removing children
      * @see {@link Container#addChildAt} For adding at specific index
      */
-    public addChild<U extends(C | IRenderLayer)[]>(...children: U): U[0]
+    public addChild<U extends C[]>(...children: U): U[0]
     {
         // #if _DEBUG
         if (!this.allowChildren)
@@ -1010,7 +1010,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             return children[0];
         }
 
-        const child = children[0] as C;
+        const child = children[0];
 
         const renderGroup = this.renderGroup || this.parentRenderGroup;
 
@@ -1082,7 +1082,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @see {@link Container#addChild} For adding children
      * @see {@link Container#removeChildren} For removing multiple children
      */
-    public removeChild<U extends(C | IRenderLayer)[]>(...children: U): U[0]
+    public removeChild<U extends C[]>(...children: U): U[0]
     {
         // if there is only one argument we can bypass looping through the them
         if (children.length > 1)
@@ -1096,7 +1096,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             return children[0];
         }
 
-        const child = children[0] as C;
+        const child = children[0];
 
         const index = this.children.indexOf(child);
 

--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -700,7 +700,7 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
      * @see {@link Container#addChild} For adding children
      * @see {@link Container#removeChild} For removing children
      */
-    public children: (C | IRenderLayer)[] = [];
+    public children: C[] = [];
     /**
      * The display object container that contains this display object.
      * This represents the parent-child relationship in the display tree.

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -1,7 +1,6 @@
 import { removeItems } from '../../../utils/data/removeItems';
 import { deprecation, v8_0_0 } from '../../../utils/logging/deprecation';
 
-import type { IRenderLayer } from '../../layers/RenderLayer';
 import type { Container, ContainerChild } from '../Container';
 
 /**
@@ -14,8 +13,8 @@ export interface ChildrenHelperMixin<C = ContainerChild>
 {
     /** @internal */
     allowChildren: boolean;
-    addChild<U extends(C | IRenderLayer)[]>(...children: U): U[0];
-    removeChild<U extends(C | IRenderLayer)[]>(...children: U): U[0];
+    addChild<U extends C[]>(...children: U): U[0];
+    removeChild<U extends C[]>(...children: U): U[0];
     /**
      * Removes all children from this container that are within the begin and end indexes.
      * @example
@@ -64,7 +63,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#removeChild} For removing specific children
      * @see {@link Container#removeChildren} For removing multiple children
      */
-    removeChildAt<U extends(C | IRenderLayer)>(index: number): U;
+    removeChildAt<U extends C>(index: number): U;
     /**
      * Returns the child at the specified index.
      * @example
@@ -88,7 +87,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#children} For direct array access
      * @see {@link Container#getChildByLabel} For name-based lookup
      */
-    getChildAt<U extends(C | IRenderLayer)>(index: number): U;
+    getChildAt<U extends C>(index: number): U;
     /**
      * Changes the position of an existing child in the container.
      * @example
@@ -111,7 +110,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#getChildIndex} For getting current index
      * @see {@link Container#swapChildren} For swapping positions
      */
-    setChildIndex(child: C | IRenderLayer, index: number): void;
+    setChildIndex(child: C, index: number): void;
     /**
      * Returns the index position of a child Container instance.
      * @example
@@ -133,7 +132,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#setChildIndex} For changing index
      * @see {@link Container#children} For direct array access
      */
-    getChildIndex(child: C | IRenderLayer): number;
+    getChildIndex(child: C): number;
     /**
      * Adds a child to the container at a specified index. If the index is out of bounds an error will be thrown.
      * If the child is already in this container, it will be moved to the specified index.
@@ -160,7 +159,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#addChild} For adding to the end
      * @see {@link Container#setChildIndex} For moving existing children
      */
-    addChildAt<U extends(C | IRenderLayer)>(child: U, index: number): U;
+    addChildAt<U extends C>(child: U, index: number): U;
     /**
      * Swaps the position of 2 Containers within this container.
      * @example
@@ -186,7 +185,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @see {@link Container#setChildIndex} For direct index placement
      * @see {@link Container#getChildIndex} For getting current positions
      */
-    swapChildren<U extends(C | IRenderLayer)>(child: U, child2: U): void;
+    swapChildren<U extends C>(child: U, child2: U): void;
     /**
      * Remove the Container from its parent Container. If the Container has no parent, do nothing.
      * @example
@@ -248,7 +247,7 @@ export interface ChildrenHelperMixin<C = ContainerChild>
      * @param {Container} oldChild - The child to replace.
      * @param {Container} newChild - The new child to add.
      */
-    replaceChild<U extends(C), T extends(C)>(oldChild: U, newChild: T): void;
+    replaceChild<U extends C, T extends C>(oldChild: U, newChild: T): void;
 }
 
 /** @internal */
@@ -307,14 +306,14 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         throw new RangeError('removeChildren: numeric values are outside the acceptable range.');
     },
 
-    removeChildAt<U extends(ContainerChild | IRenderLayer)>(index: number): U
+    removeChildAt<U extends ContainerChild>(index: number): U
     {
         const child = this.getChildAt<U>(index);
 
         return this.removeChild(child);
     },
 
-    getChildAt<U extends(ContainerChild | IRenderLayer)>(index: number): U
+    getChildAt<U extends ContainerChild>(index: number): U
     {
         if (index < 0 || index >= this.children.length)
         {
@@ -324,7 +323,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         return this.children[index] as U;
     },
 
-    setChildIndex(child: ContainerChild | IRenderLayer, index: number): void
+    setChildIndex(child: ContainerChild, index: number): void
     {
         if (index < 0 || index >= this.children.length)
         {
@@ -335,9 +334,9 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         this.addChildAt(child, index);
     },
 
-    getChildIndex(child: ContainerChild | IRenderLayer): number
+    getChildIndex(child: ContainerChild): number
     {
-        const index = this.children.indexOf(child as ContainerChild);
+        const index = this.children.indexOf(child);
 
         if (index === -1)
         {
@@ -347,7 +346,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         return index;
     },
 
-    addChildAt<U extends(ContainerChild | IRenderLayer)>(child: U, index: number): U
+    addChildAt<U extends ContainerChild>(child: U, index: number): U
     {
         // #if _DEBUG
         if (!this.allowChildren)
@@ -368,7 +367,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
 
         if (child.parent)
         {
-            const currentIndex = child.parent.children.indexOf(child as ContainerChild);
+            const currentIndex = child.parent.children.indexOf(child);
 
             // If this child is in the container and in the same position, do nothing
             if (child.parent === this && currentIndex === index)
@@ -384,11 +383,11 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
 
         if (index === children.length)
         {
-            children.push(child as ContainerChild);
+            children.push(child);
         }
         else
         {
-            children.splice(index, 0, child as ContainerChild);
+            children.splice(index, 0, child);
         }
 
         child.parent = this;
@@ -399,18 +398,18 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
 
         if (renderGroup)
         {
-            renderGroup.addChild(child as ContainerChild);
+            renderGroup.addChild(child);
         }
 
         if (this.sortableChildren) this.sortDirty = true;
 
-        this.emit('childAdded', child as ContainerChild, this, index);
+        this.emit('childAdded', child, this, index);
         child.emit('added', this);
 
         return child;
     },
 
-    swapChildren<U extends(ContainerChild | IRenderLayer)>(child: U, child2: U): void
+    swapChildren<U extends ContainerChild>(child: U, child2: U): void
     {
         if (child === child2)
         {
@@ -420,8 +419,8 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         const index1 = this.getChildIndex(child);
         const index2 = this.getChildIndex(child2);
 
-        this.children[index1] = child2 as ContainerChild;
-        this.children[index2] = child as ContainerChild;
+        this.children[index1] = child2;
+        this.children[index2] = child;
 
         const renderGroup = this.renderGroup || this.parentRenderGroup;
 
@@ -474,7 +473,7 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
         return child;
     },
 
-    replaceChild<U extends(ContainerChild), T extends(ContainerChild)>(oldChild: U, newChild: T)
+    replaceChild<U extends ContainerChild, T extends ContainerChild>(oldChild: U, newChild: T)
     {
         oldChild.updateLocalTransform();
         this.addChildAt(newChild, this.getChildIndex(oldChild));

--- a/src/scene/container/container-mixins/collectRenderablesMixin.ts
+++ b/src/scene/container/container-mixins/collectRenderablesMixin.ts
@@ -1,7 +1,7 @@
 import { type InstructionSet } from '../../../rendering/renderers/shared/instructions/InstructionSet';
 import { type InstructionPipe } from '../../../rendering/renderers/shared/instructions/RenderPipe';
 import { type Renderer, type RenderPipes } from '../../../rendering/renderers/types';
-import { type IRenderLayer } from '../../layers/RenderLayer';
+import { type RenderLayer } from '../../layers/RenderLayer';
 
 import type { Container } from '../Container';
 
@@ -19,33 +19,33 @@ export interface CollectRenderablesMixin
      * This method decides whether to use a simple or advanced collection method based on the container's properties.
      * @param {InstructionSet} instructionSet - The set of instructions to which the renderables will be added.
      * @param {Renderer} renderer - The renderer responsible for rendering the scene.
-     * @param {IRenderLayer} currentLayer - The current render layer being processed.
+     * @param {RenderLayer} currentLayer - The current render layer being processed.
      * @internal
      */
-    collectRenderables(instructionSet: InstructionSet, renderer: Renderer, currentLayer: IRenderLayer): void;
+    collectRenderables(instructionSet: InstructionSet, renderer: Renderer, currentLayer: RenderLayer): void;
 
     /**
      * Collects renderables using a simple method, suitable for containers marked as simple.
      * This method iterates over the container's children and adds their renderables to the instruction set.
      * @param {InstructionSet} instructionSet - The set of instructions to which the renderables will be added.
      * @param {Renderer} renderer - The renderer responsible for rendering the scene.
-     * @param {IRenderLayer} currentLayer - The current render layer being processed.
+     * @param {RenderLayer} currentLayer - The current render layer being processed.
      * @internal
      */
-    collectRenderablesSimple(instructionSet: InstructionSet, renderer: Renderer, currentLayer: IRenderLayer): void;
+    collectRenderablesSimple(instructionSet: InstructionSet, renderer: Renderer, currentLayer: RenderLayer): void;
 
     /**
      * Collects renderables using an advanced method, suitable for containers with complex processing needs.
      * This method handles additional effects and transformations that may be applied to the renderables.
      * @param {InstructionSet} instructionSet - The set of instructions to which the renderables will be added.
      * @param {Renderer} renderer - The renderer responsible for rendering the scene.
-     * @param {IRenderLayer} currentLayer - The current render layer being processed.
+     * @param {RenderLayer} currentLayer - The current render layer being processed.
      * @internal
      */
     collectRenderablesWithEffects(
         instructionSet: InstructionSet,
         renderer: Renderer,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     ): void;
 }
 
@@ -55,7 +55,7 @@ export interface CollectRenderablesMixin
  * @internal
  */
 export const collectRenderablesMixin: Partial<Container> = {
-    collectRenderables(instructionSet: InstructionSet, renderer: Renderer, currentLayer: IRenderLayer): void
+    collectRenderables(instructionSet: InstructionSet, renderer: Renderer, currentLayer: RenderLayer): void
     {
         // Skip processing if the container is not in the current render layer or is not fully visible.
         if ((this.parentRenderLayer && this.parentRenderLayer !== currentLayer)
@@ -84,7 +84,7 @@ export const collectRenderablesMixin: Partial<Container> = {
     collectRenderablesSimple(
         instructionSet: InstructionSet,
         renderer: Renderer,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     ): void
     {
         const children = this.children;
@@ -99,7 +99,7 @@ export const collectRenderablesMixin: Partial<Container> = {
     collectRenderablesWithEffects(
         instructionSet: InstructionSet,
         renderer: Renderer,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     ): void
     {
         const { renderPipes } = renderer;

--- a/src/scene/container/container-mixins/getFastGlobalBoundsMixin.ts
+++ b/src/scene/container/container-mixins/getFastGlobalBoundsMixin.ts
@@ -1,6 +1,6 @@
 import { Matrix } from '../../../maths/matrix/Matrix';
 import { type Renderable } from '../../../rendering/renderers/shared/Renderable';
-import { type IRenderLayer } from '../../layers/RenderLayer';
+import { type RenderLayer } from '../../layers/RenderLayer';
 import { Bounds } from '../bounds/Bounds';
 import { boundsPool } from '../bounds/utils/matrixAndBoundsPool';
 
@@ -35,13 +35,13 @@ export interface GetFastGlobalBoundsMixin
      * This method is used internally by getFastGlobalBounds to traverse the scene graph.
      * @param {boolean} factorRenderLayers - A flag indicating whether to consider render layers in the calculation.
      * @param {Bounds} bounds - The bounds object to update with the calculated values.
-     * @param {IRenderLayer} currentLayer - The current render layer being processed.
+     * @param {RenderLayer} currentLayer - The current render layer being processed.
      * @internal
      */
     _getGlobalBoundsRecursive(
         factorRenderLayers: boolean,
         bounds: Bounds,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     ): void;
 }
 
@@ -78,7 +78,7 @@ export const getFastGlobalBoundsMixin: Partial<Container> = {
     _getGlobalBoundsRecursive(
         factorRenderLayers: boolean,
         bounds: Bounds,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     )
     {
         let localBounds = bounds;

--- a/src/scene/layers/__tests__/RenderLayer.test.ts
+++ b/src/scene/layers/__tests__/RenderLayer.test.ts
@@ -1,9 +1,9 @@
-import { type IRenderLayer, RenderLayer } from '../RenderLayer';
+import { RenderLayer } from '../RenderLayer';
 import { Container } from '~/scene';
 
 describe('RenderLayer', () =>
 {
-    let layer: IRenderLayer;
+    let layer: RenderLayer;
     let container1: Container;
     let container2: Container;
 

--- a/src/scene/particle-container/shared/ParticleContainer.ts
+++ b/src/scene/particle-container/shared/ParticleContainer.ts
@@ -1,5 +1,4 @@
 import { Bounds } from '../../container/bounds/Bounds';
-import { type IRenderLayer } from '../../layers/RenderLayer';
 import { ViewContainer, type ViewContainerOptions } from '../../view/ViewContainer';
 import { type ParticleBuffer } from './ParticleBuffer';
 import { particleData } from './particleData';
@@ -589,7 +588,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @throws {Error} Always throws an error as this method is not available.
      * @ignore
      */
-    public override addChild<U extends(ContainerChild | IRenderLayer)[]>(..._children: U): U[0]
+    public override addChild<U extends ContainerChild[]>(..._children: U): U[0]
     {
         throw new Error(
             'ParticleContainer.addChild() is not available. Please use ParticleContainer.addParticle()',
@@ -602,7 +601,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @throws {Error} Always throws an error as this method is not available.
      * @ignore
      */
-    public override removeChild<U extends(ContainerChild | IRenderLayer)[]>(..._children: U): U[0]
+    public override removeChild<U extends ContainerChild[]>(..._children: U): U[0]
     {
         throw new Error(
             'ParticleContainer.removeChild() is not available. Please use ParticleContainer.removeParticle()',
@@ -631,7 +630,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @throws {Error} Always throws an error as this method is not available.
      * @ignore
      */
-    public override removeChildAt<U extends(ContainerChild | IRenderLayer)>(_index: number): U
+    public override removeChildAt<U extends ContainerChild>(_index: number): U
     {
         throw new Error(
             'ParticleContainer.removeChildAt() is not available. Please use ParticleContainer.removeParticleAt()',
@@ -645,7 +644,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @throws {Error} Always throws an error as this method is not available.
      * @ignore
      */
-    public override getChildAt<U extends(ContainerChild | IRenderLayer)>(_index: number): U
+    public override getChildAt<U extends ContainerChild>(_index: number): U
     {
         throw new Error(
             'ParticleContainer.getChildAt() is not available. Please use ParticleContainer.getParticleAt()',
@@ -689,7 +688,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @throws {Error} Always throws an error as this method is not available.
      * @ignore
      */
-    public override addChildAt<U extends(ContainerChild | IRenderLayer)>(_child: U, _index: number): U
+    public override addChildAt<U extends ContainerChild>(_child: U, _index: number): U
     {
         throw new Error(
             'ParticleContainer.addChildAt() is not available. Please use ParticleContainer.addParticleAt()',
@@ -703,7 +702,7 @@ export class ParticleContainer extends ViewContainer<ParticleBuffer> implements 
      * @param {ContainerChild} _child2
      * @ignore
      */
-    public override swapChildren<U extends(ContainerChild | IRenderLayer)>(_child: U, _child2: U): void
+    public override swapChildren<U extends ContainerChild>(_child: U, _child2: U): void
     {
         throw new Error(
             'ParticleContainer.swapChildren() is not available. Please use ParticleContainer.swapParticles()',

--- a/src/scene/view/ViewContainer.ts
+++ b/src/scene/view/ViewContainer.ts
@@ -3,7 +3,7 @@ import { type RenderPipe } from '../../rendering/renderers/shared/instructions/R
 import { type Renderer } from '../../rendering/renderers/types';
 import { Bounds } from '../container/bounds/Bounds';
 import { Container, type ContainerOptions } from '../container/Container';
-import { type IRenderLayer } from '../layers/RenderLayer';
+import { type RenderLayer } from '../layers/RenderLayer';
 
 import type { PointData } from '../../maths/point/PointData';
 import type { View } from '../../rendering/renderers/shared/view/View';
@@ -178,7 +178,7 @@ export abstract class ViewContainer<GPU_DATA extends GPUData = any> extends Cont
     public override collectRenderablesSimple(
         instructionSet: InstructionSet,
         renderer: Renderer,
-        currentLayer: IRenderLayer,
+        currentLayer: RenderLayer,
     ): void
     {
         const { renderPipes } = renderer;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Currently it is possible to provide a `IRenderLayer` as an argument to the `Container`'s `addChild` but it is not possible to provide it as an element of `children` in `ContainerOptions`.

Before this patch the following gives a typescript error:

```ts
new Container({
  children: [
    new RenderLayer(),
  ]
})
```

while

```ts
const container = new Container();
container.addChild(new RenderLayer());
```
works without typescript type error. With this change both of these cases work.

This change will also have the following side effect:

```ts
// Before patch
const parentContainer = new Container<ContainerChild>();
for (const childContainer of parentContainer.children) {
  // Calling container method on childContainer is always possible
  childContainer.getGlobalTint()
}

// After patch
const parentContainer = new Container<ContainerChild>();
for (const childContainer of parentContainer.children) {
  // Calling container method on childContainer is not possible as
  // childContainer is either ContainerChild or IRenderLayer
  childContainer.getGlobalTint()
}
```

I am open to the idea of making the change _only_ to `ContainerOptions` rather than both to the `ContainerOptions` _and_ `Container["children"]`. This would not cause the issue above, but it would continue to be misleading.

An alternative solution could be to expose `RenderLayer` as a class that extends `Container` rather than [hiding that fact](https://github.com/pixijs/pixijs/blob/8eee29cd4ceb3b5f402e3ddce3679e96e8c6cf5f/src/scene/layers/RenderLayer.ts#L521) but I do not know what that would entail.


##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
