### PR TITLE
feat: stamp render bundles with baked pipeline state

### DIFF
--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -133,6 +133,7 @@ export * from './renderers/gpu/GpuStencilSystem';
 export * from './renderers/gpu/GpuUboSystem';
 export * from './renderers/gpu/GpuUniformBatchPipe';
 export * from './renderers/gpu/pipeline/PipelineSystem';
+export * from './renderers/gpu/RenderBundle';
 export * from './renderers/gpu/renderTarget/calculateProjection';
 export * from './renderers/gpu/renderTarget/GpuRenderTarget';
 export * from './renderers/gpu/renderTarget/GpuRenderTargetAdaptor';

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -1,5 +1,7 @@
 import { ExtensionType } from '../../../extensions/Extensions';
+import { warn } from '../../../utils/logging/warn';
 import { type ShaderOverrides } from '../shared/shader/ShaderOverrides';
+import { RenderBundle } from './RenderBundle';
 
 import type { Rectangle } from '../../../maths/shapes/Rectangle';
 import type { Buffer } from '../shared/buffer/Buffer';
@@ -67,6 +69,15 @@ export class GpuEncoderSystem implements System
      * a correctly typed target — even while a bundle is being recorded.
      */
     private _passEncoder: GPURenderPassEncoder;
+    /**
+     * {@link PipelineSystem.bundleStateKey} as it was when {@link beginBundle} built the bundle
+     * encoder's descriptor, ready to stamp onto the {@link RenderBundle} that {@link endBundle}
+     * returns. Sampled at that moment so the stamp and the state the bundle actually baked cannot
+     * describe different render targets.
+     */
+    private _bundleStateKey: number;
+    /** The label passed to {@link beginBundle}, carried through to the finished bundle. */
+    private _bundleLabel: string;
 
     private readonly _renderer: WebGPURenderer;
 
@@ -120,9 +131,11 @@ export class GpuEncoderSystem implements System
      *
      * Render bundles allow pre-recording of draw commands that can be replayed multiple times
      * via {@link executeBundle}, reducing CPU overhead for repeated draw sequences.
+     * @param label - Optional debug label. Names the bundle in GPU captures and in the WebGPU
+     * validation errors it can raise when replayed, instead of `(unlabeled)`.
      * @throws If a render bundle is already being recorded.
      */
-    public beginBundle(): void
+    public beginBundle(label?: string): void
     {
         // While a bundle is recording, renderPassEncoder is swapped to the bundle encoder and no
         // longer matches the real pass. Equal references therefore mean no bundle is active.
@@ -133,7 +146,13 @@ export class GpuEncoderSystem implements System
 
         this._clearCache();
 
-        const descriptor = this._renderer.pipeline.getBundleDescriptor();
+        const pipeline = this._renderer.pipeline;
+        const descriptor = pipeline.getBundleDescriptor();
+
+        descriptor.label = label;
+
+        this._bundleStateKey = pipeline.bundleStateKey;
+        this._bundleLabel = label;
 
         // A bundle encoder exposes the same render/bind command API as the pass, so it stands in as
         // the write target while recording. The real pass stays in _passEncoder and is restored by
@@ -143,9 +162,10 @@ export class GpuEncoderSystem implements System
 
     /**
      * Finishes recording the current render bundle and restores the previous render pass encoder.
-     * @returns The recorded {@link GPURenderBundle} ready to be executed via {@link executeBundle}.
+     * @returns The recorded {@link RenderBundle}, ready to be executed via {@link executeBundle} and
+     * stamped with the pipeline state it baked so {@link isBundleValid} can vet it on later frames.
      */
-    public endBundle(): GPURenderBundle
+    public endBundle(): RenderBundle
     {
         const encoder = this.renderPassEncoder;
 
@@ -156,23 +176,89 @@ export class GpuEncoderSystem implements System
             throw new Error('endBundle called without an active render bundle.');
         }
 
-        const bundle = encoder.finish();
+        // the label goes on the bundle as well as on its encoder: WebGPU names the bundle, not the
+        // encoder, in the validation error executeBundles raises
+        const gpuBundle = encoder.finish({ label: this._bundleLabel });
 
         this.renderPassEncoder = this._passEncoder;
         this._clearCache();
 
-        return bundle;
+        return new RenderBundle(gpuBundle, this._bundleStateKey, this._bundleLabel);
     }
 
     /**
-     * Replays a previously recorded render bundle on the current render pass.
-     * The bound state cache is cleared since the bundle may set its own pipeline, bind groups, and buffers.
-     * @param bundle - The render bundle to execute.
+     * Checks whether a recorded bundle can still be replayed against the render target that is
+     * bound now.
+     *
+     * A bundle permanently bakes the attachment state it was recorded with — color format(s),
+     * color target count, depth/stencil format, sample count — and WebGPU rejects the entire
+     * command buffer if any of it differs at execute time. It also bakes the front-face winding of
+     * its pipelines, which WebGPU does *not* validate: once the target's {@link RenderTarget.flipY}
+     * parity changes, replaying silently renders geometry inside out.
+     *
+     * Ask before replaying rather than after: only the caller owns the draw commands, so only the
+     * caller can re-record. A missing bundle reports `false`, so `!isBundleValid(bundles[i])` reads
+     * correctly on the first frame, before anything has been recorded.
+     * @param bundle - The bundle to check, as returned by {@link endBundle}.
+     * @returns `true` if the bundle is safe to execute right now, `false` if it must be re-recorded.
      */
