### PR TITLE
fix: unregister GraphicsContext listeners on destroy

### DIFF
--- a/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
+++ b/src/scene/graphics/__tests__/Graphics.Destroy.test.ts
@@ -103,6 +103,21 @@ describe('Graphics Destroy', () =>
         expect(spy).toHaveBeenCalled();
     });
 
+    it('should unregister from its own context when the context is preserved', () =>
+    {
+        const graphics = new Graphics();
+        const context = graphics.context;
+
+        expect(context.listenerCount('update')).toBe(1);
+        expect(context.listenerCount('unload')).toBe(1);
+
+        graphics.destroy({ context: false });
+
+        expect(context.destroyed).toBe(false);
+        expect(context.listenerCount('update')).toBe(0);
+        expect(context.listenerCount('unload')).toBe(0);
+    });
+
     it('should not destroy its context if its managed externally', async () =>
     {
         const context = new GraphicsContext();
@@ -114,8 +129,38 @@ describe('Graphics Destroy', () =>
 
         context.on('destroy', spy);
 
+        expect(context.listenerCount('update')).toBe(1);
+        expect(context.listenerCount('unload')).toBe(1);
+
         g.destroy();
 
         expect(spy).not.toHaveBeenCalled();
+        expect(context.listenerCount('update')).toBe(0);
+        expect(context.listenerCount('unload')).toBe(0);
+    });
+
+    it('should only unregister the destroyed graphics from a shared context', () =>
+    {
+        const context = new GraphicsContext();
+        const graphicsA = new Graphics(context);
+        const graphicsB = new Graphics(context);
+
+        expect(context.listenerCount('update')).toBe(2);
+        expect(context.listenerCount('unload')).toBe(2);
+
+        graphicsA.destroy();
+
+        expect(context.listenerCount('update')).toBe(1);
+        expect(context.listenerCount('unload')).toBe(1);
+
+        graphicsB.didViewUpdate = false;
+        context.rect(0, 0, 10, 10).fill(0xFF0000);
+
+        expect(graphicsB.didViewUpdate).toBe(true);
+
+        graphicsB.destroy();
+
+        expect(context.listenerCount('update')).toBe(0);
+        expect(context.listenerCount('unload')).toBe(0);
     });
 });

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -273,11 +273,8 @@ export class Graphics extends ViewContainer<GraphicsGpuData> implements Instruct
             this._context.destroy(options);
         }
 
-        if (this._context)
-        {
-            this._context.off('update', this.onViewUpdate, this);
-            this._context.off('unload', this.unload, this);
-        }
+        this._context?.off('update', this.onViewUpdate, this);
+        this._context?.off('unload', this.unload, this);
 
         (this._ownedContext as null) = null;
         this._context = null;

--- a/src/scene/graphics/shared/Graphics.ts
+++ b/src/scene/graphics/shared/Graphics.ts
@@ -273,6 +273,12 @@ export class Graphics extends ViewContainer<GraphicsGpuData> implements Instruct
             this._context.destroy(options);
         }
 
+        if (this._context)
+        {
+            this._context.off('update', this.onViewUpdate, this);
+            this._context.off('unload', this.unload, this);
+        }
+
         (this._ownedContext as null) = null;
         this._context = null;
 


### PR DESCRIPTION
### Overview

`Graphics` instances subscribe to their `GraphicsContext`'s `update` and `unload` events but never unsubscribed on destroy. When a context outlives a destroyed `Graphics` (shared or externally managed contexts), those subscriptions retained the destroyed instance and accumulated over time. The destroy path now removes only the destroyed instance's listeners before releasing its context reference, leaving other `Graphics` sharing the same context untouched.

Fixes #12125

#### Fixes

- Destroying a `Graphics` now unregisters its `update`/`unload` listeners from its `GraphicsContext`, so contexts that outlive the graphic (shared or externally managed) no longer retain destroyed instances or accumulate listeners

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added