### PR TITLE
feat: copyDepthTexture for render targets (WebGPU/WebGL2)

### DIFF
--- a/src/rendering/batcher/gpu/generateGPULayout.ts
+++ b/src/rendering/batcher/gpu/generateGPULayout.ts
@@ -17,7 +17,7 @@ export function generateGPULayout(maxTextures: number): GPUBindGroupLayoutEntry[
                 multisampled: false,
             },
             binding: bindIndex,
-            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            visibility: GPUShaderStage.FRAGMENT,
         };
         bindIndex++;
 
@@ -26,7 +26,7 @@ export function generateGPULayout(maxTextures: number): GPUBindGroupLayoutEntry[
                 type: 'filtering',
             },
             binding: bindIndex,
-            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+            visibility: GPUShaderStage.FRAGMENT,
         };
 
         bindIndex++;

--- a/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
@@ -1,5 +1,6 @@
 import { Color } from '../../../../color/Color';
 import { DOMAdapter } from '../../../../environment/adapter';
+import { warn } from '../../../../utils/logging/warn';
 import { CanvasSource } from '../../shared/texture/sources/CanvasSource';
 
 import type { ICanvas } from '../../../../environment/canvas/ICanvas';
@@ -199,6 +200,17 @@ export class CanvasRenderTargetAdaptor implements RenderTargetAdaptor<CanvasRend
         destSource.update();
 
         return destinationTexture;
+    }
+
+    /**
+     * Copies the depth attachment from one render target to another (not supported in canvas).
+     * @param _source - Source render target.
+     * @param _destination - Destination render target.
+     * @advanced
+     */
+    public copyDepthTexture(_source: RenderTarget, _destination: RenderTarget): void
+    {
+        warn('[CanvasRenderTargetAdaptor] copyDepthTexture is not supported in the canvas renderer');
     }
 
     /**

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -90,6 +90,33 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
         return destinationTexture;
     }
 
+    public copyDepthTexture(source: RenderTarget, destination: RenderTarget): void
+    {
+        if (!source.depthStencilAttachment || !destination.depthStencilAttachment)
+        {
+            warn('[GlRenderTargetAdaptor] copyDepthTexture: source and destination must both have depth attachments');
+
+            return;
+        }
+
+        const renderTargetSystem = this._renderTargetSystem;
+        const gl = this._renderer.gl;
+
+        this.finishRenderPass(source);
+
+        const srcGl = renderTargetSystem.getGpuRenderTarget(source);
+        const dstGl = renderTargetSystem.getGpuRenderTarget(destination);
+
+        gl.bindFramebuffer(gl.READ_FRAMEBUFFER, srcGl.framebuffer);
+        gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dstGl.framebuffer);
+
+        gl.blitFramebuffer(
+            0, 0, srcGl.width, srcGl.height,
+            0, 0, dstGl.width, dstGl.height,
+            gl.DEPTH_BUFFER_BIT, gl.NEAREST,
+        );
+    }
+
     public startRenderPass(
         renderTarget: RenderTarget,
         clear: CLEAR_OR_BOOL = true,

--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -147,12 +147,11 @@ export class GpuDeviceSystem implements System<GpuContextOptions>
             'indirect-first-instance',
         ].filter((feature) => adapter.features.has(feature)) as GPUFeatureName[];
 
-        // Request adapter limits so `device.limits` matches hardware (e.g. sampled textures per stage > 16).
-        // Without `requiredLimits`, implementations typically expose only the WebGPU default minimum.
         const device = await adapter.requestDevice({
             requiredFeatures,
             requiredLimits: {
                 maxSampledTexturesPerShaderStage: adapter.limits.maxSampledTexturesPerShaderStage,
+                maxSamplersPerShaderStage: adapter.limits.maxSamplersPerShaderStage,
             },
         });
 

--- a/src/rendering/renderers/gpu/GpuLimitsSystem.ts
+++ b/src/rendering/renderers/gpu/GpuLimitsSystem.ts
@@ -54,7 +54,10 @@ export class GpuLimitsSystem implements System
     {
         const device = this._renderer.device.gpu.device;
 
-        this.maxTextures = device.limits.maxSampledTexturesPerShaderStage;
+        this.maxTextures = Math.min(
+            device.limits.maxSampledTexturesPerShaderStage,
+            device.limits.maxSamplersPerShaderStage,
+        );
         this.maxBatchableTextures = this.maxTextures;
 
         this._detectOverrideConstantsSupport(device);

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -98,6 +98,40 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
         return destinationTexture;
     }
 
+    public copyDepthTexture(source: RenderTarget, destination: RenderTarget): void
+    {
+        if (!source.depthStencilAttachment || !destination.depthStencilAttachment)
+        {
+            warn('[GpuRenderTargetAdaptor] copyDepthTexture: source and destination must both have depth attachments');
+
+            return;
+        }
+
+        const renderer = this._renderer;
+
+        const srcDepth = source.depthStencilAttachment.texture;
+        const dstDepth = destination.depthStencilAttachment.texture;
+
+        const srcGpu = renderer.texture.getGpuSource(srcDepth);
+        const dstGpu = renderer.texture.getGpuSource(dstDepth);
+
+        const standAlone = renderer.encoder.commandEncoder === null;
+        const commandEncoder = standAlone
+            ? renderer.gpu.device.createCommandEncoder()
+            : renderer.encoder.commandEncoder;
+
+        commandEncoder.copyTextureToTexture(
+            { texture: srcGpu },
+            { texture: dstGpu },
+            { width: source.pixelWidth, height: source.pixelHeight },
+        );
+
+        if (standAlone)
+        {
+            renderer.gpu.device.queue.submit([commandEncoder.finish()]);
+        }
+    }
+
     public startRenderPass(
         renderTarget: RenderTarget,
         clear: CLEAR_OR_BOOL = true,

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -171,6 +171,33 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
      * @param {RendererRenderTarget} gpuRenderTarget - the gpu render target to destroy
      */
     destroyGpuRenderTarget(gpuRenderTarget: RENDER_TARGET): void
