### PR TITLE
fix: stop GC from breaking cached bind groups when unloading buffers

### DIFF
--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -314,8 +314,18 @@ export class Buffer extends EventEmitter<{
     /** Unloads the buffer from the GPU */
     public unload()
     {
+        // the GPU buffer is about to be destroyed, so any cached bind group keyed on the
+        // old _resourceId would keep referencing it. Bump the id and emit 'change'
+        // (after 'unload' so the buffer systems have already detached their listeners)
+        // so BufferResources and bind groups re-key and rebuild on next use.
+        // Mirrors TextureSource.unload().
+        this._resourceId = uid('resource');
+
         /** Unloads the GPU data from the view container. */
         this.emit('unload', this);
+
+        if (!this.destroyed) this.emit('change', this);
+
         for (const key in this._gpuData)
         {
             this._gpuData[key]?.destroy();

--- a/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
+++ b/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
@@ -216,6 +216,42 @@ describe('Buffer', () =>
         expect(buffer._updateSize).toBe(2 * 4);
     });
 
+    it('should increment the resourceId and emit change on unload so cached bind groups re-key', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const changeObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+
+        const startingId = buffer._resourceId;
+
+        buffer.unload();
+
+        expect(buffer._resourceId).not.toBe(startingId);
+        expect(changeObserver).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not emit change from unload during destroy', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const changeObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+
+        buffer.destroy();
+
+        // only the change emitted by destroy itself
+        expect(changeObserver).toHaveBeenCalledTimes(1);
+    });
+
     itLocalOnly('should only add add listeners to buffer on first gpu init', async () =>
     {
         const renderer = (await getWebGPURenderer()) as WebGPURenderer;

--- a/src/rendering/renderers/shared/shader/UboSystem.ts
+++ b/src/rendering/renderers/shared/shader/UboSystem.ts
@@ -54,10 +54,18 @@ export class UboSystem implements System
     {
         const uniformData = this.getUniformGroupData(uniformGroup);
 
-        uniformGroup.buffer ||= new Buffer({
-            data: new Float32Array(uniformData.layout.size / 4),
-            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
-        });
+        if (!uniformGroup.buffer)
+        {
+            uniformGroup.buffer = new Buffer({
+                data: new Float32Array(uniformData.layout.size / 4),
+                usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+            });
+
+            // bind group keys are derived from the UniformGroup's _resourceId, which never
+            // changes, so a GC'd uniform buffer would leave cached bind groups pointing at
+            // a destroyed GPUBuffer. These buffers are tiny; never auto-collect them.
+            uniformGroup.buffer.autoGarbageCollect = false;
+        }
     }
 
     public getUniformGroupData(uniformGroup: UniformGroup)
@@ -99,10 +107,16 @@ export class UboSystem implements System
     {
         const uniformGroupData = this.getUniformGroupData(uniformGroup);
 
-        uniformGroup.buffer ||= new Buffer({
-            data: new Float32Array(uniformGroupData.layout.size / 4),
-            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
-        });
+        if (!uniformGroup.buffer)
+        {
+            uniformGroup.buffer = new Buffer({
+                data: new Float32Array(uniformGroupData.layout.size / 4),
+                usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+            });
+
+            // never auto-collect uniform buffers, see ensureUniformGroup
+            uniformGroup.buffer.autoGarbageCollect = false;
+        }
 
         let dataInt32: Int32Array = null;
 

--- a/src/rendering/renderers/shared/shader/__tests__/UboSystem.test.ts
+++ b/src/rendering/renderers/shared/shader/__tests__/UboSystem.test.ts
@@ -1,0 +1,22 @@
+import { UniformGroup } from '../UniformGroup';
+import { getWebGLRenderer } from '@test-utils';
+
+import type { WebGLRenderer } from '~/rendering';
+
+describe('UboSystem', () =>
+{
+    it('should opt uniform buffers out of garbage collection', async () =>
+    {
+        const renderer = (await getWebGLRenderer()) as WebGLRenderer;
+
+        const uniformGroup = new UniformGroup({
+            uTest: { value: 1, type: 'f32' },
+        });
+
+        renderer.ubo.ensureUniformGroup(uniformGroup);
+
+        // bind group keys never change for a UniformGroup, so its buffer must not
+        // be collected behind a cached bind group
+        expect(uniformGroup.buffer.autoGarbageCollect).toBe(false);
+    });
+});


### PR DESCRIPTION
##### Description of change

Fixes #12080

The GC system can destroy a uniform buffer's `GPUBuffer` while a cached `GPUBindGroup` still references it. Bind group cache keys are built from each resource's `_resourceId`, and a `UniformGroup`'s id never changes, so the stale bind group keeps being served. Every subsequent `queue.submit()` that draws with it fails validation with `used in submit while destroyed` and the whole frame is discarded, leaving the canvas black. Repro in the issue.

Two changes:

- `UboSystem` now marks the buffers it creates with `autoGarbageCollect = false`. Their bind group keys can never re-key, so they must not be collected behind the cache. They are small, and `destroy()` still frees them.
- `Buffer.unload()` now bumps `_resourceId` and emits `change`. `BufferResource` forwards the change, so bind groups holding a buffer directly or through a `BufferResource` re-key and rebuild on next use. The emit happens after the `unload` event, at which point the buffer systems have already detached their listeners, so the GPU buffer is not eagerly recreated during collection.

This is the same invalidation textures already do: `TextureSource.unload()` bumps `_resourceId` and emits `change`, with an existing unit test covering it. This change brings buffers to parity and adds the matching test.

Verified with the repro from the issue (Chrome 149, Windows 11): on 8.19.0 the validation errors start within seconds and nothing renders; on dev built with this change rendering stays correct, and vertex and index buffers still get collected and recreated on demand, so the GC keeps working where it is safe. The Buffer, UboSystem, UniformGroup, BindGroup and GCSystem suites pass locally.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