-    public executeBundle(bundle: GPURenderBundle): void
+    public isBundleValid(bundle: RenderBundle): boolean
     {
+        return bundle?.stateKey === this._renderer.pipeline.bundleStateKey;
+    }
+
+    /**
+     * Replays previously recorded render bundles on the current render pass.
+     * The bound state cache is cleared since a bundle may set its own pipeline, bind groups, and buffers.
+     *
+     * Pass a whole run of bundles rather than calling this once per bundle: WebGPU resets the pass
+     * state after every call, so N calls cost N cache clears and N trips through the binding layer
+     * for exactly the same result.
+     *
+     * Every bundle must have been recorded against a matching render target — check with
+     * {@link isBundleValid} first and re-record if it says no, as Pixi cannot rebuild your draw
+     * commands for you.
+     * @param bundle - The render bundle to execute, or a run of them to execute in one call.
+     */
+    public executeBundle(bundle: RenderBundle | RenderBundle[]): void
+    {
+        const gpuBundles: GPURenderBundle[] = [];
+
+        if (Array.isArray(bundle))
+        {
+            for (let i = 0; i < bundle.length; i++)
+            {
+                gpuBundles[i] = this._getGpuBundle(bundle[i]);
+            }
+        }
+        else
+        {
+            gpuBundles[0] = this._getGpuBundle(bundle);
+        }
+
         this._clearCache();
-        this._passEncoder.executeBundles([bundle]);
+        this._passEncoder.executeBundles(gpuBundles);
+    }
+
+    /**
+     * Unwraps a bundle for {@link executeBundle}, complaining first if it no longer matches the
+     * bound render target — the winding half of that mismatch is invisible otherwise, since WebGPU
+     * validates attachments but not front-face order.
+     * @param bundle - The bundle being executed.
+     * @returns The native bundle to hand to `executeBundles`.
+     */
+    private _getGpuBundle(bundle: RenderBundle): GPURenderBundle
+    {
+        // #if _DEBUG
+        if (!this.isBundleValid(bundle))
+        {
+            warn(`Render bundle ${bundle?.label ?? '(unlabeled)'} was recorded against a different render `
+                + 'target state. Re-record it — replaying it will either be rejected by WebGPU or draw '
+                + 'with the wrong winding. Check encoder.isBundleValid(bundle) before executing.');
+        }
+        // #endif
+
+        return bundle.gpuBundle;
     }
 
     public setViewport(viewport: Rectangle): void

