### PR TITLE
feat: export GPU shader layout helpers for advanced users

### DIFF
--- a/src/rendering/renderers/gpu/shader/utils/extractStructAndGroups.ts
+++ b/src/rendering/renderers/gpu/shader/utils/extractStructAndGroups.ts
@@ -27,8 +27,13 @@ export interface StructsAndGroups
 }
 
 /**
- * @param wgsl
- * @internal
+ * Parses a WGSL shader source and extracts its `@group`/`@binding` declarations and the
+ * structs they reference. The result feeds {@link generateGpuLayoutGroups} to build a
+ * WebGPU bind group layout.
+ * @param wgsl - The WGSL shader source to parse.
+ * @returns The structs and `@group`/`@binding` groups found in the source.
+ * @category rendering
+ * @advanced
  */
 export function extractStructAndGroups(wgsl: string): StructsAndGroups
 {

--- a/src/rendering/renderers/gpu/shader/utils/generateGpuLayoutGroups.ts
+++ b/src/rendering/renderers/gpu/shader/utils/generateGpuLayoutGroups.ts
@@ -4,9 +4,29 @@ import type { ProgramPipelineLayoutDescription } from '../GpuProgram';
 import type { StructsAndGroups } from './extractStructAndGroups';
 
 /**
- * @param root0
- * @param root0.groups
- * @internal
+ * Generates the default WebGPU bind group layout for a shader from its extracted structs and groups.
+ * Every binding is marked visible to both the vertex and fragment stages
+ * (`GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT`).
+ *
+ * This is the same generator {@link GpuProgram} uses internally when no `gpuLayout` is supplied.
+ * It is exported so you can build the default layout, tweak only the entries you care about
+ * (for example narrowing a binding's `visibility` to a single stage), and pass the complete
+ * result back in via the `gpuLayout` option - rather than hand-authoring the whole layout:
+ * @example
+ * import { extractStructAndGroups, generateGpuLayoutGroups, GpuProgram } from 'pixi.js';
+ *
+ * const gpuLayout = generateGpuLayoutGroups(extractStructAndGroups(source));
+ *
+ * // only expose this texture to the fragment stage
+ * gpuLayout[0][1].visibility = GPUShaderStage.FRAGMENT;
+ *
+ * const program = new GpuProgram({ vertex, fragment, gpuLayout });
+ * @param root0 - The structs and groups extracted from the shader source, typically produced by
+ * {@link extractStructAndGroups}.
+ * @param root0.groups - The `@group`/`@binding` entries parsed from the WGSL source.
+ * @returns The generated bind group layout description, one entry array per bind group.
+ * @category rendering
+ * @advanced
  */
 export function generateGpuLayoutGroups({ groups }: StructsAndGroups): ProgramPipelineLayoutDescription
 {


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Removes `@internal` from `extractStructAndGroups` and `generateGpuLayoutGroups` so they are part of the public API.

These are the same helpers `GpuProgram` uses to build a default WebGPU bind group layout. Exporting them lets advanced shader users generate that default layout, tweak only the entries they care about (for example narrowing a binding's `visibility` to a single stage), and pass the result back in via `gpuLayout` — rather than hand-authoring the whole layout.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Made with [Cursor](https://cursor.com)