### PR TITLE
Fix multipack spritesheet load deadlock

### DIFF
--- a/src/spritesheet/__tests__/spritesheetAsset.test.ts
+++ b/src/spritesheet/__tests__/spritesheetAsset.test.ts
@@ -104,6 +104,17 @@ describe('spritesheetAsset', () =>
         expect(pack1.height).toBe(229);
     });
 
+    it('should load related multi packs together without deadlocking', async () =>
+    {
+        const results = await loader.load<Spritesheet>([
+            `${basePath}spritesheet/multi-pack-0.json`,
+            `${basePath}spritesheet/multi-pack-1.json`,
+        ]);
+
+        expect(results[`${basePath}spritesheet/multi-pack-0.json`]).toBeInstanceOf(Spritesheet);
+        expect(results[`${basePath}spritesheet/multi-pack-1.json`]).toBeInstanceOf(Spritesheet);
+    });
+
     it('should not create multipack resources when related_multi_packs field is missing or the wrong type', async () =>
     {
         // clear the caches only to avoid cluttering the output

--- a/src/spritesheet/spritesheetAsset.ts
+++ b/src/spritesheet/spritesheetAsset.ts
@@ -210,6 +210,11 @@ export const spritesheetAsset = {
 
                     itemUrl = copySearchParams(itemUrl, options.src);
 
+                    if (loader.promiseCache[path.toAbsolute(itemUrl)])
+                    {
+                        continue;
+                    }
+
                     promises.push(loader.load<Spritesheet<SpriteSheetJson>>({
                         src: itemUrl,
                         data: {


### PR DESCRIPTION
##### Description of change
Fixes a deadlock when loading related spritesheet multipacks together. When two related packs are loaded in the same `Loader.load([...])` call, each parser can recursively wait for the other pack via `related_multi_packs`. The spritesheet parser now skips recursive multipack loads that are already present in the loader promise cache, letting the top-level load resolve both assets.

Adds a regression test for loading `multi-pack-0.json` and `multi-pack-1.json` together.

Fixes #8833

Bounty payout wallet: RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Validation run locally:
- `npx tsc -p .configs/tsconfig.build.json --noEmit`
- `npx eslint src/spritesheet/spritesheetAsset.ts src/spritesheet/__tests__/spritesheetAsset.test.ts --max-warnings 0`

Note: the Electron-based unit test runner timed out in this Windows Codex environment even for an existing single spritesheet test, after `npm rebuild electron`; no failing assertion was reported.