--- a/src/rendering/renderers/gpu/RenderBundle.ts
+++ b/src/rendering/renderers/gpu/RenderBundle.ts
@@ -1,0 +1,60 @@
+/**
+ * A recorded WebGPU render bundle, together with a stamp of the pipeline state it baked when it
+ * was recorded.
+ *
+ * Recording captures the render target permanently, in two ways:
+ *
+ * - the attachment state (color format(s), depth/stencil format, sample count). WebGPU validates
+ *   this when the bundle is executed — replaying it in a pass whose attachments differ rejects the
+ *   whole command buffer.
+ * - the front-face winding baked into every pipeline inside it. WebGPU does *not* validate this —
+ *   replaying after the target's {@link RenderTarget.flipY} parity changed silently renders
+ *   geometry inside out.
+ *
+ * {@link RenderBundle.stateKey} stamps both, so {@link GpuEncoderSystem.isBundleValid} can answer
+ * whether a cached bundle is still safe to replay against the target that is bound now.
+ *
+ * Created by {@link GpuEncoderSystem.endBundle} — there is no reason to construct one yourself.
+ * @example
+ * ```ts
+ * const record = () =>
+ * {
+ *     encoder.beginBundle('my-cached-pass');
+ *     encoder.draw({ geometry, shader });
+ *
+ *     return encoder.endBundle();
+ * };
+ *
+ * // record once, then replay on later frames — re-recording whenever the target it baked
+ * // no longer matches the one bound now
+ * if (!encoder.isBundleValid(bundle)) bundle = record();
+ * encoder.executeBundle(bundle);
+ * ```
+ * @category rendering
+ * @advanced
+ */
+export class RenderBundle
+{
+    /** The recorded native bundle, as handed to `GPURenderPassEncoder.executeBundles`. */
+    public readonly gpuBundle: GPURenderBundle;
+    /**
+     * The value {@link PipelineSystem.bundleStateKey} had when recording began. Comparing it
+     * against the pipeline's current key tells you whether this bundle still matches the bound
+     * render target — which is exactly what {@link GpuEncoderSystem.isBundleValid} does.
+     */
+    public readonly stateKey: number;
+    /** Optional debug label — names the bundle in GPU captures and in WebGPU validation errors. */
+    public readonly label?: string;
+
+    /**
+     * @param gpuBundle - The recorded native render bundle.
+     * @param stateKey - The pipeline state key captured when recording began.
+     * @param label - Optional debug label for the bundle.
+     */
+    constructor(gpuBundle: GPURenderBundle, stateKey: number, label?: string)
+    {
+        this.gpuBundle = gpuBundle;
+        this.stateKey = stateKey;
+        this.label = label;
+    }
+}

