### PR TITLE
fix: align Polygon.strokeContains with the drawn stroke

### DIFF
--- a/src/maths/__tests__/Polygon.test.ts
+++ b/src/maths/__tests__/Polygon.test.ts
@@ -127,6 +127,7 @@ describe('Polygon', () =>
         {
             expect(polygon.strokeContains(-3, -3, 2)).toBe(false);
             expect(polygon.strokeContains(15, 0, 4)).toBe(false);
+            expect(polygon.strokeContains(0, 12, 3)).toBe(false);
             expect(polygon.strokeContains(0, 13, 3)).toBe(false);
         });
 
@@ -148,6 +149,48 @@ describe('Polygon', () =>
             expect(polygonClosePathFalse.strokeContains(0, 3, 1)).toBe(false);
             expect(polygonClosePathFalse.strokeContains(0, 5, 1)).toBe(false);
             expect(polygonClosePathFalse.strokeContains(0, 7, 1)).toBe(false);
+        });
+
+        describe('alignment', () =>
+        {
+            // the same square wound both ways, so the stroke has to land on the same side of
+            // the left edge (x = 0) in both cases
+            const clockwise: Polygon = new Polygon([0, 0, 100, 0, 100, 100, 0, 100]);
+            const counterClockwise: Polygon = new Polygon([0, 0, 0, 100, 100, 100, 100, 0]);
+            const polygons = [clockwise, counterClockwise];
+
+            test('centers the stroke on the edge by default', () =>
+            {
+                for (const polygon of polygons)
+                {
+                    expect(polygon.strokeContains(-10, 50, 20)).toBe(true);
+                    expect(polygon.strokeContains(10, 50, 20)).toBe(true);
+                    expect(polygon.strokeContains(-11, 50, 20)).toBe(false);
+                    expect(polygon.strokeContains(11, 50, 20)).toBe(false);
+                }
+            });
+
+            test('puts the stroke outside the polygon with alignment 0', () =>
+            {
+                for (const polygon of polygons)
+                {
+                    expect(polygon.strokeContains(-20, 50, 20, 0)).toBe(true);
+                    expect(polygon.strokeContains(-1, 50, 20, 0)).toBe(true);
+                    expect(polygon.strokeContains(-21, 50, 20, 0)).toBe(false);
+                    expect(polygon.strokeContains(1, 50, 20, 0)).toBe(false);
+                }
+            });
+
+            test('puts the stroke inside the polygon with alignment 1', () =>
+            {
+                for (const polygon of polygons)
+                {
+                    expect(polygon.strokeContains(20, 50, 20, 1)).toBe(true);
+                    expect(polygon.strokeContains(1, 50, 20, 1)).toBe(true);
+                    expect(polygon.strokeContains(21, 50, 20, 1)).toBe(false);
+                    expect(polygon.strokeContains(-1, 50, 20, 1)).toBe(false);
+                }
+            });
         });
 
         // Add additional tests as necessary

--- a/src/maths/index.ts
+++ b/src/maths/index.ts
@@ -2,6 +2,7 @@
 export * from './matrix/groupD8';
 export * from './matrix/Matrix';
 export * from './misc/const';
+export * from './misc/getOrientationOfPoints';
 export * from './misc/pow2';
 export * from './misc/Size';
 export * from './misc/squaredDistanceToLineSegment';

--- a/src/maths/misc/getOrientationOfPoints.ts
+++ b/src/maths/misc/getOrientationOfPoints.ts
@@ -1,5 +1,8 @@
 /**
- * @param points
+ * Determines the winding order of a polygon's points.
+ * @param points - Flat array of point coordinates [x1, y1, x2, y2, ...]
+ * @returns 1 for clockwise, -1 for counter-clockwise winding
+ * @category maths
  * @internal
  */
 export function getOrientationOfPoints(points: number[]): number

--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -1,3 +1,4 @@
+import { getOrientationOfPoints } from '../../scene/graphics/shared/utils/getOrientationOfPoints';
 import { deprecation } from '../../utils/logging/deprecation';
 import { squaredDistanceToLineSegment } from '../misc/squaredDistanceToLineSegment';
 import { Rectangle } from './Rectangle';
