### PR TITLE
fix: WebGPU sibling sprite masks rendering with each other's mask matrix

### DIFF
--- a/src/rendering/mask/alpha/AlphaMaskPipe.ts
+++ b/src/rendering/mask/alpha/AlphaMaskPipe.ts
@@ -107,10 +107,13 @@ export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
 
     private _renderer: Renderer;
     private _activeMaskStage: AlphaMaskData[] = [];
+    private _usedEffects: AlphaMaskEffect[] = [];
 
     constructor(renderer: Renderer)
     {
         this._renderer = renderer;
+
+        renderer.runners.postrender.add(this);
     }
 
     public push(mask: Effect, maskedContainer: Container, instructionSet: InstructionSet): void
@@ -268,13 +271,33 @@ export class AlphaMaskPipe implements InstructionPipe<AlphaMaskInstruction>
                 TexturePool.returnTexture(maskData.filterTexture);
             }
 
-            BigPool.return(maskData.filterEffect);
+            // Returning the effect to the pool now would let the next mask in this frame
+            // reuse it, along with its MaskFilter's uniform buffer. WebGPU only reads that
+            // buffer when the frame's commands are submitted, so sharing it between masks
+            // would make every mask sample the last-written filter matrix (#12145).
+            this._usedEffects.push(maskData.filterEffect);
         }
+    }
+
+    public postrender(): void
+    {
+        const effects = this._usedEffects;
+
+        for (let i = 0; i < effects.length; i++)
+        {
+            BigPool.return(effects[i]);
+        }
+
+        effects.length = 0;
     }
 
     public destroy(): void
     {
+        this.postrender();
+
+        this._renderer.runners.postrender.remove(this);
         this._renderer = null;
         this._activeMaskStage = null;
+        this._usedEffects = null;
     }
 }

--- a/src/rendering/mask/alpha/__tests__/AlphaMaskPipe.test.ts
+++ b/src/rendering/mask/alpha/__tests__/AlphaMaskPipe.test.ts
@@ -1,0 +1,99 @@
+import { getWebGLRenderer } from '@test-utils';
+import { MaskFilter } from '~/filters';
+import { Texture } from '~/rendering';
+import { Container, Sprite } from '~/scene';
+import { BigPool } from '~/utils';
+
+import type { FilterEffect } from '~/filters';
+import type { Renderer } from '~/rendering';
+
+function createSceneWithSiblingMasks(maskSizes: number[]): Container
+{
+    const stage = new Container();
+
+    for (const size of maskSizes)
+    {
+        const panel = new Container();
+        const content = new Sprite(Texture.WHITE);
+
+        content.setSize(80, 80);
+
+        const mask = new Sprite(Texture.WHITE);
+
+        mask.setSize(size, size);
+
+        panel.addChild(content, mask);
+        panel.mask = mask;
+        stage.addChild(panel);
+    }
+
+    return stage;
+}
+
+const getReturnedMaskEffects = (spy: jest.SpyInstance): FilterEffect[] =>
+    spy.mock.calls
+        .map((call) => call[0] as FilterEffect)
+        .filter((item) => item.filters?.[0] instanceof MaskFilter);
+
+describe('AlphaMaskPipe', () =>
+{
+    let renderer: Renderer;
+
+    beforeEach(async () =>
+    {
+        renderer = await getWebGLRenderer();
+    });
+
+    afterEach(() =>
+    {
+        renderer.destroy();
+        jest.restoreAllMocks();
+    });
+
+    it('should give each sibling sprite mask its own pooled effect within a frame', () =>
+    {
+        const spy = jest.spyOn(BigPool, 'return');
+
+        renderer.render(createSceneWithSiblingMasks([40, 60]));
+
+        // reusing one effect for both masks would make them share the MaskFilter's
+        // uniform buffer, which on WebGPU renders every mask with the last mask's matrix
+        const effects = getReturnedMaskEffects(spy);
+
+        expect(effects).toHaveLength(2);
+        expect(effects[0]).not.toBe(effects[1]);
+    });
+
+    it('should not return mask effects to the pool until postrender', () =>
+    {
+        const spy = jest.spyOn(BigPool, 'return');
+        let returnsBeforePostrender = -1;
+
+        renderer.runners.renderEnd.add({
+            renderEnd: () => { returnsBeforePostrender = getReturnedMaskEffects(spy).length; },
+        });
+
+        renderer.render(createSceneWithSiblingMasks([40, 60]));
+
+        expect(returnsBeforePostrender).toBe(0);
+        expect(getReturnedMaskEffects(spy)).toHaveLength(2);
+    });
+
+    it('should reuse pooled effects across frames', () =>
+    {
+        const scene = createSceneWithSiblingMasks([40, 60]);
+        const spy = jest.spyOn(BigPool, 'return');
+
+        renderer.render(scene);
+
+        const firstFrame = getReturnedMaskEffects(spy);
+
+        spy.mockClear();
+        renderer.render(scene);
+
+        const secondFrame = getReturnedMaskEffects(spy);
+
+        expect(secondFrame).toHaveLength(2);
+        expect(new Set(secondFrame)).toEqual(new Set(firstFrame));
+    });
+});


### PR DESCRIPTION
##### Description of change

Fixes #12145

`AlphaMaskPipe` returned its pooled `AlphaMaskEffect` to `BigPool` mid-frame, so sibling masks in the same frame reused one effect — and with it the `MaskFilter`'s uniform buffer. On WebGPU every uniform upload lands before the frame's single `queue.submit`, so all masks sampled the last-written filter matrix. WebGL was unaffected (uniforms upload per draw).

The pipe now holds used effects and returns them to the pool on `postrender`, so each mask in a frame gets its own effect and uniform buffer. Pooling across frames is unchanged.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)