### PR TITLE
feat: add asset loading strategies

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -11,7 +11,7 @@ import { detectMp4 } from './detections/parsers/detectMp4';
 import { detectOgv } from './detections/parsers/detectOgv';
 import { detectWebm } from './detections/parsers/detectWebm';
 import { detectWebp } from './detections/parsers/detectWebp';
-import { Loader } from './loader/Loader';
+import { Loader, type LoadOptions } from './loader/Loader';
 import { loadJson } from './loader/parsers/loadJson';
 import { loadTxt } from './loader/parsers/loadTxt';
 import { loadWebFont } from './loader/parsers/loadWebFont';
@@ -252,6 +252,30 @@ export interface AssetInitOptions
      * ```
      */
     preferences?: Partial<AssetsPreferences>;
+
+    /**
+     * Options for defining the loading behavior of assets.
+     * @example
+     * ```ts
+     * await Assets.init({
+     *    loadOptions: {
+     *       onProgress: (progress) => console.log(`Loading: ${Math.round(progress * 100)}%`),
+     *       onError: (error, asset) => console.error(`Error loading ${asset.src}: ${error.message}`),
+     *       strategy: 'retry',
+     *       retryCount: 5,
+     *       retryDelay: 500,
+     *   }
+     * });
+     * ```
+     * @remarks
+     * - `onProgress` callback receives values from 0.0 to 1.0
+     * - `onError` callback is invoked for individual asset load failures
+     * - `strategy` can be 'throw' (default), 'retry', or 'skip'
+     * - `retryCount` sets how many times to retry failed assets (default 3)
+     * - `retryDelay` sets the delay between retries in milliseconds (default 250ms)
+     * @see {@link LoadOptions} For all available load options
+     */
+    loadOptions?: Partial<LoadOptions>;
 }
 
 /** @internal */
@@ -415,6 +439,15 @@ export class AssetsClass
         {
             this.setPreferences(options.preferences);
         }
+
+        // set load options on the loader
+        if (options.loadOptions)
+        {
+            this.loader.loadOptions = {
+                ...this.loader.loadOptions,
+                ...options.loadOptions
+            };
+        }
     }
 
     /**
@@ -539,15 +572,15 @@ export class AssetsClass
      */
     public async load<T = any>(
         urls: string | UnresolvedAsset,
-        onProgress?: ProgressCallback,
+        onProgress?: ProgressCallback | LoadOptions,
     ): Promise<T>;
     public async load<T = any>(
         urls: string[] | UnresolvedAsset[],
-        onProgress?: ProgressCallback,
+        onProgress?: ProgressCallback | LoadOptions,
     ): Promise<Record<string, T>>;
     public async load<T = any>(
         urls: ArrayOr<string> | ArrayOr<UnresolvedAsset>,
-        onProgress?: ProgressCallback
+        onProgress?: ProgressCallback | LoadOptions,
     ): Promise<T | Record<string, T>>
     {
         if (!this._initialized)
@@ -980,11 +1013,11 @@ export class AssetsClass
     /**
      * helper function to map resolved assets back to loaded assets
      * @param resolveResults - the resolve results from the resolver
-     * @param onProgress - the progress callback
+     * @param progressOrLoadOptions - the progress callback or load options
      */
     private async _mapLoadToResolve<T>(
         resolveResults: ResolvedAsset | Record<string, ResolvedAsset>,
-        onProgress?: ProgressCallback
+        progressOrLoadOptions?: ProgressCallback | LoadOptions,
     ): Promise<Record<string, T>>
     {
         const resolveArray = [...new Set(Object.values(resolveResults))] as ResolvedAsset[];
@@ -992,7 +1025,7 @@ export class AssetsClass
         // pause background loader...
         this._backgroundLoader.active = false;
 
-        const loadedAssets = await this.loader.load<T>(resolveArray, onProgress);
+        const loadedAssets = await this.loader.load<T>(resolveArray, progressOrLoadOptions);
 
         // resume background loader...
         this._backgroundLoader.active = true;

--- a/src/assets/__tests__/Assets.test.ts
+++ b/src/assets/__tests__/Assets.test.ts
@@ -28,6 +28,51 @@ describe('Assets', () =>
         expect(bunny2).toBeInstanceOf(Texture);
     });
 
+    it('should set default load options', async () =>
+    {
+        await Assets.init({
+            basePath,
+            loadOptions: {
+                retryCount: 5,
+                retryDelay: 100,
+                onProgress: () => { /** empty */ },
+            }
+        });
+
+        const bunny = await Assets.load('textures/bunny.png');
+        const bunny2 = await Assets.load({
+            src: 'textures/bunny.png'
+        });
+
+        expect(bunny).toBeInstanceOf(Texture);
+        expect(bunny2).toBeInstanceOf(Texture);
+        expect(Assets.loader.loadOptions.retryCount).toBe(5);
+        expect(Assets.loader.loadOptions.retryDelay).toBe(100);
+        expect(Assets.loader.loadOptions.onProgress).toBeInstanceOf(Function);
+    });
+
+    it('should set load options when passed directly', async () =>
+    {
+        await Assets.init({
+            basePath,
+        });
+
+        const bunny = await Assets.load('textures/bunny.png');
+        const bunny2 = await Assets.load({
+            src: 'textures/bunny.png'
+        }, {
+            retryCount: 5,
+            retryDelay: 100,
+            onProgress: () => { /** empty */ },
+        });
+
+        expect(bunny).toBeInstanceOf(Texture);
+        expect(bunny2).toBeInstanceOf(Texture);
+        expect(Assets.loader.loadOptions.retryCount).toBe(5);
+        expect(Assets.loader.loadOptions.retryDelay).toBe(100);
+        expect(Assets.loader.loadOptions.onProgress).toBeInstanceOf(Function);
+    });
+
     it('should load assets with the correct progress', async () =>
     {
         await Assets.init({

--- a/src/assets/loader/Loader.ts
+++ b/src/assets/loader/Loader.ts
@@ -1,11 +1,101 @@
 import { warn } from '../../utils/logging/warn';
 import { path } from '../../utils/path';
+import { type ProgressCallback } from '../Assets';
 import { convertToList } from '../utils/convertToList';
 import { isSingleItem } from '../utils/isSingleItem';
 
 import type { ResolvedAsset } from '../types';
 import type { LoaderParser } from './parsers/LoaderParser';
 import type { PromiseAndParser } from './types';
+
+/**
+ * Options for loading assets with the Loader
+ * @example
+ * ```ts
+ * await Assets.load(['file1.png', 'file2.png'], {
+ *   onProgress: (progress) => console.log(`Progress: ${progress * 100}%`),
+ *   onError: (error, url) => console.error(`Error loading ${url}: ${error.message}`),
+ *   strategy: 'retry', // 'throw' | 'skip' | 'retry'
+ *   retryCount: 5, // Number of retry attempts if strategy is 'retry'
+ *   retryDelay: 500, // Delay in ms between retries
+ * });
+ * ```
+ * @category assets
+ * @standard
+ */
+export interface LoadOptions
+{
+    /**
+     * Callback for progress updates during loading
+     * @param progress - A number between 0 and 1 indicating the load progress
+     * @example
+     * ```ts
+     * const options: LoadOptions = {
+     *   onProgress: (progress) => {
+     *     console.log(`Loading progress: ${progress * 100}%`);
+     *   },
+     * };
+     * await Assets.load('image.png', options);
+     * ```
+     */
+    onProgress?: (progress: number) => void;
+    /**
+     * Callback for handling errors during loading
+     * @param error - The error that occurred
+     * @param url - The URL of the asset that failed to load
+     * @example
+     * ```ts
+     * const options: LoadOptions = {
+     *   onError: (error, url) => {
+     *     console.error(`Failed to load ${url}: ${error.message}`);
+     *   },
+     * };
+     * await Assets.load('missing-file.png', options);
+     * ```
+     */
+    onError?: (error: Error, url: string | ResolvedAsset) => void;
+    /**
+     * Strategy to handle load failures
+     * - 'throw': Immediately throw an error and stop loading (default)
+     * - 'skip': Skip the failed asset and continue loading others
+     * - 'retry': Retry loading the asset a specified number of times
+     * @default 'throw'
+     * @example
+     * ```ts
+     * const options: LoadOptions = {
+     *   strategy: 'skip',
+     * };
+     * await Assets.load('sometimes-fails.png', options);
+     * ```
+     */
+    strategy?: 'throw' | 'skip' | 'retry';
+    /**
+     * Number of retry attempts if strategy is 'retry'
+     * @default 3
+     * @example
+     * ```ts
+     * const options: LoadOptions = {
+     *   strategy: 'retry',
+     *   retryCount: 5, // Retry up to 5 times
+     * };
+     * await Assets.load('unstable-asset.png', options);
+     * ```
+     */
+    retryCount?: number;
+    /**
+     * Delay in milliseconds between retry attempts
+     * @default 250
+     * @example
+     * ```ts
+     * const options: LoadOptions = {
+     *   strategy: 'retry',
+     *   retryDelay: 1000, // Wait 1 second between retries
+     * };
+     * await Assets.load('sometimes-fails.png', options);
+     * ```
+     */
+    retryDelay?: number;
+}
 
 /**
  * The Loader is responsible for loading all assets, such as images, spritesheets, audio files, etc.
@@ -20,6 +110,43 @@ import type { PromiseAndParser } from './types';
  */
 export class Loader
 {
+    /**
+     * Default options for loading assets
+     * @example
+     * ```ts
+     * // Change default load options globally
+     * Loader.defaultOptions = {
+     *   strategy: 'skip', // Change default strategy to 'skip'
+     *   retryCount: 5,   // Change default retry count to 5
+     *   retryDelay: 500, // Change default retry delay to 500ms
+     * };
+     * ```
+     */
+    public static defaultOptions: LoadOptions = {
+        onProgress: undefined,
+        onError: undefined,
+        strategy: 'throw',
+        retryCount: 3,
+        retryDelay: 250,
+    };
+    /**
+     * Options for loading assets with the loader.
+     * These options will be used as defaults for all load calls made with this loader instance.
+     * They can be overridden by passing options directly to the load method.
+     * @example
+     * ```ts
+     * // Create a loader with custom default options
+     * const loader = new Loader();
+     * loader.loadOptions = {
+     *   strategy: 'skip', // Default strategy to 'skip'
+     *   retryCount: 5,   // Default retry count to 5
+     *   retryDelay: 500, // Default retry delay to 500ms
+     * };
+     *
+     * // This load call will use the loader's default options
+     * await loader.load('image1.png');
+     */
+    public loadOptions: LoadOptions = { ...Loader.defaultOptions };
     private readonly _parsers: LoaderParser[] = [];
     private _parserHash: Record<string, LoaderParser>;
 
