### PR TITLE
fix: use the correct vertex for the first edge in Triangle.strokeContains

### DIFF
--- a/src/maths/__tests__/Triangle.test.ts
+++ b/src/maths/__tests__/Triangle.test.ts
@@ -1,0 +1,21 @@
+import { Triangle } from '../shapes/Triangle';
+
+describe('Triangle', () =>
+{
+    it('should stroke-contain a point on the first edge', () =>
+    {
+        // vertices (0,0), (100,20), (50,100); first edge is (0,0)->(100,20)
+        const triangle = new Triangle(0, 0, 100, 20, 50, 100);
+
+        // (50,10) is the midpoint of the first edge, so it lies on the stroke
+        expect(triangle.strokeContains(50, 10, 4)).toBe(true);
+    });
+
+    it('should not stroke-contain an interior point far from every edge', () =>
+    {
+        const triangle = new Triangle(0, 0, 100, 20, 50, 100);
+
+        // (50,50) is well inside the triangle, far from all three edges
+        expect(triangle.strokeContains(50, 50, 4)).toBe(false);
+    });
+});

--- a/src/maths/shapes/Triangle.ts
+++ b/src/maths/shapes/Triangle.ts
@@ -196,7 +196,7 @@ export class Triangle implements ShapePrimitive
 
         const { x, x2, x3, y, y2, y3 } = this;
 
-        if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y3) <= halfStrokeWidthSquared
+        if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y2) <= halfStrokeWidthSquared
             || squaredDistanceToLineSegment(pointX, pointY, x2, y2, x3, y3) <= halfStrokeWidthSquared
             || squaredDistanceToLineSegment(pointX, pointY, x3, y3, x, y) <= halfStrokeWidthSquared)
         {


### PR DESCRIPTION
`Triangle.strokeContains` tests the distance from the point to each of the three
edges. The vertices are `(x, y)`, `(x2, y2)` and `(x3, y3)`, so the first edge
runs from `(x, y)` to `(x2, y2)`. The check for that edge passed `(x2, y3)` as
the second endpoint, mixing vertex 2's X with vertex 3's Y. That point is not a
triangle vertex, so the first edge is tested against a phantom segment whenever
`y2` and `y3` differ (the general case). The other two edges were correct.

With the triangle `(0,0), (100,20), (50,100)`:

- `strokeContains(50, 10, 4)` returned false, but `(50,10)` is the midpoint of
  the first edge and lies on the stroke, so it must be true.
- `strokeContains(50, 50, 4)` returned true, but `(50,50)` is interior and far
  from every real edge; it was only close to the phantom segment.

The fix passes the real vertex `(x2, y2)` for the first edge. Added a test for a
point on the first edge and an interior point.
