### PR TITLE
fix: removes accessibility system event listeners correctly

### DIFF
--- a/src/accessibility/AccessibilitySystem.ts
+++ b/src/accessibility/AccessibilitySystem.ts
@@ -479,10 +479,6 @@ export class AccessibilitySystem implements System<AccessibilitySystemOptions>
         {
             this._activate();
         }
-        else if (this._activateOnTab)
-        {
-            globalThis.addEventListener('keydown', this._boundOnKeyDown, false);
-        }
 
         this._renderer.runners.postrender.remove(this);
     }


### PR DESCRIPTION
Fixes: #11698

Ensures event listeners are properly removed to prevent crash.
Stores bound function references for event listeners and uses these to properly remove the listeners.

This also ensures that unless you explicitly enable the accessibility system the `keydown` listener is not added. This can be through init options or calling setAccessibilityEnabled