--- a/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
@@ -1,0 +1,198 @@
+import { RenderTarget } from '../../shared/renderTarget/RenderTarget';
+import { TextureSource } from '../../shared/texture/sources/TextureSource';
+import { RenderBundle } from '../RenderBundle';
+import { describeLocalOnly, getWebGPURenderer } from '@test-utils';
+
+import type { TEXTURE_FORMATS } from '../../shared/texture/const';
+import type { WebGPURenderer } from '../WebGPURenderer';
+
+let renderer: WebGPURenderer;
+
+afterEach(() =>
+{
+    renderer?.destroy();
+    renderer = null;
+});
+
+function colorTarget(options: { format?: TEXTURE_FORMATS, antialias?: boolean } = {}): RenderTarget
+{
+    return new RenderTarget({
+        colorTextures: [new TextureSource({
+            width: 16,
+            height: 16,
+            format: options.format ?? 'bgra8unorm',
+            antialias: options.antialias ?? false,
+        })],
+    });
+}
+
+// records an empty bundle against `target` — the commands inside it are irrelevant here, what is
+// being tested is the state stamped onto it as it is recorded
+function record(target: RenderTarget, label?: string): RenderBundle
+{
+    renderer.pipeline.setRenderTarget(target);
+    renderer.encoder.beginBundle(label);
+
+    return renderer.encoder.endBundle();
+}
+
+describeLocalOnly('GpuEncoderSystem render bundles', () =>
+{
+    it('wraps the recorded bundle together with the state it baked', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const target = colorTarget();
+        const bundle = record(target, 'stamped-bundle');
+
+        expect(bundle).toBeInstanceOf(RenderBundle);
+        expect(bundle.gpuBundle).toBeDefined();
+        expect(bundle.label).toBe('stamped-bundle');
+
+        // re-recording against the same target has to land on the same stamp, otherwise a cached
+        // bundle could never be reused across frames
+        const second = record(target);
+
+        expect(second.stateKey).toBe(bundle.stateKey);
+        expect(second.label).toBeUndefined();
+    });
+
+    it('reports a bundle recorded against the currently bound target as valid', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const bundle = record(colorTarget());
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(true);
+    });
+
+    it('reports a bundle that has not been recorded yet as invalid', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        renderer.pipeline.setRenderTarget(colorTarget());
+
+        // the first-frame shape of a consumer's cache: nothing recorded, so nothing to replay
+        const bundles: RenderBundle[] = [];
+
+        expect(renderer.encoder.isBundleValid(bundles[0])).toBe(false);
+    });
+
+    it('invalidates a bundle when the sample count changes', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        // the bug this stamp exists for: bundles recorded into a 1-sample filter texture, then
+        // replayed against the 4-sample canvas once the filter was removed. WebGPU rejects the
+        // whole command buffer at submit, so there is nothing the consumer can catch after the fact
+        const bundle = record(colorTarget());
+
+        renderer.pipeline.setRenderTarget(colorTarget({ antialias: true }));
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+    });
+
+    it('invalidates a bundle when the color format changes', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const bundle = record(colorTarget({ format: 'bgra8unorm' }));
+
+        renderer.pipeline.setRenderTarget(colorTarget({ format: 'rgba8unorm' }));
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+    });
+
+    it('invalidates a bundle when a depth-stencil attachment appears', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const bundle = record(colorTarget());
+
+        const depthTarget = new RenderTarget({
+            colorTextures: [new TextureSource({ width: 16, height: 16, format: 'bgra8unorm' })],
+            stencil: true,
+        });
+
+        // in the real flow GpuRenderTargetAdaptor.startRenderPass materialises the depth-stencil
+        // texture before setRenderTarget sees it — mirror that precondition here
+        depthTarget.ensureDepthStencilTexture();
+        renderer.pipeline.setRenderTarget(depthTarget);
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+    });
+
+    it('invalidates a bundle when the target flipY parity changes', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const target = colorTarget();
+        const bundle = record(target);
+
+        // the attachments are untouched here, so WebGPU would happily replay this bundle — with
+        // every pipeline inside it wound the wrong way round, and nothing said about it
+        target.flipY = true;
+        renderer.pipeline.setRenderTarget(target);
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+
+        // ...and it becomes replayable again once the parity matches what it recorded
+        target.flipY = false;
+        renderer.pipeline.setRenderTarget(target);
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(true);
+    });
+
+    it('executes a run of bundles in a single call', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const target = colorTarget();
+        const first = record(target, 'first');
+        const second = record(target, 'second');
+
+        // executeBundle needs a live pass to write into; the real one is covered by the
+        // render-bundle visual scene, so stand in for it here to watch what it is handed
+        const executeBundles = jest.fn();
+
+        (renderer.encoder as unknown as { _passEncoder: unknown })._passEncoder = { executeBundles };
+
+        renderer.encoder.executeBundle([first, second]);
+
+        // one call for the whole run, not one per bundle — the pass state is reset per call, so
+        // splitting them up would cost a cache clear and a binding round trip each for no effect
+        expect(executeBundles).toHaveBeenCalledTimes(1);
+        expect(executeBundles).toHaveBeenCalledWith([first.gpuBundle, second.gpuBundle]);
+
+        executeBundles.mockClear();
+
+        // a lone bundle takes the same path, wrapped for WebGPU's sequence argument
+        renderer.encoder.executeBundle(first);
+
+        expect(executeBundles).toHaveBeenCalledWith([first.gpuBundle]);
+    });
+
+    it('invalidates a bundle when the depth attachment becomes read-only', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const depthTexture = () => new TextureSource({ width: 16, height: 16, format: 'depth24plus-stencil8' });
+        const writableTarget = new RenderTarget({
+            colorTextures: [new TextureSource({ width: 16, height: 16, format: 'bgra8unorm' })],
+            depthStencilTexture: depthTexture(),
+        });
+        const readOnlyTarget = new RenderTarget({
+            colorTextures: [new TextureSource({ width: 16, height: 16, format: 'bgra8unorm' })],
+            depthStencilTexture: depthTexture(),
+        });
+
+        readOnlyTarget.depthStencilAttachment.depthReadOnly = true;
+
+        const bundle = record(writableTarget);
+
+        // a read-only pass rejects any bundle that did not promise to leave depth alone
+        renderer.pipeline.setRenderTarget(readOnlyTarget);
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+    });
+});

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -149,6 +149,40 @@ function getGlobalStateKey(
          | multiSampleCount; // 1 bit for multiSampleCount at the least significant position
 }
 
