### PR TITLE
fix: prevent duplicate onRender registrations from same-parent reorders

### DIFF
--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -354,12 +354,17 @@ export class RenderGroup implements Instruction
      */
     public addOnRender(container: Container)
     {
-        this._onRenderContainers.push(container);
+        if (this._onRenderContainers.indexOf(container) === -1)
+        {
+            this._onRenderContainers.push(container);
+        }
     }
 
     public removeOnRender(container: Container)
     {
-        this._onRenderContainers.splice(this._onRenderContainers.indexOf(container), 1);
+        const idx = this._onRenderContainers.indexOf(container);
+
+        if (idx !== -1) this._onRenderContainers.splice(idx, 1);
     }
 
     public runOnRender(renderer: Renderer)

--- a/src/scene/container/__tests__/RenderGroup.test.ts
+++ b/src/scene/container/__tests__/RenderGroup.test.ts
@@ -675,5 +675,90 @@ describe('RenderGroup', () =>
 
         expect(child._updateFlags).toEqual(0b1111);
     });
+
+    describe('same-parent reorders', () =>
+    {
+        it('should not duplicate onRender containers when reordering via addChildAt', () =>
+        {
+            const container = new Container({ isRenderGroup: true });
+            const a = new Container();
+            const b = new Container();
+
+            a.onRender = jest.fn();
+
+            container.addChild(a, b);
+
+            expect(container.renderGroup['_onRenderContainers']).toEqual([a]);
+
+            container.addChildAt(a, 1);
+            container.addChildAt(a, 0);
+
+            expect(container.renderGroup['_onRenderContainers']).toEqual([a]);
+        });
+
+        it('should not duplicate onRender containers when reordering via setChildIndex', () =>
+        {
+            const container = new Container({ isRenderGroup: true });
+            const a = new Container();
+            const b = new Container();
+
+            a.onRender = jest.fn();
+
+            container.addChild(a, b);
+
+            container.setChildIndex(a, 1);
+            container.setChildIndex(a, 0);
+
+            expect(container.renderGroup['_onRenderContainers']).toEqual([a]);
+        });
+
+        it('should flag a render group as dirty and reorder children via addChildAt', async () =>
+        {
+            const renderer = await getWebGLRenderer();
+
+            const container = new Container({ isRenderGroup: true });
+            const a = new Container();
+            const b = new Container();
+
+            const onRender = jest.fn();
+
+            a.onRender = onRender;
+
+            container.addChild(a, b);
+
+            renderer.render(container);
+
+            expect(container.renderGroup.structureDidChange).toBeFalse();
+
+            container.addChildAt(a, 1);
+
+            expect(container.renderGroup.structureDidChange).toBeTrue();
+            expect(container.children).toEqual([b, a]);
+
+            renderer.render(container);
+
+            expect(onRender).toHaveBeenCalledTimes(2);
+
+            renderer.destroy();
+        });
+
+        it('should unregister onRender via removeChild after reorders', () =>
+        {
+            const container = new Container({ isRenderGroup: true });
+            const a = new Container();
+            const b = new Container();
+
+            a.onRender = jest.fn();
+
+            container.addChild(a, b);
+
+            container.addChildAt(a, 1);
+            container.setChildIndex(a, 0);
+
+            container.removeChild(a);
+
+            expect(container.renderGroup['_onRenderContainers']).toEqual([]);
+        });
+    });
 });
 

--- a/src/scene/container/__tests__/RenderGroup.test.ts
+++ b/src/scene/container/__tests__/RenderGroup.test.ts
@@ -760,5 +760,37 @@ describe('RenderGroup', () =>
             expect(container.renderGroup['_onRenderContainers']).toEqual([]);
         });
     });
+
+    it('removeOnRender should leave the list unchanged when the container is not registered', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        BigPool.getPool(RenderGroup).clear();
+
+        const container = new Container({ isRenderGroup: true });
+
+        const a = new Container();
+        const b = new Container();
+        const c = new Container();
+
+        a.onRender = () => { /* noop */ };
+        b.onRender = () => { /* noop */ };
+        c.onRender = () => { /* noop */ };
+
+        container.addChild(a);
+        container.addChild(b);
+        // `c` is intentionally never parented under `container`
+
+        renderer.render(container);
+
+        const before = [...container.renderGroup['_onRenderContainers']];
+
+        // `c` was never registered in this renderGroup; this should be a no-op
+        container.renderGroup.removeOnRender(c);
+
+        expect(container.renderGroup['_onRenderContainers']).toEqual(before);
+
+        renderer.destroy();
+    });
 });
 

--- a/src/scene/container/container-mixins/childrenHelperMixin.ts
+++ b/src/scene/container/container-mixins/childrenHelperMixin.ts
@@ -366,9 +366,6 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
             throw new Error(`${child}addChildAt: The index ${index} supplied is out of bounds ${children.length}`);
         }
 
-        // TODO - check if child is already in the list?
-        // we should be able to optimise this!
-
         const sameParent = child.parent === this;
 
         if (child.parent)
@@ -401,23 +398,29 @@ export const childrenHelperMixin: ChildrenHelperMixin<ContainerChild> = {
             children.splice(index, 0, child);
         }
 
+        const renderGroup = this.renderGroup || this.parentRenderGroup;
+
+        if (this.sortableChildren) this.sortDirty = true;
+
+        // Same parent reorder: parentRenderGroup, depth and onRender membership are all
+        // unchanged, so an instruction rebuild is enough. Don't emit added events.
+        if (sameParent)
+        {
+            if (renderGroup)
+            {
+                renderGroup.structureDidChange = true;
+            }
+
+            return child;
+        }
+
         child.parent = this;
         child.didChange = true;
         child._updateFlags = 0b1111;
 
-        const renderGroup = this.renderGroup || this.parentRenderGroup;
-
         if (renderGroup)
         {
             renderGroup.addChild(child);
-        }
-
-        if (this.sortableChildren) this.sortDirty = true;
-
-        // If same parent, don't emit added events
-        if (sameParent)
-        {
-            return child;
         }
 
         this.emit('childAdded', child, this, index);


### PR DESCRIPTION
### Overview

`addChildAt` (and `setChildIndex`, which delegates to it) called `RenderGroup.addChild` even when the child was only being reordered under the same parent. With no matching `removeChild`, every reorder re-registered the child's subtree with the render group: `onRender` containers accumulated duplicate entries (callbacks fired multiple times per frame, and stale entries survived `removeChild`), and update state was redundantly reset for every descendant. Same-parent reorders now follow the same path as `Container.addChild`: reorder the children array and flag `structureDidChange` for an instruction rebuild.

This PR supersedes #12057 and includes @astrocreep's defensive guards from it (commit preserved): `addOnRender` is idempotent, and `removeOnRender` no longer calls `splice(-1, 1)` for unregistered containers, which silently deleted the last registered entry. The root-cause fix and the guards are complementary — the guards also protect any future caller that double-registers.

#### Fixes

- Reordering a child via `addChildAt` or `setChildIndex` no longer duplicates its `onRender` registration; callbacks fire once per frame regardless of reorders, and no stale callbacks remain after `removeChild`
- `RenderGroup.removeOnRender` for an unregistered container is now a no-op instead of silently unregistering an unrelated container's `onRender` callback
- Same-parent reorders skip the redundant `RenderGroup.addChild` subtree walk and instead trigger a single instruction rebuild

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