+
+    /**
+     * Copies the depth attachment from one render target to another.
+     * Both source and destination must have a depthStencilAttachment.
+     *
+     * **Important Note:** When using the copied depth buffer in a subsequent render pass,
+     * you must ensure you do not clear the depth buffer again. If you need to clear the color
+     * buffer of the destination render target, use `clear: CLEAR.COLOR` to preserve the copied depth data.
+     * @example
+     * ```js
+     * renderer.renderTarget.copyDepthTexture(sourceRT, destRT);
+     *
+     * // In the subsequent render pass, clear ONLY the color buffer!
+     * renderer.render({
+     *   target: destRT,
+     *   container: myMesh,
+     *   clear: CLEAR.COLOR, // Preserves the copied depth
+     *   clearColor: [0, 0, 0, 1]
+     * });
+     * ```
+     * @param {RenderTarget} source - the render target to copy depth from
+     * @param {RenderTarget} destination - the render target to copy depth to
+     */
+    copyDepthTexture(
+        source: RenderTarget,
+        destination: RenderTarget,
+    ): void
 }
 
 /**
@@ -645,6 +672,36 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
             size,
             originDest
         );
+    }
+
+    /**
+     * Copies the depth attachment from one render target to another.
+     * Both source and destination must have a depthStencilAttachment.
+     *
+     * **Important Note:** When using the copied depth buffer in a subsequent render pass,
+     * you must ensure you do not clear the depth buffer again. If you need to clear the color
+     * buffer of the destination render target, use `clear: CLEAR.COLOR` to preserve the copied depth data.
+     * @example
+     * ```js
+     * renderer.renderTarget.copyDepthTexture(sourceRT, destRT);
+     *
+     * // In the subsequent render pass, clear ONLY the color buffer!
+     * renderer.render({
+     *   target: destRT,
+     *   container: myMesh,
+     *   clear: CLEAR.COLOR, // Preserves the copied depth
+     *   clearColor: [0, 0, 0, 1]
+     * });
+     * ```
+     * @param source - the render target to copy depth from
+     * @param destination - the render target to copy depth to
+     */
+    public copyDepthTexture(
+        source: RenderTarget,
+        destination: RenderTarget,
+    ): void
+    {
+        this.adaptor.copyDepthTexture(source, destination);
     }
 
     /**

--- a/tests/visual/scenes/textures/copy-depth-texture.scene.ts
+++ b/tests/visual/scenes/textures/copy-depth-texture.scene.ts
@@ -1,0 +1,232 @@
+import { CLEAR, Geometry, RenderTarget, Shader, State, Texture, TextureSource } from '~/rendering';
+import { Mesh, Sprite } from '~/scene';
+
+import type { TestScene } from '../../types';
+import type { Renderer } from '~/rendering';
+import type { Container } from '~/scene';
+
+export const scene: TestScene = {
+    it: 'should copy depth from one render target to another via copyDepthTexture',
+    renderers: {
+        webgpu: true,
+        webgl2: true,
+        webgl1: false,
+    },
+    create: async (scene: Container, renderer: Renderer) =>
+    {
+        // -- Textures --
+
+        const sourceColorSource = new TextureSource({
+            width: 128,
+            height: 128,
+            resolution: 1,
+            mipLevelCount: 1,
+            autoGenerateMipmaps: false,
+        });
+
+        const sourceDepthSource = new TextureSource({
+            width: 128,
+            height: 128,
+            resolution: 1,
+            format: 'depth24plus-stencil8',
+            mipLevelCount: 1,
+            autoGenerateMipmaps: false,
+        });
+
+        const destColorSource = new TextureSource({
+            width: 128,
+            height: 128,
+            resolution: 1,
+            mipLevelCount: 1,
+            autoGenerateMipmaps: false,
+        });
+
+        const destColorTexture = new Texture({ source: destColorSource });
+
+        const destDepthSource = new TextureSource({
+            width: 128,
+            height: 128,
+            resolution: 1,
+            format: 'depth24plus-stencil8',
+            mipLevelCount: 1,
+            autoGenerateMipmaps: false,
+        });
+
+        // -- Render Targets --
+
+        const sourceRT = new RenderTarget({
+            colorAttachments: [{
+                texture: sourceColorSource,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: [0, 0, 0, 1],
+            }],
+            depthStencilAttachment: {
+                texture: sourceDepthSource,
+                depthLoadOp: 'clear',
+                depthStoreOp: 'store',
+                depthClearValue: 1.0,
+            },
+        });
+
+        const destRT = new RenderTarget({
+            colorAttachments: [{
+                texture: destColorSource,
+                loadOp: 'clear',
+                storeOp: 'store',
+                clearValue: [0, 0, 0, 1],
+            }],
+            depthStencilAttachment: {
+                texture: destDepthSource,
+                depthLoadOp: 'load',
+                depthStoreOp: 'store',
+            },
+        });
+
+        // -- Shaders --
+
+        // IMPORTANT NOTE FOR CUSTOM SHADERS ON MESHES:
+        // Do NOT use the uniform name `uColor` in your custom shaders if you are
+        // rendering them via `Mesh`. PixiJS's `MeshPipe` injects its own `localUniforms`
+        // which includes a `uColor` property (used for mesh tinting).
+        // In WebGPU, this is fine if you use a different bind group, but in WebGL,
+        // uniforms share a flat namespace per program, and the internal `uColor`
+        // will overwrite your custom uniform! Use a distinct name like `uTestColor`.
+        const gpuShaderSrc = /* wgsl */`
+            struct Uniforms {
+                uTestColor: vec4<f32>,
+                uDepth: f32,
+            }
+
+            @group(0) @binding(0) var<uniform> uniforms : Uniforms;
+
+            struct VSOutput {
+                @builtin(position) position: vec4<f32>,
+            };
+
+            @vertex
+            fn vsMain(@location(0) aPosition : vec2<f32>) -> VSOutput {
+                var out: VSOutput;
+                out.position = vec4<f32>(aPosition, uniforms.uDepth, 1.0);
+                return out;
+            }
+
+            @fragment
+            fn fsMain() -> @location(0) vec4<f32> {
+                return uniforms.uTestColor;
+            }
+        `;
+
+        const glShader = {
+            vertex: `#version 300 es
+                precision highp float;
+                in vec2 aPosition;
+                uniform float uDepth;
+                void main() {
+                    gl_Position = vec4(aPosition, uDepth, 1.0);
+                }
+            `,
+            fragment: `#version 300 es
+                precision highp float;
+                uniform vec4 uTestColor;
+                out vec4 fragColor;
+                void main() {
+                    fragColor = uTestColor;
+                }
+            `,
+        };
+
+        // Left-half quad
+        const leftQuadGeom = new Geometry({
+            attributes: {
+                aPosition: [-1, -1, 0, -1, 0, 1, -1, -1, 0, 1, -1, 1],
+            },
+        });
+
+        // Full-screen quad
+        const fullQuadGeom = new Geometry({
+            attributes: {
+                aPosition: [-1, -1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1],
+            },
+        });
+
+        const depthState = new State();
+
+        depthState.depthTest = true;
+        depthState.depthMask = true;
+        depthState.blendMode = 'none';
+
+        // -- PASS 1: Write a green left-half quad at depth 0.3 into sourceRT --
+
+        const greenQuad = new Mesh({
+            geometry: leftQuadGeom,
+            shader: Shader.from({
+                gl: glShader,
+                gpu: {
+                    vertex: { source: gpuShaderSrc, entryPoint: 'vsMain' },
+                    fragment: { source: gpuShaderSrc, entryPoint: 'fsMain' },
+                },
+                resources: {
+                    uniforms: {
+                        uTestColor: { value: [0, 1, 0, 1], type: 'vec4<f32>' },
+                        uDepth: { value: 0.3, type: 'f32' },
+                    },
+                },
+            }),
+            state: depthState,
+        });
+
+        renderer.render({
+            target: sourceRT,
+            container: greenQuad,
+            clear: true,
+            clearColor: [0, 0, 0, 1],
+        });
+
+        // -- COPY: Copy the depth buffer from sourceRT to destRT --
+
+        renderer.renderTarget.copyDepthTexture(sourceRT, destRT);
+
+        // -- PASS 2: Render a full-screen red quad at depth 0.5 into destRT --
+        // The left half should be blocked by the copied depth (0.3 < 0.5),
+        // so only the right half should show red.
+        //
+        // IMPORTANT NOTE FOR DEPTH/STENCIL PRESERVATION:
+        // We MUST explicitly clear ONLY the color buffer here (`clear: CLEAR.COLOR`).
+        // If we passed `clear: false`, the newly created `destRT`'s color attachment
+        // would be completely uninitialized (transparent), causing the background
+        // to bleed through where the depth test fails.
+        // If we passed `clear: true`, we would inadvertently clear the Depth buffer
+        // that we just painstakingly copied!
+
+        const redQuad = new Mesh({
+            geometry: fullQuadGeom,
+            shader: Shader.from({
+                gl: glShader,
+                gpu: {
+                    vertex: { source: gpuShaderSrc, entryPoint: 'vsMain' },
+                    fragment: { source: gpuShaderSrc, entryPoint: 'fsMain' },
+                },
+                resources: {
+                    uniforms: {
+                        uTestColor: { value: [1, 0, 0, 1], type: 'vec4<f32>' },
+                        uDepth: { value: 0.5, type: 'f32' },
+                    },
+                },
+            }),
+            state: depthState,
+        });
+
+        renderer.render({
+            target: destRT,
+            container: redQuad,
+            clear: CLEAR.COLOR,
+            clearColor: [0, 0, 0, 1],
+        });
+
+        // Expected: left half = black (depth-blocked), right half = red.
+        const result = new Sprite(destColorTexture);
+
+        scene.addChild(result);
+    },
+};


