### PR TITLE
Fix onRender subclass method type collision

### DIFF
--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -135,7 +135,7 @@ export class RenderGroup implements Instruction
     {
         this.root = root;
 
-        if (root._onRender) this.addOnRender(root);
+        if (root._onRenderCallback) this.addOnRender(root);
 
         root.didChange = true;
 
@@ -264,7 +264,7 @@ export class RenderGroup implements Instruction
             return;
         }
 
-        if (child._onRender) this.addOnRender(child);
+        if (child._onRenderCallback) this.addOnRender(child);
 
         const children = child.children;
 
@@ -279,7 +279,7 @@ export class RenderGroup implements Instruction
         // remove all the children...
         this.structureDidChange = true;
 
-        if (child._onRender)
+        if (child._onRenderCallback)
         {
             // Remove the child to the onRender list under the following conditions:
             // 1. If the child is not a render group.
@@ -366,7 +366,7 @@ export class RenderGroup implements Instruction
     {
         for (let i = 0; i < this._onRenderContainers.length; i++)
         {
-            this._onRenderContainers[i]._onRender(renderer);
+            this._onRenderContainers[i]._onRenderCallback(renderer);
         }
     }
 

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -3,6 +3,23 @@ import { Container } from '../Container';
 import { updateRenderGroupTransforms } from '../utils/updateRenderGroupTransforms';
 import { Matrix } from '~/maths/matrix/Matrix';
 
+/* eslint-disable jest/expect-expect */
+class OnRenderContainer extends Container
+{
+    constructor()
+    {
+        super();
+
+        this.onRender = this._onRender.bind(this);
+    }
+
+    private _onRender()
+    {
+        // User-defined render hook.
+    }
+}
+/* eslint-enable jest/expect-expect */
+
 describe('Container', () =>
 {
     describe('constructor', () =>
@@ -82,6 +99,11 @@ describe('Container', () =>
         expect(container.children).toContain(children[0]);
         expect(container.children).toContain(children[1]);
         expect(addedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow subclasses to define an _onRender method', () =>
+    {
+        expect(new OnRenderContainer().onRender).toBeInstanceOf(Function);
     });
 
     it('should assign to parent correctly is passed to constructor', () =>

--- a/src/scene/container/container-mixins/onRenderMixin.ts
+++ b/src/scene/container/container-mixins/onRenderMixin.ts
@@ -37,12 +37,12 @@ export interface OnRenderMixinConstructor
 export interface OnRenderMixin extends Required<OnRenderMixinConstructor>
 {
     /** @private */
-    _onRender: ((renderer: Renderer) => void) | null;
+    _onRenderCallback: ((renderer: Renderer) => void) | null;
 }
 
 /** @internal */
 export const onRenderMixin: Partial<Container> = {
-    _onRender: null,
+    _onRenderCallback: null,
 
     set onRender(func: (renderer: Renderer) => void)
     {
@@ -50,26 +50,26 @@ export const onRenderMixin: Partial<Container> = {
 
         if (!func)
         {
-            if (this._onRender)
+            if (this._onRenderCallback)
             {
                 renderGroup?.removeOnRender(this);
             }
 
-            this._onRender = null;
+            this._onRenderCallback = null;
 
             return;
         }
 
-        if (!this._onRender)
+        if (!this._onRenderCallback)
         {
             renderGroup?.addOnRender(this);
         }
 
-        this._onRender = func;
+        this._onRenderCallback = func;
     },
 
     get onRender(): (renderer: Renderer) => void
     {
-        return this._onRender;
+        return this._onRenderCallback;
     }
 } as Container;


### PR DESCRIPTION
## Description

Fixes #11594.

The `OnRenderMixin` currently exposes a private `_onRender` callback slot on `Container`, which conflicts with user-defined subclass methods named `_onRender`. That exact method name is used in the v8 migration guide example for replacing `updateTransform` with `onRender`, so TypeScript requires users to define `_onRender` as a callback property instead of a normal method.

This renames the internal callback slot to `_onRenderCallback` and updates render group usage accordingly, leaving user-defined `_onRender` methods free to typecheck normally.

## Changes

- Rename the internal on-render callback field from `_onRender` to `_onRenderCallback`.
- Update `RenderGroup` to check/call `_onRenderCallback`.
- Add a regression test with a subclass that defines `_onRender()` as a method and assigns it to `onRender`.

## Verification

- `npm run test -- types`
- `npm run test -- lint`