@@ -315,11 +316,17 @@ export class Polygon implements ShapePrimitive
      */
     public strokeContains(x: number, y: number, strokeWidth: number, alignment = 0.5): boolean
     {
-        const strokeWidthSquared = strokeWidth * strokeWidth;
-        const rightWidthSquared = strokeWidthSquared * (1 - alignment);
-        const leftWidthSquared = strokeWidthSquared - rightWidthSquared;
-
         const { points } = this;
+
+        // the stroke is built with the alignment flipped by the winding order, so the hit
+        // area has to flip with it to stay on the same side of the edge as the drawn line
+        const alignedByWinding = ((alignment - 0.5) * getOrientationOfPoints(points)) + 0.5;
+
+        const outerWidth = strokeWidth * alignedByWinding;
+        const innerWidth = strokeWidth - outerWidth;
+        const outerWidthSquared = outerWidth * outerWidth;
+        const innerWidthSquared = innerWidth * innerWidth;
+
         const iterationLength = points.length - (this.closePath ? 0 : 2);
 
         for (let i = 0; i < iterationLength; i += 2)
@@ -333,7 +340,7 @@ export class Polygon implements ShapePrimitive
 
             const sign = Math.sign(((x2 - x1) * (y - y1)) - ((y2 - y1) * (x - x1)));
 
-            if (distanceSquared <= (sign < 0 ? leftWidthSquared : rightWidthSquared))
+            if (distanceSquared <= (sign < 0 ? outerWidthSquared : innerWidthSquared))
             {
                 return true;
             }

--- a/src/maths/shapes/Polygon.ts
+++ b/src/maths/shapes/Polygon.ts
@@ -1,5 +1,5 @@
-import { getOrientationOfPoints } from '../../scene/graphics/shared/utils/getOrientationOfPoints';
 import { deprecation } from '../../utils/logging/deprecation';
+import { getOrientationOfPoints } from '../misc/getOrientationOfPoints';
 import { squaredDistanceToLineSegment } from '../misc/squaredDistanceToLineSegment';
 import { Rectangle } from './Rectangle';
 
@@ -320,7 +320,9 @@ export class Polygon implements ShapePrimitive
 
         // the stroke is built with the alignment flipped by the winding order, so the hit
         // area has to flip with it to stay on the same side of the edge as the drawn line
-        const alignedByWinding = ((alignment - 0.5) * getOrientationOfPoints(points)) + 0.5;
+        const alignedByWinding = alignment === 0.5
+            ? alignment
+            : ((alignment - 0.5) * getOrientationOfPoints(points)) + 0.5;
 
         const outerWidth = strokeWidth * alignedByWinding;
         const innerWidth = strokeWidth - outerWidth;

--- a/src/scene/graphics/shared/buildCommands/buildLine.ts
+++ b/src/scene/graphics/shared/buildCommands/buildLine.ts
@@ -1,6 +1,6 @@
+import { getOrientationOfPoints } from '../../../../maths/misc/getOrientationOfPoints';
 import { Point } from '../../../../maths/point/Point';
 import { closePointEps, curveEps } from '../const';
-import { getOrientationOfPoints } from '../utils/getOrientationOfPoints';
 
 import type { StrokeAttributes } from '../FillTypes';
 

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -83,7 +83,6 @@ export * from './graphics/shared/utils/buildGeometryFromPath';
 export * from './graphics/shared/utils/convertFillInputToFillStyle';
 export * from './graphics/shared/utils/generateTextureFillMatrix';
 export * from './graphics/shared/utils/getMaxMiterRatio';
-export * from './graphics/shared/utils/getOrientationOfPoints';
 export * from './graphics/shared/utils/triangulateWithHoles';
 export * from './layers/RenderLayer';
 export * from './mesh-perspective/PerspectiveMesh';


### PR DESCRIPTION
### Overview

`Polygon.strokeContains` split the stroke width by alignment on the *squared* width, and ignored winding order, so hit areas on stroked polygons didn't match the line `buildLine` draws: at the default alignment the hit area was 41% wider than the stroke, and at alignment 0/1 on a clockwise polygon it sat on the opposite side of the edge entirely. The hit test now splits the width linearly (like every other shape) and applies the same winding flip as the renderer, so it matches the drawn stroke for every alignment and either winding. Measured on the square `[0, 0, 100, 0, 100, 100, 0, 100]` with `width: 20` at `y = 50`:

| alignment | drawn stroke | hit area (before) | hit area (after) |
| --- | --- | --- | --- |
| 0 | -20 … 0 | 0 … 20 | -20 … 0 |
| 0.5 | -10 … 10 | -14.1 … 14.1 | -10 … 10 |
| 1 | 0 … 20 | -20 … 0 | 0 … 20 |

#### Breaking Changes / Behavior Changes

- Hit-testing stroked polygons (`Polygon.strokeContains`, `Graphics.containsPoint`, pointer events on stroked `Graphics`) now matches the drawn stroke; points visually outside the line no longer register as hits, and non-centred alignments select the correct side of the edge

```ts
const graphics = new Graphics()
    .poly([0, 0, 100, 0, 100, 100, 0, 100], true)
    .stroke({ width: 20, alignment: 0 });

graphics.containsPoint({ x: -10, y: 50 }); // now true - inside the drawn stroke
graphics.containsPoint({ x: 10, y: 50 });  // now false - nothing is drawn there
```

#### Fixes

- `Polygon.strokeContains` splits the stroke width linearly by `alignment` (matching `Rectangle`, `Circle`, `Ellipse` and `RoundedRectangle`) instead of splitting the squared width
- `Polygon.strokeContains` accounts for the polygon's winding order, matching the side of the edge the stroke is drawn on

#### Chores

- Moved `getOrientationOfPoints` from `src/scene/graphics/shared/utils` to `src/maths/misc` so `maths` no longer imports from `scene`
- Skipped the winding-order computation at the default `alignment` of `0.5`, where it has no effect

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added