### PR TITLE
fix: make addOnRender idempotent and guard removeOnRender

### DIFF
--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -354,12 +354,17 @@ export class RenderGroup implements Instruction
      */
     public addOnRender(container: Container)
     {
-        this._onRenderContainers.push(container);
+        if (this._onRenderContainers.indexOf(container) === -1)
+        {
+            this._onRenderContainers.push(container);
+        }
     }
 
     public removeOnRender(container: Container)
     {
-        this._onRenderContainers.splice(this._onRenderContainers.indexOf(container), 1);
+        const idx = this._onRenderContainers.indexOf(container);
+
+        if (idx !== -1) this._onRenderContainers.splice(idx, 1);
     }
 
     public runOnRender(renderer: Renderer)

--- a/src/scene/container/__tests__/RenderGroup.test.ts
+++ b/src/scene/container/__tests__/RenderGroup.test.ts
@@ -675,5 +675,68 @@ describe('RenderGroup', () =>
 
         expect(child._updateFlags).toEqual(0b1111);
     });
+
+    it('addOnRender should be idempotent for same-parent addChildAt reorder', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        BigPool.getPool(RenderGroup).clear();
+
+        const container = new Container({ isRenderGroup: true });
+
+        const sibling = new Container();
+        const child = new Container();
+
+        child.onRender = () => { /* noop */ };
+
+        container.addChild(sibling); // index 0
+        container.addChild(child); // index 1
+
+        renderer.render(container);
+
+        const onRenderContainers = container.renderGroup['_onRenderContainers'];
+        const count = (c: Container): number => onRenderContainers.filter((x: Container) => x === c).length;
+
+        expect(count(child)).toBe(1);
+
+        // Same-parent reorder via addChildAt (currentIndex=1, index=0)
+        container.addChildAt(child, 0);
+
+        expect(count(child)).toBe(1);
+
+        renderer.destroy();
+    });
+
+    it('removeOnRender should leave the list unchanged when the container is not registered', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        BigPool.getPool(RenderGroup).clear();
+
+        const container = new Container({ isRenderGroup: true });
+
+        const a = new Container();
+        const b = new Container();
+        const c = new Container();
+
+        a.onRender = () => { /* noop */ };
+        b.onRender = () => { /* noop */ };
+        c.onRender = () => { /* noop */ };
+
+        container.addChild(a);
+        container.addChild(b);
+        // `c` is intentionally never parented under `container`
+
+        renderer.render(container);
+
+        const before = [...container.renderGroup['_onRenderContainers']];
+
+        // `c` was never registered in this renderGroup; this should be a no-op
+        container.renderGroup.removeOnRender(c);
+
+        expect(container.renderGroup['_onRenderContainers']).toEqual(before);
+
+        renderer.destroy();
+    });
 });
 


### PR DESCRIPTION
##### Description of change
- `RenderGroup.addOnRender` now skips the push if the container is already in `_onRenderContainers`.
- `RenderGroup.removeOnRender` now guards against `indexOf === -1` — previously `splice(-1, 1)` would silently delete the last entry.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`) another test failed, but not my new one.