+// The state a render bundle bakes into itself at record time, packed into one int. Deliberately
+// not getGlobalStateKey: colorMask and stencilMode are ambient draw state that a bundle captures
+// per-pipeline as it records, so folding them in here would invalidate cached bundles whenever
+// unrelated 2D state (a mask elsewhere in the scene) happened to differ at execute time.
+//
+// multiSampleCount   = 1;  // bit 0     // 2 states // value 0-1 (normalized from sampleCount 1|4)
+// colorTargetCount   = 9;  // bits 1-4  // supports 0-8 color targets (WebGPU maxColorAttachments)
+// depthStencilFormat = 7;  // bits 5-7  // 8 states // value 0-7 (0 = no depth/stencil attachment)
+// depthReadOnly      = 1;  // bit 8     // 2 states // value 0-1
+// stencilReadOnly    = 1;  // bit 9     // 2 states // value 0-1
+// invertFrontFace    = 1;  // bit 10    // 2 states // value 0-1 (flipY winding inversion)
+// colorFormatId      = n;  // bits 11+  // interned color attachment formats (see getColorFormatId)
+function getBundleStateKey(
+    multiSampleCount: number,
+    colorTargetCount: number,
+    depthStencilFormat: number,
+    depthReadOnly: number,
+    stencilReadOnly: number,
+    invertFrontFace: number,
+    colorFormatId: number,
+): number
+{
+    // colorFormatId takes the open top of the key: a format id is only minted per distinct
+    // attachment format ever seen (realistically 1-3), so it cannot approach the 32-bit
+    // boundary these bitwise ops work in
+    return (colorFormatId << 11)
+         | (invertFrontFace << 10)
+         | (stencilReadOnly << 9)
+         | (depthReadOnly << 8)
+         | (depthStencilFormat << 5)
+         | (colorTargetCount << 1)
+         | multiSampleCount;
+}
+
 // a Map, not a plain object: the combined graphics key exceeds 2^31, and big numeric
 // keys on objects get stringified per lookup (dictionary mode) — Map hashes numbers
 // natively, which benchmarks ~3x faster on this per-draw path
@@ -202,6 +236,7 @@ export class PipelineSystem implements System
     private _depthStencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
     private _depthStencilFormatData = emptyDepthStencilFormatData;
     private _depthReadOnly = false;
+    private _stencilReadOnly = false;
     private _invertFrontFace = false;
 
     constructor(renderer: WebGPURenderer)