@@ -162,21 +289,26 @@ export class Loader
      */
     public async load<T = any>(
         assetsToLoadIn: string | ResolvedAsset,
-        onProgress?: (progress: number) => void,
+        onProgress?: ProgressCallback | LoadOptions,
     ): Promise<T>;
     public async load<T = any>(
         assetsToLoadIn: string[] | ResolvedAsset[],
-        onProgress?: (progress: number) => void,
+        onProgress?: ProgressCallback | LoadOptions,
     ): Promise<Record<string, T>>;
     public async load<T = any>(
         assetsToLoadIn: string | string[] | ResolvedAsset | ResolvedAsset[],
-        onProgress?: (progress: number) => void,
+        onProgressOrOptions?: ProgressCallback | LoadOptions,
     ): Promise<T | Record<string, T>>
     {
         if (!this._parsersValidated)
         {
             this._validateParsers();
         }
+
+        const options: LoadOptions = typeof onProgressOrOptions === 'function'
+            ? { ...Loader.defaultOptions, ...this.loadOptions, onProgress: onProgressOrOptions }
+            : { ...Loader.defaultOptions, ...this.loadOptions, ...(onProgressOrOptions || {}) };
+        const { onProgress, onError, strategy, retryCount, retryDelay } = options;
 
         let count = 0;
 
@@ -196,31 +328,11 @@ export class Loader
         {
             const url = path.toAbsolute(asset.src);
 
-            if (!assets[asset.src])
-            {
-                try
-                {
-                    if (!this.promiseCache[url])
-                    {
-                        this.promiseCache[url] = this._getLoadPromiseAndParser(url, asset);
-                    }
+            if (assets[asset.src]) return;
 
-                    assets[asset.src] = await this.promiseCache[url].promise;
+            await this._loadAssetWithRetry(url, asset, { onProgress, onError, strategy, retryCount, retryDelay }, assets);
 
-                    // Only progress if nothing goes wrong
-                    if (onProgress) onProgress(++count / total);
-                }
-                catch (e)
-                {
-                    // Delete eventually registered file and promises from internal cache
-                    // so they can be eligible for another loading attempt
-                    delete this.promiseCache[url];
-                    delete assets[asset.src];
-
-                    // Stop further execution
-                    throw new Error(`[Loader.load] Failed to load ${url}.\n${e}`);
-                }
-            }
+            if (onProgress) onProgress(++count / total);
         });
 
         await Promise.all(promises);
