### PR TITLE
feat: object-form bind/push and capturable, replayable bind state

### DIFF
--- a/src/filters/FilterSystem.ts
+++ b/src/filters/FilterSystem.ts
@@ -640,7 +640,7 @@ export class FilterSystem implements System
             filterData.backTexture = this.getBackTexture(renderTarget, bounds, previousFilterData?.bounds);
         }
 
-        renderer.renderTarget.bind(filterData.inputTexture, true);
+        renderer.renderTarget.bind({ target: filterData.inputTexture, clear: true });
 
         // set the global uniforms to take into account the bounds offset required
         renderer.globalUniforms.push({
@@ -747,7 +747,7 @@ export class FilterSystem implements System
         // set the output texture - this is where we are going to render to
         const renderTarget = this.renderer.renderTarget.getRenderTarget(output);
 
-        this.renderer.renderTarget.bind(output, !!clear);
+        this.renderer.renderTarget.bind({ target: output, clear: !!clear });
 
         if (output instanceof Texture)
         {

--- a/src/rendering/mask/alpha/AlphaMaskPipe.ts
+++ b/src/rendering/mask/alpha/AlphaMaskPipe.ts
@@ -203,7 +203,7 @@ export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
                     colorTextureSource.antialias
                 );
 
-                renderer.renderTarget.push(filterTexture, true);
+                renderer.renderTarget.push({ target: filterTexture, clear: true });
 
                 renderer.globalUniforms.push({
                     offset: bounds,

--- a/src/rendering/renderers/__tests__/RenderTarget.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTarget.test.ts
@@ -115,7 +115,7 @@ describe('isRenderingToScreen', () =>
 
         const renderTexture = RenderTexture.create({ width: 100, height: 100 });
 
-        renderer.renderTarget.bind(renderTexture);
+        renderer.renderTarget.bind({ target: renderTexture });
 
         const renderTarget = renderer.renderTarget.getRenderTarget(renderTexture);
 
@@ -136,7 +136,7 @@ describe('isRenderingToScreen', () =>
 
         const renderTexture = RenderTexture.create({ width: 100, height: 100 });
 
-        renderer.renderTarget.bind(renderTexture);
+        renderer.renderTarget.bind({ target: renderTexture });
 
         const renderTarget = renderer.renderTarget.getRenderTarget(renderTexture);
 
@@ -260,7 +260,7 @@ describe('Depth-only RenderTarget', () =>
             depth: true,
         });
 
-        expect(() => renderer.renderTarget.bind(renderTarget, true)).not.toThrow();
+        expect(() => renderer.renderTarget.bind({ target: renderTarget, clear: true })).not.toThrow();
 
         renderTarget.destroy();
     });

--- a/src/rendering/renderers/__tests__/RenderTargetSystem.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTargetSystem.test.ts
@@ -3,16 +3,44 @@ import { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import { TextureSource } from '../shared/texture/sources/TextureSource';
 import { Texture } from '../shared/texture/Texture';
 import { describeLocalOnly, getWebGLRenderer, getWebGPURenderer } from '@test-utils';
+import { AlphaFilter } from '~/filters/defaults/alpha/AlphaFilter';
+import { Rectangle } from '~/maths/shapes/Rectangle';
+import { Container } from '~/scene/container/Container';
 import { Graphics } from '~/scene/graphics/shared/Graphics';
 
 import type { WebGLRenderer } from '../gl/WebGLRenderer';
 import type { WebGPURenderer } from '../gpu/WebGPURenderer';
+import type { BindOptions } from '../shared/renderTarget/RenderTargetSystem';
 
 function createTarget(options: Partial<ConstructorParameters<typeof TextureSource>[0]> = {})
 {
     return new RenderTarget({
         colorTextures: [new TextureSource({ width: 64, height: 64, ...options })],
     });
+}
+
+/**
+ * collects the bind-deprecation messages captured by the console spies
+ * @param warnSpy - spy on console.warn
+ * @param groupSpy - spy on console.groupCollapsed
+ */
+function findBindDeprecations(warnSpy: jest.SpyInstance, groupSpy: jest.SpyInstance): string[]
+{
+    const allCalls = warnSpy.mock.calls.concat(groupSpy.mock.calls);
+    const found: string[] = [];
+
+    for (const call of allCalls)
+    {
+        for (const arg of call)
+        {
+            if (typeof arg === 'string' && arg.includes('positional arguments'))
+            {
+                found.push(arg);
+            }
+        }
+    }
+
+    return found;
 }
 
 let renderer: WebGLRenderer | WebGPURenderer;
@@ -49,8 +77,8 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
         const viewportSpy = jest.spyOn(renderer.encoder, 'setViewport');
 
-        renderer.renderTarget.bind(target, false);
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
+        renderer.renderTarget.bind({ target, clear: false });
 
         // one real begin, but the viewport moves on every bind
         expect(beginSpy).toHaveBeenCalledTimes(1);
@@ -65,11 +93,11 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
 
         const target = createTarget();
 
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
-        renderer.renderTarget.bind(target, true);
+        renderer.renderTarget.bind({ target, clear: true });
 
         expect(beginSpy).toHaveBeenCalledTimes(1);
     });
@@ -82,11 +110,11 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
 
         const target = createTarget();
 
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
-        renderer.renderTarget.bind(target, CLEAR.DEPTH);
+        renderer.renderTarget.bind({ target, clear: CLEAR.DEPTH });
 
         expect(beginSpy).toHaveBeenCalledTimes(1);
     });
@@ -99,11 +127,11 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
 
         const target = createTarget({ mipLevelCount: 2 });
 
-        renderer.renderTarget.bind(target, false, null, null, 0);
+        renderer.renderTarget.bind({ target, clear: false, mipLevel: 0 });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
-        renderer.renderTarget.bind(target, false, null, null, 1);
+        renderer.renderTarget.bind({ target, clear: false, mipLevel: 1 });
 
         expect(beginSpy).toHaveBeenCalledTimes(1);
     });
@@ -116,11 +144,11 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
 
         const target = createTarget({ arrayLayerCount: 2 });
 
-        renderer.renderTarget.bind(target, false, null, null, 0, 0);
+        renderer.renderTarget.bind({ target, clear: false, layer: 0 });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
-        renderer.renderTarget.bind(target, false, null, null, 0, 1);
+        renderer.renderTarget.bind({ target, clear: false, layer: 1 });
 
         expect(beginSpy).toHaveBeenCalledTimes(1);
     });
