### PR TITLE
chore: pin node to 24.15.0 and update GitHub Actions

### DIFF
--- a/.configs/knip.jsonc
+++ b/.configs/knip.jsonc
@@ -46,7 +46,6 @@
         // Transitive dep of typedoc; used directly in typedoc-plugin-stackblitz
         "@gerrit0/mini-shiki",
         // Used in build script
-        "dts-bundle-generator",
-        "tsc-silent"
+        "dts-bundle-generator"
     ]
 }

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,16 +4,17 @@ inputs:
   node-version:
     description: "Node.js version"
     required: true
-    default: "24"
+    # Pinned: Node >=24.16 breaks Electron install (extract-zip). electron/electron#51619
+    default: "24.15.0"
   npm-version:
     description: "npm version"
     required: true
-    default: "8"
+    default: "11"
 runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: "https://registry.npmjs.org"
@@ -22,7 +23,7 @@ runs:
       run: npm install -g npm@${{ inputs.npm-version }}
     - name: Cache Dependencies
       id: node-modules-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}

--- a/.github/actions/unit/action.yml
+++ b/.github/actions/unit/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Upload Visual Test Images
       if: ${{ success() || failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pr_uploads
         path: .pr_uploads/

--- a/.github/workflows/publish-branch.yaml
+++ b/.github/workflows/publish-branch.yaml
@@ -12,7 +12,7 @@ jobs:
         env:
             BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref }}
 

--- a/.github/workflows/pull-name.yml
+++ b/.github/workflows/pull-name.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check PR Title
         uses: clowdhaus/actions/pr-title@v0.5.0
         with:

--- a/.github/workflows/pull-unit.yml
+++ b/.github/workflows/pull-unit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Project
       uses: ./.github/actions/setup

--- a/.github/workflows/pull-visuals.yml
+++ b/.github/workflows/pull-visuals.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-26
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Project
       uses: ./.github/actions/setup

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup project
       uses: ./.github/actions/setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup project
       uses: ./.github/actions/setup

--- a/.github/workflows/stack-blitz-publish.yaml
+++ b/.github/workflows/stack-blitz-publish.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Project
         uses: ./.github/actions/setup


### PR DESCRIPTION
##### Description of change

Updates CI/CD infrastructure and pins Node.js to fix the Electron-based test runners.

**CI fix (Node pin):**
- Pins Node.js to `24.15.0` in the setup action. Node `>=24.16` breaks Electron's binary install — zip extraction fails in `extract-zip` — producing `Electron failed to install correctly` on the runners (electron/electron#51619). `24.15.0` is the last known-good version; unpin once the upstream fix lands.

**GitHub Actions version bumps:**
- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/cache` v4 → v5
- `actions/upload-artifact` v4 → v7

**Tooling:**
- Default npm version 8 → 11 in the setup action
- Removes unused `tsc-silent` from the knip config

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
