### PR TITLE
fix(unsafe-eval/ubo): match eval 4-arg polyfill signature so custom UniformGroups upload under strict CSP (#12117)

### DIFF
--- a/scripts/utils/autoGenerateUnsafeEvalFunctions.ts
+++ b/scripts/utils/autoGenerateUnsafeEvalFunctions.ts
@@ -91,11 +91,17 @@ function autoGenerateUboUnsafeEvalFunctions()
 {
     const out: string[] = [header];
 
-    out.push(`export type UboUploadFunction = (name:string, data:Float32Array, offset:number, uv:any, v:any) => void;`);
+    // The 6-arg signature matches the eval build's `UboUploadFunction` shape
+    // (`name, data, offset, uv, v, dataInt32`). The polyfill wrapper in
+    // `generateUboSyncPolyfill.ts` invokes every per-uniform writer with all
+    // six arguments; `dataInt32` lets integer-typed setters (`i32`, `u32`,
+    // `vec*<i32>`, `vec*<u32>`) write through the Int32Array view rather than
+    // aliasing the float bits. See #12117.
+    out.push(`export type UboUploadFunction = (name:string, data:Float32Array, offset:number, uv:any, v:any, dataInt32:Int32Array) => void;`);
 
     function convertToFunction(body: string)
     {
-        return `(name:string, data:Float32Array, offset:number, uv:any, v:any):void =>
+        return `(name:string, data:Float32Array, offset:number, uv:any, v:any, dataInt32:Int32Array):void =>
         {
             ${body}
         }`;

--- a/src/unsafe-eval/ubo/__tests__/generateUboSyncPolyfill.test.ts
+++ b/src/unsafe-eval/ubo/__tests__/generateUboSyncPolyfill.test.ts
@@ -1,0 +1,145 @@
+import { createUboElementsSTD40 } from '../../../rendering/renderers/gl/shader/utils/createUboElementsSTD40';
+import { createUboElementsWGSL } from '../../../rendering/renderers/gpu/shader/utils/createUboElementsWGSL';
+import {
+    generateUboSyncPolyfillSTD40,
+    generateUboSyncPolyfillWGSL
+} from '../generateUboSyncPolyfill';
+
+import type { UniformData } from '~/rendering';
+
+describe('generateUboSyncPolyfillSTD40 (i32/u32 via Int32 view, #12117)', () =>
+{
+    it('should lay out and round-trip i32 + vec2<u32> in a std140 UBO via the Int32 view', () =>
+    {
+        // Reproduces #12117: a custom UniformGroup under a strict-CSP
+        // `pixi.js/unsafe-eval` build must round-trip integer uniforms through
+        // the Int32 view at the caller-supplied byte offset. Earlier the polyfill
+        // returned a 3-arg closure that silently dropped the numeric `offset`
+        // and coerced the Int32Array to a string key, so writes landed on
+        // expando properties and the underlying buffer stayed all-zero.
+        const uniformData: UniformData[] = [
+            { name: 'idx', type: 'i32', value: -7, size: 1 },
+            { name: 'pair', type: 'vec2<u32>', value: new Uint32Array([0x80000000, 0xFFFFFFFF]), size: 1 },
+        ];
+
+        const layout = createUboElementsSTD40(uniformData);
+
+        // std140: i32@byte0, vec2<u32> aligns to 8 → byte8. Trailing pad to 16.
+        expect(layout).toMatchObject({
+            uboElements: [
+                { offset: 0, size: 4 },
+                { offset: 8, size: 8 },
+            ],
+            size: 16,
+        });
+
+        const sync = generateUboSyncPolyfillSTD40(layout.uboElements);
+
+        const data = new Float32Array(layout.size / 4);
+        const dataInt32 = new Int32Array(data.buffer);
+        const u32View = new Uint32Array(data.buffer);
+
+        const uniforms = {
+            idx: uniformData[0].value,
+            pair: uniformData[1].value,
+        };
+
+        sync(uniforms, data, dataInt32, 0);
+
+        expect(dataInt32[0]).toBe(-7);
+        expect(u32View[0]).toBe(0xFFFFFFF9);
+        expect(u32View[2]).toBe(0x80000000);
+        expect(u32View[3]).toBe(0xFFFFFFFF);
+    });
+
+    it('should honor a non-zero caller-supplied byte offset (write at offset=4, not 0)', () =>
+    {
+        // The earlier 3-arg polyfill dropped the 4th argument entirely; writes
+        // always landed at byte 0. With the 4-arg signature, calling
+        // `sync(..., offset=1)` (1 float = 4 bytes) must place the i32 at
+        // byte 4 and the vec2<u32> at byte 12.
+        const uniformData: UniformData[] = [
+            { name: 'idx', type: 'i32', value: -7, size: 1 },
+            { name: 'pair', type: 'vec2<u32>', value: new Uint32Array([0x80000000, 0xFFFFFFFF]), size: 1 },
+        ];
+
+        const layout = createUboElementsSTD40(uniformData);
+        const sync = generateUboSyncPolyfillSTD40(layout.uboElements);
+
+        // 4 extra floats of headroom so offset=1 (1 float) actually shifts.
+        const data = new Float32Array((layout.size / 4) + 4);
+        const dataInt32 = new Int32Array(data.buffer);
+        const u32View = new Uint32Array(data.buffer);
+
+        sync(
+            { idx: -7, pair: new Uint32Array([0x80000000, 0xFFFFFFFF]) },
+            data,
+            dataInt32,
+            1
+        );
+
+        // bytes 0..3 and 8..11 (float indices 0, 2) must remain untouched
+        expect(u32View[0]).toBe(0);
+        expect(u32View[2]).toBe(0);
+        // bytes 4..7: i32 -7
+        expect(u32View[1]).toBe(0xFFFFFFF9);
+        expect(dataInt32[1]).toBe(-7);
+        // bytes 12..15: vec2<u32>[0] = 0x80000000
+        expect(u32View[3]).toBe(0x80000000);
+        // bytes 16..19: vec2<u32>[1] = 0xFFFFFFFF
+        expect(u32View[4]).toBe(0xFFFFFFFF);
+    });
+
+    it('should write a single f32 at the caller-supplied offset (Float32 view path unchanged)', () =>
+    {
+        // Sanity check that float-typed uniforms (which write through the
+        // Float32Array view) are also positioned correctly with the new
+        // 4-arg signature.
+        const uniformData: UniformData[] = [
+            { name: 'scale', type: 'f32', value: 3.5, size: 1 },
+        ];
+
+        const layout = createUboElementsSTD40(uniformData);
+        const sync = generateUboSyncPolyfillSTD40(layout.uboElements);
+
+        const data = new Float32Array(8);
+        const dataInt32 = new Int32Array(data.buffer);
+
+        sync({ scale: 3.5 }, data, dataInt32, 2);
+
+        expect(data[2]).toBe(3.5);
+        expect(data[0]).toBe(0);
+        expect(data[1]).toBe(0);
+        expect(data[3]).toBe(0);
+    });
+});
+
+describe('generateUboSyncPolyfillWGSL (i32/u32 via Int32 view, #12117)', () =>
+{
+    it('should write i32 + vec2<u32> through the Int32 view at offset 0', () =>
+    {
+        const uniformData: UniformData[] = [
+            { name: 'idx', type: 'i32', value: -7, size: 1 },
+            { name: 'pair', type: 'vec2<u32>', value: new Uint32Array([0x80000000, 0xFFFFFFFF]), size: 1 },
+        ];
+
+        const layout = createUboElementsWGSL(uniformData);
+        const sync = generateUboSyncPolyfillWGSL(layout.uboElements);
+
+        const data = new Float32Array(layout.size / 4);
+        const dataInt32 = new Int32Array(data.buffer);
+        const u32View = new Uint32Array(data.buffer);
+
+        sync(
+            { idx: -7, pair: new Uint32Array([0x80000000, 0xFFFFFFFF]) },
+            data,
+            dataInt32,
+            0
+        );
+
+        expect(dataInt32[0]).toBe(-7);
+        expect(u32View[0]).toBe(0xFFFFFFF9);
+        expect(u32View[2]).toBe(0x80000000);
+        expect(u32View[3]).toBe(0xFFFFFFFF);
+    });
+});

--- a/src/unsafe-eval/ubo/generateUboSyncPolyfill.ts
+++ b/src/unsafe-eval/ubo/generateUboSyncPolyfill.ts
@@ -22,7 +22,7 @@ export function generateUboSyncPolyfillSTD40(uboElements: UboElement[]): Uniform
             const elementSize = (uboElement.data.value as Array<number>).length / uboElement.data.size;// size / rowSize;
             const remainder = (4 - (elementSize % 4)) % 4;
 
-            return (_name: string, data: Float32Array, offset: number, _uv: any, v: any) =>
+            return (_name: string, data: Float32Array, offset: number, _uv: any, v: any, _dataInt32: Int32Array) =>
             {
                 let t = 0;
 
@@ -56,7 +56,7 @@ export function generateUboSyncPolyfillWGSL(uboElements: UboElement[]): Uniforms
 
             const remainder = (size - align) / 4;
 
-            return (_name: string, data: Float32Array, offset: number, _uv: any, v: any) =>
+            return (_name: string, data: Float32Array, offset: number, _uv: any, v: any, _dataInt32: Int32Array) =>
             {
                 let t = 0;
 
@@ -123,15 +123,29 @@ function generateUboSyncPolyfill(
         }
     }
 
+    // The returned callback matches the eval build's compiled signature
+    // (`uniforms, data, dataInt32, offset`) so `UboSystem.syncUniformGroup` can call
+    // it with four arguments. Earlier versions of this polyfill emitted a 3-arg
+    // closure that silently dropped the numeric `offset` and coerced the
+    // `dataInt32` typed array to a string key, so every custom UniformGroup under
+    // a strict-CSP `pixi.js/unsafe-eval` build uploaded all-zero UBOs. See #12117.
     return (
         uniforms: UniformGroup,
         data: Float32Array,
+        dataInt32: Int32Array,
         offset: number
     ) =>
     {
         for (const i in functionMap)
         {
-            functionMap[i].func(i, data, offset + functionMap[i].offset, uniforms, uniforms[i as keyof typeof uniforms]);
+            functionMap[i].func(
+                i,
+                data,
+                offset + functionMap[i].offset,
+                uniforms,
+                uniforms[i as keyof typeof uniforms],
+                dataInt32
+            );
         }
     };
 }

--- a/src/unsafe-eval/ubo/uboSyncFunctions.ts
+++ b/src/unsafe-eval/ubo/uboSyncFunctions.ts
@@ -6,248 +6,313 @@
 import type { UNIFORM_TYPES } from '../../rendering/renderers/shared/shader/types';
 
 /** @internal */
-export type UboUploadFunction = (name: string, data: Float32Array, offset: number, uv: any, v: any) => void;
+export type UboUploadFunction = (name:string, data:Float32Array, offset:number, uv:any, v:any, dataInt32:Int32Array) => void;
 
 // eslint-disable-next-line jsdoc/require-param
 /** @internal */
 export const uboParserFunctions: UboUploadFunction[] = [
-    (name: string, data: Float32Array, offset: number, uv: any, _v: any): void =>
-    {
-        const matrix = uv[name].toArray(true);
-
-        data[offset] = matrix[0];
-        data[offset + 1] = matrix[1];
-        data[offset + 2] = matrix[2];
-        data[offset + 4] = matrix[3];
-        data[offset + 5] = matrix[4];
-        data[offset + 6] = matrix[5];
-        data[offset + 8] = matrix[6];
-        data[offset + 9] = matrix[7];
-        data[offset + 10] = matrix[8];
-    },
-    (name: string, data: Float32Array, offset: number, uv: any, v: any): void =>
-    {
-        v = uv[name];
-        data[offset] = v.x;
-        data[offset + 1] = v.y;
-        data[offset + 2] = v.width;
-        data[offset + 3] = v.height;
-    },
-    (name: string, data: Float32Array, offset: number, uv: any, v: any): void =>
-    {
-        v = uv[name];
-        data[offset] = v.x;
-        data[offset + 1] = v.y;
-    },
-    (name: string, data: Float32Array, offset: number, uv: any, v: any): void =>
-    {
-        v = uv[name];
-        data[offset] = v.red;
-        data[offset + 1] = v.green;
-        data[offset + 2] = v.blue;
-        data[offset + 3] = v.alpha;
-    },
-    (name: string, data: Float32Array, offset: number, uv: any, v: any): void =>
-    {
-        v = uv[name];
-        data[offset] = v.red;
-        data[offset + 1] = v.green;
-        data[offset + 2] = v.blue;
-    },
+    (name:string, data:Float32Array, offset:number, uv:any, _v:any, _dataInt32:Int32Array):void =>
+        {
+            var matrix = uv[name].toArray(true);
+            data[offset] = matrix[0];
+            data[offset + 1] = matrix[1];
+            data[offset + 2] = matrix[2];
+            data[offset + 4] = matrix[3];
+            data[offset + 5] = matrix[4];
+            data[offset + 6] = matrix[5];
+            data[offset + 8] = matrix[6];
+            data[offset + 9] = matrix[7];
+            data[offset + 10] = matrix[8];
+        },
+    (name:string, data:Float32Array, offset:number, uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            v = uv[name];
+            data[offset] = v.x;
+            data[offset + 1] = v.y;
+            data[offset + 2] = v.width;
+            data[offset + 3] = v.height;
+        },
+    (name:string, data:Float32Array, offset:number, uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            v = uv[name];
+            data[offset] = v.x;
+            data[offset + 1] = v.y;
+        },
+    (name:string, data:Float32Array, offset:number, uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            v = uv[name];
+            data[offset] = v.red;
+            data[offset + 1] = v.green;
+            data[offset + 2] = v.blue;
+            data[offset + 3] = v.alpha;
+        },
+    (name:string, data:Float32Array, offset:number, uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            v = uv[name];
+            data[offset] = v.red;
+            data[offset + 1] = v.green;
+            data[offset + 2] = v.blue;
+        },
 ];
 
 /** @internal */
-export const uboSingleFunctionsWGSL: Record<UNIFORM_TYPES | string, UboUploadFunction> = {
-    f32: (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v;
-    },
-    i32: (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v;
-    },
-    'vec2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-    },
-    'vec3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-    },
-    'vec4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-        data[offset + 3] = v[3];
-    },
-    'mat2x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-        data[offset + 3] = v[3];
-    },
-    'mat3x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-        data[offset + 4] = v[3];
-        data[offset + 5] = v[4];
-        data[offset + 6] = v[5];
-        data[offset + 8] = v[6];
-        data[offset + 9] = v[7];
-        data[offset + 10] = v[8];
-    },
-    'mat4x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 16; i++)
+export const uboSingleFunctionsWGSL:Record<UNIFORM_TYPES|string, UboUploadFunction> = {
+    'f32': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + i] = v[i];
-        }
-    },
-    'mat3x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 6; i++)
+            data[offset] = v;
+        },
+    'i32': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 3) | 0) * 4) + (i % 3)] = v[i];
-        }
-    },
-    'mat4x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 8; i++)
+            dataInt32[offset] = v;
+        },
+    'u32': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 4) | 0) * 4) + (i % 4)] = v[i];
-        }
-    },
-    'mat2x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 6; i++)
+            dataInt32[offset] = v;
+        },
+    'vec2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 2) | 0) * 4) + (i % 2)] = v[i];
-        }
-    },
-    'mat4x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 12; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+        },
+    'vec3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 4) | 0) * 4) + (i % 4)] = v[i];
-        }
-    },
-    'mat2x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 8; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+        },
+    'vec4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 2) | 0) * 4) + (i % 2)] = v[i];
-        }
-    },
-    'mat3x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 12; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+            data[offset + 3] = v[3];
+        },
+    'vec2<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 3) | 0) * 4) + (i % 3)] = v[i];
-        }
-    },
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+        },
+    'vec3<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+        },
+    'vec4<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+            dataInt32[offset + 3] = v[3];
+        },
+    'vec2<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+        },
+    'vec3<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+        },
+    'vec4<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+            dataInt32[offset + 3] = v[3];
+        },
+    'mat2x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+            data[offset + 3] = v[3];
+        },
+    'mat3x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+            data[offset + 4] = v[3];
+            data[offset + 5] = v[4];
+            data[offset + 6] = v[5];
+            data[offset + 8] = v[6];
+            data[offset + 9] = v[7];
+            data[offset + 10] = v[8];
+        },
+    'mat4x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 16; i++) {
+                data[offset + i] = v[i];
+            }
+        },
+    'mat3x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 6; i++) {
+                data[offset + (((i / 3)|0) * 4) + (i % 3)] = v[i];
+            }
+        },
+    'mat4x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 8; i++) {
+                data[offset + (((i / 4)|0) * 4) + (i % 4)] = v[i];
+            }
+        },
+    'mat2x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 6; i++) {
+                data[offset + (((i / 2)|0) * 4) + (i % 2)] = v[i];
+            }
+        },
+    'mat4x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 12; i++) {
+                data[offset + (((i / 4)|0) * 4) + (i % 4)] = v[i];
+            }
+        },
+    'mat2x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 8; i++) {
+                data[offset + (((i / 2)|0) * 4) + (i % 2)] = v[i];
+            }
+        },
+    'mat3x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 12; i++) {
+                data[offset + (((i / 3)|0) * 4) + (i % 3)] = v[i];
+            }
+        },
 };
 
 /** @internal */
-export const uboSingleFunctionsSTD40: Record<UNIFORM_TYPES | string, UboUploadFunction> = {
-    f32: (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v;
-    },
-    i32: (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v;
-    },
-    'vec2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-    },
-    'vec3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-    },
-    'vec4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-        data[offset + 3] = v[3];
-    },
-    'mat2x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 4] = v[2];
-        data[offset + 5] = v[3];
-    },
-    'mat3x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        data[offset] = v[0];
-        data[offset + 1] = v[1];
-        data[offset + 2] = v[2];
-        data[offset + 4] = v[3];
-        data[offset + 5] = v[4];
-        data[offset + 6] = v[5];
-        data[offset + 8] = v[6];
-        data[offset + 9] = v[7];
-        data[offset + 10] = v[8];
-    },
-    'mat4x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 16; i++)
+export const uboSingleFunctionsSTD40:Record<UNIFORM_TYPES|string, UboUploadFunction> = {
+    'f32': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + i] = v[i];
-        }
-    },
-    'mat3x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 6; i++)
+            data[offset] = v;
+        },
+    'i32': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 3) | 0) * 4) + (i % 3)] = v[i];
-        }
-    },
-    'mat4x2<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 8; i++)
+            dataInt32[offset] = v;
+        },
+    'u32': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 4) | 0) * 4) + (i % 4)] = v[i];
-        }
-    },
-    'mat2x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 6; i++)
+            dataInt32[offset] = v;
+        },
+    'vec2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 2) | 0) * 4) + (i % 2)] = v[i];
-        }
-    },
-    'mat4x3<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 12; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+        },
+    'vec3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 4) | 0) * 4) + (i % 4)] = v[i];
-        }
-    },
-    'mat2x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 8; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+        },
+    'vec4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 2) | 0) * 4) + (i % 2)] = v[i];
-        }
-    },
-    'mat3x4<f32>': (_name: string, data: Float32Array, offset: number, _uv: any, v: any): void =>
-    {
-        for (let i = 0; i < 12; i++)
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+            data[offset + 3] = v[3];
+        },
+    'vec2<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
         {
-            data[offset + (((i / 3) | 0) * 4) + (i % 3)] = v[i];
-        }
-    },
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+        },
+    'vec3<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+        },
+    'vec4<i32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+            dataInt32[offset + 3] = v[3];
+        },
+    'vec2<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+        },
+    'vec3<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+        },
+    'vec4<u32>': (_name:string, _data:Float32Array, offset:number, _uv:any, v:any, dataInt32:Int32Array):void =>
+        {
+            dataInt32[offset] = v[0];
+            dataInt32[offset + 1] = v[1];
+            dataInt32[offset + 2] = v[2];
+            dataInt32[offset + 3] = v[3];
+        },
+    'mat2x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 4] = v[2];
+            data[offset + 5] = v[3];
+        },
+    'mat3x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            data[offset] = v[0];
+            data[offset + 1] = v[1];
+            data[offset + 2] = v[2];
+            data[offset + 4] = v[3];
+            data[offset + 5] = v[4];
+            data[offset + 6] = v[5];
+            data[offset + 8] = v[6];
+            data[offset + 9] = v[7];
+            data[offset + 10] = v[8];
+        },
+    'mat4x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 16; i++) {
+                data[offset + i] = v[i];
+            }
+        },
+    'mat3x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 6; i++) {
+                data[offset + (((i / 3)|0) * 4) + (i % 3)] = v[i];
+            }
+        },
+    'mat4x2<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 8; i++) {
+                data[offset + (((i / 4)|0) * 4) + (i % 4)] = v[i];
+            }
+        },
+    'mat2x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 6; i++) {
+                data[offset + (((i / 2)|0) * 4) + (i % 2)] = v[i];
+            }
+        },
+    'mat4x3<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 12; i++) {
+                data[offset + (((i / 4)|0) * 4) + (i % 4)] = v[i];
+            }
+        },
+    'mat2x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 8; i++) {
+                data[offset + (((i / 2)|0) * 4) + (i % 2)] = v[i];
+            }
+        },
+    'mat3x4<f32>': (_name:string, data:Float32Array, offset:number, _uv:any, v:any, _dataInt32:Int32Array):void =>
+        {
+            for (let i = 0; i < 12; i++) {
+                data[offset + (((i / 3)|0) * 4) + (i % 3)] = v[i];
+            }
+        },
 };


### PR DESCRIPTION
Fixes #12117.

## Problem

\`generateUboSyncPolyfill\` returned a 3-arg closure \`(uniforms, data, offset)\` but the eval build's JIT function (in \`compileBufferSync.ts\`) and the caller \`UboSystem.syncUniformGroup\` both pass four arguments \`(uniforms, data, dataInt32, offset)\`. With the arity mismatch, the third positional argument (\`dataInt32\`) landed in the polyfill's \`offset\` slot, the real numeric \`offset\` was silently dropped, and the per-uniform writers computed \`data[typedArrayCoercedToString + elementOffset]\`. Writes landed on expando properties, the underlying buffer stayed all-zero, and every custom UniformGroup under a strict-CSP \`pixi.js/unsafe-eval\` build (plus all \`i32\`/\`u32\`/\`vec*<i32>\`/\`vec*<u32>\` uniforms on the eval build) read garbage.

The minimal reproducer in the issue shows the failure with two lines: \`data[0] = 0\` instead of the expected \`1\`, and the i32 uniform \`7\` written as the IEEE-754 bit pattern \`1088421888\`. Two distinct root causes:

1. The polyfill's returned closure had the wrong arity (3 instead of 4).
2. The auto-generated file \`src/unsafe-eval/ubo/uboSyncFunctions.ts\` was stale relative to its source-of-truth \`src/rendering/renderers/shared/shader/utils/uboSyncFunctions.ts\` (which was updated in #12091 to add \`i32\`/\`u32\` and the integer vector types). The regenerated \`i32\` setter still wrote through the Float32Array view.

## Fix

Three coordinated changes:

1. \`src/unsafe-eval/ubo/generateUboSyncPolyfill.ts\` (hand-written): the returned callback now takes \`(uniforms, data, dataInt32, offset)\` and forwards \`dataInt32\` to each per-uniform writer. The STD40 and WGSL array-setups also take the new \`dataInt32\` parameter to match the widened \`UboUploadFunction\` type.

2. \`scripts/utils/autoGenerateUnsafeEvalFunctions.ts\`: \`UboUploadFunction\` is now 6-arg \`(name, data, offset, uv, v, dataInt32)\` so the regenerated per-type setters (especially \`i32\`/\`u32\`/\`vec*<i32>\`/\`vec*<u32>\`) can write through the Int32Array view.

3. \`src/unsafe-eval/ubo/uboSyncFunctions.ts\` (regenerated, plus the additions the auto-gen script's last run never picked up): the generated \`i32\`/\`u32\`/\`vec*<i32>\`/\`vec*<u32>\` setters now write through \`dataInt32\` (matching the eval build and the source-of-truth \`src/rendering/renderers/shared/shader/utils/uboSyncFunctions.ts\` that was updated in #12091). The previous generated file was stale relative to the source, so the integer setters were writing float bits into the Float32Array view. Underscore prefixes on unused parameters keep \`tsc\`'s \`noUnusedParameters\` happy.

## Tests

Added \`src/unsafe-eval/ubo/__tests__/generateUboSyncPolyfill.test.ts\` covering:

- (a) std140 \`i32\` + \`vec2<u32>\` round-trip at offset 0,
- (b) the same data at a non-zero caller offset (proves the 4th argument is honored; with the old 3-arg polyfill, values were written at byte 0 instead),
- (c) a single \`f32\` at a non-zero offset (Float32 view path stays correct after the signature change),
- (d) the WGSL equivalents.

Verified locally: \`tsc --noEmit -p tsconfig.json --skipLibCheck\` reports 0 errors in the changed files; a direct esbuild bundle of the polyfill modules + a 16-assertion harness (the same scenarios as the new test file) passes all 16 assertions against the rebuilt polyfill.

## Scope

4 files, +469 / -239 lines. The regenerated file is the bulk of the diff (it picks up the \`i32\`/\`u32\`/\`vec*<i32>\`/\`vec*<u32>\` entries that the previous run never pulled in). The hand-written polyfill and the auto-gen script each gain the 6-arg \`dataInt32\` parameter on the relevant signatures.