### PR TITLE
fix: copy radius in RoundedRectangle.copyFrom

### DIFF
--- a/src/maths/__tests__/RoundedRectangle.test.ts
+++ b/src/maths/__tests__/RoundedRectangle.test.ts
@@ -33,6 +33,20 @@ describe('RoundedRectangle', () =>
         expect(rrect1).not.toBe(rrect2);
     });
 
+    it('should copy from another rounded rectangle', () =>
+    {
+        const source = new RoundedRectangle(10, 20, 100, 200, 15);
+        const target = new RoundedRectangle();
+
+        target.copyFrom(source);
+
+        expect(target.x).toEqual(10);
+        expect(target.y).toEqual(20);
+        expect(target.width).toEqual(100);
+        expect(target.height).toEqual(200);
+        expect(target.radius).toEqual(15);
+    });
+
     it('should check if point is within rounded rectangle', () =>
     {
         const rrect1 = new RoundedRectangle(0, 0, 200, 200, 50);

--- a/src/maths/shapes/RoundedRectangle.ts
+++ b/src/maths/shapes/RoundedRectangle.ts
@@ -233,6 +233,7 @@ export class RoundedRectangle implements ShapePrimitive
         this.y = rectangle.y;
         this.width = rectangle.width;
         this.height = rectangle.height;
+        this.radius = rectangle.radius;
 
         return this;
     }


### PR DESCRIPTION
### Overview

`RoundedRectangle.copyFrom()` assigned `x`, `y`, `width` and `height` but not `radius`, so a copied rounded rectangle silently kept the destination's previous radius (default `20`) instead of the source's; `copyTo()` delegates to `copyFrom()` and inherited the same defect. Every other shape copies all of its defining fields, and this class's own `clone()` already copies `radius`, so any geometry derived from the copy (`contains()`, `strokeContains()`, re-rendered corners) was computed with the wrong corner radius.

#### Fixes

- `RoundedRectangle.copyFrom` (and `copyTo`, which delegates to it) now copies `radius`, so copies no longer keep the destination's previous corner radius

```ts
const source = new RoundedRectangle(0, 0, 100, 100, 0); // sharp corners
const target = new RoundedRectangle();                  // default radius 20

target.copyFrom(source);
target.radius; // now 0 — previously stayed 20
```

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added