@@ -133,12 +161,12 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
 
         const target = createTarget();
 
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
         renderer.renderTarget.finishRenderPass();
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         expect(beginSpy).toHaveBeenCalledTimes(1);
     });
@@ -152,7 +180,7 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
         const target = createTarget();
 
         // a real begin clears the cache, so prime it after the first (real) bind
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         const encoder = renderer.encoder as unknown as { _boundPipeline: unknown };
         const sentinel = {};
@@ -160,11 +188,11 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
         encoder._boundPipeline = sentinel;
 
         // reused bind: cache must survive so the next draw doesn't re-set pipeline/bind groups
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
         expect(encoder._boundPipeline).toBe(sentinel);
 
         // a real begin must flush the cache
-        renderer.renderTarget.bind(target, true);
+        renderer.renderTarget.bind({ target, clear: true });
         expect(encoder._boundPipeline).toBeNull();
     });
 
@@ -177,12 +205,12 @@ describeLocalOnly('RenderTargetSystem idempotent bind (WebGPU)', () =>
         const target = createTarget();
 
         // first push opens the pass with a clear (default CLEAR.ALL) -> real begin
-        renderer.renderTarget.push(target);
+        renderer.renderTarget.push({ target });
 
         const beginSpy = jest.spyOn(renderer.encoder, 'beginRenderPass');
 
         // pushing the same target again with a clear forces another begin...
-        renderer.renderTarget.push(target);
+        renderer.renderTarget.push({ target });
         // ...but popping back to it is a no-clear bind on the still-open pass -> reuse
         renderer.renderTarget.pop();
 
@@ -200,11 +228,11 @@ describe('RenderTargetSystem idempotent bind (WebGL)', () =>
         const target = createTarget();
 
         // prime: first bind initialises + binds the framebuffer
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         const bindFramebufferSpy = jest.spyOn(renderer.gl, 'bindFramebuffer');
 
-        renderer.renderTarget.bind(target, false);
+        renderer.renderTarget.bind({ target, clear: false });
 
         expect(bindFramebufferSpy).not.toHaveBeenCalled();
     });
@@ -216,11 +244,11 @@ describe('RenderTargetSystem idempotent bind (WebGL)', () =>
         const targetA = createTarget();
         const targetB = createTarget();
 
-        renderer.renderTarget.bind(targetA, false);
+        renderer.renderTarget.bind({ target: targetA, clear: false });
 
         const bindFramebufferSpy = jest.spyOn(renderer.gl, 'bindFramebuffer');
 
-        renderer.renderTarget.bind(targetB, false);
+        renderer.renderTarget.bind({ target: targetB, clear: false });
 
         expect(bindFramebufferSpy).toHaveBeenCalled();
     });
@@ -236,22 +264,22 @@ describe('RenderTargetSystem flipY orientation toggle (WebGL)', () =>
         const { renderTarget } = renderer;
 
         // default (toggle off): a texture target flips as it always has -> positive Y scale (matrix.d)
-        renderTarget.bind(target);
+        renderTarget.bind({ target });
         expect(target.flipY).toBeUndefined();
         expect(renderTarget.projectionMatrix.d).toBeGreaterThan(0);
 
         // flipY:false is inert -> identical to the default
-        renderTarget.bind(target, true, null, null, 0, 0, false);
+        renderTarget.bind({ target, clear: true, flipY: false });
         expect(target.flipY).toBe(false);
         expect(renderTarget.projectionMatrix.d).toBeGreaterThan(0);
 
         // flipY:true inverts the orientation -> screen-oriented -> negative Y scale
-        renderTarget.bind(target, true, null, null, 0, 0, true);
+        renderTarget.bind({ target, clear: true, flipY: true });
         expect(target.flipY).toBe(true);
         expect(renderTarget.projectionMatrix.d).toBeLessThan(0);
 
         // omitting flipY again resets the (pooled) target back to the default
-        renderTarget.bind(target);
+        renderTarget.bind({ target });
         expect(target.flipY).toBeUndefined();
         expect(renderTarget.projectionMatrix.d).toBeGreaterThan(0);
     });
@@ -266,15 +294,15 @@ describe('RenderTargetSystem flipY orientation toggle (WebGL)', () =>
         const b = createTarget();
 
         // default texture: inverted as it always has been (welded to its automatic flip)
-        renderTarget.bind(a);
+        renderTarget.bind({ target: a });
         expect(state._invertFrontFace).toBe(true);
 
         // flipY:false is inert -> still inverted (switch target to force the change to re-emit)
-        renderTarget.bind(b, true, null, null, 0, 0, false);
+        renderTarget.bind({ target: b, clear: true, flipY: false });
         expect(state._invertFrontFace).toBe(true);
 
         // flipY:true toggles the winding the other way, in lockstep with the projection
-        renderTarget.bind(a, true, null, null, 0, 0, true);
+        renderTarget.bind({ target: a, clear: true, flipY: true });
         expect(state._invertFrontFace).toBe(false);
     });
 
@@ -288,17 +316,17 @@ describe('RenderTargetSystem flipY orientation toggle (WebGL)', () =>
         const b = createTarget();
 
         // non-root texture, default: WebGL's inherent flip inverts the winding
-        renderTarget.bind(a);
+        renderTarget.bind({ target: a });
         expect(renderTarget.frontFaceInverted).toBe(true);
         expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
 
         // flipY:false is inert -> still inverted (switch target to force the change to re-emit)
-        renderTarget.bind(b, true, null, null, 0, 0, false);
+        renderTarget.bind({ target: b, clear: true, flipY: false });
         expect(renderTarget.frontFaceInverted).toBe(true);
         expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
 
         // flipY:true cancels the inherent flip -> not inverted
-        renderTarget.bind(a, true, null, null, 0, 0, true);
+        renderTarget.bind({ target: a, clear: true, flipY: true });
         expect(renderTarget.frontFaceInverted).toBe(false);
         expect(renderTarget.frontFaceInverted).toBe(state._invertFrontFace);
     });
