### PR TITLE
fix(maths/Triangle): use the correct second vertex when testing the first edge (#12105)

### DIFF
--- a/src/maths/__tests__/Triangle.test.ts
+++ b/src/maths/__tests__/Triangle.test.ts
@@ -1,0 +1,72 @@
+import { Triangle } from '../shapes/Triangle';
+
+describe('Triangle', () =>
+{
+    it('should create a new triangle', () =>
+    {
+        const triangle = new Triangle();
+
+        expect(triangle.x).toEqual(0);
+        expect(triangle.y).toEqual(0);
+        expect(triangle.x2).toEqual(0);
+        expect(triangle.y2).toEqual(0);
+        expect(triangle.x3).toEqual(0);
+        expect(triangle.y3).toEqual(0);
+    });
+
+    it('should create a triangle with the given coordinates', () =>
+    {
+        const triangle = new Triangle(0, 0, 100, 20, 50, 100);
+
+        expect(triangle.x).toEqual(0);
+        expect(triangle.y).toEqual(0);
+        expect(triangle.x2).toEqual(100);
+        expect(triangle.y2).toEqual(20);
+        expect(triangle.x3).toEqual(50);
+        expect(triangle.y3).toEqual(100);
+    });
+
+    describe('strokeContains', () =>
+    {
+        // Regression test for #12105. The triangle (0,0), (100,20), (50,100)
+        // has three edges:
+        //   edge A: (0,0) -> (100,20), midpoint (50,10)
+        //   edge B: (100,20) -> (50,100)
+        //   edge C: (50,100) -> (0,0)
+        // Before the fix, edge A's check used `(x2, y3)` = (100, 100) as the
+        // second endpoint, so any point on edge A's true line segment was
+        // tested against a phantom segment that ran from the origin to
+        // (100, 100) instead.
+        const triangle = new Triangle(0, 0, 100, 20, 50, 100);
+
+        it('returns true for a point on the first edge', () =>
+        {
+            // (50, 10) is the midpoint of edge A and lies on the stroke.
+            expect(triangle.strokeContains(50, 10, 4)).toBe(true);
+        });
+
+        it('returns false for an interior point that is far from every real edge', () =>
+        {
+            // (50, 50) is the rough centroid - well inside the triangle but
+            // not within 4px of any actual edge.
+            expect(triangle.strokeContains(50, 50, 4)).toBe(false);
+        });
+
+        it('returns false for a point well outside the triangle', () =>
+        {
+            expect(triangle.strokeContains(500, 500, 4)).toBe(false);
+        });
+
+        it('returns true for a point on the second edge', () =>
+        {
+            // Midpoint of edge B: ((100 + 50) / 2, (20 + 100) / 2) = (75, 60).
+            expect(triangle.strokeContains(75, 60, 4)).toBe(true);
+        });
+
+        it('returns true for a point on the third edge', () =>
+        {
+            // Midpoint of edge C: ((50 + 0) / 2, (100 + 0) / 2) = (25, 50).
+            expect(triangle.strokeContains(25, 50, 4)).toBe(true);
+        });
+    });
+});

--- a/src/maths/shapes/Triangle.ts
+++ b/src/maths/shapes/Triangle.ts
@@ -196,7 +196,7 @@ export class Triangle implements ShapePrimitive
 
         const { x, x2, x3, y, y2, y3 } = this;
 
-        if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y3) <= halfStrokeWidthSquared
+        if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y2) <= halfStrokeWidthSquared
             || squaredDistanceToLineSegment(pointX, pointY, x2, y2, x3, y3) <= halfStrokeWidthSquared
             || squaredDistanceToLineSegment(pointX, pointY, x3, y3, x, y) <= halfStrokeWidthSquared)
         {


### PR DESCRIPTION
Fixes #12105.

## Bug

\`Triangle.strokeContains\` walked each of the three edges with \`squaredDistanceToLineSegment\` and OR-ed the three distance checks. The vertices are \`(x, y)\`, \`(x2, y2)\`, and \`(x3, y3)\`, so the first edge runs from \`(x, y)\` to \`(x2, y2)\`. The check for that edge passed \`(x2, y3)\` as the second endpoint, mixing vertex 2's X with vertex 3's Y. That point is not a triangle vertex, so the first edge was tested against a phantom segment whenever \`y2 !== y3\`.

The other two edges were already correct.

## Concrete repro

Triangle \`(0,0), (100,20), (50,100)\`:

- \`strokeContains(50, 10, 4)\` returned false. \`(50, 10)\` is the midpoint of the first edge and lies on the stroke.
- \`strokeContains(50, 50, 4)\` returned true. \`(50, 50)\` is the rough centroid - well inside the triangle and far from every real edge. The phantom segment from \`(0,0)\` to \`(100, 100)\` was the only thing close enough.

## Fix

Pass the real second vertex \`(x2, y2)\` for the first edge:

```diff
-if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y3) <= halfStrokeWidthSquared
+if (squaredDistanceToLineSegment(pointX, pointY, x, y, x2, y2) <= halfStrokeWidthSquared
     || squaredDistanceToLineSegment(pointX, pointY, x2, y2, x3, y3) <= halfStrokeWidthSquared
     || squaredDistanceToLineSegment(pointX, pointY, x3, y3, x, y) <= halfStrokeWidthSquared)
```

## Tests

Added \`src/maths/__tests__/Triangle.test.ts\` (Triangle previously had no dedicated unit test file in the suite):

- Constructor smoke tests for both default and parameterized forms.
- \`strokeContains\` tests covering all three edges with their midpoints, plus an interior centroid point and an exterior far-away point.

The midpoints are chosen so each falls on exactly one of the three real edges and is more than half a stroke width away from any other edge, so the test isolates each branch of the OR.

2 files changed, +73/-1.