### PR TITLE
Fix #11790: HTML Text: incorrect texture reference when batch updating resolution

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -110,6 +110,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         // It's necessary to ensure that the texture won't be captured by another field and overwritten with their
         // content, while our texture is still in progress.
         const oldTexturePromise = batchableHTMLText.texturePromise;
+        const oldTextureKey = batchableHTMLText.currentKey;
 
         batchableHTMLText.texturePromise = null;
 
@@ -117,35 +118,36 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
 
         htmlText._resolution = htmlText._autoResolution ? this._renderer.resolution : htmlText.resolution;
 
-        let texturePromise = this._renderer.htmlText.getTexturePromise(htmlText);
-
-        if (oldTexturePromise)
-        {
-            // Release old texture after new one is generated.
-            texturePromise = texturePromise.finally(() =>
-            {
-                this._renderer.htmlText.decreaseReferenceCount(batchableHTMLText.currentKey);
-                this._renderer.htmlText.returnTexturePromise(oldTexturePromise);
-            });
-        }
+        const texturePromise = this._renderer.htmlText.getTexturePromise(htmlText);
 
         batchableHTMLText.texturePromise = texturePromise;
         batchableHTMLText.currentKey = htmlText.styleKey;
 
-        batchableHTMLText.texture = await texturePromise;
-
-        // need a rerender...
-        const renderGroup = htmlText.renderGroup || htmlText.parentRenderGroup;
-
-        if (renderGroup)
+        try
         {
-            // need a rebuild of the render group
-            renderGroup.structureDidChange = true;
+            batchableHTMLText.texture = await texturePromise;
+
+            if (oldTexturePromise)
+            {
+                this._renderer.htmlText.decreaseReferenceCount(oldTextureKey);
+                this._renderer.htmlText.returnTexturePromise(oldTexturePromise);
+            }
+
+            // need a rerender...
+            const renderGroup = htmlText.renderGroup || htmlText.parentRenderGroup;
+
+            if (renderGroup)
+            {
+                // need a rebuild of the render group
+                renderGroup.structureDidChange = true;
+            }
+
+            updateTextBounds(batchableHTMLText, htmlText);
         }
-
-        batchableHTMLText.generatingTexture = false;
-
-        updateTextBounds(batchableHTMLText, htmlText);
+        finally
+        {
+            batchableHTMLText.generatingTexture = false;
+        }
     }
 
     private _getGpuText(htmlText: HTMLText)
@@ -190,4 +192,3 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         this._renderer = null;
     }
 }
-

--- a/src/scene/text-html/__tests__/HTMLText.test.ts
+++ b/src/scene/text-html/__tests__/HTMLText.test.ts
@@ -1,5 +1,6 @@
 import { HTMLText } from '../HTMLText';
 import { getWebGLRenderer } from '@test-utils';
+import { Texture } from '~/rendering/renderers/shared/texture/Texture';
 
 describe('HTMLText', () =>
 {
@@ -41,6 +42,36 @@ describe('HTMLText', () =>
         text.destroy();
 
         expect(() => { renderer.resolution = 3; }).not.toThrow();
+
+        renderer.destroy();
+    });
+
+    it('should release the previous texture using the previous style key after resolution updates', async () =>
+    {
+        const text = new HTMLText({ text: 'foo' });
+
+        const renderer = await getWebGLRenderer();
+        const htmlTextPipe = renderer.renderPipes.htmlText as any;
+
+        const getTexturePromiseSpy = jest.spyOn(renderer.htmlText, 'getTexturePromise')
+            .mockResolvedValueOnce(Texture.EMPTY)
+            .mockResolvedValueOnce(Texture.WHITE);
+        const decreaseReferenceCountSpy = jest.spyOn(renderer.htmlText, 'decreaseReferenceCount')
+            .mockImplementation(() => undefined);
+        const returnTexturePromiseSpy = jest.spyOn(renderer.htmlText, 'returnTexturePromise')
+            .mockImplementation(() => undefined);
+
+        await htmlTextPipe['_updateGpuText'](text);
+
+        const oldStyleKey = text.styleKey;
+
+        text.resolution = 2;
+
+        await htmlTextPipe['_updateGpuText'](text);
+
+        expect(getTexturePromiseSpy).toHaveBeenCalledTimes(2);
+        expect(decreaseReferenceCountSpy).toHaveBeenCalledWith(oldStyleKey);
+        expect(returnTexturePromiseSpy).toHaveBeenCalledTimes(1);
 
         renderer.destroy();
     });


### PR DESCRIPTION
## Summary

This PR resolves #11790.

### Changes

Fixed HTMLText async texture update cleanup to keep old texture references stable during resolution changes by capturing and releasing the previous key/promise only after the new texture is applied, and added a regression unit test for the previous-key release behavior.

### Files Modified

- `src/scene/text-html/HTMLTextPipe.ts`
- `src/scene/text-html/__tests__/HTMLText.test.ts`
- `DONE.json`

Happy to address any feedback or make adjustments.

/claim #11790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<details>
<summary>Release Notes</summary>

##### Fixes
- Fixed HTMLText instances losing or receiving incorrect texture references when updating resolution in batch operations. Previous texture references are now properly retained during resolution changes by capturing and releasing the previous texture key only after the new texture is applied.

</details>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->