### PR TITLE
chore: bump @xmldom/xmldom to 0.8.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@pixi/colord": "^2.9.6",
         "@types/earcut": "^3.0.0",
         "@webgpu/types": "^0.1.69",
-        "@xmldom/xmldom": "^0.8.13",
+        "@xmldom/xmldom": "^0.8.15",
         "earcut": "^3.0.2",
         "eventemitter3": "^5.0.1",
         "gifuct-js": "^2.1.2",
@@ -5513,9 +5513,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -22948,9 +22948,9 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="
     },
     "@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA=="
     },
     "abab": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@pixi/colord": "^2.9.6",
     "@types/earcut": "^3.0.0",
     "@webgpu/types": "^0.1.69",
-    "@xmldom/xmldom": "^0.8.13",
+    "@xmldom/xmldom": "^0.8.15",
     "earcut": "^3.0.2",
     "eventemitter3": "^5.0.1",
     "gifuct-js": "^2.1.2",


### PR DESCRIPTION
## Description

Bumps `@xmldom/xmldom` from `^0.8.13` to `^0.8.15`. Installing pixi.js currently prints:

```
npm warn deprecated @xmldom/xmldom@0.8.14: this version has critical issues, please update to the latest version
```

0.8.15 is the maintained, non-deprecated release on the 0.8 line. Staying on 0.8.x (rather than 0.9.x, which changes the `DOMParser` return types) keeps this a safe patch-level change for a patch release.

Only used by `WebWorkerAdapter.parseXML`; types and a parser smoke check pass.

Fixes #12161

## Type of change

- [x] Chore