### PR TITLE
fix: Rectangle.containsRect treats identical rectangles as contained

### DIFF
--- a/src/maths/__tests__/Rectangle.test.ts
+++ b/src/maths/__tests__/Rectangle.test.ts
@@ -483,12 +483,24 @@ describe('Rectangle', () =>
             expect(outer.containsRect(edge3)).toBe(true);
         });
 
-        it('should handle identical rectangles', () =>
+        it('should return true for identical rectangles', () =>
         {
+            // Rectangles that occupy the same space are considered to be containing each other.
             const rect1 = new Rectangle(0, 0, 100, 100);
             const rect2 = new Rectangle(0, 0, 100, 100);
 
-            expect(rect1.containsRect(rect2)).toBe(false);
+            expect(rect1.containsRect(rect2)).toBe(true);
+            expect(rect1.containsRect(rect1)).toBe(true);
+        });
+
+        it('should return false when an arealess rectangle sits on the edge', () =>
+        {
+            const outer = new Rectangle(0, 0, 100, 100);
+
+            // An arealess rectangle can only be contained if it is strictly inside.
+            expect(outer.containsRect(new Rectangle(50, 50, 0, 0))).toBe(true);
+            expect(outer.containsRect(new Rectangle(0, 50, 0, 0))).toBe(false);
+            expect(outer.containsRect(new Rectangle(100, 50, 0, 0))).toBe(false);
         });
     });
 });

--- a/src/maths/shapes/Rectangle.ts
+++ b/src/maths/shapes/Rectangle.ts
@@ -794,17 +794,15 @@ export class Rectangle implements ShapePrimitive
      */
     public containsRect(other: Rectangle): boolean
     {
-        if (this.width <= 0 || this.height <= 0) return false;
+        // An arealess rectangle can be contained, but only if it sits strictly inside this one.
+        if (other.width <= 0 || other.height <= 0)
+        {
+            return other.x > this.x && other.y > this.y && other.right < this.right && other.bottom < this.bottom;
+        }
 
-        const x1 = other.x;
-        const y1 = other.y;
-        const x2 = other.x + other.width;
-        const y2 = other.y + other.height;
-
-        return x1 >= this.x && x1 < this.x + this.width
-            && y1 >= this.y && y1 < this.y + this.height
-            && x2 >= this.x && x2 < this.x + this.width
-            && y2 >= this.y && y2 < this.y + this.height;
+        // Rectangles that occupy the same space are considered to be containing each other,
+        // so the shared edges are inclusive (`<=` / `>=`).
+        return other.x >= this.x && other.y >= this.y && other.right <= this.right && other.bottom <= this.bottom;
     }
 
     /**


### PR DESCRIPTION
Closes #12082.


##### Description of change
`Rectangle.containsRect` used strict `<` on the far edges, so a rectangle did not contain itself —
  contradicting its own docs ("Rectangles that occupy the same space are considered to be containing
  each other") and the canonical implementation in `math-extras/rectangleExtras.ts`.

  This aligns the core `containsRect` with that reference: inclusive `<=` / `>=` on shared edges,
  with the existing strict behaviour kept for arealess (`width` / `height <= 0`) rectangles. Updated
  the unit test that asserted the old (incorrect) result and added coverage for arealess-on-edge
  cases.


##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
