### PR TITLE
fix: stop publish-branch job from poisoning the node_modules cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,3 +33,8 @@ runs:
       if: steps.node-modules-cache.outputs.cache-hit != 'true'
       shell: bash
       run: npm ci
+    # A restored cache (or an interrupted install) can be missing Electron's binary,
+    # which fails every test job with "Electron failed to install correctly".
+    - name: Verify Electron
+      shell: bash
+      run: node -e "require('electron')" || node node_modules/electron/install.js

--- a/.github/workflows/publish-branch.yaml
+++ b/.github/workflows/publish-branch.yaml
@@ -16,11 +16,11 @@ jobs:
               with:
                   ref: ${{ github.head_ref }}
 
+            # No node-version/npm-version overrides: the setup action pins Node 24.15
+            # because Node >=24.16 silently skips Electron's binary install, and this
+            # job's cache post-step would then poison Linux-node-modules-* for unit tests.
             - name: Setup Project
               uses: ./.github/actions/setup
-              with:
-                  node-version: 24
-                  npm-version: latest
 
             - name: Build Project
               run: npm run build


### PR DESCRIPTION
## Problem

Unit test CI has been failing since ~Aug 11 with:

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
```

This wasn't a test failure — the unit job was restoring a **poisoned `node_modules` cache** with no Electron binary in it.

## Root cause

1. The setup action pins Node to **24.15** because Node >=24.16 breaks Electron's binary install (electron/electron#51619) — but `publish-branch.yaml` overrode that with `node-version: 24` / `npm-version: latest`, so it ran on **Node v24.18.0 / npm 11.16.0**.
2. On Aug 11 (push to `dev`, run [31492381179](https://github.com/pixijs/pixijs/actions/runs/31492381179)) that job hit a cache miss and ran `npm ci`. Electron's postinstall silently failed to download the binary, but the job succeeded — it never runs Electron.
3. Its cache post-step saved the broken tree under the shared key `Linux-node-modules-<lockhash>` (**71.6 MiB** vs the healthy **~160 MiB** macOS caches — the missing ~90 MiB is Electron's `dist`).
4. Every PR unit run since then hit that cache, skipped `npm ci`, and jest-electron died at launch.

Visual tests were unaffected because they run on macOS → different cache key (`macOS-node-modules-*`) with a healthy Electron.

## Fix

- **Delete the poisoned cache** (done separately via `gh cache delete`) so the next Linux run reinstalls fresh.
- **Drop the Node/npm overrides in `publish-branch.yaml`** so it uses the pinned 24.15 defaults like every other job and can't re-poison the shared cache.
- **Add a `Verify Electron` step to the setup action**: after cache restore/install, `node -e "require('electron')"` and re-run `node_modules/electron/install.js` if it's broken — so a bad cache self-repairs instead of failing every test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)