### PR TITLE
fix: preserve UBO offsets in unsafe-eval polyfill

### DIFF
--- a/src/unsafe-eval/ubo/__tests__/generateUboSyncPolyfill.test.ts
+++ b/src/unsafe-eval/ubo/__tests__/generateUboSyncPolyfill.test.ts
@@ -1,0 +1,27 @@
+import { generateUboSyncPolyfillWGSL } from '~/unsafe-eval/ubo/generateUboSyncPolyfill';
+
+import type { UboElement } from '~/rendering/renderers/shared/shader/types';
+
+describe('generateUboSyncPolyfillWGSL', () =>
+{
+    it('uses the fourth argument as the shared-buffer offset', () =>
+    {
+        const uboElements: UboElement[] = [{
+            data: {
+                name: 'uValue',
+                type: 'f32',
+                value: 0,
+                size: 1,
+            },
+            offset: 0,
+            size: 4,
+        }];
+        const syncFunction = generateUboSyncPolyfillWGSL(uboElements);
+        const data = new Float32Array(8);
+
+        syncFunction({ uValue: 42 }, data, null, 4);
+
+        expect(data[0]).toBe(0);
+        expect(data[4]).toBe(42);
+    });
+});

--- a/src/unsafe-eval/ubo/generateUboSyncPolyfill.ts
+++ b/src/unsafe-eval/ubo/generateUboSyncPolyfill.ts
@@ -126,6 +126,7 @@ function generateUboSyncPolyfill(
     return (
         uniforms: UniformGroup,
         data: Float32Array,
+        _dataInt32: Int32Array | null,
         offset: number
     ) =>
     {


### PR DESCRIPTION
Fixes #12106.

`generateUboSyncPolyfill` currently returns a three-argument callback while `UboSystem.syncUniformGroup` invokes UBO sync callbacks with four arguments: `(uniforms, data, dataInt32, offset)`. The polyfill therefore receives the Int32 view in its `offset` parameter and drops the actual shared-buffer offset.

This keeps the fix intentionally narrow: the polyfill now matches the four-argument callback contract, and a focused regression test verifies a non-zero shared-buffer offset is honored.

This is related to the broader work in #12118 / #12117, but does not include the separate integer-view changes from that closed PR.