### PR TITLE
fix: release mask bindings when pooled AlphaMaskEffect returns to the pool

### DIFF
--- a/src/filters/mask/MaskFilter.ts
+++ b/src/filters/mask/MaskFilter.ts
@@ -84,6 +84,21 @@ export class MaskFilter extends Filter
         this._textureMatrix = textureMatrix;
     }
 
+    /**
+     * Rebinds the filter to a new mask sprite, moving the texture-matrix `update`
+     * listener and the bind group's `change` subscription over to the new sprite's
+     * texture. `apply` refreshes the same bindings on every use — this method exists
+     * to release the previous sprite's texture immediately, without waiting for
+     * (or requiring) another `apply`.
+     * @param sprite - the sprite to mask with from now on.
+     */
+    public setSprite(sprite: Sprite): void
+    {
+        this.sprite = sprite;
+        this._textureMatrix.texture = sprite.texture;
+        this.resources.uMaskTexture = sprite.texture.source;
+    }
+
     set inverse(value: boolean)
     {
         this.resources.filterUniforms.uniforms.uInverse = value ? 1 : 0;
@@ -122,5 +137,13 @@ export class MaskFilter extends Filter
         this.resources.uMaskTexture = this.sprite.texture.source;
 
         filterManager.applyFilter(this, input, output, clearMode);
+    }
+
+    public destroy(destroyPrograms = false): void
+    {
+        // the texture matrix subscribes to its texture outside the bind-group resource
+        // system, so the base destroy would leave that `update` listener behind
+        this._textureMatrix.destroy();
+        super.destroy(destroyPrograms);
     }
 }

