### PR TITLE
fix: GCSystem unload resources before nulling hash entry

### DIFF
--- a/src/rendering/renderers/shared/GCSystem.ts
+++ b/src/rendering/renderers/shared/GCSystem.ts
@@ -486,6 +486,19 @@ export class GCSystem implements System<GCSystemOptions>
 
             if (!isRecentlyUsed && resource.autoGarbageCollect)
             {
+                if (type === 'renderable')
+                {
+                    const res = resource as Renderable;
+                    const renderGroup = res.renderGroup ?? res.parentRenderGroup;
+
+                    if (renderGroup) renderGroup.structureDidChange = true;
+                }
+
+                // Call the cleanup function
+                resource.unload();
+                resource._gcData = null;
+                resource._gcLastUsed = -1;
+
                 // Lazily create the clone only when we need to remove something
                 if (!hashClone)
                 {
@@ -501,19 +514,6 @@ export class GCSystem implements System<GCSystemOptions>
                         hashClone = this._createHashClone(hashValue, key);
                     }
                 }
-
-                if (type === 'renderable')
-                {
-                    const res = resource as Renderable;
-                    const renderGroup = res.renderGroup ?? res.parentRenderGroup;
-
-                    if (renderGroup) renderGroup.structureDidChange = true;
-                }
-
-                // Call the cleanup function
-                resource.unload();
-                resource._gcData = null;
-                resource._gcLastUsed = -1;
             }
             else if (hashClone)
             {

--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -649,6 +649,32 @@ describe('GCSystem', () =>
             expect(context.myHash.key1).toBeNull();
         });
 
+        it('should call unload() before nulling the hash entry so listeners can still access the resource', () =>
+        {
+            const resource = createMockResource();
+
+            resource._gcData = {
+                type: 'resource',
+            };
+            resource._gcLastUsed = gcSystem.now - 2000;
+
+            const context = { myHash: { key1: resource } as Record<string, GCable | null> };
+            let hashEntryDuringUnload: GCable | null = null;
+
+            resource.unload = jest.fn(() =>
+            {
+                hashEntryDuringUnload = context.myHash.key1;
+            }) as any;
+
+            gcSystem.addResourceHash(context, 'myHash', 'resource');
+
+            gcSystem.run();
+
+            expect(resource.unload).toHaveBeenCalled();
+            expect(hashEntryDuringUnload).toBe(resource);
+            expect(context.myHash.key1).toBeNull();
+        });
+
         it('should keep recently used resources in hash', () =>
         {
             const resource = createMockResource();


### PR DESCRIPTION
### Overview

`GCSystem.runOnHash()` was nulling the hash entry before calling `resource.unload()`. Resource unload listeners (e.g. `GlTextureSystem.onSourceUnload`) check the hash entry and bail out when it's already null, so GPU resources like textures were never actually freed via `gl.deleteTexture()`, even though the GC reported them as collected. This reorders the operations so `unload()` runs first, before the hash slot is cleared.

Fixes #12022

#### Fixes
- GCSystem now calls `resource.unload()` and clears `_gcData` before nulling the hash entry, so unload listeners can still observe the resource and free associated GPU memory

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
