### PR TITLE
fix: prevent lastTime reset when listeners trigger _requestIfNeeded during tick

### DIFF
--- a/src/ticker/Ticker.ts
+++ b/src/ticker/Ticker.ts
@@ -253,6 +253,8 @@ export class Ticker
     private _protected = false;
     /** The last time keyframe was executed. Maintains a relatively fixed interval with the previous value. */
     private _lastFrame = -1;
+    /** Whether listeners are currently being invoked within _tick. */
+    private _isRunningListeners = false;
     /**
      * Internal tick method bound to ticker instance.
      * This is because in early 2015, Function.bind
@@ -276,8 +278,9 @@ export class Ticker
 
             if (this.started)
             {
-                // Invoke listeners now
+                this._isRunningListeners = true;
                 this.update(time);
+                this._isRunningListeners = false;
                 // Listener side effects may have modified ticker state.
                 if (this.started && this._requestId === null && this._head.next)
                 {
@@ -296,9 +299,12 @@ export class Ticker
     {
         if (this._requestId === null && this._head.next)
         {
-            // ensure callbacks get correct delta
-            this.lastTime = performance.now();
-            this._lastFrame = this.lastTime;
+            if (!this._isRunningListeners)
+            {
+                // ensure callbacks get correct delta
+                this.lastTime = performance.now();
+                this._lastFrame = this.lastTime;
+            }
             this._requestId = requestAnimationFrame(this._tick);
         }
     }

--- a/src/ticker/__tests__/Ticker.test.ts
+++ b/src/ticker/__tests__/Ticker.test.ts
@@ -458,6 +458,37 @@ describe('Ticker', () =>
             ticker.start();
         }));
 
+    it('should not reset lastTime when a listener triggers _requestIfNeeded', () =>
+    {
+        const ticker = new Ticker();
+
+        ticker.start();
+        // Simulate a first tick so lastTime is set
+        ticker.update(1000);
+
+        const lastTimeBefore = ticker.lastTime;
+
+        // Listener adds another listener during emit, which calls _startIfPossible -> _requestIfNeeded
+        const innerListener = jest.fn();
+        const outerListener = jest.fn(() =>
+        {
+            ticker.add(innerListener);
+        });
+
+        ticker.add(outerListener);
+
+        // Simulate next tick
+        ticker.update(1016);
+
+        // lastTime should reflect the update time (1016), not a performance.now() reset
+        expect(ticker.lastTime).toBe(1016);
+        expect(ticker.lastTime).not.toBe(lastTimeBefore);
+
+        ticker.remove(outerListener);
+        ticker.remove(innerListener);
+        ticker.destroy();
+    });
+
     describe('minFPS / maxFPS', () =>
     {
         it('should set minFPS independently when maxFPS is unlimited (0)', () =>


### PR DESCRIPTION
##### Description of change

When a ticker listener adds another listener mid-tick (e.g., AnimatedSprite is stopped and restarted),
`_startIfPossible` calls `_requestIfNeeded` which resets `lastTime` and `_lastFrame` to `performance.now()`. This
corrupts the delta calculation for the next frame, causing consistent frame drops when maxFps is set.

**Reproduction:** https://www.pixiplayground.com/#/edit/woVEklzQkEOJdKZECLl0R

**The bug:**
1. `_tick(time)` calls `update(time)` which iterates listeners
2. A listener calls `ticker.add(fn)` -> `_startIfPossible` -> `_requestIfNeeded`
3. `_requestIfNeeded` sets `this._lastFrame = performance.now()` 
4. With `maxFPS` set, the next frame computes `delta = nextTime - _lastFrame` which is smaller than expected
5. If `delta < _minElapsedMS`, the frame is skipped entirely (early return)
6. The frame after that sees double the elapsed time, producing a deltaTime spike of ~2.0

**The fix:**
Adds an `_isRunningListeners` flag set during listener execution. `_requestIfNeeded` skips the time reset when this flag
is true, since `update()` will set `lastTime` correctly at the end of the frame.



##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
 