### PR TITLE
fix: rebuild cached bind groups when the GC unloads uniform buffers (WebGPU)

### DIFF
--- a/src/rendering/renderers/__tests__/BindGroup.test.ts
+++ b/src/rendering/renderers/__tests__/BindGroup.test.ts
@@ -112,6 +112,87 @@ describe('BindGroup', () =>
         expect(bindGroupKey).not.toBe(bindGroup._key);
     });
 
+    it('should let a BindGroup know when a buffer is unloaded', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array(100),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const bindGroup = new BindGroup({
+            0: buffer,
+        });
+
+        const bindGroupKey = bindGroup._key;
+
+        buffer.unload();
+
+        expect(bindGroup._key).not.toBe(bindGroupKey);
+    });
+
+    it('should re-key when the buffer behind a uniform group is unloaded', () =>
+    {
+        const uniformGroup = new UniformGroup({
+            test: { value: 1, type: 'f32' },
+        });
+
+        const buffer = new Buffer({
+            data: new Float32Array(16),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        uniformGroup.buffer = buffer;
+
+        const bindGroup = new BindGroup({
+            0: uniformGroup,
+        });
+
+        const bindGroupKey = bindGroup._key;
+
+        buffer.unload();
+
+        expect(bindGroup._key).not.toBe(bindGroupKey);
+    });
+
+    it('_touch should stamp the buffers behind uniform groups and buffer resources', () =>
+    {
+        const uniformGroup = new UniformGroup({
+            test: { value: 1, type: 'f32' },
+        });
+
+        const groupBuffer = new Buffer({
+            data: new Float32Array(16),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        uniformGroup.buffer = groupBuffer;
+
+        const buffer = new Buffer({
+            data: new Float32Array(64),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const bufferResource = new BufferResource({
+            buffer,
+            offset: 0,
+            size: 128,
+        });
+
+        const bindGroup = new BindGroup({
+            0: uniformGroup,
+            1: bufferResource,
+        });
+
+        bindGroup._touch(123, 7);
+
+        expect(groupBuffer._gcLastUsed).toBe(123);
+        expect(buffer._gcLastUsed).toBe(123);
+
+        // the proxies delegate their own stamp straight through to the buffer
+        expect(uniformGroup._gcLastUsed).toBe(123);
+        expect(bufferResource._gcLastUsed).toBe(123);
+    });
+
     it('should let have a unique id for a bind group, no clashes', () =>
     {
         resetUids();

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -1,7 +1,6 @@
 import { ExtensionType } from '../../../../extensions/Extensions';
 import { type GPUData } from '../../../../scene/view/ViewContainer';
 import { GCManagedHash } from '../../../../utils/data/GCManagedHash';
-import { uid } from '../../../../utils/data/uid';
 import { fastCopy } from '../../shared/buffer/utils/fastCopy';
 
 import type { Buffer } from '../../shared/buffer/Buffer';
@@ -112,7 +111,6 @@ export class GpuBufferSystem implements System
         const gpuBuffer = this._gpu.device.createBuffer(buffer.descriptor);
 
         buffer._updateID = 0;
-        buffer._resourceId = uid('resource');
 
         if (buffer.data)
         {

--- a/src/rendering/renderers/shared/buffer/Buffer.ts
+++ b/src/rendering/renderers/shared/buffer/Buffer.ts
@@ -99,7 +99,7 @@ export class Buffer extends EventEmitter<{
 }> implements BindResource, GPUDataOwner, GCable
 {
     /**
-     * emits when the underlying buffer has changed shape (i.e. resized)
+     * emits when the underlying buffer has changed shape (i.e. resized) or been unloaded,
      * letting the renderer know that it needs to discard the old buffer on the GPU and create a new one
      * @event change
      */
@@ -327,6 +327,17 @@ export class Buffer extends EventEmitter<{
             this._gpuData[key]?.destroy();
         }
         this._gpuData = Object.create(null);
+
+        // re-key so cached bind groups referencing the destroyed GPU buffer rebuild on next
+        // use. This must happen after 'unload' — the buffer systems detach their 'change'
+        // listeners there, so this emit reaches only bind groups / buffer resources and the
+        // GPU buffer is recreated lazily rather than eagerly right after being freed.
+        // destroy() emits its own 'change', so skip re-keying on that path.
+        if (!this.destroyed)
+        {
+            this._resourceId = uid('resource');
+            this.emit('change', this);
+        }
     }
 
     /** Destroys the buffer */

--- a/src/rendering/renderers/shared/buffer/BufferResource.ts
+++ b/src/rendering/renderers/shared/buffer/BufferResource.ts
@@ -94,6 +94,22 @@ export class BufferResource extends EventEmitter<{
         this.buffer.on('change', this.onBufferChange, this);
     }
 
+    /**
+     * The GC tracks the underlying buffer, not this resource — a GC stamp here (see
+     * BindGroup._touch) must land on the buffer, or the GC collects it while cached
+     * bind groups still reference it.
+     * @internal
+     */
+    get _gcLastUsed(): number
+    {
+        return this.buffer?._gcLastUsed ?? -1;
+    }
+
+    set _gcLastUsed(value: number)
+    {
+        if (this.buffer) this.buffer._gcLastUsed = value;
+    }
+
     protected onBufferChange(): void
     {
         this._resourceId = uid('resource');

--- a/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
+++ b/src/rendering/renderers/shared/buffer/__tests__/Buffer.test.ts
@@ -216,6 +216,62 @@ describe('Buffer', () =>
         expect(buffer._updateSize).toBe(2 * 4);
     });
 
+    it('unload should re-key the buffer and emit a change event', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const startingId = buffer._resourceId;
+        const changeObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+
+        buffer.unload();
+
+        expect(buffer._resourceId).not.toBe(startingId);
+        expect(changeObserver).toHaveBeenCalledTimes(1);
+    });
+
+    it('destroy should only emit a single change event', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        const changeObserver = jest.fn();
+
+        buffer.on('change', changeObserver);
+
+        buffer.destroy();
+
+        expect(changeObserver).toHaveBeenCalledTimes(1);
+    });
+
+    itLocalOnly('should re-add listeners when a buffer is used again after unload', async () =>
+    {
+        const renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const buffer = new Buffer({
+            data: new Float32Array([1, 2, 3]),
+            usage: 1,
+        });
+
+        renderer.buffer.updateBuffer(buffer);
+
+        expect(buffer.listenerCount('update')).toBe(1);
+
+        buffer.unload();
+
+        expect(buffer.listenerCount('update')).toBe(0);
+
+        renderer.buffer.updateBuffer(buffer);
+
+        expect(buffer.listenerCount('update')).toBe(1);
+    });
+
     itLocalOnly('should only add add listeners to buffer on first gpu init', async () =>
     {
         const renderer = (await getWebGPURenderer()) as WebGPURenderer;

--- a/src/rendering/renderers/shared/shader/UniformGroup.ts
+++ b/src/rendering/renderers/shared/shader/UniformGroup.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'eventemitter3';
 import { uid } from '../../../../utils/data/uid';
 import { createIdFromString } from '../utils/createIdFromString';
 import { UNIFORM_TYPES_MAP, UNIFORM_TYPES_VALUES, type UniformData } from './types';
@@ -85,8 +86,16 @@ export type UniformGroupOptions = {
  * @category rendering
  * @advanced
  */
-export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any> implements BindResource
+export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any> extends EventEmitter<{
+    change: BindResource,
+}> implements BindResource
 {
+    /**
+     * emits when the underlying buffer needs to be re-bound (it resized or was unloaded),
+     * letting cached bind groups know they must rebuild
+     * @event change
+     */
+
     /** The default options used by the uniform group. */
     public static defaultOptions: UniformGroupOptions = {
         /** if true the UniformGroup is handled as an Uniform buffer object. */
@@ -119,8 +128,7 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
     public uniforms: ExtractUniformObject<UNIFORMS>;
     /** true if it should be used as a uniform buffer object */
     public ubo: boolean;
-    /** an underlying buffer that will be uploaded to the GPU when using this UniformGroup */
-    public buffer?: Buffer;
+    private _buffer?: Buffer;
     /**
      * if true, then you are responsible for when the data is uploaded to the GPU.
      * otherwise, the data is reuploaded each frame.
@@ -149,6 +157,8 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
      */
     constructor(uniformStructures: UNIFORMS, options?: UniformGroupOptions)
     {
+        super();
+
         options = { ...UniformGroup.defaultOptions, ...options };
 
         this.uniformStructures = uniformStructures;
@@ -193,6 +203,51 @@ export class UniformGroup<UNIFORMS extends { [key: string]: UniformData } = any>
         this._signature = createIdFromString(Object.keys(uniforms).map(
             (i) => `${i}-${(uniformStructures[i as keyof typeof uniformStructures] as UniformData).type}`
         ).join('-'), 'uniform-group');
+    }
+
+    /**
+     * an underlying buffer that will be uploaded to the GPU when using this UniformGroup.
+     * It is created lazily by the renderer's ubo system on first use.
+     */
+    get buffer(): Buffer | undefined
+    {
+        return this._buffer;
+    }
+
+    set buffer(value: Buffer | undefined)
+    {
+        if (this._buffer === value) return;
+
+        this._buffer?.off('change', this.onBufferChange, this);
+        this._buffer = value;
+        value?.on('change', this.onBufferChange, this);
+    }
+
+    /**
+     * The GC tracks this group's underlying buffer, not the group itself — a GC stamp on the
+     * group (see BindGroup._touch) must land on the buffer, or the GC collects it while
+     * cached bind groups still reference it.
+     * @internal
+     */
+    get _gcLastUsed(): number
+    {
+        return this._buffer?._gcLastUsed ?? -1;
+    }
+
+    set _gcLastUsed(value: number)
+    {
+        if (this._buffer) this._buffer._gcLastUsed = value;
+    }
+
+    /**
+     * Bind group keys are built from this group's _resourceId, not the buffer's — so when the
+     * buffer re-keys (it resized, or the GC unloaded its GPU copy), this group must re-key too,
+     * or cached GPUBindGroups keep referencing the destroyed GPU buffer.
+     */
+    protected onBufferChange(): void
+    {
+        this._resourceId = uid('resource');
+        this.emit('change', this);
     }
 
     /** Call this if you want the uniform groups data to be uploaded to the GPU only useful if `isStatic` is true. */

--- a/src/rendering/renderers/shared/shader/__tests__/UniformGroup.test.ts
+++ b/src/rendering/renderers/shared/shader/__tests__/UniformGroup.test.ts
@@ -1,3 +1,5 @@
+import { Buffer } from '../../buffer/Buffer';
+import { BufferUsage } from '../../buffer/const';
 import { UniformGroup } from '../UniformGroup';
 
 describe('UniformGroup', () =>
@@ -73,5 +75,61 @@ describe('UniformGroup', () =>
         });
 
         expect(uniformGroup.uniforms.uActions).toEqual([1, 2, 3]);
+    });
+
+    it('should re-key and emit change when its buffer is unloaded', () =>
+    {
+        const uniformGroup = new UniformGroup({
+            uTest: { value: 1, type: 'f32' },
+        });
+
+        const buffer = new Buffer({
+            data: new Float32Array(4),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        uniformGroup.buffer = buffer;
+
+        const startingId = uniformGroup._resourceId;
+        const changeObserver = jest.fn();
+
+        uniformGroup.on('change', changeObserver);
+
+        buffer.unload();
+
+        expect(uniformGroup._resourceId).not.toBe(startingId);
+        expect(changeObserver).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop listening to a buffer it no longer owns', () =>
+    {
+        const uniformGroup = new UniformGroup({
+            uTest: { value: 1, type: 'f32' },
+        });
+
+        const oldBuffer = new Buffer({
+            data: new Float32Array(4),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const newBuffer = new Buffer({
+            data: new Float32Array(4),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        uniformGroup.buffer = oldBuffer;
+        uniformGroup.buffer = newBuffer;
+
+        const changeObserver = jest.fn();
+
+        uniformGroup.on('change', changeObserver);
+
+        oldBuffer.unload();
+
+        expect(changeObserver).not.toHaveBeenCalled();
+
+        newBuffer.unload();
+
+        expect(changeObserver).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
##### Description of change

Fixes #12080

The GC could unload a uniform buffer while cached bind groups still pointed at the destroyed `GPUBuffer` → black screen on WebGPU.

Now `Buffer.unload()` emits `change` (like textures already do) and `UniformGroup` forwards it as an event emitter, so bind groups re-key and the buffer is recreated on next use. GC stamps also pass through to the underlying buffer, so buffers in use every frame don't get collected at all.

Cleanup follow-up: #12146

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)