### PR TITLE
fix: calculate DOMContainer position relative to parent element

### DIFF
--- a/src/dom/CanvasObserver.ts
+++ b/src/dom/CanvasObserver.ts
@@ -61,9 +61,13 @@ export class CanvasObserver
     public readonly updateTranslation = () =>
     {
         if (!this._canvas) return;
-        const parent = this._canvas.parentElement;
+        const parentNode = this._canvas.parentNode;
 
-        if (!parent) return;
+        if (!parentNode) return;
+
+        const parent = parentNode instanceof ShadowRoot ? parentNode.host : parentNode;
+
+        if (!(parent instanceof Element)) return;
 
         const canvasRect = this._canvas.getBoundingClientRect();
         const parentRect = parent.getBoundingClientRect();

--- a/src/dom/CanvasObserver.ts
+++ b/src/dom/CanvasObserver.ts
@@ -61,15 +61,20 @@ export class CanvasObserver
     public readonly updateTranslation = () =>
     {
         if (!this._canvas) return;
+        const parent = this._canvas.parentElement;
 
-        const rect = this._canvas.getBoundingClientRect(); // still needed for left/top
+        if (!parent) return;
+
+        const canvasRect = this._canvas.getBoundingClientRect();
+        const parentRect = parent.getBoundingClientRect();
         const contentWidth = this._canvas.width;
         const contentHeight = this._canvas.height;
 
-        const sx = (rect.width / contentWidth) * this._renderer.resolution;
-        const sy = (rect.height / contentHeight) * this._renderer.resolution;
-        const tx = rect.left;
-        const ty = rect.top;
+        const sx = (canvasRect.width / contentWidth) * this._renderer.resolution;
+        const sy = (canvasRect.height / contentHeight) * this._renderer.resolution;
+        // Calculate position relative to parent, not viewport
+        const tx = canvasRect.left - parentRect.left;
+        const ty = canvasRect.top - parentRect.top;
 
         const newTransform = `translate(${tx}px, ${ty}px) scale(${sx}, ${sy})`;
 

--- a/src/dom/CanvasObserver.ts
+++ b/src/dom/CanvasObserver.ts
@@ -76,9 +76,14 @@ export class CanvasObserver
 
         const sx = (canvasRect.width / contentWidth) * this._renderer.resolution;
         const sy = (canvasRect.height / contentHeight) * this._renderer.resolution;
-        // Calculate position relative to parent, not viewport
-        const tx = canvasRect.left - parentRect.left;
-        const ty = canvasRect.top - parentRect.top;
+
+        // Check if canvas uses absolute/fixed positioning
+        const canvasStyle = getComputedStyle(this._canvas);
+        const isPositioned = canvasStyle.position === 'absolute' || canvasStyle.position === 'fixed';
+
+        // For positioned elements, use viewport coords; otherwise calculate relative to parent
+        const tx = isPositioned ? canvasRect.left : canvasRect.left - parentRect.left;
+        const ty = isPositioned ? canvasRect.top : canvasRect.top - parentRect.top;
 
         const newTransform = `translate(${tx}px, ${ty}px) scale(${sx}, ${sy})`;
 


### PR DESCRIPTION
## Summary
Fixes #11690

## Problem
The `DOMContainer` translate was incorrectly using viewport coordinates from `getBoundingClientRect()` directly. When the canvas is inside a positioned parent element (e.g., `position: absolute` with `left` offset), this caused the `DOMContainer` to be offset by the parent's position.

## Solution
Calculate the canvas position relative to its parent element by subtracting the parent's bounding rect from the canvas bounding rect:

```typescript
const canvasRect = this._canvas.getBoundingClientRect();
const parentRect = parent.getBoundingClientRect();
const tx = canvasRect.left - parentRect.left;
const ty = canvasRect.top - parentRect.top;
```

## Testing
- Build passes
- Verified fix with the reproduction from the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed DOMContainer translation being offset when the canvas is inside a positioned DOM parent element (absolute, fixed, or relative positioning). The fix now correctly computes canvas position relative to its parent instead of always using viewport coordinates.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->