### PR TITLE
fix: Container.updateTransform honors zero scale (#12044)

### DIFF
--- a/src/scene/container/Container.ts
+++ b/src/scene/container/Container.ts
@@ -1749,8 +1749,8 @@ export class Container<C extends ContainerChild = ContainerChild> extends EventE
             typeof opts.y === 'number' ? opts.y : this.position.y
         );
         this.scale.set(
-            typeof opts.scaleX === 'number' ? opts.scaleX || 1 : this.scale.x,
-            typeof opts.scaleY === 'number' ? opts.scaleY || 1 : this.scale.y
+            typeof opts.scaleX === 'number' ? opts.scaleX : this.scale.x,
+            typeof opts.scaleY === 'number' ? opts.scaleY : this.scale.y
         );
         this.rotation = typeof opts.rotation === 'number' ? opts.rotation : this.rotation;
         this.skew.set(

--- a/src/scene/container/__tests__/Container.test.ts
+++ b/src/scene/container/__tests__/Container.test.ts
@@ -51,7 +51,7 @@ describe('Container', () =>
             expect(object.origin.y).toEqual(9);
         });
 
-        it('should convert zero scale to one', () =>
+        it('should apply zero scale exactly', () =>
         {
             const object = new Container();
 
@@ -60,8 +60,8 @@ describe('Container', () =>
                 scaleY: 0,
             });
 
-            expect(object.scale.x).toEqual(1);
-            expect(object.scale.y).toEqual(1);
+            expect(object.scale.x).toEqual(0);
+            expect(object.scale.y).toEqual(0);
         });
     });
 


### PR DESCRIPTION
### Overview

Closes #12044. `Container.updateTransform()` used `opts.scaleX || 1` after a `typeof === 'number'` check, so passing `0` fell through to `1` and diverged from `scale.set(0, 0)`. Dropping the `|| 1` makes both paths apply zero scale identically.

#### Fixes
- `Container.updateTransform({ scaleX: 0, scaleY: 0 })` now applies zero scale instead of silently substituting `1`, matching `scale.set(0, 0)`.

```ts
const container = new Container();
container.updateTransform({ scaleX: 0, scaleY: 0 });
// before: container.scale = (1, 1) — container visible
// after:  container.scale = (0, 0) — container hidden
```

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