@@ -242,6 +277,10 @@ export class PipelineSystem implements System
         this._depthStencilFormat = renderTarget.depthStencilAttachment?.texture.format;
         this._depthStencilFormatData = depthStencilFormatMap[this._depthStencilFormat] || emptyDepthStencilFormatData;
         this._depthReadOnly = renderTarget.depthStencilAttachment?.depthReadOnly ?? false;
+        // same derivation the pass descriptor uses (GpuRenderTargetAdaptor): a read-only depth
+        // attachment is usually about sampling the texture, which WebGPU only allows when the
+        // entire attachment — stencil included — is read-only
+        this._stencilReadOnly = renderTarget.depthStencilAttachment?.stencilReadOnly ?? this._depthReadOnly;
         // WebGPU bakes winding into the (cached) pipeline, not as live state. `flipY` is opt-in: off →
         // the framebuffer's natural ccw (exactly today); on → invert to cw so the projection flip and the
         // winding flip cancel and culling is preserved. This bit feeds the cache key (getGlobalStateKey),
@@ -270,8 +309,41 @@ export class PipelineSystem implements System
     }
 
     /**
+     * A packed key for everything a render bundle recorded right now would bake into itself: the
+     * attachment state WebGPU validates when the bundle is executed (color format(s), color target
+     * count, depth/stencil format, sample count, read-only aspects), plus the front-face winding
+     * its pipelines capture — which WebGPU does *not* validate.
+     *
+     * Equal keys mean a bundle recorded then is compatible with, and correct for, the pass now;
+     * different keys mean it has to be re-recorded before it is replayed. Comparing the two is
+     * what {@link GpuEncoderSystem.isBundleValid} does.
+     *
+     * `colorMask` and `stencilMode` are deliberately left out, unlike the pipeline cache key: they
+     * are ambient draw state a bundle bakes per-pipeline as it records, so their value at execute
+     * time says nothing about whether the bundle is still good.
+     */
+    public get bundleStateKey(): number
+    {
+        const formatData = this._depthStencilFormatData;
+
+        return getBundleStateKey(
+            // normalize the raw sample count (1 or 4 — WebGPU's only renderable counts) to a
+            // true single bit, so it cannot spill into the colorTargetCount field above it
+            this._multisampleCount === 1 ? 0 : 1,
+            this._colorTargetCount,
+            formatData.index,
+            // the same two flags getBundleDescriptor sets — keep them in step
+            formatData.depth && this._depthReadOnly ? 1 : 0,
+            formatData.stencil && this._stencilReadOnly ? 1 : 0,
+            this._invertFrontFace ? 1 : 0,
+            this._colorFormatId,
+        );
+    }
+
+    /**
      * Builds a {@link GPURenderBundleEncoderDescriptor} that matches the current render target
-     * configuration (color formats, sample count, and depth/stencil format).
+     * configuration (color formats, sample count, depth/stencil format, and which of its aspects
+     * are read-only).
      * Used by {@link GpuEncoderSystem.beginBundle} to create a compatible render bundle encoder.
      * @returns A descriptor for creating a GPURenderBundleEncoder.
      */
@@ -289,9 +361,19 @@ export class PipelineSystem implements System
             sampleCount: this._multisampleCount,
         };
 
-        if (this._depthStencilFormatData.depth || this._depthStencilFormatData.stencil)
+        const formatData = this._depthStencilFormatData;
+
+        if (formatData.depth || formatData.stencil)
         {
             descriptor.depthStencilFormat = this._depthStencilFormat;
+
+            // A read-only pass only accepts bundles that promise the same, so mirror the target's
+            // flags — gated by the aspects the format actually has, exactly how
+            // GpuRenderTargetAdaptor gates them on the pass. The promise holds: pipelines recorded
+            // against a read-only attachment already force depthWriteEnabled off (_createPipeline).
+            // bundleStateKey stamps these same two bits, so the two must move together.
+            if (formatData.depth && this._depthReadOnly) descriptor.depthReadOnly = true;
+            if (formatData.stencil && this._stencilReadOnly) descriptor.stencilReadOnly = true;
         }
 
         return descriptor;