@@ -296,5 +408,60 @@ export class Loader
 
                 return hash;
             }, {} as Record<string, LoaderParser>);
+    }
+
+    private async _loadAssetWithRetry(
+        url: string,
+        asset: ResolvedAsset,
+        options: LoadOptions,
+        assets: Record<string, Promise<any>>
+    )
+    {
+        let attempt = 0;
+        const { onError, strategy, retryCount, retryDelay } = options;
+        const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+        while (true)
+        {
+            try
+            {
+                if (!this.promiseCache[url])
+                {
+                    this.promiseCache[url] = this._getLoadPromiseAndParser(url, asset);
+                }
+
+                assets[asset.src] = await this.promiseCache[url].promise;
+
+                return;
+            }
+            catch (e)
+            {
+                // clear cache for a new attempt
+                delete this.promiseCache[url];
+                delete assets[asset.src];
+
+                attempt++;
+
+                const isLast = strategy !== 'retry' || attempt > retryCount;
+
+                if (strategy === 'retry' && !isLast)
+                {
+                    if (onError) onError(e as Error, asset);
+                    await wait(retryDelay);
+                    continue;
+                }
+
+                if (strategy === 'skip')
+                {
+                    if (onError) onError(e as Error, asset);
+
+                    return;
+                }
+
+                // strategy 'throw' or exhausted 'retry'
+                if (onError) onError(e as Error, asset);
+                throw new Error(`[Loader.load] Failed to load ${url}.\n${e}`);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds load options for configuring asset loading behavior, including retry strategies and error handling.

Provides a new `LoadOptions` interface with properties for:
- Progress and error callbacks
- Failure handling strategies ('throw', 'skip', 'retry')
  - 'throw': Immediately throw an error and stop loading (default)
  - 'skip': Skip the failed asset and continue loading others
  - 'retry': Retry loading the asset a specified number of times  
- Retry attempt count and delay

example:

```ts
const options: LoadOptions = {
  strategy: 'retry',
  retryCount: 5, // Retry up to 5 times
};
await Assets.load('unstable-asset.png', options);
```
```ts
await Assets.init({
    basePath,
    loadOptions: { strategy: 'skip', onError: (error, asset) => console.log(error, asset.url) },
});

Assets.addBundle('testBundle', [
    { alias: 'bunny', src: 'textures/bunny_no_img.png' },
    { alias: 'bunny2', src: 'textures/bunny.png' },
]);

// only bunny2 is defined and did not throw an error
const assets = await Assets.loadBundle('testBundle');
```

Implements #10609
