### PR TITLE
fix: detach from shared TextStyle on destroy (#12049)

### DIFF
--- a/src/scene/text/AbstractText.ts
+++ b/src/scene/text/AbstractText.ts
@@ -647,6 +647,10 @@ export abstract class AbstractText<
      */
     public override destroy(options: DestroyOptions = false): void
     {
+        // detach from the style so a shared style does not keep a reference
+        // to this destroyed instance (issue #12049)
+        this._style?.off('update', this.onViewUpdate, this);
+
         super.destroy(options);
 
         (this as any).owner = null;

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -210,6 +210,56 @@ describe('Text', () =>
 
             expect(style.fill).toBe(null);
         });
+
+        it('should remove the update listener from a shared style on destroy (no leak)', () =>
+        {
+            const style = new TextStyle({ fill: 'red' });
+
+            const text1 = new Text({ text: 'foo', style });
+            const text2 = new Text({ text: 'bar', style });
+
+            expect(style.listenerCount('update')).toEqual(2);
+
+            text1.destroy();
+
+            // Text must detach from the shared style so the destroyed instance
+            // can be garbage collected. #12049
+            expect(style.listenerCount('update')).toEqual(1);
+
+            text2.destroy();
+
+            expect(style.listenerCount('update')).toEqual(0);
+        });
+
+        it('should detach from the old style when assigning a new one', () =>
+        {
+            const styleA = new TextStyle({ fill: 'red' });
+            const styleB = new TextStyle({ fill: 'blue' });
+
+            const text = new Text({ text: 'foo', style: styleA });
+
+            expect(styleA.listenerCount('update')).toEqual(1);
+
+            text.style = styleB;
+
+            expect(styleA.listenerCount('update')).toEqual(0);
+            expect(styleB.listenerCount('update')).toEqual(1);
+        });
+
+        it('should remove the update listener from a shared style for BitmapText too (#12049)', () =>
+        {
+            const style = new TextStyle({ fontFamily: 'Arial' });
+
+            const text1 = new BitmapText({ text: 'foo', style });
+            const text2 = new BitmapText({ text: 'bar', style });
+
+            expect(style.listenerCount('update')).toEqual(2);
+
+            text1.destroy();
+            text2.destroy();
+
+            expect(style.listenerCount('update')).toEqual(0);
+        });
     });
 
     describe('text', () =>


### PR DESCRIPTION
Closes #12049

## Problem

A `TextStyle` kept alive by the application (created once, shared across many
texts) grows without bound. Each `Text`/`BitmapText`/`HTMLText` registers an
`update` listener on the shared style, but `destroy()` never unregisters it —
so the style retains a strong reference to every destroyed text instance.

As long as the shared style remains reachable, the listener keeps each
destroyed text reachable as well, preventing it from being garbage-collected.
This matches the reported behavior: listener counts continue to grow with
destroyed text instances, along with the GPU resources associated with those
instances.

## Root cause

`AbstractText.destroy()` nulled `this._style` without detaching the listener
the style setter registered:

```ts
set style(style) {
    this._style?.off('update', this.onViewUpdate, this); // setter detaches…
    this._style = …;
    this._style.on('update', this.onViewUpdate, this);   // …then attaches
}
```

`destroy({ style: true })` happens to remove the listener because destroying
the style calls `removeAllListeners()`, but that does not help when the style
is shared and intentionally kept alive — which is the exact scenario in the
issue. The missing symmetric `off` on the destroy path is the leak.

`Mesh` already does exactly this in its own destroy:
`this._geometry?.off('update', this.onViewUpdate, this)` (`Mesh.ts:361`).

## Fix

Unregister the listener in `destroy()` regardless of who owns the style:

```ts
public override destroy(options: DestroyOptions = false): void
{
    // detach from the style so a shared style does not keep a reference
    // to this destroyed instance (issue #12049)
    this._style?.off('update', this.onViewUpdate, this);

    super.destroy(options);
    …
}
```

- Applies to `Text`, `BitmapText` and `HTMLText` alike (all extend
  `AbstractText`).
- Safe in every state: `off` is a no-op when the event has no listeners
  (eventemitter3 guards on `!this._events[evt]`), `removeAllListeners()`
  resets `_events` so `off` after a destroyed style is still safe, and `?.`
  covers a nulled style. Double `destroy()` is therefore harmless.
- Leaves the `style: true` destroy path unchanged.

## Tests

Three tests added to `src/scene/text/__tests__/Text.test.ts`:

- Shared style + two `Text`: destroying one drops the listener count 2 → 1,
  destroying the other → 0.
- Same for `BitmapText` (explicitly reported in the issue).
- Reassigning `text.style` still detaches from the old style (regression guard
  on the existing setter behaviour).

The listener-count assertion fails on the pre-fix code (`count` stays 2 after
destroying one of two texts) and passes with the fix.

Verified: all `destroy` tests pass, all text suites pass, `eslint` and
`tsc --noEmit` clean. The only pre-existing failures in the text suite
(`TextMetrics` font-metric thresholds, a float-precision width assertion) fail
identically on `dev` and are unrelated.