--- a/src/rendering/renderers/gpu/pipeline/__tests__/PipelineSystem.test.ts
+++ b/src/rendering/renderers/gpu/pipeline/__tests__/PipelineSystem.test.ts
@@ -2,6 +2,7 @@ import { RenderTarget } from '../../../shared/renderTarget/RenderTarget';
 import { TextureSource } from '../../../shared/texture/sources/TextureSource';
 import { describeLocalOnly, getWebGPURenderer } from '@test-utils';
 
+import type { TEXTURE_FORMATS } from '../../../shared/texture/const';
 import type { WebGPURenderer } from '../../WebGPURenderer';
 
 let renderer: WebGPURenderer;
@@ -183,5 +184,103 @@ describeLocalOnly('PipelineSystem color target count cache', () =>
         // sharing a bucket would hand one pass a GPURenderPipeline built for the
         // other's attachment layout -> WebGPU 'incompatible render pipeline' error
         expect(mrtCache).not.toBe(depthOnlyCache);
+    });
+});
+
+describeLocalOnly('PipelineSystem bundle descriptor', () =>
+{
+    const colorTexture = () => new TextureSource({ width: 16, height: 16, format: 'bgra8unorm' });
+    const depthStencilTarget = (format: TEXTURE_FORMATS) => new RenderTarget({
+        colorTextures: [colorTexture()],
+        depthStencilTexture: new TextureSource({ width: 16, height: 16, format }),
+    });
+
+    it('mirrors a read-only depth attachment onto the bundle descriptor', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const writableTarget = depthStencilTarget('depth24plus-stencil8');
+        const readOnlyTarget = depthStencilTarget('depth24plus-stencil8');
+
+        readOnlyTarget.depthStencilAttachment.depthReadOnly = true;
+
+        renderer.pipeline.setRenderTarget(writableTarget);
+        const writableDescriptor = renderer.pipeline.getBundleDescriptor();
+        const writableKey = renderer.pipeline.bundleStateKey;
+
+        expect(writableDescriptor.depthReadOnly).toBeFalsy();
+        expect(writableDescriptor.stencilReadOnly).toBeFalsy();
+
+        renderer.pipeline.setRenderTarget(readOnlyTarget);
+        const readOnlyDescriptor = renderer.pipeline.getBundleDescriptor();
+
+        // WebGPU rejects a bundle executed in a read-only pass unless the bundle promised the same,
+        // so the descriptor has to carry the flag the pass will be built with
+        expect(readOnlyDescriptor.depthReadOnly).toBe(true);
+        // ...and the stencil aspect follows depth by default, exactly as the pass derives it
+        expect(readOnlyDescriptor.stencilReadOnly).toBe(true);
+
+        // the two are not interchangeable: their pipelines bake different depth writes
+        expect(renderer.pipeline.bundleStateKey).not.toBe(writableKey);
+    });
+
+    it('keeps stencil writable when the target asks for a read-only depth aspect only', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const target = depthStencilTarget('depth24plus-stencil8');
+
+        target.depthStencilAttachment.depthReadOnly = true;
+        target.depthStencilAttachment.stencilReadOnly = false;
+
+        renderer.pipeline.setRenderTarget(target);
+        const descriptor = renderer.pipeline.getBundleDescriptor();
+
+        expect(descriptor.depthReadOnly).toBe(true);
+        expect(descriptor.stencilReadOnly).toBeFalsy();
+    });
+
+    it('tracks a read-only stencil aspect independently of depth', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const target = depthStencilTarget('depth24plus-stencil8');
+
+        // the attachment lets stencil go read-only on its own, and GpuRenderTargetAdaptor builds
+        // the pass that way — so a bundle that inherited the flag from depth instead would be
+        // recorded without the promise, and every executeBundles into that pass would fail
+        target.depthStencilAttachment.stencilReadOnly = true;
+
+        renderer.pipeline.setRenderTarget(target);
+        const descriptor = renderer.pipeline.getBundleDescriptor();
+
+        expect(descriptor.stencilReadOnly).toBe(true);
+        expect(descriptor.depthReadOnly).toBeFalsy();
+    });
+
+    it('never marks an aspect the format does not have as read-only', async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        const depthOnlyTarget = depthStencilTarget('depth24plus');
+
+        depthOnlyTarget.depthStencilAttachment.depthReadOnly = true;
+
+        renderer.pipeline.setRenderTarget(depthOnlyTarget);
+        const depthOnlyDescriptor = renderer.pipeline.getBundleDescriptor();
+
+        expect(depthOnlyDescriptor.depthStencilFormat).toBe('depth24plus');
+        expect(depthOnlyDescriptor.depthReadOnly).toBe(true);
+        // the stencil default follows depth, but this format has no stencil aspect to promise
+        expect(depthOnlyDescriptor.stencilReadOnly).toBeFalsy();
+
+        const colorOnlyTarget = new RenderTarget({ colorTextures: [colorTexture()] });
+
+        renderer.pipeline.setRenderTarget(colorOnlyTarget);
+        const colorOnlyDescriptor = renderer.pipeline.getBundleDescriptor();
+
+        expect(colorOnlyDescriptor.depthStencilFormat).toBeUndefined();
+        expect(colorOnlyDescriptor.depthReadOnly).toBeFalsy();
+        expect(colorOnlyDescriptor.stencilReadOnly).toBeFalsy();
     });
 });

