### PR TITLE
docs(assets): correct BackgroundLoader concurrency comments

### DIFF
--- a/src/assets/BackgroundLoader.ts
+++ b/src/assets/BackgroundLoader.ts
@@ -8,7 +8,7 @@ import type { ResolvedAsset } from './types';
  * Key features:
  * - Sequential loading of assets
  * - Automatic pause when high-priority loads occur
- * - Configurable concurrency
+ * - Loads one asset at a time (concurrency is fixed)
  * @example
  * ```ts
  * import { Assets } from 'pixi.js';
@@ -120,9 +120,9 @@ export class BackgroundLoader
     }
 
     /**
-     * Loads the next set of assets. Will try to load as many assets as it can at the same time.
+     * Loads the next set of assets, up to `_maxConcurrent` at a time.
      *
-     * The max assets it will try to load at one time will be 4.
+     * The max assets it will try to load at one time is 1.
      */
     private async _next(): Promise<void>
     {


### PR DESCRIPTION
## Summary
- Fixes outdated BackgroundLoader docs that said concurrency was configurable and capped at 4.
- `_maxConcurrent` is private, readonly, and set to 1, so the class and `_next()` comments now match the code.

Closes #11823

## Test plan
- [ ] Confirm JSDoc/comments in `src/assets/BackgroundLoader.ts` match `_maxConcurrent = 1`
- [ ] No runtime behavior change (docs only)