### PR TITLE
fix: add persistentDeviceId to FederatedPointerEvent

### DIFF
--- a/src/events/EventBoundary.ts
+++ b/src/events/EventBoundary.ts
@@ -1317,6 +1317,7 @@ export class EventBoundary
         to.tiltX = from.tiltX;
         to.tiltY = from.tiltY;
         to.twist = from.twist;
+        to.persistentDeviceId = from.persistentDeviceId;
     }
 
     /**

--- a/src/events/FederatedPointerEvent.ts
+++ b/src/events/FederatedPointerEvent.ts
@@ -128,6 +128,12 @@ export class FederatedPointerEvent extends FederatedMouseEvent implements Pointe
      */
     public twist: number;
 
+    /**
+     * A unique identifier for the pointing device generating the event, that persists across events.
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/persistentDeviceId
+     */
+    public persistentDeviceId = 0;
+
     /** This is the number of clicks that occurs in 200ms/click of each other. */
     public detail: number;
 

--- a/src/events/__tests__/EventBoundary.test.ts
+++ b/src/events/__tests__/EventBoundary.test.ts
@@ -26,6 +26,17 @@ describe('EventBoundary', () =>
         await getApp();
     });
 
+    it('should expose a persistentDeviceId property defaulting to 0', () =>
+    {
+        const boundary = new EventBoundary(new Container());
+        const event = new FederatedPointerEvent(boundary);
+
+        expect(event.persistentDeviceId).toBe(0);
+
+        event.persistentDeviceId = 7;
+        expect(event.persistentDeviceId).toBe(7);
+    });
+
     it('should fire capture, bubble events on the correct target', () =>
     {
         const stage = new Container();


### PR DESCRIPTION
Closes #12101.

##### Description of change

TypeScript 6's `lib.dom.d.ts` made `persistentDeviceId` a required member of `PointerEvent`. Since `FederatedPointerEvent implements PointerEvent`, downstream apps on TS 6 fail to compile with:

`TS2420: Class 'FederatedPointerEvent' incorrectly implements interface 'PointerEvent'. Property 'persistentDeviceId' is missing.`

This declares `persistentDeviceId` on `FederatedPointerEvent` (defaulting to `0`) and copies it in `EventBoundary.copyPointerData`, mirroring how the other pointer properties are handled.

Note: it is intentionally **not** read from the native event in `EventSystem`, because PixiJS builds on TypeScript 5.9 whose `lib.dom` does not yet declare `persistentDeviceId` — referencing it there would break the library's own type check. This matches the existing treatment of `altitudeAngle` / `azimuthAngle`.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
