### PR TITLE
fix: stabilize HTMLText visual tests against CI flakiness

### DIFF
--- a/playground/src/scenes/sceneRunner.ts
+++ b/playground/src/scenes/sceneRunner.ts
@@ -4,6 +4,29 @@ import type { Renderer, RendererOptions } from 'pixi.js';
 import type { TestScene } from '../../../tests/visual/types';
 import type { RenderType } from '../types';
 
+async function waitForPendingHTMLText(container: Container, renderer: Renderer): Promise<void>
+{
+    const promises: Promise<unknown>[] = [];
+
+    const visit = (c: Container): void =>
+    {
+        if (c.renderPipeId === 'htmlText')
+        {
+            const gpuData = (c as unknown as {
+                _gpuData: Record<number, { texturePromise?: Promise<unknown> }>,
+            })._gpuData[renderer.uid];
+
+            if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
+        }
+
+        for (let i = 0; i < c.children.length; i++) visit(c.children[i]);
+    };
+
+    visit(container);
+
+    if (promises.length) await Promise.all(promises);
+}
+
 const defaultRendererOptions = {
     width: 128,
     height: 128,
@@ -58,6 +81,7 @@ export async function runScene(
     stage.addChild(sceneContainer);
 
     await scene.create(sceneContainer, renderer);
+    await waitForPendingHTMLText(stage, renderer);
 
     const canvas = renderer.extract.canvas({
         target: stage,

--- a/playground/src/scenes/sceneRunner.ts
+++ b/playground/src/scenes/sceneRunner.ts
@@ -19,12 +19,12 @@ async function waitForPendingHTMLText(container: Container, renderer: Renderer):
             if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
         }
 
-        for (let i = 0; i < c.children.length; i++) visit(c.children[i]);
+        c.children.forEach(visit);
     };
 
     visit(container);
 
-    if (promises.length) await Promise.all(promises);
+    await Promise.all(promises);
 }
 
 const defaultRendererOptions = {

--- a/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment-tagged.scene.ts
@@ -55,6 +55,5 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-alignment.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-alignment.scene.ts
@@ -51,6 +51,5 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-basic.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-basic.scene.ts
@@ -33,6 +33,5 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds-tagged.scene.ts
@@ -66,6 +66,5 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-bounds.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-bounds.scene.ts
@@ -59,6 +59,5 @@ export const scene: TestScene = {
         scene.addChild(textRect2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-all-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-all-tagged.scene.ts
@@ -37,6 +37,5 @@ export const scene: TestScene = {
         scene.addChild(text2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-all.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-all.scene.ts
@@ -33,6 +33,5 @@ export const scene: TestScene = {
         scene.addChild(text2);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-word-at-start-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-word-at-start-tagged.scene.ts
@@ -34,6 +34,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-word-at-start.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-word-at-start.scene.ts
@@ -31,6 +31,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-word-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-word-tagged.scene.ts
@@ -44,6 +44,5 @@ export const scene: TestScene = {
         scene.addChild(hyphenated);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-break-word.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-break-word.scene.ts
@@ -40,6 +40,5 @@ export const scene: TestScene = {
         scene.addChild(hyphenated);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-broken.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-broken.scene.ts
@@ -19,6 +19,5 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-tagged.scene.ts
@@ -39,6 +39,5 @@ export const scene: TestScene = {
         text.style.dropShadow.color = 'green';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap-tagged.scene.ts
@@ -102,6 +102,5 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow-word-wrap.scene.ts
@@ -78,6 +78,5 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-drop-shadow.scene.ts
@@ -34,6 +34,5 @@ export const scene: TestScene = {
         text.style.dropShadow.color = 'red';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-destroy.scene.ts
@@ -66,6 +66,5 @@ export const scene: TestScene = {
         container.addChild(text2);
         scene.addChild(container);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic-update.scene.ts
@@ -34,6 +34,5 @@ export const scene: TestScene = {
         text2.text = '1';
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-dynamic.scene.ts
@@ -28,6 +28,5 @@ export const scene: TestScene = {
         text.resolution = 0.5;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family-multi.scene.ts
@@ -51,6 +51,5 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-family.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-family.scene.ts
@@ -40,6 +40,5 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles-tagged.scene.ts
@@ -62,6 +62,5 @@ export const scene: TestScene = {
         scene.addChild(styleComparison, variantComparison, combinedStyle);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-styles.scene.ts
@@ -65,6 +65,5 @@ export const scene: TestScene = {
         );
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights-tagged.scene.ts
@@ -49,6 +49,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-font-weights.scene.ts
@@ -31,6 +31,5 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-letter-spacing.scene.ts
@@ -36,6 +36,5 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-line-height.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-line-height.scene.ts
@@ -37,6 +37,5 @@ export const scene: TestScene = {
         }
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha-tagged.scene.ts
@@ -38,6 +38,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-alpha.scene.ts
@@ -20,6 +20,5 @@ export const scene: TestScene = {
         scene.addChild(text1);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-anchor-tagged.scene.ts
@@ -41,6 +41,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow-tagged.scene.ts
@@ -43,7 +43,5 @@ export const scene: TestScene = {
 
         scene.addChild(text);
         renderer.render(scene);
-
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-shadow.scene.ts
@@ -36,7 +36,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke-tagged.scene.ts
@@ -41,6 +41,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-stroke.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-stroke.scene.ts
@@ -34,6 +34,5 @@ export const scene: TestScene = {
         scene.addChild(text);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-tagged.scene.ts
@@ -42,6 +42,5 @@ export const scene: TestScene = {
         text.style.wordWrapWidth = 120;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-texture-style.scene.ts
@@ -26,6 +26,5 @@ export const scene: TestScene = {
         text.scale = 10;
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace-tagged.scene.ts
@@ -100,6 +100,5 @@ export const scene: TestScene = {
         scene.addChild(text4);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-whitespace.scene.ts
@@ -76,6 +76,5 @@ export const scene: TestScene = {
         });
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap-long.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap-long.scene.ts
@@ -18,7 +18,6 @@ export const scene: TestScene = {
         addBlock(scene, 210, 'This has only short words.');
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };
 

--- a/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap-tagged.scene.ts
@@ -70,6 +70,5 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
+++ b/tests/visual/scenes/text-html/html-text-word-wrap.scene.ts
@@ -59,6 +59,5 @@ export const scene: TestScene = {
         scene.addChild(text3);
 
         renderer.render(scene);
-        await new Promise((resolve) => setTimeout(resolve, 350));
     },
 };

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -33,12 +33,12 @@ async function waitForPendingHTMLText(container: Container, renderer: Renderer):
             if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
         }
 
-        for (let i = 0; i < c.children.length; i++) visit(c.children[i]);
+        c.children.forEach(visit);
     };
 
     visit(container);
 
-    if (promises.length) await Promise.all(promises);
+    await Promise.all(promises);
 }
 
 function toArrayBuffer(buf: Buffer): ArrayBuffer

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -8,6 +8,38 @@ import { Container, Graphics } from '~/scene';
 
 import type { RenderType } from './types';
 import type { Renderer, RendererOptions } from '~/rendering';
+import type { BatchableHTMLText } from '~/scene/text-html/BatchableHTMLText';
+
+/**
+ * After `renderer.render()`, HTMLText asynchronously generates its texture (font fetch,
+ * SVG image load). On slow CI runs this can outlast a fixed `setTimeout` in the scene,
+ * causing extract.canvas to read an empty texture and produce a flaky pixel diff. This
+ * walks the stage and awaits every in-flight HTMLText texture promise so extraction always
+ * sees the resolved texture.
+ * @param container
+ * @param renderer
+ */
+async function waitForPendingHTMLText(container: Container, renderer: Renderer): Promise<void>
+{
+    const promises: Promise<unknown>[] = [];
+
+    const visit = (c: Container): void =>
+    {
+        if (c.renderPipeId === 'htmlText')
+        {
+            const gpuData = (c as unknown as { _gpuData: Record<number, BatchableHTMLText> })
+                ._gpuData[renderer.uid];
+
+            if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
+        }
+
+        for (let i = 0; i < c.children.length; i++) visit(c.children[i]);
+    };
+
+    visit(container);
+
+    if (promises.length) await Promise.all(promises);
+}
 
 function toArrayBuffer(buf: Buffer): ArrayBuffer
 {
@@ -102,6 +134,7 @@ export async function renderTest(
     stage.addChild(scene);
 
     await createFunction(scene, renderer);
+    await waitForPendingHTMLText(stage, renderer);
 
     const testId = `${id}-${rendererType}`;
 


### PR DESCRIPTION
### Overview

The HTMLText visual scenes relied on a fixed `setTimeout(350ms)` after `renderer.render()` to wait for async texture generation (font fetch + SVG image load). On slower CI runs the timeout could expire before the texture promise resolved, causing `extract.canvas` to read `Texture.EMPTY` and producing large pixel diffs that randomly failed the suite (e.g. `webgpu-html-text-whitespace-tagged` with a 37851-pixel diff). The tester now walks the stage and awaits every in-flight HTMLText `texturePromise` before extraction, removing the race entirely. The trailing `setTimeout` waits in 37 scenes are no longer needed and have been deleted; the four dynamic scenes keep their intermediate wait since it sequences a property change between two renders, which the tester-level wait can't replace.

#### Fixes
- HTMLText visual tests no longer flake on CI when font/SVG loads exceed the 350ms wait

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
