### PR TITLE
fix: guard against null entries and missing render pipes

### DIFF
--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -333,7 +333,12 @@ export class RenderGroup implements Instruction
     public updateRenderable(renderable: ViewContainer)
     {
         if (renderable.globalDisplayStatus < 0b111) return;
-        this.instructionSet.renderPipes[renderable.renderPipeId].updateRenderable(renderable);
+
+        const pipe = this.instructionSet.renderPipes[renderable.renderPipeId];
+
+        if (!pipe) return;
+
+        pipe.updateRenderable(renderable);
         renderable.didViewUpdate = false;
     }
 

--- a/src/scene/container/RenderGroupSystem.ts
+++ b/src/scene/container/RenderGroupSystem.ts
@@ -227,6 +227,8 @@ export class RenderGroupSystem implements System
         {
             const container = list[i];
 
+            if (!container) continue;
+
             if (container.didViewUpdate)
             {
                 renderGroup.updateRenderable(container as ViewContainer);

--- a/src/scene/container/utils/validateRenderables.ts
+++ b/src/scene/container/utils/validateRenderables.ts
@@ -17,12 +17,18 @@ export function validateRenderables(renderGroup: RenderGroup, renderPipes: Rende
     {
         const container = list[i];
 
-        // note to self: there is no need to check if container.parentRenderGroup || !container.renderGroup
-        // exist here, as this function is only called if the structure did NOT change
-        // which means they have to be valid if this function is called
+        if (!container) continue;
 
         const renderable = container;
         const pipe = renderPipes[renderable.renderPipeId as keyof RenderPipes] as RenderPipe<any>;
+
+        if (!pipe)
+        {
+            // Missing pipe — force a full instruction rebuild to re-sync the
+            // render group instead of crashing.
+            rebuildRequired = true;
+            break;
+        }
 
         rebuildRequired = pipe.validateRenderable(container);
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Adds null guards to three render group code paths that crash when entries in `childrenRenderablesToUpdate.list` are null or when `renderPipes[renderPipeId]` is undefined:                                                    
                                                                                            
- **`RenderGroup.updateRenderable`** — extract pipe lookup, early return if missing                            
- **`RenderGroupSystem._updateRenderables`** — skip null entries in the update list
- **`validateRenderables`** — skip null entries, force full instruction rebuild if pipe is missing (safe       
 recovery instead of crash)                                                                                     

## Reproduction                                                                                                
These are latent on desktop Chrome but crash on Android WebView (tested on Pixel 4a / Adreno 618 with Chrome 145, and Samsung S23 / Adreno 740). Different GC and timing behavior on mobile surfaces null entries and missing pipe states that desktop never hits.                                                                                                                                                                      

Errors observed:
- `TypeError: Cannot read properties of undefined (reading 'updateRenderable')`
- `TypeError: Cannot read properties of undefined (reading 'validateRenderable')`                              

Both originate from unguarded `renderPipes[renderable.renderPipeId]` access. The null list entries cause `clearList()` to break on the first null, leaving stale entries in the array tail that compound the problem on subsequent frames.                                                                                             

## Approach
Minimal defensive guards — no behavioral changes for the happy path. When a pipe is missing in  `validateRenderables`, the fix forces `rebuildRequired = true` to trigger a full instruction rebuild via  `_buildInstructions`, which safely re-syncs the render group state.                   

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)