@@ -313,13 +341,13 @@ describe('RenderTargetSystem flipY orientation toggle (WebGL)', () =>
         const inner = createTarget();
 
         // capture into `outer` toggled to screen orientation (the ContainerSource case): flipY:true
-        renderTarget.push(outer, true, null, null, 0, 0, true);
+        renderTarget.push({ target: outer, clear: true, flipY: true });
         expect(outer.flipY).toBe(true);
         expect(renderTarget.projectionMatrix.d).toBeLessThan(0);
         expect(state._invertFrontFace).toBe(false);
 
         // a nested render group / mask pushes its own target with the default orientation
-        renderTarget.push(inner);
+        renderTarget.push({ target: inner });
         expect(renderTarget.projectionMatrix.d).toBeGreaterThan(0);
         expect(state._invertFrontFace).toBe(true);
 
@@ -365,11 +393,395 @@ describeLocalOnly('RenderTargetSystem flipY orientation toggle (WebGPU)', () =>
         const target = createTarget();
 
         // no inherent flip on WebGPU: isRoot never enters the equation, so it tracks flipY directly
-        renderTarget.bind(target, true, null, null, 0, 0, false);
+        renderTarget.bind({ target, clear: true, flipY: false });
         expect(renderTarget.frontFaceInverted).toBe(false);
 
-        renderTarget.bind(target, true, null, null, 0, 0, true);
+        renderTarget.bind({ target, clear: true, flipY: true });
         expect(renderTarget.frontFaceInverted).toBe(true);
+    });
+});
+
+describe('RenderTargetSystem object-form bind', () =>
+{
+    it('deprecates the positional form: warns once and matches the object form exactly', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+        const other = createTarget();
+        const frame = new Rectangle(4, 8, 16, 12);
+
+        const startSpy = jest.spyOn(renderTarget.adaptor, 'startRenderPass');
+
+        // reference run: object form
+        const boundObject = renderTarget.bind({ target, clear: CLEAR.COLOR, frame, flipY: true });
+        const objectArgs = startSpy.mock.calls.at(-1);
+        const objectViewport = renderTarget.viewport.clone();
+        const objectProjection = renderTarget.projectionMatrix.clone();
+
+        // move away so replaying the same bind is a real rebind, not a reuse
+        renderTarget.bind({ target: other });
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const groupSpy = jest.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+        const deprecationCount = () => findBindDeprecations(warnSpy, groupSpy).length;
+
+        // the same bind through the deprecated positional form
+        const boundPositional = renderTarget.bind(target, CLEAR.COLOR, undefined, frame, 0, 0, true);
+
+        expect(deprecationCount()).toBe(1);
+        expect(boundPositional).toBe(boundObject);
+        expect(renderTarget.viewport).toEqual(objectViewport);
+        expect(renderTarget.projectionMatrix).toEqual(objectProjection);
+
+        // startRenderPass(renderTarget, clear, clearColor, viewport, mipLevel, layer) receives
+        // identical arguments from both forms (the shared viewport rect is compared above)
+        const positionalArgs = startSpy.mock.calls.at(-1);
+
+        expect(positionalArgs[0]).toBe(objectArgs[0]);
+        expect(positionalArgs[1]).toBe(objectArgs[1]);
+        expect(positionalArgs[2]).toBe(objectArgs[2]);
+        expect(positionalArgs[4]).toBe(objectArgs[4]);
+        expect(positionalArgs[5]).toBe(objectArgs[5]);
+
+        // the deprecation only fires once per process
+        renderTarget.bind(target, CLEAR.COLOR, undefined, frame, 0, 0, true);
+        expect(deprecationCount()).toBe(1);
+
+        // positional push carries its own (distinct) deprecation, also once per process
+        renderTarget.push(target, CLEAR.COLOR);
+        expect(deprecationCount()).toBe(2);
+        renderTarget.push(target, CLEAR.COLOR);
+        expect(deprecationCount()).toBe(2);
+
+        warnSpy.mockRestore();
+        groupSpy.mockRestore();
+    });
+
+    it('defaults clear to true when omitted (parity with the positional default)', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+
+        const startSpy = jest.spyOn(renderTarget.adaptor, 'startRenderPass');
+
+        renderTarget.bind({ target });
+
+        expect(startSpy.mock.calls.at(-1)[1]).toBe(true);
+    });
+
+    it('applies the Texture frame fallback when no frame is given', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const texture = new Texture({
+            source: new TextureSource({ width: 64, height: 64 }),
+            frame: new Rectangle(0, 0, 20, 10),
+        });
+
+        renderTarget.bind({ target: texture, clear: true });
+
+        expect(renderTarget.viewport.width).toBe(20);
+        expect(renderTarget.viewport.height).toBe(10);
+    });
+});
+
+describe('RenderTargetSystem push/pop replay', () =>
+{
+    it('re-applies a pushed Texture frame fallback when popping back to it', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const texture = new Texture({
+            source: new TextureSource({ width: 64, height: 64 }),
+            frame: new Rectangle(0, 0, 20, 10),
+        });
+        const inner = createTarget();
+
+        // pushed without an explicit frame: the texture's own frame defines the viewport
+        renderTarget.push({ target: texture, clear: true });
+        expect(renderTarget.viewport.width).toBe(20);
+
+        renderTarget.push({ target: inner, clear: true });
+        expect(renderTarget.viewport.width).toBe(64);
+
+        // popping back must restore the texture's frame viewport, not the full 64x64 source
+        renderTarget.pop();
+        expect(renderTarget.renderTarget).toBe(renderTarget.getRenderTarget(texture));
+        expect(renderTarget.viewport.width).toBe(20);
+        expect(renderTarget.viewport.height).toBe(10);
+    });
+
+    it('snapshots the pushed frame so caller rect reuse cannot leak into pop', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const outer = createTarget();
+        const inner = createTarget();
+        const frame = new Rectangle(0, 0, 16, 8);
+
+        renderTarget.push({ target: outer, clear: true, frame });
+        expect(renderTarget.viewport.width).toBe(16);
+
+        // the caller reuses its rect (the per-frame pattern) while `outer` is still on the stack
+        frame.width = 32;
+        frame.height = 32;
+
+        renderTarget.push({ target: inner, clear: true });
+        renderTarget.pop();
+
+        expect(renderTarget.viewport.width).toBe(16);
+        expect(renderTarget.viewport.height).toBe(8);
+    });
+
+    it('throws on an unbalanced pop', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+
+        renderTarget.push({ target: createTarget() });
+
+        // popping the only entry leaves nothing to restore
+        expect(() => renderTarget.pop()).toThrow(/unbalanced pop/);
+    });
+
+    it('never hits the deprecated positional path from internal engine code', async () =>
+    {
+        renderer = await getWebGLRenderer({ width: 64, height: 64, useBackBuffer: true }) as WebGLRenderer;
+
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const groupSpy = jest.spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+
+        const scene = new Container();
+        const filtered = new Graphics().rect(0, 0, 32, 32).fill(0xff0000);
+
+        filtered.filters = [new AlphaFilter()];
+
+        const cached = new Container();
+
+        cached.addChild(new Graphics().rect(0, 0, 16, 16).fill(0x00ff00));
+        cached.cacheAsTexture(true);
+        scene.addChild(filtered, cached);
+
+        // exercises renderStart->push, FilterSystem binds, RenderGroupPipe push/pop and the
+        // back-buffer present bind
+        renderer.render({ container: scene });
+
+        const deprecations = findBindDeprecations(warnSpy, groupSpy);
+
+        warnSpy.mockRestore();
+        groupSpy.mockRestore();
+
+        expect(deprecations).toEqual([]);
+    });
+});
+
+describe('RenderTargetSystem getBindState', () =>
+{
+    it('round-trips: bind(getBindState()) exactly reproduces the captured binding', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+        const other = createTarget();
+        const frame = new Rectangle(4, 8, 16, 12);
+
+        const bound = renderTarget.bind({ target, clear: true, frame, flipY: true });
+        const viewport = renderTarget.viewport.clone();
+        const projection = renderTarget.projectionMatrix.clone();
+        const inverted = renderTarget.frontFaceInverted;
+
+        const saved = renderTarget.getBindState();
+
+        expect(saved.target).toBe(target);
+        expect(saved.clear).toBe(CLEAR.NONE);
+        expect(saved.flipY).toBe(true);
+        expect(saved.frame).not.toBe(frame);
+        expect(saved.frame).toEqual(frame);
+
+        // move away: different target, default orientation
+        renderTarget.bind({ target: other, clear: true });
+        expect(renderTarget.renderTarget).not.toBe(bound);
+
+        renderTarget.bind(saved);
+
+        expect(renderTarget.renderTarget).toBe(bound);
+        expect(renderTarget.renderSurface).toBe(target);
+        expect(renderTarget.viewport).toEqual(viewport);
+        expect(renderTarget.projectionMatrix).toEqual(projection);
+        expect(renderTarget.mipLevel).toBe(0);
+        expect(renderTarget.layer).toBe(0);
+        expect(renderTarget.frontFaceInverted).toBe(inverted);
+    });
+
+    it('restores without clearing (the captured clear is NONE, passed through to the adaptor)', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+        const other = createTarget();
+
+        renderTarget.bind({ target, clear: true });
+
+        const saved = renderTarget.getBindState();
+
+        renderTarget.bind({ target: other, clear: true });
+
+        const startSpy = jest.spyOn(renderTarget.adaptor, 'startRenderPass');
+
+        renderTarget.bind(saved);
+
+        expect(startSpy.mock.calls.at(-1)[1]).toBe(CLEAR.NONE);
+    });
+
+    it('deep-copies the frame: captures are independent of the caller, each other, and later binds', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+        const frame = new Rectangle(0, 0, 16, 8);
+
+        renderTarget.bind({ target, clear: true, frame });
+
+        const savedA = renderTarget.getBindState();
+        const savedB = renderTarget.getBindState();
+
+        expect(savedA.frame).not.toBe(frame);
+        expect(savedA.frame).not.toBe(savedB.frame);
+
+        // mutating one capture affects neither the other capture nor the live binding
+        savedA.frame.width = 1;
+        renderTarget.bind(savedB);
+        expect(renderTarget.viewport.width).toBe(16);
+
+        // a later bind with a different frame cannot reach into an existing capture
+        renderTarget.bind({ target, clear: false, frame: new Rectangle(0, 0, 2, 2) });
+        expect(savedB.frame.width).toBe(16);
+    });
+
+    it('fills and returns the provided out object, overwriting every stale field', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+
+        renderTarget.bind({ target, clear: true });
+
+        // poison every field with stale values from a previous (imaginary) capture
+        const out: BindOptions = {
+            target: createTarget(),
+            clear: true,
+            clearColor: [1, 0, 0, 1],
+            frame: new Rectangle(1, 2, 3, 4),
+            mipLevel: 3,
+            layer: 2,
+            flipY: true,
+        };
+
+        const result = renderTarget.getBindState(out);
+
+        expect(result).toBe(out);
+        expect(out.target).toBe(target);
+        expect(out.clear).toBe(CLEAR.NONE);
+        expect(out.clearColor).toBeUndefined();
+        expect(out.frame).toBeUndefined();
+        expect(out.mipLevel).toBe(0);
+        expect(out.layer).toBe(0);
+        expect(out.flipY).toBe(false);
+    });
+
+    it('reuses the out frame rectangle across captures that carry frames', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const target = createTarget();
+
+        renderTarget.bind({ target, clear: true, frame: new Rectangle(0, 0, 8, 8) });
+
+        const out = renderTarget.getBindState();
+        const rect = out.frame;
+
+        renderTarget.bind({ target, clear: false, frame: new Rectangle(0, 0, 24, 24) });
+        renderTarget.getBindState(out);
+
+        // the out object's rect is reused in place, not reallocated
+        expect(out.frame).toBe(rect);
+        expect(out.frame.width).toBe(24);
+    });
+
+    it('captures an omitted frame as undefined so restore re-derives the Texture fallback', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        const { renderTarget } = renderer;
+        const texture = new Texture({
+            source: new TextureSource({ width: 64, height: 64 }),
+            frame: new Rectangle(0, 0, 20, 10),
+        });
+        const other = createTarget();
+
+        renderTarget.bind({ target: texture, clear: true });
+
+        const saved = renderTarget.getBindState();
+
+        // the surface as passed (not the resolved render target), no baked frame
+        expect(saved.target).toBe(texture);
+        expect(saved.frame).toBeUndefined();
+
+        renderTarget.bind({ target: other, clear: true });
+        renderTarget.bind(saved);
+
+        expect(renderTarget.viewport.width).toBe(20);
+        expect(renderTarget.viewport.height).toBe(10);
+    });
+
+    it('throws when nothing is bound yet', async () =>
+    {
+        renderer = await getWebGLRenderer() as WebGLRenderer;
+
+        expect(() => renderer.renderTarget.getBindState())
+            .toThrow(/only valid while a render surface is bound/);
+    });
+});
+
+describeLocalOnly('RenderTargetSystem getBindState (WebGPU)', () =>
+{
+    it('round-trips mip level and array layer', async () =>
+    {
+        renderer = await getWebGPURenderer() as WebGPURenderer;
+
+        renderer.encoder.renderStart();
+
+        const { renderTarget } = renderer;
+        const target = createTarget({ mipLevelCount: 2, arrayLayerCount: 2 });
+        const other = createTarget();
+
+        renderTarget.bind({ target, clear: true, mipLevel: 1, layer: 1 });
+
+        const viewport = renderTarget.viewport.clone();
+        const saved = renderTarget.getBindState();
+
+        expect(saved.mipLevel).toBe(1);
+        expect(saved.layer).toBe(1);
+
+        renderTarget.bind({ target: other, clear: true });
+        renderTarget.bind(saved);
+
+        expect(renderTarget.mipLevel).toBe(1);
+        expect(renderTarget.layer).toBe(1);
+        expect(renderTarget.viewport).toEqual(viewport);
     });
 });
 

