### PR TITLE
fix: restore WebGL context on any loss (v7 parity)

### DIFF
--- a/src/rendering/renderers/gl/context/GlContextSystem.ts
+++ b/src/rendering/renderers/gl/context/GlContextSystem.ts
@@ -174,7 +174,6 @@ export class GlContextSystem implements System<ContextSystemOptions>
     public canvas: ICanvas;
 
     private _renderer: WebGLRenderer;
-    private _contextLossForced: boolean;
 
     /** @param renderer - The renderer this System works for. */
     constructor(renderer: WebGLRenderer)
@@ -400,19 +399,19 @@ export class GlContextSystem implements System<ContextSystemOptions>
     {
         event.preventDefault();
 
-        // only restore if we purposefully nuked it
-        if (this._contextLossForced)
+        // Restore the context after this event has exited.
+        // v8 previously gated this behind `_contextLossForced`  to avoid resurrecting
+        // a context mid-teardown — but destroy() removes the webglcontextlost listener *before*
+        // calling loseContext(), so that guard is redundant. Restoring on ANY loss (GPU crash, an
+        // app calling WEBGL_lose_context.loseContext() directly, or forceContextLoss()) is required
+        // because the browser never auto-restores an API-triggered loss (matches v7 behaviour).
+        setTimeout(() =>
         {
-            this._contextLossForced = false;
-            // Restore the context after this event has exited
-            setTimeout(() =>
+            if (this.gl.isContextLost())
             {
-                if (this.gl.isContextLost())
-                {
-                    this.extensions.loseContext?.restoreContext();
-                }
-            }, 0);
-        }
+                this.extensions.loseContext?.restoreContext();
+            }
+        }, 0);
     }
 
     /** Handles a restored webgl context. */
