### PR TITLE
feat: copy depth into textures and expose resolved front-face orientation

### DIFF
--- a/src/rendering/renderers/__tests__/RenderTargetSystem.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTargetSystem.test.ts
@@ -1,6 +1,7 @@
 import { CLEAR } from '../gl/const';
 import { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import { TextureSource } from '../shared/texture/sources/TextureSource';
+import { Texture } from '../shared/texture/Texture';
 import { describeLocalOnly, getWebGLRenderer, getWebGPURenderer } from '@test-utils';
 import { Graphics } from '~/scene/graphics/shared/Graphics';
 
@@ -277,6 +278,31 @@ describe('RenderTargetSystem flipY orientation toggle (WebGL)', () =>
         expect(state._invertFrontFace).toBe(false);
     });
 
+    it('exposes frontFaceInverted matching the baked winding inversion (welded to flipY and isRoot)', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const state = (renderer as WebGLRenderer).state as unknown as { _invertFrontFace: boolean };
+        const a = createTarget();
+        const b = createTarget();
+
+        // non-root texture, default: WebGL's inherent flip inverts the winding
+        renderTarget.bind(a);
+        expect(renderTarget.frontFaceInverted).toBe(true);
+        expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
+
+        // flipY:false is inert -> still inverted (switch target to force the change to re-emit)
+        renderTarget.bind(b, true, null, null, 0, 0, false);
+        expect(renderTarget.frontFaceInverted).toBe(true);
+        expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
+
+        // flipY:true cancels the inherent flip -> not inverted
+        renderTarget.bind(a, true, null, null, 0, 0, true);
+        expect(renderTarget.frontFaceInverted).toBe(false);
+        expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
+    });
+
     it('restores flipY when popping back to a target pushed with flipY:true', async () =>
     {
         renderer = await getWebGLRenderer() as WebGLRenderer;
@@ -328,6 +354,23 @@ describeLocalOnly('RenderTargetSystem flipY orientation toggle (WebGPU)', () =>
         renderer.render({ container: graphics, target, clear: true, flipY: true });
         expect(spy.mock.calls.some(([d]) => d.primitive?.frontFace === 'cw')).toBe(true);
     });
+
+    it('exposes frontFaceInverted as the raw flipY (WebGPU has no inherent Y-flip)', async () =>
+    {
+        renderer = await getWebGPURenderer() as WebGPURenderer;
+
+        renderer.encoder.renderStart();
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+
+        // no inherent flip on WebGPU: isRoot never enters the equation, so it tracks flipY directly
+        renderTarget.bind(target, true, null, null, 0, 0, false);
+        expect(renderTarget.frontFaceInverted).toBe(false);
+
+        renderTarget.bind(target, true, null, null, 0, 0, true);
+        expect(renderTarget.frontFaceInverted).toBe(true);
+    });
 });
 
 describe('copyDepthTexture argument safety', () =>
@@ -336,13 +379,14 @@ describe('copyDepthTexture argument safety', () =>
     {
         renderer = await getWebGLRenderer({ width: 64, height: 64 });
 
-        const makeTarget = () => new RenderTarget({
+        const source = new RenderTarget({
             colorTextures: [new TextureSource({ width: 32, height: 32 })],
             depthStencilTexture: new TextureSource({ width: 32, height: 32, format: 'depth24plus-stencil8' }),
         });
 
-        const source = makeTarget();
-        const destination = makeTarget();
+        const destination = new Texture({
+            source: new TextureSource({ width: 32, height: 32, format: 'depth24plus-stencil8' }),
+        });
 
         // the per-frame reuse pattern: one rect object, used every call —
         // negative origin and oversized extent both force clamping

--- a/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/canvas/renderTarget/CanvasRenderTargetAdaptor.ts
@@ -203,9 +203,9 @@ export class CanvasRenderTargetAdaptor implements RenderTargetAdaptor<CanvasRend
     }
 
     /**
-     * Copies the depth attachment from one render target to another (not supported in canvas).
+     * Copies the depth attachment of a render target into a texture (not supported in canvas).
      * @param _source - Source render target.
-     * @param _destination - Destination render target.
+     * @param _destination - Destination depth/stencil texture.
      * @param _originSrc - Source origin of the copy.
      * @param _originSrc.x
      * @param _originSrc.y
@@ -219,7 +219,7 @@ export class CanvasRenderTargetAdaptor implements RenderTargetAdaptor<CanvasRend
      */
     public copyDepthTexture(
         _source: RenderTarget,
-        _destination: RenderTarget,
+        _destination: Texture,
         _originSrc?: { x: number; y: number; },
         _size?: { width: number; height: number; },
         _originDest?: { x: number; y: number; },

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -92,26 +92,23 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
 
     public copyDepthTexture(
         source: RenderTarget,
-        destination: RenderTarget,
+        destination: Texture,
         originSrc: { x: number; y: number; },
         size: { width: number; height: number; },
         originDest: { x: number; y: number; },
     ): void
     {
-        if (!source.depthStencilAttachment || !destination.depthStencilAttachment)
-        {
-            warn('[GlRenderTargetAdaptor] copyDepthTexture: source and destination must both have depth attachments');
-
-            return;
-        }
-
         const renderTargetSystem = this._renderTargetSystem;
         const gl = this._renderer.gl;
 
         this.finishRenderPass(source);
 
+        // blitFramebuffer moves depth between framebuffers, so the destination texture is
+        // resolved to its (depth-only) render target to provide one to blit into
+        const destinationRenderTarget = renderTargetSystem.getRenderTarget(destination);
+
         const srcGl = renderTargetSystem.getGpuRenderTarget(source);
-        const dstGl = renderTargetSystem.getGpuRenderTarget(destination);
+        const dstGl = renderTargetSystem.getGpuRenderTarget(destinationRenderTarget);
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, srcGl.framebuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, dstGl.framebuffer);

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -100,30 +100,23 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
 
     public copyDepthTexture(
         source: RenderTarget,
-        destination: RenderTarget,
+        destination: Texture,
         originSrc: { x: number; y: number; },
         size: { width: number; height: number; },
         originDest: { x: number; y: number; },
     ): void
     {
-        if (!source.depthStencilAttachment || !destination.depthStencilAttachment)
-        {
-            warn('[GpuRenderTargetAdaptor] copyDepthTexture: source and destination must both have depth attachments');
-
-            return;
-        }
-
         const renderer = this._renderer;
 
         // a copy cannot be recorded while a render pass holds the shared command encoder —
         // close the pass first (no-op when none is open), matching the GL adaptor
         this.finishRenderPass();
 
+        // depth is just a GPUTexture, so it copies straight into the destination's source
         const srcDepth = source.depthStencilAttachment.texture;
-        const dstDepth = destination.depthStencilAttachment.texture;
 
         const srcGpu = renderer.texture.getGpuSource(srcDepth);
-        const dstGpu = renderer.texture.getGpuSource(dstDepth);
+        const dstGpu = renderer.texture.getGpuSource(destination.source);
 
         const standAlone = renderer.encoder.commandEncoder === null;
         const commandEncoder = standAlone

--- a/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
+++ b/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
@@ -1,5 +1,6 @@
 import { RenderTarget } from '../../../shared/renderTarget/RenderTarget';
 import { TextureSource } from '../../../shared/texture/sources/TextureSource';
+import { Texture } from '../../../shared/texture/Texture';
 import { describeLocalOnly, getWebGPURenderer } from '@test-utils';
 
 import type { WebGPURenderer } from '../../WebGPURenderer';
@@ -12,13 +13,20 @@ function makeTarget(): RenderTarget
     });
 }
 
+function makeDepthTexture(): Texture
+{
+    return new Texture({
+        source: new TextureSource({ width: 16, height: 16, format: 'depth24plus-stencil8' }),
+    });
+}
+
 describeLocalOnly('GpuRenderTargetAdaptor copies', () =>
 {
     it('should close an open render pass before recording copyDepthTexture mid-frame', async () =>
     {
         const renderer = (await getWebGPURenderer()) as WebGPURenderer;
         const source = makeTarget();
-        const destination = makeTarget();
+        const destination = makeDepthTexture();
 
         const device = renderer.gpu.device;
 

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -3,6 +3,7 @@ import { Rectangle } from '../../../../maths/shapes/Rectangle';
 import { warn } from '../../../../utils/logging/warn';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';
+import { type Renderer, RendererType } from '../../types';
 import { SystemRunner } from '../system/SystemRunner';
 import { CanvasSource } from '../texture/sources/CanvasSource';
 import { TextureSource } from '../texture/sources/TextureSource';
@@ -17,7 +18,6 @@ import type { CanvasRenderTarget } from '../../canvas/renderTarget/CanvasRenderT
 import type { CLEAR_OR_BOOL } from '../../gl/const';
 import type { GlRenderTarget } from '../../gl/GlRenderTarget';
 import type { GpuRenderTarget } from '../../gpu/renderTarget/GpuRenderTarget';
-import type { Renderer } from '../../types';
 import type { System } from '../system/System';
 import type { BindableTexture } from '../texture/Texture';
 
@@ -175,8 +175,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
     destroyGpuRenderTarget(gpuRenderTarget: RENDER_TARGET): void
 
     /**
-     * Copies the depth attachment from one render target to another.
-     * Both source and destination must have a depthStencilAttachment.
+     * Copies the depth attachment of a render target into a depth/stencil texture.
      *
      * **Important Note:** When using the copied depth buffer in a subsequent render pass,
      * you must ensure you do not clear the depth buffer again. If you need to clear the color
@@ -184,7 +183,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
      * @example
      * ```js
      * renderer.renderTarget.copyDepthTexture(
-     *   sourceRT, destRT, { x: 0, y: 0 }, { width: 200, height: 200 }, { x: 0, y: 0 }
+     *   sourceRT, destDepthTexture, { x: 0, y: 0 }, { width: 200, height: 200 }, { x: 0, y: 0 }
      * );
      *
      * // In the subsequent render pass, clear ONLY the color buffer!
@@ -196,7 +195,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
      * });
      * ```
      * @param {RenderTarget} source - the render target to copy depth from
-     * @param {RenderTarget} destination - the render target to copy depth to
+     * @param {Texture} destination - the depth/stencil texture to copy depth to
      * @param {object} originSrc - the origin of the copy
      * @param {number} originSrc.x - the x origin of the copy
      * @param {number} originSrc.y - the y origin of the copy
@@ -209,7 +208,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
      */
     copyDepthTexture(
         source: RenderTarget,
-        destination: RenderTarget,
+        destination: Texture,
         originSrc: { x: number; y: number },
         size: { width: number; height: number },
         originDest?: { x: number; y: number },
@@ -532,6 +531,38 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         return renderTarget;
     }
 
+    /**
+     * The effective front-face orientation of the current bind — `true` when a front-facing triangle
+     * ends up wound the opposite way on the surface (so the winding/cull has been inverted to compensate).
+     *
+     * This is the requested `flipY` combined with the backend's inherent orientation, not the raw request:
+     *
+     * ```text
+     * frontFaceInverted = flipY XOR (isWebGL && !isRoot)
+     * ```
+     *
+     * WebGL's non-root FBOs carry an inherent Y-flip vs the root (the classic render-texture flip), so the
+     * same requested `flipY` lands with the opposite winding depending on `isRoot`. WebGPU has no such
+     * inherent flip, so there it is simply `flipY`. This is exactly the winding inversion each backend bakes
+     * at bind ({@link GlStateSystem} / {@link PipelineSystem}), exposed so consumers (e.g. 3D pipelines) can
+     * read the resolved orientation instead of re-deriving it from `flipY`, `isRoot`, and a backend check of
+     * their own.
+     *
+     * It is per-bind, not per-target: `flipY` is set on every `bind`/`renderStart` while `isRoot` is fixed on
+     * the target, so this recomputes from whatever the last bind resolved.
+     * @returns whether the current bind's front face is inverted
+     */
+    public get frontFaceInverted(): boolean
+    {
+        const renderTarget = this.renderTarget;
+
+        if (!renderTarget) return false;
+
+        const glInherentFlip = this._renderer.type === RendererType.WEBGL && !renderTarget.isRoot;
+
+        return !!renderTarget.flipY !== glInherentFlip;
+    }
+
     public clear(
         target?: RenderSurface,
         clear: CLEAR_OR_BOOL = CLEAR.ALL,
@@ -659,7 +690,7 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      * The best way to copy a canvas is to create a texture from it. Then render with that.
      *
      * Parsing in a RenderTarget canvas context (with a 2d context)
-     * @param sourceRenderSurfaceTexture - the render surface to copy from
+     * @param sourceRenderSurface - the render surface (render target, texture, or canvas) to copy from
      * @param {Texture} destinationTexture - the texture to copy to
      * @param {object} originSrc - the origin of the copy
      * @param {number} originSrc.x - the x origin of the copy
@@ -672,13 +703,16 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      * @param {number} originDest.y - the y origin of the paste
      */
     public copyToTexture(
-        sourceRenderSurfaceTexture: RenderTarget,
+        sourceRenderSurface: RenderSurface,
         destinationTexture: Texture,
         originSrc: { x: number; y: number },
         size: { width: number; height: number },
         originDest: { x: number; y: number; },
     )
     {
+        // a texture or canvas source is copied from its render target's framebuffer
+        const sourceRenderTarget = this.getRenderTarget(sourceRenderSurface);
+
         // fit the size to the source we don't want to go out of bounds
 
         if (originSrc.x < 0)
@@ -695,13 +729,13 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
             originSrc.y = 0;
         }
 
-        const { pixelWidth, pixelHeight } = sourceRenderSurfaceTexture;
+        const { pixelWidth, pixelHeight } = sourceRenderTarget;
 
         size.width = Math.min(size.width, pixelWidth - originSrc.x);
         size.height = Math.min(size.height, pixelHeight - originSrc.y);
 
         return this.adaptor.copyToTexture(
-            sourceRenderSurfaceTexture,
+            sourceRenderTarget,
             destinationTexture,
             originSrc,
             size,
@@ -730,8 +764,8 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      *   clearColor: [0, 0, 0, 1]
      * });
      * ```
-     * @param source - the render target to copy depth from
-     * @param destination - the render target to copy depth to
+     * @param source - the render surface (render target, depth texture, or canvas) to copy depth from
+     * @param destination - the depth/stencil texture to copy depth to
      * @param {object} originSrc - the origin of the copy
      * @param {number} originSrc.x - the x origin of the copy
      * @param {number} originSrc.y - the y origin of the copy
@@ -743,13 +777,33 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      * @param {number} originDest.y - the y origin of the paste
      */
     public copyDepthTexture(
-        source: RenderTarget,
-        destination: RenderTarget,
+        source: RenderSurface,
+        destination: Texture,
         originSrc: { x: number; y: number },
         size: { width: number; height: number },
         originDest: { x: number; y: number; } = { x: 0, y: 0 },
     ): void
     {
+        // a depth texture source is copied from its render target's depth attachment
+        const sourceRenderTarget = this.getRenderTarget(source);
+
+        if (!sourceRenderTarget.depthStencilAttachment)
+        {
+            warn('[RenderTargetSystem] copyDepthTexture: the source render target has no depth attachment to copy from');
+
+            return;
+        }
+
+        const destSource = destination.source;
+
+        if (!destSource.format.includes('depth') && !destSource.format.includes('stencil'))
+        {
+            warn('[RenderTargetSystem] copyDepthTexture: the destination texture must have a depth/stencil format '
+                + `(got '${destSource.format}')`);
+
+            return;
+        }
+
         // clamp into locals — callers often reuse their rect objects across frames,
         // so the arguments must never be mutated
         let srcX = originSrc.x;
@@ -774,18 +828,18 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
             srcY = 0;
         }
 
-        width = Math.min(width, source.pixelWidth - srcX);
-        height = Math.min(height, source.pixelHeight - srcY);
+        width = Math.min(width, sourceRenderTarget.pixelWidth - srcX);
+        height = Math.min(height, sourceRenderTarget.pixelHeight - srcY);
 
         // fit to the destination bounds too — WebGPU validates the copy against them
         // (GL silently clips), and an oversized copy would discard the whole frame
-        width = Math.min(width, destination.pixelWidth - destX);
-        height = Math.min(height, destination.pixelHeight - destY);
+        width = Math.min(width, destSource.pixelWidth - destX);
+        height = Math.min(height, destSource.pixelHeight - destY);
 
         if (width <= 0 || height <= 0) return;
 
         this.adaptor.copyDepthTexture(
-            source, destination,
+            sourceRenderTarget, destination,
             { x: srcX, y: srcY },
             { width, height },
             { x: destX, y: destY },
@@ -850,9 +904,13 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         }
         else if (renderSurface instanceof TextureSource)
         {
-            renderTarget = new RenderTarget({
-                colorTextures: [renderSurface],
-            });
+            // a depth/stencil-format source is a depth attachment, any other format is a color one
+            const format = renderSurface.format;
+            const isDepthStencil = format.includes('depth') || format.includes('stencil');
+
+            renderTarget = isDepthStencil
+                ? new RenderTarget({ colorTextures: 0, depthStencilTexture: renderSurface })
+                : new RenderTarget({ colorTextures: [renderSurface] });
 
             if (renderSurface.source instanceof CanvasSource)
             {

--- a/tests/visual/scenes/textures/copy-depth-texture.scene.ts
+++ b/tests/visual/scenes/textures/copy-depth-texture.scene.ts
@@ -53,6 +53,8 @@ export const scene: TestScene = {
             autoGenerateMipmaps: false,
         });
 
+        const destDepthTexture = new Texture({ source: destDepthSource });
+
         // -- Render Targets --
 
         const sourceRT = new RenderTarget({
@@ -188,7 +190,7 @@ export const scene: TestScene = {
 
         renderer.renderTarget.copyDepthTexture(
             sourceRT,
-            destRT,
+            destDepthTexture,
             { x: 0, y: 0 },
             { width: sourceRT.pixelWidth, height: sourceRT.pixelHeight },
             { x: 0, y: 0 },


### PR DESCRIPTION
> [!NOTE]
> Stacked on #12098 (`gbd/add-flipy-webgl-webgpu`) — only the last commit is new here.

### Overview
#### Features
- `copyDepthTexture` now copies into a depth/stencil `Texture` instead of requiring a fully-formed destination `RenderTarget` — callers hand over just the texture they want the depth in:
  ```ts
  renderer.renderTarget.copyDepthTexture(sourceRT, destDepthTexture, { x: 0, y: 0 }, size);
  ```
  Internally the GL adaptor still resolves the texture to a depth-only render target to have a framebuffer to blit into; the WebGPU adaptor copies straight into the destination's `GPUTexture`.
- Both `copyToTexture` and `copyDepthTexture` accept any `RenderSurface` as source (render target, texture, or canvas), resolved through `getRenderTarget` — and `getRenderTarget` now wraps a depth/stencil-format texture source as a depth-only render target rather than misfiling it as a color attachment.
- New `RenderTargetSystem.frontFaceInverted` getter exposing the current bind's resolved winding inversion (`flipY` XOR WebGL's inherent non-root flip; plain `flipY` on WebGPU), so consumers such as 3D pipelines can read the effective orientation instead of re-deriving it from `flipY`, `isRoot`, and a backend check.

#### Chores
- Validation for depth copies (source must have a depth attachment, destination must be a depth/stencil format) moves out of the per-backend adaptors into the shared `RenderTargetSystem`, so both backends warn identically.
- Unit tests cover the new destination-texture signature and `frontFaceInverted` on both backends; the `copy-depth-texture` visual scene now exercises the texture-destination path.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added

🤖 Generated with [Claude Code](https://claude.com/claude-code)