--- a/src/rendering/renderers/gl/GlBackBufferSystem.ts
+++ b/src/rendering/renderers/gl/GlBackBufferSystem.ts
@@ -172,7 +172,7 @@ export class GlBackBufferSystem implements System<GlBackBufferOptions>
 
         if (!this._useBackBufferThisRender) return;
 
-        renderer.renderTarget.bind(this._targetTexture, false);
+        renderer.renderTarget.bind({ target: this._targetTexture, clear: false });
 
         this._bigTriangleShader.resources.uTexture = this._backBufferTexture.source;
 

--- a/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
+++ b/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
@@ -35,7 +35,7 @@ describeLocalOnly('GpuRenderTargetAdaptor copies', () =>
         // simulate the documented mid-frame use: a frame is underway and a render
         // pass is open when the copy is requested
         renderer.encoder.renderStart();
-        renderer.renderTarget.bind(source, true);
+        renderer.renderTarget.bind({ target: source, clear: true });
 
         renderer.renderTarget.copyDepthTexture(
             source, destination,
@@ -64,7 +64,7 @@ describeLocalOnly('GpuRenderTargetAdaptor labels', () =>
         });
 
         renderer.encoder.renderStart();
-        renderer.renderTarget.bind(target, true);
+        renderer.renderTarget.bind({ target, clear: true });
 
         const gpuRenderTarget = renderer.renderTarget.getGpuRenderTarget(target);
 

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1,5 +1,6 @@
 import { Matrix } from '../../../../maths/matrix/Matrix';
 import { Rectangle } from '../../../../maths/shapes/Rectangle';
+import { deprecation } from '../../../../utils/logging/deprecation';
 import { warn } from '../../../../utils/logging/warn';
 import { CLEAR } from '../../gl/const';
 import { calculateProjection } from '../../gpu/renderTarget/calculateProjection';
@@ -32,21 +33,54 @@ import type { BindableTexture } from '../texture/Texture';
 export type RenderSurface = ICanvas | BindableTexture | RenderTarget;
 
 /**
- * stores a render target and its frame
- * @ignore
+ * The persistent description of a render-surface binding: the target plus the frame,
+ * subresource, and orientation axes. Captured by {@link RenderTargetSystem.getBindState}.
+ *
+ * A clear is a per-call action, not part of the binding — see {@link BindOptions}.
+ * @category rendering
+ * @advanced
  */
-interface RenderTargetAndFrame
+export interface BindState
 {
-    /** the render target */
-    renderTarget: RenderTarget;
-    /** the frame to use when using the render target */
-    frame: Rectangle;
-    /** mip level to render to (subresource) */
-    mipLevel: number;
-    /** array layer to render to (subresource) */
-    layer: number;
-    /** per-render Y-flip override; restored on `pop` so nested pushes don't lose it */
+    /** the render surface to bind: a texture, canvas, or render target */
+    target: RenderSurface;
+    /**
+     * the frame to render to, in base mip (mip 0) pixel space. When omitted, a {@link Texture}
+     * target falls back to its own frame and any other target binds in full.
+     */
+    frame?: Rectangle;
+    /**
+     * the mip level to render to (subresource)
+     * @default 0
+     */
+    mipLevel?: number;
+    /**
+     * the array layer (or slice/face) of the render surface to render to (subresource)
+     * @default 0
+     */
+    layer?: number;
+    /**
+     * opt-in Y-orientation toggle. `false`/omitted is a no-op (the historical `!isRoot`
+     * behavior); `true` inverts the orientation, and the winding with it.
+     */
     flipY?: boolean;
+}
+
+/**
+ * Options for binding a render surface via {@link RenderTargetSystem.bind}: the persistent
+ * {@link BindState} plus the per-call clear actions.
+ * @category rendering
+ * @advanced
+ */
+export interface BindOptions extends BindState
+{
+    /**
+     * the clear mode to use. Can be `true` or a CLEAR number 'COLOR | DEPTH | STENCIL' 0b111
+     * @default true
+     */
+    clear?: CLEAR_OR_BOOL;
+    /** the color to clear to */
+    clearColor?: RgbaArray;
 }
 
 /**
@@ -234,7 +268,7 @@ export interface RenderTargetAdaptor<RENDER_TARGET extends RendererRenderTarget>
  * });
  *
  * // bind the render target
- * renderer.renderTarget.bind(renderTarget);
+ * renderer.renderTarget.bind({ target: renderTarget });
  *
  * // draw something!
  * ```
@@ -251,14 +285,8 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     public renderingToScreen: boolean;
     /** the current active render target */
     public renderTarget: RenderTarget;
-    /** the current active render surface that the render target is created from */
-    public renderSurface: RenderSurface;
     /** the current viewport that the gpu is using */
     public readonly viewport = new Rectangle();
-    /** the current mip level being rendered to (for texture subresources) */
-    public mipLevel = 0;
-    /** the current array layer being rendered to (for array-backed targets) */
-    public layer = 0;
     /**
      * a runner that lets systems know if the active render target has changed.
      * Eg the Stencil System needs to know so it can manage the stencil buffer
@@ -278,12 +306,22 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         = new Map();
     /** A hash that stores a gpu render target for a given render target. */
     private _gpuRenderTargetHash: Record<number, RENDER_TARGET> = Object.create(null);
+    /** the pushed bindings; each entry is a replayable BindOptions that pop() re-binds */
+    private readonly _renderTargetStack: BindOptions[] = [];
     /**
-     * A stack that stores the render target and frame that is currently being rendered to.
-     * When push is called, the current render target is stored in this stack.
-     * When pop is called, the previous render target is restored.
+     * the state of the current binding, written on every bind — backs the `renderSurface`,
+     * `mipLevel` and `layer` getters and `getBindState`. Its `frame` aliases `_bindFrame`
+     * and must never be handed out by reference.
      */
-    private readonly _renderTargetStack: RenderTargetAndFrame[] = [];
+    private readonly _bindState: BindState = {
+        target: null,
+        frame: undefined,
+        mipLevel: 0,
+        layer: 0,
+        flipY: false,
+    };
+    /** system-owned rect backing `_bindState.frame`; as-passed frames are copied into it */
+    private readonly _bindFrame = new Rectangle();
     /** A reference to the renderer */
     private readonly _renderer: Renderer;
 
@@ -293,6 +331,24 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         renderer.gc.addCollection(this, '_gpuRenderTargetHash', 'hash');
     }
 
