### PR TITLE
fix: support chrome 150+ HTML-in-Canvas upload signatures

### DIFF
--- a/src/html-source/glUploadHTMLResource.ts
+++ b/src/html-source/glUploadHTMLResource.ts
@@ -5,16 +5,28 @@ import type { GlTexture } from '../rendering/renderers/gl/texture/GlTexture';
 import type { GLTextureUploader } from '../rendering/renderers/gl/texture/uploaders/GLTextureUploader';
 import type { HTMLSourceResource, HTMLUploadableSource } from './HTMLSourceTypes';
 
+// Chromium 150+ collapsed the upload signature to (target, internalFormat, source).
+// See https://github.com/WICG/html-in-canvas/pull/128/changes and
+// https://github.com/KhronosGroup/WebGL/pull/3752.
+type TexElementImage2DModern = (
+    target: number,
+    internalFormat: number,
+    source: HTMLSourceResource,
+) => void;
+
+// Pre-Chromium 150 signature, kept for backwards compatibility.
+type TexElementImage2DLegacy = (
+    target: number,
+    level: number,
+    internalFormat: number,
+    format: number,
+    type: number,
+    source: HTMLSourceResource,
+) => void;
+
 interface GlTexElementImageContext extends GlRenderingContext
 {
-    texElementImage2D?: (
-        target: number,
-        level: number,
-        internalFormat: number,
-        format: number,
-        type: number,
-        source: HTMLSourceResource,
-    ) => void;
+    texElementImage2D?: TexElementImage2DModern | TexElementImage2DLegacy;
 }
 
 function ensureAllocated(
@@ -88,15 +100,24 @@ export const glUploadHTMLResource: GLTextureUploader & { extension: { type: Exte
             return;
         }
 
-        upload.call(
-            gl,
-            target,
-            0,
-            glTexture.internalFormat,
-            glTexture.format,
-            glTexture.type,
-            source.resource,
-        );
+        // Detect the Chromium 150+ three-argument form by its arity; older builds still expect
+        // the full (target, level, internalFormat, format, type, source) signature.
+        if (upload.length === 3)
+        {
+            (upload as TexElementImage2DModern).call(gl, target, glTexture.internalFormat, source.resource);
+        }
+        else
+        {
+            (upload as TexElementImage2DLegacy).call(
+                gl,
+                target,
+                0,
+                glTexture.internalFormat,
+                glTexture.format,
+                glTexture.type,
+                source.resource,
+            );
+        }
 
         glTexture.width = textureWidth;
         glTexture.height = textureHeight;

--- a/src/html-source/gpuUploadHTMLResource.ts
+++ b/src/html-source/gpuUploadHTMLResource.ts
@@ -4,14 +4,37 @@ import type { GPU } from '../rendering/renderers/gpu/GpuDeviceSystem';
 import type { GpuTextureUploader } from '../rendering/renderers/gpu/texture/uploaders/GpuTextureUploader';
 import type { HTMLSourceResource, HTMLUploadableSource } from './HTMLSourceTypes';
 
+// Chromium 150+ collapsed the upload signature into source/destination dictionaries.
+// See https://github.com/WICG/html-in-canvas/pull/128/changes and
+// https://github.com/gpuweb/gpuweb/pull/6250.
+interface GPUCopyElementImageSource
+{
+    source: HTMLSourceResource;
+}
+
+interface GPUCopyElementImageDestination
+{
+    destination: GPUImageCopyTextureTagged;
+    width?: number;
+    height?: number;
+}
+
+type CopyElementImageModern = (
+    source: GPUCopyElementImageSource,
+    destination: GPUCopyElementImageDestination,
+) => void;
+
+// Pre-Chromium 150 signature, kept for backwards compatibility.
+type CopyElementImageLegacy = (
+    source: HTMLSourceResource,
+    width: number,
+    height: number,
+    destination: GPUImageCopyTextureTagged,
+) => void;
+
 interface GpuCopyElementImageQueue extends GPUQueue
 {
-    copyElementImageToTexture?: (
-        source: HTMLSourceResource,
-        width: number,
-        height: number,
-        destination: GPUImageCopyTextureTagged,
-    ) => void;
+    copyElementImageToTexture?: CopyElementImageModern | CopyElementImageLegacy;
 }
 
 /** @internal */
@@ -59,6 +82,25 @@ export const gpuUploadHTMLResource: GpuTextureUploader<HTMLUploadableSource> & {
         const width = Math.min(gpuTexture.width, source.pixelWidth);
         const height = Math.min(gpuTexture.height, source.pixelHeight);
 
-        copyElementImageToTexture.call(queue, source.resource, width, height, destination);
+        // Detect the Chromium 150+ two-argument form by its arity; older builds still expect
+        // the (source, width, height, destination) signature.
+        if (copyElementImageToTexture.length === 2)
+        {
+            (copyElementImageToTexture as CopyElementImageModern).call(
+                queue,
+                { source: source.resource },
+                { destination, width, height },
+            );
+        }
+        else
+        {
+            (copyElementImageToTexture as CopyElementImageLegacy).call(
+                queue,
+                source.resource,
+                width,
+                height,
+                destination,
+            );
+        }
     },
 };


### PR DESCRIPTION
### Overview

From chrome 150+, the experimental HTML-in-Canvas API ([WICG/html-in-canvas#128](https://github.com/WICG/html-in-canvas/pull/128/changes)) changed the method signatures for uploading DOM elements to textures, addressing community-group feedback. This adapts both the WebGL and WebGPU `HTMLSource` uploaders to the new signatures via runtime arity detection (`.length`), so the texture uploads keep working on chrome 150+ while still supporting older Chrome builds that ship the previous signatures.

#### Fix

- `HTMLSource` / `ElementImageSource` now support the chrome 150+ HTML-in-Canvas upload signatures, with automatic fallback to the pre-150 signatures for backwards compatibility.
  - WebGL `texElementImage2D` collapsed to `(target, internalFormat, source)` ([KhronosGroup/WebGL#3752](https://github.com/KhronosGroup/WebGL/pull/3752)).
  - WebGPU `copyElementImageToTexture` collapsed to `(sourceDict, destDict)` ([gpuweb/gpuweb#6250](https://github.com/gpuweb/gpuweb/pull/6250)).

##### Pre-Merge Checklist

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
