### PR TITLE
fix: apply render group world color and alpha to ParticleContainer

### DIFF
--- a/src/scene/particle-container/shared/ParticleContainerPipe.ts
+++ b/src/scene/particle-container/shared/ParticleContainerPipe.ts
@@ -4,6 +4,7 @@ import { UniformGroup } from '../../../rendering/renderers/shared/shader/Uniform
 import { getAdjustedBlendModeBlend } from '../../../rendering/renderers/shared/state/getAdjustedBlendModeBlend';
 import { State } from '../../../rendering/renderers/shared/state/State';
 import { GCManagedHash } from '../../../utils/data/GCManagedHash';
+import { multiplyHexColors } from '../../container/utils/multiplyHexColors';
 import { color32BitToUniform } from '../../graphics/gpu/colorToUniform';
 import { ParticleBuffer } from './ParticleBuffer';
 import { ParticleShader } from './shader/ParticleShader';
@@ -143,8 +144,17 @@ export class ParticleContainerPipe implements RenderPipe<ParticleContainer>
         uniforms.uResolution = globalUniformData.resolution;
         uniforms.uRound = renderer._roundPixels | container._roundPixels;
 
+        // The particle shader has no uWorldColorAlpha, so the render group's world
+        // color/alpha has to be composed into uColor here. Without this, particles
+        // ignore the tint and alpha of any ancestor render group.
+        const groupColorAlpha = container.groupColorAlpha;
+        const worldColorAlpha = globalUniformData.worldColor;
+
+        const alpha = (((groupColorAlpha >>> 24) * (worldColorAlpha >>> 24)) / 255) | 0;
+        const bgr = multiplyHexColors(groupColorAlpha & 0xFFFFFF, worldColorAlpha & 0xFFFFFF);
+
         color32BitToUniform(
-            container.groupColorAlpha,
+            ((alpha << 24) | bgr) >>> 0,
             uniforms.uColor,
             0
         );

--- a/src/scene/particle-container/shared/__tests__/ParticleContainerWorldColor.test.ts
+++ b/src/scene/particle-container/shared/__tests__/ParticleContainerWorldColor.test.ts
@@ -1,0 +1,62 @@
+import { ParticleContainer } from '../ParticleContainer';
+import { getWebGLRenderer } from '@test-utils';
+import { Texture } from '~/rendering';
+import { Container, Particle } from '~/scene';
+
+describe('ParticleContainer world color and alpha', () =>
+{
+    const renderWithAncestor = async (apply: (root: Container) => void) =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        const root = new Container({ isRenderGroup: true });
+        const inner = new Container({ isRenderGroup: true });
+        const particles = new ParticleContainer({ texture: Texture.WHITE });
+
+        particles.addParticle(new Particle({ texture: Texture.WHITE }));
+        inner.addChild(particles);
+        root.addChild(inner);
+
+        apply(root);
+
+        renderer.render(root);
+
+        return (renderer.renderPipes as unknown as {
+            particle: { localUniforms: { uniforms: { uColor: Float32Array } } };
+        }).particle.localUniforms.uniforms.uColor;
+    };
+
+    it('should apply the alpha of an ancestor render group', async () =>
+    {
+        const uColor = await renderWithAncestor((root) =>
+        {
+            root.alpha = 0.5;
+        });
+
+        expect(uColor[3]).toBeCloseTo(0.5, 2);
+    });
+
+    it('should apply the tint of an ancestor render group', async () =>
+    {
+        const uColor = await renderWithAncestor((root) =>
+        {
+            root.tint = 0xff0000;
+        });
+
+        // premultiplied red: green and blue are removed
+        expect(uColor[0]).toBeCloseTo(1, 2);
+        expect(uColor[1]).toBeCloseTo(0, 2);
+        expect(uColor[2]).toBeCloseTo(0, 2);
+        expect(uColor[3]).toBeCloseTo(1, 2);
+    });
+
+    it('should leave the color untouched when no ancestor tint or alpha is set', async () =>
+    {
+        const uColor = await renderWithAncestor(() => { /* no ancestor color */ });
+
+        expect(uColor[0]).toBeCloseTo(1, 2);
+        expect(uColor[1]).toBeCloseTo(1, 2);
+        expect(uColor[2]).toBeCloseTo(1, 2);
+        expect(uColor[3]).toBeCloseTo(1, 2);
+    });
+});


### PR DESCRIPTION
## Description

`ParticleContainer` ignores the world color and alpha of its `RenderGroup`, so particles do not fade or tint with an ancestor's alpha while every other display object does (#12127).

Unlike the other pipes, the particle shader has no `uWorldColorAlpha` uniform — `particles.vert` computes `vColor = vec4(aColor.rgb * aColor.a, aColor.a) * uColor`. `ParticleContainerPipe.execute` wrote only `container.groupColorAlpha` into `uColor`, so the render group's world color never reached the shader.

Confirmed locally before fixing: with an ancestor render group at `alpha = 0.5`, `uColor[3]` was `1.0`; with this change it is `0.5`.

## Changes

- `src/scene/particle-container/shared/ParticleContainerPipe.ts`: compose `globalUniformData.worldColor` into `uColor`, multiplying the alpha channels and the BGR channels separately (reusing the existing `multiplyHexColors` helper).
- `src/scene/particle-container/shared/__tests__/ParticleContainerWorldColor.test.ts`: new regression tests for an ancestor render group's alpha, an ancestor tint, and the unchanged no-ancestor-color case.

## Testing

- `npx jest --config .configs/jest.config.js --testPathPattern "ParticleContainer"` — 10/10 pass.
- `--testPathPattern "src/scene"` — 81 suites, 997 tests pass.
- Full suite: 1921 pass. The one failing suite (`tests/visual/visuals.test.ts`, html-text-stroke snapshots) fails identically on a clean `dev` checkout with these changes stashed, so it is pre-existing and unrelated.
- `eslint` clean on both changed files.

Fixes #12127
