### PR TITLE
chore: remove dead https://pixijs.io/customize link in v7 migration guide

### DIFF
--- a/src/__docs__/migrations/v7.md
+++ b/src/__docs__/migrations/v7.md
@@ -49,7 +49,7 @@ const image = Sprite.from(texture);
 
 ## 🤝 Abandon the use of peerDependencies
 
-~~PixiJS heavily uses `peerDependencies` in the **package.json** within each package. This design choice has plagued Pixi with many issues. It's a breaking change to remove, so now was a good time. We have decided to completely remove `peerDependencies`, instead opting for _nothing_. This should make installing and upgrading `pixi.js` much easier. We are working on updating [our tooling](https://pixijs.io/customize) for composing a custom version with packages.~~ **Edit: As of 7.2.0, we have reverted this change to keep compatibility with some module-based CDNs.**
+~~PixiJS heavily uses `peerDependencies` in the **package.json** within each package. This design choice has plagued Pixi with many issues. It's a breaking change to remove, so now was a good time. We have decided to completely remove `peerDependencies`, instead opting for _nothing_. This should make installing and upgrading `pixi.js` much easier. We are working on updating our tooling for composing a custom version with packages.~~ **Edit: As of 7.2.0, we have reverted this change to keep compatibility with some module-based CDNs.**
 
 ## 👂 Other Changes
 


### PR DESCRIPTION
## What / Why

The link `https://pixijs.io/customize` in `src/__docs__/migrations/v7.md` returns 404. The 'customize' tool was never published to `pixijs.io`, and the surrounding text is in strikethrough (the change was reverted in 7.2.0, so the link has been dead for years).

## Fix

Remove the link, keeping the prose:

```
- We are working on updating [our tooling](https://pixijs.io/customize) for composing a custom version with packages.
+ We are working on updating our tooling for composing a custom version with packages.
```

Found by a HEAD-link sweep of the docs/ directory.