### PR TITLE
chore: tidy cube/mip handling in GPU & GL texture systems

### DIFF
--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -134,6 +134,19 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, gpuRenderTarget.framebuffer);
 
+        if (mipLevel > 0)
+        {
+            if (gpuRenderTarget.msaa)
+            {
+                throw new Error('[RenderTargetSystem] Rendering to mip levels is not supported with MSAA render targets.');
+            }
+
+            if (this._renderer.context.webGLVersion < 2)
+            {
+                throw new Error('[RenderTargetSystem] Rendering to mip levels requires WebGL2.');
+            }
+        }
+
         // Re-attach color textures at the requested mip level.
         // (Framebuffer attachments are per-FBO, so we must re-attach when mipLevel changes.)
         // IMPORTANT: This must also run when returning from mip>0 back to mip=0, because attachments are stateful.

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -134,19 +134,6 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
 
         gl.bindFramebuffer(gl.FRAMEBUFFER, gpuRenderTarget.framebuffer);
 
-        if (mipLevel > 0)
-        {
-            if (gpuRenderTarget.msaa)
-            {
-                throw new Error('[RenderTargetSystem] Rendering to mip levels is not supported with MSAA render targets.');
-            }
-
-            if (this._renderer.context.webGLVersion < 2)
-            {
-                throw new Error('[RenderTargetSystem] Rendering to mip levels requires WebGL2.');
-            }
-        }
-
         // Re-attach color textures at the requested mip level.
         // (Framebuffer attachments are per-FBO, so we must re-attach when mipLevel changes.)
         // IMPORTANT: This must also run when returning from mip>0 back to mip=0, because attachments are stateful.

--- a/src/rendering/renderers/gl/texture/GlTextureSystem.ts
+++ b/src/rendering/renderers/gl/texture/GlTextureSystem.ts
@@ -250,12 +250,6 @@ export class GlTextureSystem implements System, CanvasGenerator
             throw new Error(`Unsupported view dimension: ${source.viewDimension} with this webgl version: ${this._renderer.context.webGLVersion}`);
         }
 
-        // Cube textures use a different GL target.
-        if (source.uploadMethodId === 'cube')
-        {
-            glTexture.target = gl.TEXTURE_CUBE_MAP;
-        }
-
         if (source.autoGenerateMipmaps && (this._renderer.context.supports.nonPowOf2mipmaps || source.isPowerOfTwo))
         {
             const biggestDimension = Math.max(source.width, source.height);

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -169,6 +169,7 @@ export class GpuTextureSystem implements System, CanvasGenerator
 
         const textureDescriptor: GPUTextureDescriptor = {
             label: source.label,
+            // WebGPU cube textures are 2D textures with 6 array layers and a cube view.
             size: { width, height, depthOrArrayLayers: source.arrayLayerCount },
             format: source.format,
             sampleCount: source.sampleCount,


### PR DESCRIPTION
### 📚 Part 1 of 6 — feat-3d (WebGPU 3D-readiness) stack

Stacked PRs, merge bottom-up:

1. **texture-system cleanup ← you are here** _(base: `dev`)_
2. #12089 — shader overrides & GPU plumbing
3. #12090 — geometry / render bundles & depth-only targets
4. #12091 — RenderTarget WebGPU-first attachments & TextureView
5. #12092 — copyDepthTexture
6. #12093 — hardening capstone _(tree-identical to the full feat-3d)_

---

## Summary

Small cleanup of the GPU/GL texture systems that forms the base of the stack. The net change is intentionally tiny (**+1 / −6 lines**): a mid-range mip-guard is reverted, leaving only a documentation comment for cube-texture allocation. The substantive mip / array-layer / cube rendering features land in later PRs.

## Changes

- `GpuTextureSystem` / `GlTextureSystem`: remove a dead cube/mip-target branch and document cube-texture allocation.

## Notes

- Build ✅ and type-check ✅ clean.
