### PR TITLE
fix: Rectangle containsRect edge containment

### DIFF
--- a/src/maths/__tests__/Rectangle.test.ts
+++ b/src/maths/__tests__/Rectangle.test.ts
@@ -474,13 +474,19 @@ describe('Rectangle', () =>
         it('should handle edge touching cases', () =>
         {
             const outer = new Rectangle(0, 0, 100, 100);
-            const edge = new Rectangle(0, 0, 50, 50); // Touches at corner
+            const edge = new Rectangle(0, 0, 50, 50); // Touches at top-left corner
             const edge2 = new Rectangle(0, 25, 50, 50); // Touches at left edge
             const edge3 = new Rectangle(25, 0, 50, 50); // Touches at top edge
+            const edge4 = new Rectangle(50, 25, 50, 50); // Touches at right edge
+            const edge5 = new Rectangle(25, 50, 50, 50); // Touches at bottom edge
+            const edge6 = new Rectangle(50, 50, 50, 50); // Touches at bottom-right corner
 
             expect(outer.containsRect(edge)).toBe(true);
             expect(outer.containsRect(edge2)).toBe(true);
             expect(outer.containsRect(edge3)).toBe(true);
+            expect(outer.containsRect(edge4)).toBe(true);
+            expect(outer.containsRect(edge5)).toBe(true);
+            expect(outer.containsRect(edge6)).toBe(true);
         });
 
         it('should handle identical rectangles', () =>

--- a/src/maths/__tests__/Rectangle.test.ts
+++ b/src/maths/__tests__/Rectangle.test.ts
@@ -488,7 +488,7 @@ describe('Rectangle', () =>
             const rect1 = new Rectangle(0, 0, 100, 100);
             const rect2 = new Rectangle(0, 0, 100, 100);
 
-            expect(rect1.containsRect(rect2)).toBe(false);
+            expect(rect1.containsRect(rect2)).toBe(true);
         });
     });
 });

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -783,9 +783,9 @@ export class Rectangle implements ShapePrimitive
      * const partial = new Rectangle(75, 75, 50, 50);
      * console.log(container.containsRect(partial)); // false
      *
-     * // Zero-area rectangles
+     * // Zero-area rectangles can't contain anything
      * const empty = new Rectangle(0, 0, 0, 100);
-     * console.log(container.containsRect(empty)); // false
+     * console.log(empty.containsRect(inner)); // false
      * ```
      * @param other - The Rectangle to check for containment
      * @returns True if other is fully contained within this Rectangle

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -803,8 +803,8 @@ export class Rectangle implements ShapePrimitive
 
         return x1 >= this.x && x1 < this.x + this.width
             && y1 >= this.y && y1 < this.y + this.height
-            && x2 >= this.x && x2 < this.x + this.width
-            && y2 >= this.y && y2 < this.y + this.height;
+            && x2 >= this.x && x2 <= this.x + this.width
+            && y2 >= this.y && y2 <= this.y + this.height;
     }
 
     /**


### PR DESCRIPTION
##### Description of change
Fixes #12082.

Updates `Rectangle.containsRect` so the contained rectangle's right and bottom edges are inclusive. This matches the documented behavior that rectangles occupying the same space contain each other.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`NODE_OPTIONS=--max-old-space-size=4096 npm run test:lint`)
- [x] Tests passed (`xvfb-run -a env ELECTRON_DISABLE_SANDBOX=1 npm run test -- unit --testPathPattern=src/maths/__tests__/Rectangle.test.ts --runInBand`)