+    /** the current active render surface that the render target is created from */
+    public get renderSurface(): RenderSurface
+    {
+        return this._bindState.target;
+    }
+
+    /** the current mip level being rendered to (for texture subresources) */
+    public get mipLevel(): number
+    {
+        return this._bindState.mipLevel;
+    }
+
+    /** the current array layer being rendered to (for array-backed targets) */
+    public get layer(): number
+    {
+        return this._bindState.layer;
+    }
+
     /** called when dev wants to finish a render pass */
     public finishRenderPass()
     {
@@ -300,48 +356,16 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     }
 
     /**
-     * called when the renderer starts to render a scene.
-     * @param options
-     * @param options.target - the render target to render to
-     * @param options.clear - the clear mode to use. Can be true or a CLEAR number 'COLOR | DEPTH | STENCIL' 0b111
-     * @param options.clearColor - the color to clear to
-     * @param options.frame - the frame to render to
-     * @param options.mipLevel - the mip level to render to
-     * @param options.layer - The layer of the render target to render to. Used for array or 3D textures, or when rendering
-     * to a specific layer of a layered render target. Optional.
-     * @param options.flipY - Opt-in Y-orientation toggle. `false`/omitted is a no-op (the historical
-     * `!isRoot` behavior); `true` inverts the orientation (and the winding with it). Optional.
+     * called when the renderer starts to render a scene: resets the bind stack and binds the
+     * root render surface
+     * @param options - the {@link BindOptions} for the root binding
      */
