### PR TITLE
fix: handle null from getShaderSource/getShaderInfoLog on lost context (#12032)

### DIFF
--- a/src/rendering/renderers/gl/shader/program/__tests__/logProgramError.test.ts
+++ b/src/rendering/renderers/gl/shader/program/__tests__/logProgramError.test.ts
@@ -1,0 +1,47 @@
+import { compileShader } from '../compileShader';
+import { logProgramError } from '../logProgramError';
+import { DOMAdapter } from '~/environment';
+
+describe('logProgramError', () =>
+{
+    it('should not throw when WebGL context is lost and shader sources are unavailable', () =>
+    {
+        const canvas = DOMAdapter.get().createCanvas();
+        const gl = canvas.getContext('webgl') as WebGLRenderingContext;
+
+        const vertexShader = compileShader(gl, gl.VERTEX_SHADER, `
+            attribute vec4 aPosition;
+            void main() { gl_Position = aPosition; }
+        `);
+        const fragmentShader = compileShader(gl, gl.FRAGMENT_SHADER, `
+            precision mediump float;
+            void main() { gl_FragColor = vec4(1.0); }
+        `);
+        const program = gl.createProgram();
+
+        gl.attachShader(program, vertexShader);
+        gl.attachShader(program, fragmentShader);
+        gl.linkProgram(program);
+
+        gl.getExtension('WEBGL_lose_context')?.loseContext();
+
+        // After context loss getShaderSource and getShaderInfoLog return null;
+        // logProgramError must tolerate this rather than throwing TypeError on null.split
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => { /* silence */ });
+        const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => { /* silence */ });
+        const groupCollapsed = jest.spyOn(console, 'groupCollapsed').mockImplementation(() => { /* silence */ });
+        const groupEnd = jest.spyOn(console, 'groupEnd').mockImplementation(() => { /* silence */ });
+
+        try
+        {
+            expect(() => logProgramError(gl, program, vertexShader, fragmentShader)).not.toThrow();
+        }
+        finally
+        {
+            consoleError.mockRestore();
+            consoleWarn.mockRestore();
+            groupCollapsed.mockRestore();
+            groupEnd.mockRestore();
+        }
+    });
+});

--- a/src/rendering/renderers/gl/shader/program/logProgramError.ts
+++ b/src/rendering/renderers/gl/shader/program/logProgramError.ts
@@ -21,7 +21,6 @@ function logPrettyShaderError(gl: WebGLRenderingContext, shader: WebGLShader): v
         .split('\n')
         .map((line, index) => `${index}: ${line}`);
 
-    // getShaderInfoLog can also return null on GL errors; fall back to an empty string
     const shaderLog = gl.getShaderInfoLog(shader) ?? '';
     const splitShader = shaderLog.split('\n');
 

--- a/src/rendering/renderers/gl/shader/program/logProgramError.ts
+++ b/src/rendering/renderers/gl/shader/program/logProgramError.ts
@@ -6,15 +6,13 @@
  */
 function logPrettyShaderError(gl: WebGLRenderingContext, shader: WebGLShader): void
 {
-    // getShaderSource and getShaderInfoLog return null on GL errors (e.g. lost context); see
+    // getShaderSource returns null on GL errors (e.g. lost context); see
     // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.9
     const rawSource = gl.getShaderSource(shader);
-    const shaderLog = gl.getShaderInfoLog(shader) ?? '';
 
     if (rawSource === null)
     {
         console.error('PixiJS Error: Could not retrieve shader source (WebGL context may be lost).');
-        if (shaderLog) console.error(shaderLog);
 
         return;
     }
@@ -22,6 +20,9 @@ function logPrettyShaderError(gl: WebGLRenderingContext, shader: WebGLShader): v
     const shaderSrc = rawSource
         .split('\n')
         .map((line, index) => `${index}: ${line}`);
+
+    // getShaderInfoLog can also return null on GL errors; fall back to an empty string
+    const shaderLog = gl.getShaderInfoLog(shader) ?? '';
     const splitShader = shaderLog.split('\n');
 
     const dedupe: Record<number, boolean> = {};

--- a/src/rendering/renderers/gl/shader/program/logProgramError.ts
+++ b/src/rendering/renderers/gl/shader/program/logProgramError.ts
@@ -6,11 +6,22 @@
  */
 function logPrettyShaderError(gl: WebGLRenderingContext, shader: WebGLShader): void
 {
-    const shaderSrc = gl.getShaderSource(shader)
+    // getShaderSource and getShaderInfoLog return null on GL errors (e.g. lost context); see
+    // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.9
+    const rawSource = gl.getShaderSource(shader);
+    const shaderLog = gl.getShaderInfoLog(shader) ?? '';
+
+    if (rawSource === null)
+    {
+        console.error('PixiJS Error: Could not retrieve shader source (WebGL context may be lost).');
+        if (shaderLog) console.error(shaderLog);
+
+        return;
+    }
+
+    const shaderSrc = rawSource
         .split('\n')
         .map((line, index) => `${index}: ${line}`);
-
-    const shaderLog = gl.getShaderInfoLog(shader);
     const splitShader = shaderLog.split('\n');
 
     const dedupe: Record<number, boolean> = {};


### PR DESCRIPTION
### Overview

Fixes #12032. When the WebGL context is lost, `gl.getShaderSource` and `gl.getShaderInfoLog` return `null` per the WebGL spec (§5.14.9), causing `logPrettyShaderError` to throw a `TypeError` on `.split` and masking the original render failure. The error path now logs a clear context-lost message and returns early instead.

#### Fixes
- Handle null returned from `getShaderSource`/`getShaderInfoLog` so a lost WebGL context no longer crashes shader-error logging during `render()`.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