### PR DESCRIPTION
### 📚 Part 5 of 6 — feat-3d (WebGPU 3D-readiness) stack

Stacked PRs, merge bottom-up (each PR targets the one below; base of #12088 is `dev`):

1. #12088 — texture-system cleanup _(base: `dev`)_
2. #12089 — shader overrides & GPU plumbing
3. #12090 — geometry / render bundles & depth-only targets
4. #12091 — RenderTarget WebGPU-first attachments & TextureView
5. **copyDepthTexture ← you are here**
6. #12093 — hardening capstone _(tree-identical to the full feat-3d)_

_Base of this PR: `stack-3d/04-rendertarget-webgpu-attachments`._

---

## Summary

Adds `copyDepthTexture` — copy one render target's depth buffer into another — across the Canvas / WebGL2 / WebGPU adaptors.

## Changes

- **`copyDepthTexture`** on `RenderTargetSystem` and each adaptor; copies the depth attachment between render targets (WebGPU / WebGL2; Canvas no-op).
- Adds a `copy-depth-texture` visual scene.

The interim signature here is 2-arg (`source`, `destination`); the capstone (#12093) widens it to take `origin` / `size` and clamps to the destination bounds.

> ℹ️ **Stacked PR.** Test-suite hardening is consolidated in the capstone (#12093), so some unit tests on this intermediate branch are red until the full stack lands. **Build and type-check are clean** on this branch.