--- a/src/rendering/mask/alpha/AlphaMaskPipe.ts
+++ b/src/rendering/mask/alpha/AlphaMaskPipe.ts
@@ -27,12 +27,15 @@ const tempBounds = new Bounds();
 /** @internal */
 class AlphaMaskEffect extends FilterEffect implements PoolItem
 {
+    /** the sprite the pooled filter is parked on between uses */
+    private readonly _placeholderSprite = new Sprite(Texture.EMPTY);
+
     constructor()
     {
         super();
 
         this.filters = [new MaskFilter({
-            sprite: new Sprite(Texture.EMPTY),
+            sprite: this._placeholderSprite,
             inverse: false,
             resolution: 'inherit',
             antialias: 'inherit'
@@ -46,7 +49,7 @@ class AlphaMaskEffect extends FilterEffect implements PoolItem
 
     set sprite(value: Sprite)
     {
-        (this.filters[0] as MaskFilter).sprite = value;
+        (this.filters[0] as MaskFilter).setSprite(value);
     }
 
     get inverse(): boolean
@@ -67,6 +70,19 @@ class AlphaMaskEffect extends FilterEffect implements PoolItem
     set channel(value: MaskChannel)
     {
         (this.filters[0] as MaskFilter).channel = value;
+    }
+
+    /**
+     * Called by {@link BigPool} when the pipe returns the effect: parks the filter
+     * on the empty placeholder so a pooled effect keeps no bindings to the last
+     * mask it applied. Without this, the pooled filter pins the mask sprite and
+     * its texture for as long as the effect sits in the pool, and destroying that
+     * texture's source hits a bind group subscription the user cannot release.
+     */
+    public reset(): void
+    {
+        this._placeholderSprite.texture = Texture.EMPTY;
+        this.sprite = this._placeholderSprite;
     }
 
     public init: () => void;

--- a/src/rendering/mask/alpha/__tests__/AlphaMaskPipe.test.ts
+++ b/src/rendering/mask/alpha/__tests__/AlphaMaskPipe.test.ts
@@ -1,0 +1,123 @@
+import { getWebGLRenderer } from '@test-utils';
+import { Texture, TextureSource } from '~/rendering';
+import { Container, Sprite } from '~/scene';
+import { BigPool } from '~/utils/pool/PoolGroup';
+
+describe('AlphaMaskPipe', () =>
+{
+    it('should release the mask bindings when the pooled effect returns to the pool', async () =>
+    {
+        const returned: any[] = [];
+        const originalReturn = BigPool.return;
+
+        (BigPool as any).return = function poolReturn(item: any)
+        {
+            originalReturn.call(this, item);
+
+            if (item.constructor.name === 'AlphaMaskEffect')
+            {
+                returned.push(item);
+            }
+        };
+
+        const renderer = await getWebGLRenderer();
+
+        const stage = new Container();
+        const content = new Sprite(Texture.WHITE);
+        const maskTexture = new Texture({ source: new TextureSource({ width: 16, height: 16 }) });
+        const mask = new Sprite(maskTexture);
+
+        stage.addChild(content, mask);
+        content.mask = mask;
+
+        try
+        {
+            renderer.render(stage);
+        }
+        finally
+        {
+            (BigPool as any).return = originalReturn;
+        }
+
+        expect(returned).toHaveLength(1);
+
+        const effect = returned[0];
+
+        // parked on the placeholder — the pooled effect must not pin the last mask
+        expect(effect.sprite).not.toBe(mask);
+        expect(effect.sprite.texture).toBe(Texture.EMPTY);
+        expect(effect.filters[0].resources.uMaskTexture).toBe(Texture.EMPTY.source);
+
+        // and the bind group's 'change' subscription must have left the mask texture
+        const maskSource = maskTexture.source as any;
+        const changeListeners = maskSource.listeners('change').map((fn: any) => fn.name);
+
+        expect(changeListeners).not.toContain('onResourceChange');
+
+        renderer.destroy();
+    });
+
+    it('should survive destroying a texture source that was used as a sprite mask', async () =>
+    {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        const renderer = await getWebGLRenderer();
+
+        const stage = new Container();
+        const content = new Sprite(Texture.WHITE);
+        const maskTexture = new Texture({ source: new TextureSource({ width: 16, height: 16 }) });
+        const mask = new Sprite(maskTexture);
+
+        stage.addChild(content, mask);
+        content.mask = mask;
+
+        // the pooled AlphaMaskEffect applies maskTexture and goes back to the pool
+        renderer.render(stage);
+
+        // fully release the mask, then destroy its texture — nothing of pixi's
+        // may still be subscribed to the destroyed source
+        content.mask = null;
+        stage.removeChild(mask);
+        mask.destroy();
+        maskTexture.destroy(true);
+
+        // the next sprite-mask render pulls the pooled effect again
+        const nextMask = new Sprite(Texture.WHITE);
+
+        stage.addChild(nextMask);
+        content.mask = nextMask;
+
+        expect(() => renderer.render(stage)).not.toThrow();
+
+        const bindGroupWarnings = warnSpy.mock.calls.filter((call) => call.join(' ').includes('[BindGroup]'));
+
+        expect(bindGroupWarnings).toHaveLength(0);
+
+        warnSpy.mockRestore();
+        renderer.destroy();
+    });
+
+    it('should not leave listeners on Texture.EMPTY after pooled effects are destroyed', async () =>
+    {
+        // reap effects parked by earlier tests, then measure the clean baseline
+        BigPool.clear();
+
+        const listenersBefore = Texture.EMPTY.listenerCount('update');
+
+        const renderer = await getWebGLRenderer();
+
+        const stage = new Container();
+        const content = new Sprite(Texture.WHITE);
+        const mask = new Sprite(Texture.WHITE);
+
+        stage.addChild(content, mask);
+        content.mask = mask;
+
+        renderer.render(stage);
+
+        // true -> GlobalResourceRegistry.release() -> BigPool.clear() destroys the parked effect
+        renderer.destroy(true);
+
+        expect(Texture.EMPTY.listenerCount('update')).toBe(listenersBefore);
+    });
+});

--- a/src/rendering/renderers/shared/texture/TextureMatrix.ts
+++ b/src/rendering/renderers/shared/texture/TextureMatrix.ts
@@ -118,6 +118,13 @@ export class TextureMatrix
         this.update();
     }
 
+    /** Releases the observed texture, removing the `update` listener from it. */
+    public destroy(): void
+    {
+        this._texture?.removeListener('update', this.update, this);
+        this._texture = null;
+    }
+
     /**
      * Multiplies uvs array to transform
      * @param uvs - mesh uvs


### PR DESCRIPTION
##### Description of change

**TL;DR:** Add the `reset()` pool hook to `AlphaMaskEffect` so that, when an effect is returned to `BigPool`, it releases all bindings to the mask it previously used.

This fixes the pooled-effect memory leak described in #11847. On the released 8.19.x line, it also prevents a permanently frozen canvas after destroying a texture that had previously been used as a sprite mask (#11994, #12072).

## The problem

When `AlphaMaskPipe` finishes rendering a sprite mask, it returns its `AlphaMaskEffect` to `BigPool` without resetting it.

As a result, while the effect is idle in the pool, its internal `MaskFilter` still holds references to:

* the last mask `Sprite` and its `Texture`;
* an update listener on that texture, through the filter's `TextureMatrix`;
* a change subscription on the texture's `TextureSource`, through the filter's bind group.

A pooled effect should not retain user-owned objects, but currently it does.

This causes two problems.

### 1. Memory leak

The pooled effect keeps the last mask sprite and its texture alive until another sprite-mask render happens to reuse and rebind that effect.

### 2. Destroying the mask texture can leave an invalid internal binding

Consider the normal cleanup sequence:

```ts
container.mask = null;
mask.destroy();
maskTexture.destroy(true);
```

Even after the mask is detached and destroyed, the pooled effect is still subscribed to its texture source.

On released 8.19.0, `BindGroup.onResourceChange` reacts to the destroyed source by destroying the entire bind group (`resources = null`).

The next sprite-mask render then retrieves that broken effect from the pool and throws:

```text
TypeError: Cannot read properties of null (reading '0')
```

The exception occurs in `BindGroup.getResource` when the pipe sets `filterEffect.inverse`. It escapes into the `requestAnimationFrame` callback, so the ticker never schedules another frame and the canvas remains permanently frozen.

We hit this in production: a texture that had previously been used as a sprite mask was unloaded during the session, and the next masked render froze the app on a black screen.

On current `dev`, the bind group no longer destroys itself, so the crash is gone. However, destroying the texture still logs:

```text
[BindGroup] a 'textureSource' was destroyed while still bound to a shader.
Remove it from the shader before destroying it.
```

The shader is the `MaskFilter` inside the pooled `AlphaMaskEffect`. This is an internal, non-exported object, so the warning asks the user to remove a binding that only PixiJS can access.

## The fix

`Pool.return()` already calls `item.reset?.()` for every returned item. This PR implements that hook for `AlphaMaskEffect`.

* Each effect already creates an empty sprite in its constructor. `reset()` restores the filter to this placeholder, so a pooled effect no longer references user-owned objects.
* `MaskFilter` gets a `setSprite(sprite)` method that moves both texture listeners — the `TextureMatrix` update listener and the bind group's change listener — to the new sprite's texture.
* The `AlphaMaskEffect.sprite` setter now uses `setSprite()`.
* `MaskFilter` also gets a `destroy()` override, backed by a new small `TextureMatrix.destroy()`, that removes the texture-matrix update listener. Without it, destroying a parked pooled effect (for example `renderer.destroy(true)`, which clears `BigPool`) would leave that listener permanently attached to the shared `Texture.EMPTY` — its `destroy` is a no-op, so such listeners could only accumulate.

This is the same rebinding that `apply()` already performs when the effect is used. The difference is that it now also happens when the effect is returned to the pool, releasing the old texture immediately instead of waiting for the next `apply()`.

**Cost:** two listener swaps each time an effect returns to the pool, i.e. once per mask per frame. This is comparable to the work already done by `apply()`. There are no additional allocations: the placeholder sprite is created once per pooled effect.

### Side note

In the render-to-texture path, the pipe assigns:

```ts
sprite.texture = filterTexture;
```

to whichever sprite the effect currently holds.

Before this change, that could still be the previous user's mask sprite. After `reset()`, it is always the effect's own placeholder sprite.

## Related issues

Closes #11847, which specifically asks for this `reset()` hook.

It also fixes the frozen-canvas crash behind #11994 and #12072 on the 8.19.x line, and removes the remaining symptom on `dev`: the spurious bind-group warning.

#12072 also demonstrates a second, unrelated case — rendering a sprite whose texture was unloaded and never replaced. That case is not addressed by this PR.

## Reproduction

```ts
const content = new Sprite(Texture.WHITE);
const mask = new Sprite(maskTexture);

stage.addChild(content, mask);
content.mask = mask;

renderer.render(stage);
// pooled AlphaMaskEffect is now bound to maskTexture

content.mask = null;
stage.removeChild(mask);
mask.destroy();
maskTexture.destroy(true);

content.mask = new Sprite(Texture.WHITE);
renderer.render(stage);
// 8.19.0: TypeError + frozen canvas
// dev: spurious BindGroup warning
```

I verified this in a browser against the stock 8.19.0 build. Without the fix, the second render throws the `TypeError` above. With reset-on-return applied, it renders normally.

## Tests

The two unit tests added in this PR fail on current `dev` without the fix:

* **should release the mask bindings when the pooled effect returns to the pool**
  Without the fix, the pooled effect still references the user's mask sprite, and the mask's `TextureSource` still contains the bind group's `onResourceChange` listener.

* **should survive destroying a texture source that was used as a sprite mask**
  Without the fix, destroying the source triggers the `[BindGroup] ... destroyed while still bound to a shader` warning.

* **should not leave listeners on Texture.EMPTY after pooled effects are destroyed**
  Without the `destroy()` override, every destroyed pooled effect leaves one update listener on `Texture.EMPTY`.

The full unit test suite, the three `tsc --noEmit` type checks (build, examples, playground configs), and ESLint pass.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
