### PR TITLE
fix: stop Geometry.destroy from double-freeing the index buffer

### DIFF
--- a/src/rendering/renderers/__tests__/Geometry.test.ts
+++ b/src/rendering/renderers/__tests__/Geometry.test.ts
@@ -62,6 +62,50 @@ describe('Geometry', () =>
         expect(buffer.data).toBeNull();
     });
 
+    it('should not destroy the index buffer when destroyBuffers is false', () =>
+    {
+        const indexBuffer = new Buffer({
+            data: new Uint16Array([0, 1, 2]),
+            usage: BufferUsage.INDEX,
+        });
+        const destroySpy = jest.spyOn(indexBuffer, 'destroy');
+
+        const geometry = new Geometry({
+            attributes: {
+                aPosition: [0, 0, 1, 0, 1, 1],
+            },
+            indexBuffer,
+        });
+
+        geometry.destroy(false);
+
+        expect(destroySpy).not.toHaveBeenCalled();
+        expect(indexBuffer.destroyed).toBe(false);
+        expect(indexBuffer.data).not.toBeNull();
+    });
+
+    it('should destroy the index buffer only once when destroyBuffers is true', () =>
+    {
+        const indexBuffer = new Buffer({
+            data: new Uint16Array([0, 1, 2]),
+            usage: BufferUsage.INDEX,
+        });
+        const destroySpy = jest.spyOn(indexBuffer, 'destroy');
+
+        const geometry = new Geometry({
+            attributes: {
+                aPosition: [0, 0, 1, 0, 1, 1],
+            },
+            indexBuffer,
+        });
+
+        geometry.destroy(true);
+
+        expect(destroySpy).toHaveBeenCalledTimes(1);
+        expect(indexBuffer.destroyed).toBe(true);
+        expect(indexBuffer.data).toBeNull();
+    });
+
     it('should set a cast data correctly', () =>
     {
         const buffer = new Buffer({

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -360,7 +360,6 @@ export class Geometry extends EventEmitter<{
 
         this.unload();
 
-        this.indexBuffer?.destroy();
         (this.attributes as null) = null;
         (this.buffers as null) = null;
         (this.indexBuffer as null) = null;


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

`Geometry.addIndex` already pushes the index buffer into `this.buffers`, but `destroy` then called `this.indexBuffer?.destroy()` unconditionally.

That meant:
- `destroy(true)` destroyed the index buffer twice
- `destroy(false)` destroyed it anyway, which is the opposite of what the flag says

The extra destroy call is removed so the index buffer follows `destroyBuffers` like every other buffer. Tests cover both `destroy(false)` (index buffer left intact) and `destroy(true)` (destroyed once).

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)

Made with [Cursor](https://cursor.com)