### PR TITLE
fix: skip pointermove on canvas when pointer is over an overlapping D…

### DIFF
--- a/src/events/EventSystem.ts
+++ b/src/events/EventSystem.ts
@@ -666,6 +666,20 @@ export class EventSystem implements System<EventSystemOptions>
         if (!this.features.move) return;
         this.rootBoundary.rootTarget = this.renderer.lastObjectRendered;
 
+        // If the pointer is over an overlapping DOM element (not the canvas) and no buttons are held
+        // (i.e. not dragging), skip processing to avoid spurious hover events on canvas objects.
+        let target = nativeEvent.target;
+
+        if (nativeEvent.composedPath && nativeEvent.composedPath().length > 0)
+        {
+            target = nativeEvent.composedPath()[0];
+        }
+
+        if (target && target !== this.domElement && ('buttons' in nativeEvent ? nativeEvent.buttons : 0) === 0)
+        {
+            return;
+        }
+
         EventsTicker.pointerMoved();
 
         const normalizedEvents = this._normalizeToPointerData(nativeEvent);

--- a/src/events/__tests__/EventSystem.test.ts
+++ b/src/events/__tests__/EventSystem.test.ts
@@ -1219,4 +1219,56 @@ describe('EventSystem', () =>
 
         expect(eventSpy).toHaveBeenCalledTimes(2);
     });
+
+    it('should not fire canvas hover events when pointer is over an overlapping DOM element', async () =>
+    {
+        const renderer = await createRenderer();
+        const [stage, graphics] = createScene();
+
+        renderer.render(stage);
+
+        const moveSpy = jest.fn();
+        const overSpy = jest.fn();
+
+        graphics.on('pointermove', moveSpy);
+        graphics.on('pointerover', overSpy);
+
+        // Simulate a pointermove whose target is an overlapping div (not the canvas)
+        const overlayDiv = document.createElement('div');
+        const moveEvent = new PointerEvent('pointermove', { clientX: 25, clientY: 25, bubbles: true });
+
+        Object.defineProperty(moveEvent, 'target', { writable: false, value: overlayDiv });
+
+        renderer.events['_onPointerMove'](moveEvent);
+
+        expect(moveSpy).not.toHaveBeenCalled();
+        expect(overSpy).not.toHaveBeenCalled();
+    });
+
+    it('should still fire canvas events during drag when pointer moves over an overlapping DOM element', async () =>
+    {
+        const renderer = await createRenderer();
+        const [stage, graphics] = createScene();
+
+        renderer.render(stage);
+
+        // First, press down on the canvas so a drag is in progress
+        renderer.events['_onPointerDown'](
+            new PointerEvent('pointerdown', { clientX: 25, clientY: 25, buttons: 1 })
+        );
+
+        const moveSpy = jest.fn();
+
+        graphics.on('pointermove', moveSpy);
+
+        // Simulate a pointermove over an overlapping div, but with buttons held (dragging)
+        const overlayDiv = document.createElement('div');
+        const dragMoveEvent = new PointerEvent('pointermove', { clientX: 25, clientY: 25, buttons: 1, bubbles: true });
+
+        Object.defineProperty(dragMoveEvent, 'target', { writable: false, value: overlayDiv });
+
+        renderer.events['_onPointerMove'](dragMoveEvent);
+
+        expect(moveSpy).toHaveBeenCalledOnce();
+    });
 });


### PR DESCRIPTION
fix: skip pointermove when pointer is over an overlapping DOM element

`pointermove`/`mousemove` events are registered on `globalThis.document` with `capture: true` so that dragging works outside the canvas. This caused hover events to fire on canvas objects even when the cursor was over an overlapping DOM element (e.g. a UI overlay `<div>`).

Fix: in `_onPointerMove`, resolve the real event target via `composedPath()` (for shadow DOM parity with `_onPointerUp`) and return early when the target is a known non-canvas element and no pointer buttons are held. The `buttons` guard preserves drag-outside-canvas behaviour: while a button is pressed events continue to flow regardless of which element the cursor is over.

Fixes #10975

##### Description of change

When a DOM element (e.g. a UI overlay) is placed on top of a PixiJS canvas, moving the cursor over it incorrectly triggers `pointermove`/`pointerover` events on canvas objects beneath it. This is because move events are captured at the `document` level before the browser routes them to the actual target element.

The fix adds a target check to `_onPointerMove` — the same pattern already used in `_onPointerUp` — that skips processing when the event's real target is not the canvas and no mouse button is held down.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
