### PR TITLE
feat: expose WebGPU canvas and pipeline color formats for HDR output

### DIFF
--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -19,6 +19,23 @@ import type { WebGPURenderer } from '../WebGPURenderer';
  */
 export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarget>
 {
+    /**
+     * The pixel format used when configuring the WebGPU canvas context. Must
+     * match {@link GpuStateSystem.colorTargetFormat} and any render-target
+     * texture formats. Override before renderer initialization to enable HDR
+     * output (e.g. `'rgba16float'`).
+     * @default 'bgra8unorm'
+     */
+    public static canvasFormat: GPUTextureFormat = 'bgra8unorm';
+
+    /**
+     * Optional tone mapping applied when configuring the WebGPU canvas
+     * context. Set to `{ mode: 'extended' }` to enable HDR output on capable
+     * displays (Chrome 131+, Safari 18.x+). Non-HDR displays receive a
+     * clamped/tone-mapped SDR presentation.
+     */
+    public static canvasToneMapping: GPUCanvasToneMapping | undefined;
+
     private _renderTargetSystem: RenderTargetSystem<GpuRenderTarget>;
     private _renderer: WebGPURenderer<HTMLCanvasElement>;
 
@@ -295,15 +312,22 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
 
                 try
                 {
-                    context.configure({
+                    const contextConfig: GPUCanvasConfiguration = {
                         device: this._renderer.gpu.device,
                         usage: GPUTextureUsage.TEXTURE_BINDING
                             | GPUTextureUsage.COPY_DST
                             | GPUTextureUsage.RENDER_ATTACHMENT
                             | GPUTextureUsage.COPY_SRC,
-                        format: 'bgra8unorm',
+                        format: GpuRenderTargetAdaptor.canvasFormat,
                         alphaMode,
-                    });
+                    };
+
+                    if (GpuRenderTargetAdaptor.canvasToneMapping)
+                    {
+                        contextConfig.toneMapping = GpuRenderTargetAdaptor.canvasToneMapping;
+                    }
+
+                    context.configure(contextConfig);
                 }
                 catch (e)
                 {

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -19,6 +19,23 @@ import type { WebGPURenderer } from '../WebGPURenderer';
  */
 export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarget>
 {
+    /**
+     * The pixel format used when configuring the WebGPU canvas context. Must
+     * match {@link GpuStateSystem.colorTargetFormat} and any render-target
+     * texture formats. Override before renderer initialization to enable HDR
+     * output (e.g. `'rgba16float'`).
+     * @default 'bgra8unorm'
+     */
+    public static canvasFormat: GPUTextureFormat = 'bgra8unorm';
+
+    /**
+     * Optional tone mapping applied when configuring the WebGPU canvas
+     * context. Set to `{ mode: 'extended' }` to enable HDR output on capable
+     * displays (Chrome 131+, Safari 18.x+). Non-HDR displays receive a
+     * clamped/tone-mapped SDR presentation.
+     */
+    public static canvasToneMapping: GPUCanvasToneMapping | undefined;
+
     private _renderTargetSystem: RenderTargetSystem<GpuRenderTarget>;
     private _renderer: WebGPURenderer<HTMLCanvasElement>;
 
@@ -309,15 +326,22 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
 
                 try
                 {
-                    context.configure({
+                    const contextConfig: GPUCanvasConfiguration = {
                         device: this._renderer.gpu.device,
                         usage: GPUTextureUsage.TEXTURE_BINDING
                             | GPUTextureUsage.COPY_DST
                             | GPUTextureUsage.RENDER_ATTACHMENT
                             | GPUTextureUsage.COPY_SRC,
-                        format: 'bgra8unorm',
+                        format: GpuRenderTargetAdaptor.canvasFormat,
                         alphaMode,
-                    });
+                    };
+
+                    if (GpuRenderTargetAdaptor.canvasToneMapping)
+                    {
+                        contextConfig.toneMapping = GpuRenderTargetAdaptor.canvasToneMapping;
+                    }
+
+                    context.configure(contextConfig);
                 }
                 catch (e)
                 {

--- a/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
+++ b/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
@@ -1,0 +1,34 @@
+import { GpuRenderTargetAdaptor } from '../GpuRenderTargetAdaptor';
+
+describe('GpuRenderTargetAdaptor', () =>
+{
+    afterEach(() =>
+    {
+        GpuRenderTargetAdaptor.canvasFormat = 'bgra8unorm';
+        GpuRenderTargetAdaptor.canvasToneMapping = undefined;
+    });
+
+    it('should default canvasFormat to bgra8unorm', () =>
+    {
+        expect(GpuRenderTargetAdaptor.canvasFormat).toEqual('bgra8unorm');
+    });
+
+    it('should default canvasToneMapping to undefined', () =>
+    {
+        expect(GpuRenderTargetAdaptor.canvasToneMapping).toBeUndefined();
+    });
+
+    it('should allow canvasFormat to be overridden for HDR output', () =>
+    {
+        GpuRenderTargetAdaptor.canvasFormat = 'rgba16float';
+
+        expect(GpuRenderTargetAdaptor.canvasFormat).toEqual('rgba16float');
+    });
+
+    it('should allow canvasToneMapping to be overridden for HDR output', () =>
+    {
+        GpuRenderTargetAdaptor.canvasToneMapping = { mode: 'extended' };
+
+        expect(GpuRenderTargetAdaptor.canvasToneMapping).toEqual({ mode: 'extended' });
+    });
+});

--- a/src/rendering/renderers/gpu/state/GpuStateSystem.ts
+++ b/src/rendering/renderers/gpu/state/GpuStateSystem.ts
@@ -20,6 +20,17 @@ export class GpuStateSystem implements System
         ],
         name: 'state',
     } as const;
+
+    /**
+     * The pixel format used for color targets on WebGPU pipelines. Must match
+     * the canvas format configured in {@link GpuRenderTargetAdaptor.canvasFormat}
+     * and any render-target texture formats, or WebGPU will throw a pipeline
+     * format mismatch. Override before renderer initialization to enable HDR
+     * output (e.g. `'rgba16float'`).
+     * @default 'bgra8unorm'
+     */
+    public static colorTargetFormat: GPUTextureFormat = 'bgra8unorm';
+
     /**
      * State ID
      * @readonly
@@ -77,7 +88,7 @@ export class GpuStateSystem implements System
 
         const targets: GPUColorTargetState[] = [];
         const target = {
-            format: 'bgra8unorm',
+            format: GpuStateSystem.colorTargetFormat,
             writeMask: 0,
             blend,
         } as GPUColorTargetState;

--- a/src/rendering/renderers/gpu/state/__tests__/GpuStateSystem.test.ts
+++ b/src/rendering/renderers/gpu/state/__tests__/GpuStateSystem.test.ts
@@ -1,0 +1,36 @@
+import { State } from '../../../shared/state/State';
+import { GpuStateSystem } from '../GpuStateSystem';
+
+describe('GpuStateSystem', () =>
+{
+    afterEach(() =>
+    {
+        GpuStateSystem.colorTargetFormat = 'bgra8unorm';
+    });
+
+    it('should default colorTargetFormat to bgra8unorm', () =>
+    {
+        expect(GpuStateSystem.colorTargetFormat).toEqual('bgra8unorm');
+    });
+
+    it('should use the default format for returned color targets', () =>
+    {
+        const system = new GpuStateSystem();
+        const targets = system.getColorTargets(new State(), 1);
+
+        expect(targets).toHaveLength(1);
+        expect(targets[0].format).toEqual('bgra8unorm');
+    });
+
+    it('should propagate an overridden colorTargetFormat to returned color targets', () =>
+    {
+        GpuStateSystem.colorTargetFormat = 'rgba16float';
+
+        const system = new GpuStateSystem();
+        const targets = system.getColorTargets(new State(), 2);
+
+        expect(targets).toHaveLength(2);
+        expect(targets[0].format).toEqual('rgba16float');
+        expect(targets[1].format).toEqual('rgba16float');
+    });
+});


### PR DESCRIPTION
##### Description of change

Closes #12019.

Three call sites in the WebGPU renderer hardcode `'bgra8unorm'`:

1. `GpuRenderTargetAdaptor.initGpuRenderTarget` (canvas context format)
2. `GpuStateSystem.getColorTargets` (pipeline color target format)
3. `TextureSource.defaultOptions.format` (already publicly mutable)

All three must agree or WebGPU throws a pipeline/target format mismatch, which prevents users from opting into `rgba16float` canvas output required for HDR presentation.

This PR exposes the two non-mutable formats plus an optional canvas tone mapping as public static properties, so a user can opt in before `renderer.init()`:

```ts
import {
    GpuRenderTargetAdaptor,
    GpuStateSystem,
    TextureSource,
} from 'pixi.js';

GpuStateSystem.colorTargetFormat = 'rgba16float';
GpuRenderTargetAdaptor.canvasFormat = 'rgba16float';
GpuRenderTargetAdaptor.canvasToneMapping = { mode: 'extended' };
TextureSource.defaultOptions.format = 'rgba16float';

await app.init({ /* ... */ });
```

Defaults are unchanged, so existing projects see no behavior difference.

This is intentionally minimal. If a higher-level `hdr: true` option on `WebGPUOptions` is preferred, happy to iterate toward that shape in follow-up commits. Wanted to get the lowest-friction escape hatch landed first so the three format values stop needing prototype-level monkeypatching in userland.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Static checks (lint, types, index, prune) pass locally. Jest unit tests run inside Electron via `@pixi/jest-electron` and could not be executed in the contributor's headless environment; relying on CI to validate the two added test files.