### PR TITLE
feat: added rotate to Point math-extras

### DIFF
--- a/src/math-extras/MathExtraMixins.d.ts
+++ b/src/math-extras/MathExtraMixins.d.ts
@@ -428,6 +428,42 @@ declare global
             normal: import('../maths/point/PointData').PointData,
             outPoint?: T
         ): T;
+
+        /**
+         * Rotates `this` vector.
+         *
+         * Like a light ray bouncing off a mirror surface.
+         * `this` vector is the light and `normal` is a vector perpendicular to the mirror.
+         * `this.reflect(normal)` is the reflection of `this` on that mirror.
+         *
+         * > [!IMPORTANT] Only available with **pixi.js/math-extras**.
+         * @example
+         * ```ts
+         * // Basic point rotation
+         * const point = new Point(10, 20);
+         * const degrees = 45
+         * const radians = degrees * (Math.PI / 180)
+         * const result = point.rotate(radians);
+         * console.log(result); // {x: -7.071067811865474, y: 21.213203435596427}
+         *
+         * // Using output point for efficiency
+         * const output = new Point(10, 20);
+         * point.rotate(90 * (Math.PI / 180), output);
+         * console.log(result); // {x: -7.071067811865474, y: 21.213203435596427}
+         *
+         * // Chain multiple additions
+         * const final = point.rotate(radians).rotate(radians2);
+         * ```
+         * @remarks
+         * convert degrees to radians with const radians = degrees * (Math.PI / 180)
+         * @param {PointData} radians - The rotation angle in radians
+         * @param {PointData} outPoint - Optional Point-like object to store result
+         * @returns The outPoint or a new Point with rotated result
+         */
+        rotate<T extends import('../maths/point/PointData').PointData = import('../maths/point/Point').Point>(
+            radians: number,
+            outPoint?: T
+        ): T;
     }
 }
 

--- a/src/math-extras/__tests__/Point.test.ts
+++ b/src/math-extras/__tests__/Point.test.ts
@@ -562,5 +562,100 @@ describe('Point', () =>
             expect(oc.y).toEqual(-86);
         });
     });
+
+    describe('rotate', () =>
+    {
+        it('should rotate component-wise', () =>
+        {
+            const radians = 45 * (Math.PI / 180);
+            const cosTheta = Math.cos(radians);
+            const sinTheta = Math.sin(radians);
+            const rotated = {
+                x: (2 * cosTheta) - (3 * sinTheta),
+                y: (2 * sinTheta) + (3 * cosTheta)
+            };
+
+            // Point
+            const a = new Point(2, 3);
+            const c = a.rotate(radians);
+
+            expect(c.x).toBeCloseTo(rotated.x, 0.001);
+            expect(c.y).toBeCloseTo(rotated.y, 0.001);
+
+            // ObservablePoint
+            const oa = new ObservablePoint(observer, 2, 3);
+            const oc = oa.rotate(radians);
+
+            expect(oc.x).toBeCloseTo(rotated.x, 0.001);
+            expect(oc.y).toBeCloseTo(rotated.y, 0.001);
+        });
+
+        it('should return the same reference given', () =>
+        {
+            const radians = 45 * (Math.PI / 180);
+
+            // Point
+            const a = new Point(1, 2);
+            const c = a.rotate(radians, a);
+
+            expect(c).toEqual(a);
+
+            // ObservablePoint
+            const oa = new ObservablePoint(observer, 1, 2);
+            const oc = oa.rotate(radians, oa);
+
+            expect(oc).toEqual(oa);
+        });
+
+        it('can output into any IPointData given', () =>
+        {
+            const radians = 45 * (Math.PI / 180);
+            const cosTheta = Math.cos(radians);
+            const sinTheta = Math.sin(radians);
+            const rotated = {
+                x: (2 * cosTheta) - (3 * sinTheta),
+                y: (2 * sinTheta) + (3 * cosTheta)
+            };
+
+            // Point
+            const a = new Point(2, 3);
+            const c = a.rotate(radians, { x: 0, y: 0 });
+
+            expect(c.x).toBeCloseTo(rotated.x, 0.001);
+            expect(c.y).toBeCloseTo(rotated.y, 0.001);
+
+            // ObservablePoint
+            const oa = new ObservablePoint(observer, 2, 3);
+            const oc = oa.rotate(radians, { x: 0, y: 0 });
+
+            expect(oc.x).toBeCloseTo(rotated.x, 0.001);
+            expect(oc.y).toBeCloseTo(rotated.y, 0.001);
+        });
+
+        it('can take any IPointData as other input', () =>
+        {
+            const radians = 45 * (Math.PI / 180);
+            const cosTheta = Math.cos(radians);
+            const sinTheta = Math.sin(radians);
+            const rotated = {
+                x: (2 * cosTheta) - (3 * sinTheta),
+                y: (2 * sinTheta) + (3 * cosTheta)
+            };
+
+            // Point
+            const a = new Point(2, 3);
+            const c = a.rotate(radians, { x: 4, y: 5 });
+
+            expect(c.x).toBeCloseTo(rotated.x, 0.001);
+            expect(c.y).toBeCloseTo(rotated.y, 0.001);
+
+            // ObservablePoint
+            const oa = new ObservablePoint(observer, 2, 3);
+            const oc = oa.rotate(radians, { x: 4, y: 5 });
+
+            expect(oc.x).toBeCloseTo(rotated.x, 0.001);
+            expect(oc.y).toBeCloseTo(rotated.y, 0.001);
+        });
+    });
 });
 

--- a/src/math-extras/pointExtras.ts
+++ b/src/math-extras/pointExtras.ts
@@ -115,5 +115,20 @@ export const pointExtraMixins: any = {
         outPoint.y = this.y - (2 * dotProduct * normal.y);
 
         return outPoint;
+    },
+    rotate<T extends PointData>(radians: number, outPoint?: T): T
+    {
+        if (!outPoint)
+        {
+            outPoint = new Point() as PointData as T;
+        }
+
+        const cosTheta = Math.cos(radians);
+        const sinTheta = Math.sin(radians);
+
+        outPoint.x = (this.x * cosTheta) - (this.y * sinTheta);
+        outPoint.y = (this.x * sinTheta) + (this.y * cosTheta);
+
+        return outPoint;
     }
 };

--- a/src/math-extras/pointExtras.ts
+++ b/src/math-extras/pointExtras.ts
@@ -118,10 +118,7 @@ export const pointExtraMixins: any = {
     },
     rotate<T extends PointData>(radians: number, outPoint?: T): T
     {
-        if (!outPoint)
-        {
-            outPoint = new Point() as PointData as T;
-        }
+        outPoint ??= new Point() as PointData as T;
 
         const cosTheta = Math.cos(radians);
         const sinTheta = Math.sin(radians);


### PR DESCRIPTION
##### Description of change
Added a vector rotation method to the Point and ObservablePoint classes in `math-extras`
Includes types, tests, and docs
##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

Related question:
Is there a way to generate type data for the files like `pointExtras.d.ts` and `rectangelExtras.d.ts` ? 
You can currently do stuff like `import { multiplyScalar } from '@pixi/math-extras/lib/pointExtras.js'` but it is missing type data. This would let you import and mixin only the methods you are using