@@ -447,7 +446,6 @@ export class GlContextSystem implements System<ContextSystemOptions>
     public forceContextLoss(): void
     {
         this.extensions.loseContext?.loseContext();
-        this._contextLossForced = true;
     }
     /**
      * Validate context.

--- a/src/rendering/renderers/gl/context/__tests__/GlContextSystem.test.ts
+++ b/src/rendering/renderers/gl/context/__tests__/GlContextSystem.test.ts
@@ -1,0 +1,94 @@
+import { getWebGLRenderer } from '@test-utils';
+import { Texture } from '~/rendering';
+import { Container, Sprite } from '~/scene';
+
+async function waitFor(condition: () => boolean, timeout = 2000): Promise<void>
+{
+    const start = Date.now();
+
+    while (!condition())
+    {
+        if (Date.now() - start > timeout) throw new Error('Timed out waiting for condition');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+}
+
+describe('GlContextSystem', () =>
+{
+    it('should restore the context after an externally-triggered context loss', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        try
+        {
+            const ext = renderer.context.extensions.loseContext;
+
+            expect(ext).toBeTruthy();
+
+            // An external context loss — a real GPU crash, or an app calling
+            // WEBGL_lose_context.loseContext() directly. This is NOT Pixi's own forceContextLoss().
+            const restoreSpy = jest.spyOn(ext, 'restoreContext');
+
+            ext.loseContext();
+
+            // wait for the loss to actually register
+            await waitFor(() => renderer.context.isLost);
+
+            // v7 restored the context here by calling restoreContext() in handleContextLost.
+            // v8 gates that call behind `_contextLossForced`, so an external loss never restores.
+            await waitFor(() => !renderer.context.isLost, 1500).catch(() =>
+            {
+                // timing out here is expected on a broken build — the assertion below decides
+            });
+
+            expect(restoreSpy).toHaveBeenCalled();
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+
+    it('should keep rendering correctly after an externally-triggered context loss and recovery', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        try
+        {
+            const ext = renderer.context.extensions.loseContext;
+
+            const sprite = new Sprite(Texture.WHITE);
+
+            sprite.width = 50;
+            sprite.height = 50;
+
+            const container = new Container();
+
+            container.addChild(sprite);
+
+            // render a baseline frame and confirm something was actually drawn
+            renderer.render(container);
+            const before = renderer.extract.pixels(container).pixels;
+
+            expect(before.some((v) => v !== 0)).toBe(true);
+
+            // trigger an external context loss
+            ext.loseContext();
+            await waitFor(() => renderer.context.isLost);
+
+            // the renderer should recover on its own
+            await waitFor(() => !renderer.context.isLost);
+
+            // rendering must still produce output identical to the baseline
+            renderer.render(container);
+            const after = renderer.extract.pixels(container).pixels;
+
+            expect(after.length).toBe(before.length);
+            expect(after).toEqual(before);
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+});

--- a/src/rendering/renderers/gl/context/__tests__/_fiddle_repro.test.ts
+++ b/src/rendering/renderers/gl/context/__tests__/_fiddle_repro.test.ts
@@ -1,0 +1,110 @@
+import { getWebGLRenderer } from '@test-utils';
+import { Texture } from '~/rendering';
+import { Container, Sprite } from '~/scene';
+
+async function waitFor(condition: () => boolean, timeout = 3000): Promise<void>
+{
+    const start = Date.now();
+
+    while (!condition())
+    {
+        if (Date.now() - start > timeout) throw new Error('Timed out waiting for condition');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+}
+
+// Mirrors the JSFiddle repro (vote138y/6) from issue #12134:
+// "Lose Context" button does ext.loseContext(); Pixi must recover WITHOUT the (broken) Restore button.
+
+describe('JSFiddle repro: Lose Context button flow', () =>
+{
+    it('recovers automatically after external loseContext(), no manual restore needed', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        try
+        {
+            // --- the fiddle's scene: a square + a render ---
+            const sprite = new Sprite(Texture.WHITE);
+
+            sprite.width = 50;
+            sprite.height = 50;
+
+            const container = new Container();
+
+            container.addChild(sprite);
+            renderer.render(container);
+            const before = renderer.extract.pixels(container).pixels;
+
+            expect(before.some((v) => v !== 0)).toBe(true);
+
+            // --- the fiddle's "Lose Context" button handler ---
+            const ext = renderer.context.extensions.loseContext; // Pixi's stored ref, same as fiddle's ext
+
+            expect(ext).toBeTruthy();
+
+            ext.loseContext();
+
+            // the context goes lost
+            await waitFor(() => renderer.context.isLost);
+
+            // --- WHY the fiddle's "Restore Context" button is broken ---
+            // After loss, getExtension() on the dead context returns null → alert("not supported")
+            const deadGl = renderer.gl;
+
+            expect(deadGl.getExtension('WEBGL_lose_context')).toBeNull();
+
+            // --- WITH OUR FIX: Pixi auto-restores using its stored extension ref ---
+            // no manual restoreContext() call here — the fix handles it inside handleContextLost
+            await waitFor(() => !renderer.context.isLost);
+
+            // scene must be back and identical to baseline
+            renderer.render(container);
+            const after = renderer.extract.pixels(container).pixels;
+
+            expect(after).toEqual(before);
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+
+    it('keeps recovering across 3 repeated losses (fiddle "Auto Test (3x)" flow)', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        try
+        {
+            const ext = renderer.context.extensions.loseContext;
+
+            const sprite = new Sprite(Texture.WHITE);
+
+            sprite.width = 50;
+            sprite.height = 50;
+
+            const container = new Container();
+
+            container.addChild(sprite);
+            renderer.render(container);
+            const baseline = renderer.extract.pixels(container).pixels;
+
+            for (let i = 0; i < 3; i++)
+            {
+                ext.loseContext();
+                await waitFor(() => renderer.context.isLost);
+                // our fix auto-restores (no manual restoreContext)
+                await waitFor(() => !renderer.context.isLost);
+
+                renderer.render(container);
+                const pixels = renderer.extract.pixels(container).pixels;
+
+                expect(pixels).toEqual(baseline);
+            }
+        }
+        finally
+        {
+            renderer.destroy();
+        }
+    });
+});


### PR DESCRIPTION
# Fix: restore WebGL context on any loss (v7 parity)

Closes #12134

## Problem

Since v8, an externally-triggered WebGL context loss never recovers — the canvas stays permanently blank. v7 restored the context unconditionally; v8 does not.

Reproduction (JSFiddle vote138y/6 from #12134):
- Click "Lose Context" → scene disappears, never comes back.
- "Restore Context" button cannot help: after loss, `gl.getExtension('WEBGL_lose_context')` returns `null`, so the alert "WEBGL_lose_context not supported" fires and the scene stays blank.
- A real GPU crash (`chrome://gpucrash`) may recover once, then fails on a second crash.

## Root cause

`GlContextSystem.handleContextLost` only called `restoreContext()` when `_contextLossForced` was `true` — a flag set only by Pixi's own `forceContextLoss()`. For every other loss path (real GPU crash, or an app calling `loseContext()` directly) the gate never opens, and because the browser **never auto-restores an API-triggered loss**, the context stays lost forever.

The gate was added in PR #10111 to avoid resurrecting a context during teardown. That concern no longer applies: `destroy()` removes the `webglcontextlost` listener **before** calling `loseContext()`, so the handler never runs during teardown. The guard is redundant.

## Fix

Restore the v7 behaviour — attempt `restoreContext()` on any loss, not just Pixi-initiated ones.

In `src/rendering/renderers/gl/context/GlContextSystem.ts`, removed the `_contextLossForced` gate and its field:

```ts
protected handleContextLost(event: WebGLContextEvent): void
{
    event.preventDefault();

    // v8 previously gated this behind `_contextLossForced` (PR #10111) to avoid
    // resurrecting a context mid-teardown — but destroy() removes the
    // webglcontextlost listener *before* calling loseContext(), so that guard
    // is redundant. Restoring on ANY loss (GPU crash, an app calling
    // WEBGL_lose_context.loseContext() directly, or forceContextLoss()) is
    // required because the browser never auto-restores an API-triggered loss
    // (matches v7 behaviour).
    setTimeout(() =>
    {
        if (this.gl.isContextLost())
        {
            this.extensions.loseContext?.restoreContext();
        }
    }, 0);
}
```

Also removed:
- the `private _contextLossForced: boolean;` field
- `this._contextLossForced = true;` in `forceContextLoss()`

Why it's safe: `destroy()` (lines 422-435) removes the `webglcontextlost` listener **before** calling `loseContext()`, so `handleContextLost` never runs during teardown — the original purpose of the gate is already handled by that code, making the gate redundant.

## Tests

Two new test files (run on Electron / real WebGL2):

- `GlContextSystem.test.ts` — external `loseContext()` → `restoreContext()` is called and rendering matches the baseline (red on the pre-fix code, green with the fix).
- `_fiddle_repro.test.ts` — mirrors the JSFiddle repro: automatic recovery with no manual restore, incl. 3 repeated losses; also asserts that `getExtension('WEBGL_lose_context')` is `null` after loss (why the fiddle's Restore button cannot work).

Both fail on the pre-fix code and pass with the fix. Also verified:
- `destroy()` does not trigger `restoreContext()`.
- `forceContextLoss()` still restores — the "sleep / release GPU" feature is unchanged.
- All GL renderer tests pass; lint and type-check clean.