--- a/tests/visual/scenes/gpu/render-bundle.scene.ts
+++ b/tests/visual/scenes/gpu/render-bundle.scene.ts
@@ -54,11 +54,18 @@ export const scene: TestScene = {
                 const gpuRenderer = renderer as WebGPURenderer;
                 const encoder = gpuRenderer.encoder;
 
-                encoder.beginBundle();
+                encoder.beginBundle('triangle-a');
                 encoder.draw({ geometry, shader, state });
-                const bundle = encoder.endBundle();
+                const first = encoder.endBundle();
 
-                encoder.executeBundle(bundle);
+                encoder.beginBundle('triangle-b');
+                encoder.draw({ geometry, shader, state });
+                const second = encoder.endBundle();
+
+                // replayed as one run. Drawing the same opaque triangle twice is pixel-identical to
+                // drawing it once, so this covers the batched path against real WebGPU validation
+                // without changing what the scene looks like.
+                encoder.executeBundle([first, second]);
             },
             addBounds: (bounds) =>
             {


### PR DESCRIPTION
##### Description of change

A recorded `GPURenderBundle` bakes the state of the pass it was recorded in, and replaying it somewhere else fails two ways. Attachment state (formats, sample count) is validated by WebGPU, so a mismatch rejects the whole command buffer at submit. Front-face winding is not validated, so a change in `flipY` parity quietly draws geometry inside out.

`PipelineSystem` tracks all of that already. Nothing carried it across the API boundary, so a consumer had to re-derive the bound target's state by hand to know when to re-record.

`endBundle()` now returns a `RenderBundle`, holding the native bundle plus a `stateKey` taken from the new `PipelineSystem.bundleStateKey` and an optional label from `beginBundle(label?)`. `isBundleValid(bundle)` compares that stamp against the pipeline's current key, so a caller can re-record before replaying instead of finding out at submit. `executeBundle()` takes one bundle or an array, since WebGPU resets the pass state per call.

`getBundleDescriptor()` also sets `depthReadOnly` and `stencilReadOnly` now, which the spec requires of any bundle executed in a read-only pass.

Breaking: `endBundle()` and `executeBundle()` change signature with no deprecation path. The bundle API shipped in v8.20.0 and pixi-3d is its only known consumer.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