-    public renderStart({
-        target,
-        clear,
-        clearColor,
-        frame,
-        mipLevel,
-        layer,
-        flipY
-    }: {
-        target: RenderSurface;
-        clear: CLEAR_OR_BOOL;
-        clearColor: RgbaArray;
-        frame?: Rectangle;
-        mipLevel?: number;
-        layer?: number;
-        flipY?: boolean;
-    }): void
+    public renderStart(options: BindOptions): void
     {
         // TODO no need to reset this - use optimised index instead
         this._renderTargetStack.length = 0;
 
-        this.push(
-            target,
-            clear,
-            clearColor,
-            frame,
-            mipLevel || 0,
-            layer || 0,
-            flipY
-        );
+        this.push(options);
 
         this.rootViewPort.copyFrom(this.viewport);
         this.rootRenderTarget = this.renderTarget;
@@ -380,21 +404,34 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
      *   render into
      *   the underlying {@link TextureSource} (Pixi will create/use a {@link RenderTarget} for the source) using the
      *   texture's frame to define the region (in mip 0 space).
+     * @param options - the bind options: see {@link BindOptions}
+     * @returns the render target that was bound
+     */
+    public bind(options: BindOptions): RenderTarget;
+    /**
+     * Binds a render surface using positional arguments.
      * @param renderSurface - the render surface to bind
      * @param clear - the clear mode to use. Can be true or a CLEAR number 'COLOR | DEPTH | STENCIL' 0b111
      * @param clearColor - the color to clear to
      * @param frame - the frame to render to
      * @param mipLevel - the mip level to render to
-     * @param layer - the layer (or slice) of the render surface to render to. For array textures,
-     * 3D textures, or cubemaps, this specifies the target layer or face. Defaults to 0 (the first layer/face).
-     * Ignored for surfaces that do not support layers.
-     * @param flipY - opt-in Y-orientation toggle. `false`/omitted is a no-op (the historical `!isRoot`
-     * behavior); `true` inverts the orientation. The projection and the WebGL front-face inversion both
-     * flip with it, so back-face culling stays correct.
+     * @param layer - the layer (or slice) of the render surface to render to
+     * @param flipY - opt-in Y-orientation toggle
      * @returns the render target that was bound
+     * @deprecated since 8.20.0 — use an options object instead:
+     * `bind({ target, clear, clearColor, frame, mipLevel, layer, flipY })`
      */
     public bind(
         renderSurface: RenderSurface,
+        clear?: CLEAR_OR_BOOL,
+        clearColor?: RgbaArray,
+        frame?: Rectangle,
+        mipLevel?: number,
+        layer?: number,
+        flipY?: boolean
+    ): RenderTarget;
+    public bind(
+        surfaceOrOptions: RenderSurface | BindOptions,
         clear: CLEAR_OR_BOOL = true,
         clearColor?: RgbaArray,
         frame?: Rectangle,
@@ -403,12 +440,40 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         flipY?: boolean
     ): RenderTarget
     {
+        let options: BindOptions;
+
+        if ('target' in surfaceOrOptions)
+        {
+            options = surfaceOrOptions;
+        }
+        else
+        {
+            // legacy positional call: sanitise the arguments into a BindOptions and carry on
+            // #if _DEBUG
+            deprecation('8.20.0', 'RenderTargetSystem.bind: positional arguments are deprecated, '
+                + 'please use an options object instead: '
+                + 'bind({ target, clear, clearColor, frame, mipLevel, layer, flipY })');
+            // #endif
+
+            options = { target: surfaceOrOptions, clear, clearColor, frame, mipLevel, layer, flipY };
+        }
+
+        // the options object is caller-owned and read-only: read everything into locals here
+        // and never write back into it (the frame fallback below reassigns the local)
+        const renderSurface = options.target;
+
+        clear = options.clear ?? true;
+        clearColor = options.clearColor;
+        mipLevel = (options.mipLevel ?? 0) | 0;
+        layer = (options.layer ?? 0) | 0;
+        flipY = options.flipY;
+        frame = options.frame;
+
         const renderTarget = this.getRenderTarget(renderSurface);
 
         const didChange = this.renderTarget !== renderTarget;
 
         this.renderTarget = renderTarget;
-        this.renderSurface = renderSurface;
 
         const gpuRenderTarget = this.getGpuRenderTarget(renderTarget);
 
@@ -425,18 +490,20 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         const viewport = this.viewport;
         const arrayLayerCount = source.arrayLayerCount || 1;
 
-        if ((layer | 0) !== layer)
-        {
-            layer |= 0;
-        }
-
         if (layer < 0 || layer >= arrayLayerCount)
         {
             throw new Error(`[RenderTargetSystem] layer ${layer} is out of bounds (arrayLayerCount=${arrayLayerCount}).`);
         }
 
-        this.mipLevel = mipLevel | 0;
-        this.layer = layer | 0;
+        // retain the as-passed bind state for the getters and getBindState; the frame is
+        // copied, not referenced — callers reuse their rects
+        const bindState = this._bindState;
+
+        bindState.target = renderSurface;
+        bindState.frame = frame ? this._bindFrame.copyFrom(frame) : undefined;
+        bindState.mipLevel = mipLevel;
+        bindState.layer = layer;
+        bindState.flipY = flipY;
 
         const pixelWidth = Math.max(source.pixelWidth >> mipLevel, 1);
         const pixelHeight = Math.max(source.pixelHeight >> mipLevel, 1);
@@ -452,7 +519,7 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         if (frame)
         {
             const resolution = source._resolution;
-            const scale = 1 << Math.max(mipLevel | 0, 0);
+            const scale = 1 << Math.max(mipLevel, 0);
 
             // Convert frame to pixel units (mip 0), then scale to the requested mip level.
             const baseX = ((frame.x * resolution) + 0.5) | 0;
@@ -532,6 +599,66 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     }
 
     /**
+     * Captures the current binding as a {@link BindOptions} that can be passed back to
+     * {@link RenderTargetSystem.bind} to restore it. The capture replays non-destructively:
+     * its `clear` is `CLEAR.NONE`, so restoring never wipes the target.
+     *
+     * ```js
+     * const saved = renderer.renderTarget.getBindState();
+     *
+     * renderer.renderTarget.bind({ target: scratchTexture, clear: true });
+     * // ... draw ...
+     * renderer.renderTarget.bind(saved);
+     *
+     * // or compose: the saved binding, but into mip 1
+     * renderer.renderTarget.bind({ ...saved, mipLevel: 1 });
+     * ```
+     *
+     * The capture is a snapshot owned by the caller — later binds cannot change it — and holds
+     * `target` and `frame` as they were passed, so a Texture bound without an explicit frame
+     * replays through its frame fallback. It stays valid for as long as its target does.
+     * Pass `out` to reuse one object across captures; every field of it is overwritten.
+     * @param out - an optional object to write the bind state into; allocated when omitted
+     * @returns the captured bind state (`out` when provided)
+     */
+    public getBindState(out?: BindOptions): BindOptions
+    {
+        if (!this.renderTarget)
+        {
+            throw new Error('[RenderTargetSystem] getBindState is only valid while a render surface is bound');
+        }
+
+        const bindState = this._bindState;
+
+        out ??= {} as BindOptions;
+
+        out.target = bindState.target;
+        // pinned to NONE so replaying the capture never clears the restored target
+        out.clear = CLEAR.NONE;
+        out.clearColor = undefined;
+
+        if (!bindState.frame)
+        {
+            out.frame = undefined;
+        }
+        else if (out.frame)
+        {
+            // reuse the out object's own rect in place
+            out.frame.copyFrom(bindState.frame);
+        }
+        else
+        {
+            out.frame = bindState.frame.clone();
+        }
+
+        out.mipLevel = bindState.mipLevel;
+        out.layer = bindState.layer;
+        out.flipY = !!bindState.flipY;
+
+        return out;
+    }
+
+    /**
      * The effective front-face orientation of the current bind — `true` when a front-facing triangle
      * ends up wound the opposite way on the surface (so the winding/cull has been inverted to compensate).
      *
@@ -594,55 +721,96 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     }
 
     /**
-     * Push a render surface to the renderer. This will bind the render surface to the renderer,
+     * Push a render surface to the renderer. This will bind the render surface to the renderer
+     * and store the binding on a stack, so `pop()` can restore the previous binding.
+     * @param options - the bind options: see {@link BindOptions}
+     * @returns the render target that was bound
+     */
+    public push(options: BindOptions): RenderTarget;
+    /**
+     * Push a render surface using positional arguments.
      * @param renderSurface - the render surface to push
      * @param clear - the clear mode to use. Can be true or a CLEAR number 'COLOR | DEPTH | STENCIL' 0b111
      * @param clearColor - the color to clear to
      * @param frame - the frame to use when rendering to the render surface
      * @param mipLevel - the mip level to render to
-     * @param layer - The layer of the render surface to render to. For array textures or cube maps, this specifies
-     * which layer or face to target. Defaults to 0 (the first layer).
-     * @param flipY - opt-in Y-orientation toggle; stored on the stack so it is restored on `pop`.
+     * @param layer - the layer of the render surface to render to
+     * @param flipY - opt-in Y-orientation toggle; stored on the stack so it is restored on `pop`
+     * @returns the render target that was bound
+     * @deprecated since 8.20.0 — use an options object instead:
+     * `push({ target, clear, clearColor, frame, mipLevel, layer, flipY })`
      */
     public push(
         renderSurface: RenderSurface,
+        clear?: CLEAR | boolean,
+        clearColor?: RgbaArray,
+        frame?: Rectangle,
+        mipLevel?: number,
+        layer?: number,
+        flipY?: boolean
+    ): RenderTarget;
+    public push(
+        surfaceOrOptions: RenderSurface | BindOptions,
         clear: CLEAR | boolean = CLEAR.ALL,
         clearColor?: RgbaArray,
         frame?: Rectangle,
         mipLevel = 0,
         layer = 0,
         flipY?: boolean
-    )
+    ): RenderTarget
     {
-        const renderTarget = this.bind(renderSurface, clear, clearColor, frame, mipLevel, layer, flipY);
+        let options: BindOptions;
 
+        if ('target' in surfaceOrOptions)
+        {
+            options = surfaceOrOptions;
+        }
+        else
+        {
+            // legacy positional call: sanitise the arguments into a BindOptions and carry on
+            // #if _DEBUG
+            deprecation('8.20.0', 'RenderTargetSystem.push: positional arguments are deprecated, '
+                + 'please use an options object instead: '
+                + 'push({ target, clear, clearColor, frame, mipLevel, layer, flipY })');
+            // #endif
+
+            options = { target: surfaceOrOptions, clear, clearColor, frame, mipLevel, layer, flipY };
+        }
+
+        const renderTarget = this.bind(options);
+
+        // the entry is replayed by pop(): the target is stored as passed (a Texture keeps its
+        // frame fallback), the frame is copied (callers reuse their rects), and clear is false
+        // (restoring must not wipe the target)
         this._renderTargetStack.push({
-            renderTarget,
-            frame,
-            mipLevel,
-            layer,
-            flipY,
+            target: options.target,
+            clear: false,
+            clearColor: undefined,
+            frame: options.frame ? options.frame.clone() : undefined,
+            mipLevel: options.mipLevel,
+            layer: options.layer,
+            flipY: options.flipY,
         });
 
         return renderTarget;
     }
 
-    /** Pops the current render target from the renderer and restores the previous render target. */
-    public pop()
+    /**
+     * Pops the current render target and restores the previous binding.
+     * @returns the render target that was restored
+     */
+    public pop(): RenderTarget
     {
         this._renderTargetStack.pop();
 
-        const currentRenderTargetData = this._renderTargetStack[this._renderTargetStack.length - 1];
+        const previous = this._renderTargetStack[this._renderTargetStack.length - 1];
 
-        this.bind(
-            currentRenderTargetData.renderTarget,
-            false,
-            null,
-            currentRenderTargetData.frame,
-            currentRenderTargetData.mipLevel,
-            currentRenderTargetData.layer,
-            currentRenderTargetData.flipY
-        );
+        if (!previous)
+        {
+            throw new Error('[RenderTargetSystem] pop: no previous binding to restore (unbalanced pop)');
+        }
+
+        return this.bind(previous);
     }
 
     /**
@@ -963,6 +1131,6 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     public resetState(): void
     {
         this.renderTarget = null;
-        this.renderSurface = null;
+        this._bindState.target = null;
     }
 }

--- a/src/scene/container/RenderGroupPipe.ts
+++ b/src/scene/container/RenderGroupPipe.ts
@@ -102,7 +102,11 @@ export class RenderGroupPipe implements InstructionPipe<RenderGroup>
                 -renderGroup._textureBounds.y
             );
 
-            this._renderer.renderTarget.push(renderGroup.texture, true, null, renderGroup.texture.frame);
+            this._renderer.renderTarget.push({
+                target: renderGroup.texture,
+                clear: true,
+                frame: renderGroup.texture.frame,
+            });
 
             this._renderer.globalUniforms.push({
                 worldTransformMatrix,

--- a/src/scene/text/shared/AbstractTextSystem.ts
+++ b/src/scene/text/shared/AbstractTextSystem.ts
@@ -277,7 +277,7 @@ export abstract class AbstractTextSystem implements System
         });
 
         // Restore the previous render target
-        this._renderer.renderTarget.bind(currentRenderTarget, false);
+        this._renderer.renderTarget.bind({ target: currentRenderTarget, clear: false });
 
         // Return the resulting texture with the filters applied
         return resultTexture;

--- a/src/utils/__tests__/detectVideoAlphaMode.test.ts
+++ b/src/utils/__tests__/detectVideoAlphaMode.test.ts
@@ -70,7 +70,7 @@ describe('detectVideoAlphaMode', () =>
         const renderTexture = RenderTexture.create({ width: 1, height: 1 });
 
         renderer.render({ container, target: renderTexture, clear: true });
-        renderer.renderTarget.bind(renderTexture);
+        renderer.renderTarget.bind({ target: renderTexture });
 
         const pixel = new Uint8Array([0x00, 0x40, 0x80, 0xFF]);
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #12103 (`feat/copy-texture`) — only the last commit is new here.

### Overview
#### Features
- `RenderTargetSystem.bind` and `push` now take an options object, in line with the rest of the v8 API. The positional forms remain as deprecated overloads that warn once and are sanitised into options, so existing callers keep byte-identical behavior:
  ```ts
  renderer.renderTarget.bind({ target: texture, clear: false, flipY: true });
  ```
- New `BindState` interface (`target`, `frame`, `mipLevel`, `layer`, `flipY`) describing what a binding *is*, with `BindOptions extends BindState` adding the per-call `clear`/`clearColor` actions. The system now retains the live binding as a `BindState` — the `renderSurface`/`mipLevel`/`layer` getters and `getBindState()` all read from that single source of truth, written once per bind.
- New `getBindState(out?)`: captures the current binding as a `BindOptions` that replays exactly and non-destructively — `clear` is pinned to `CLEAR.NONE`, the frame is deep-copied, and `target`/`frame` are held as passed (a Texture bound without a frame replays through its frame fallback). Save/restore around a temporary bind no longer needs to enumerate bind axes, and survives future ones:
  ```ts
  const saved = renderer.renderTarget.getBindState();

  renderer.renderTarget.bind({ target: scratchTexture, clear: true });
  // ... draw ...
  renderer.renderTarget.bind(saved);

  // or compose: the saved binding, but into mip 1
  renderer.renderTarget.bind({ ...saved, mipLevel: 1 });
  ```
  Pass `out` to reuse one capture object (zero allocation per capture); `bind(getBindState())` is a no-op.

#### Fixes
- `push()` stack entries are now themselves replayable `BindOptions` holding the as-passed surface and a deep-copied frame. This fixes two latent `pop()` bugs: popping back to a Texture pushed without an explicit frame now re-applies its frame fallback (previously it rebound the full po2 source — the TexturePool case), and a caller mutating its reused frame rect can no longer leak into a later pop.
- `pop()` with no previous binding now throws a clear "unbalanced pop" error instead of failing cryptically inside `bind`; it also returns the restored render target, matching `push`.

#### Chores
- `renderStart()` takes a `BindOptions` instead of a field-for-field duplicate inline type.
- All internal engine call sites (FilterSystem, GlBackBufferSystem, AbstractTextSystem, AlphaMaskPipe, RenderGroupPipe) are migrated to the object forms — a test renders across filters, cacheAsTexture, and the back buffer asserting no internal path ever hits the deprecation.
- Unit tests cover positional/object parity (adaptor args, viewport, projection), warn-once deprecations for both methods, the `getBindState` round-trip (including `flipY`/`frontFaceInverted` and WebGPU mip/layer), frame deep-copy independence, poisoned-`out` overwrite and rect reuse, fallback replay, unbound/unbalanced throws, and the pop replay fixes.

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added

🤖 Generated with [Claude Code](https://claude.com/claude-code)