### PR TITLE
fix: make GCSystem lazy-hash-replacement tests independent of real elapsed time

### DIFF
--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -832,9 +832,21 @@ describe('GCSystem', () =>
 
     describe('lazy hash replacement', () =>
     {
+        // These tests rely on a fixed "now" to decide which resources are stale. Using the real
+        // performance.now() made them order-dependent: under a full-suite run, real elapsed time
+        // between marking a resource as recently-used and calling `run()` can vary with system
+        // load, occasionally pushing it past `maxUnusedTime`. Mocking the clock removes that variance.
+        let nowSpy: jest.SpyInstance;
+
         beforeEach(() =>
         {
             gcSystem.init({ gcActive: true, gcMaxUnusedTime: 1000, gcFrequency: 100 });
+            nowSpy = jest.spyOn(performance, 'now').mockReturnValue(1_000_000);
+        });
+
+        afterEach(() =>
+        {
+            nowSpy.mockRestore();
         });
 
         it('should set GC\'d entry to null instead of replacing hash (below threshold)', () =>


### PR DESCRIPTION
### Overview

The `GCSystem › lazy hash replacement` tests were order-dependent: they passed in isolation but could fail intermittently in a full unit-suite run. They computed staleness from real `performance.now()` calls, so under a loaded full-suite run (many parallel test files competing for CPU) the wall-clock delay between marking a resource as recently used and calling `run()` could exceed `maxUnusedTime` (1000ms in these tests) and flip the expected GC outcome. The describe block now mocks `performance.now()` to a fixed value (`beforeEach`/`afterEach`), computing staleness from a controlled clock instead of real elapsed time.

Fixes #12084

#### Chores

- Removed order and system-load dependence from the `GCSystem` lazy-hash-replacement tests by mocking `performance.now()`, eliminating intermittent full-suite failures

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added