### PR TITLE
fix: reuse GPU buffers across frames instead of re-creating them every frame (#12163)

### DIFF
--- a/src/rendering/batcher/shared/BatcherPipe.ts
+++ b/src/rendering/batcher/shared/BatcherPipe.ts
@@ -43,6 +43,14 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
 
     private readonly _batchersByInstructionSet: Record<number, Record<string, Batcher>> = Object.create(null);
 
+    /**
+     * Batchers released by destroyed instruction sets, pooled for reuse by new
+     * ones (keyed by batcher name). Reusing a batcher reuses its geometry and
+     * the underlying GPU buffers across frames, instead of allocating fresh
+     * ones for every rebuilt scene.
+     */
+    private readonly _batcherPool: Record<string, Batcher[]> = Object.create(null);
+
     private _adaptor: BatcherAdaptor;
 
     /** A record of all active batchers, keyed by their names */
@@ -52,6 +60,9 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
     private _activeBatch: Batcher;
 
     public static _availableBatchers: Record<string, new (options: BatcherOptions) => Batcher> = Object.create(null);
+
+    /** How many released batchers to keep per batcher name for reuse. */
+    private static readonly _maxPooledBatchers = 64;
 
     public static getBatcher(name: string, maxTextures: number): Batcher
     {
@@ -73,7 +84,7 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
         if (!batchers)
         {
             batchers = this._batchersByInstructionSet[instructionSet.uid] = Object.create(null);
-            batchers.default ||= new DefaultBatcher({
+            batchers.default ||= this._batcherPool.default?.pop() ?? new DefaultBatcher({
                 maxTextures: this.renderer.limits.maxBatchableTextures,
             });
         }
@@ -99,7 +110,8 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
             if (!batch)
             {
                 batch = this._activeBatches[batchableObject.batcherName]
-                    = BatcherPipe.getBatcher(batchableObject.batcherName, this.renderer.limits.maxBatchableTextures);
+                    = this._batcherPool[batchableObject.batcherName]?.pop()
+                        ?? BatcherPipe.getBatcher(batchableObject.batcherName, this.renderer.limits.maxBatchableTextures);
                 batch.begin();
             }
 
@@ -149,6 +161,47 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
         }
     }
 
+    /**
+     * Called when an instruction set is destroyed: returns its batchers to the
+     * pool so future instruction sets reuse them (geometry, buffers and all)
+     * rather than allocating new ones every frame.
+     * @param instructionSet - the destroyed instruction set
+     */
+    public destroyInstructionSet(instructionSet: InstructionSet)
+    {
+        // the pipe itself may already have been destroyed (renderer torn down
+        // before the scene) - nothing to release then
+        if (!this._batcherPool) return;
+
+        const batchers = this._batchersByInstructionSet[instructionSet.uid];
+
+        if (!batchers) return;
+
+        delete this._batchersByInstructionSet[instructionSet.uid];
+
+        // _activeBatches may still point at this record; drop it so the pipe's
+        // own destroy() cannot double-destroy pooled batchers
+        if (this._activeBatches === batchers)
+        {
+            this._activeBatches = Object.create(null);
+        }
+
+        for (const name in batchers)
+        {
+            const batcher = batchers[name];
+            const pool = (this._batcherPool[name] ??= []);
+
+            if (pool.length < BatcherPipe._maxPooledBatchers)
+            {
+                pool.push(batcher);
+            }
+            else
+            {
+                batcher.destroy();
+            }
+        }
+    }
+
     public execute(batch: Batch)
     {
         if (batch.action === 'startBatch')
@@ -176,6 +229,18 @@ export class BatcherPipe implements InstructionPipe<Batch>, BatchPipe
         }
 
         this._activeBatches = null;
+
+        for (const name in this._batcherPool)
+        {
+            const pool = this._batcherPool[name];
+
+            for (let i = 0; i < pool.length; i++)
+            {
+                pool[i].destroy();
+            }
+        }
+
+        (this._batcherPool as null) = null;
     }
 }
 

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -13,6 +13,15 @@ import type { BindResource } from './shader/BindResource';
 import type { GpuProgram } from './shader/GpuProgram';
 import type { WebGPURenderer } from './WebGPURenderer';
 
+interface BindGroupCacheEntry
+{
+    gpuBindGroup: GPUBindGroup;
+    /** the pixi Buffers behind buffer-backed resources, for cache revalidation */
+    srcBuffers: Buffer[] | null;
+    /** the GPUBuffer each srcBuffer resolved to when this bind group was created */
+    gpuBuffers: GPUBuffer[] | null;
+}
+
 /**
  * This manages the WebGPU bind groups. this is how data is bound to a shader when rendering
  * @category rendering
@@ -30,7 +39,7 @@ export class BindGroupSystem implements System
 
     private readonly _renderer: WebGPURenderer;
 
-    private _hash: Record<string, GPUBindGroup> = Object.create(null);
+    private _hash: Record<string, BindGroupCacheEntry> = Object.create(null);
     private _gpu: GPU;
 
     constructor(renderer: WebGPURenderer)
@@ -52,17 +61,50 @@ export class BindGroupSystem implements System
         // Bit shift combines layoutKey and groupIndex into single number (groupIndex < 16)
         const key = `${bindGroup._key}:${(program._layoutKey << 4) | groupIndex}`;
 
-        const gpuBindGroup = this._hash[key] || this._createBindGroup(key, bindGroup, program, groupIndex);
+        let entry = this._hash[key];
 
-        return gpuBindGroup;
+        // the key tracks resource ids, but not the identity of the GPUBuffer
+        // behind a buffer-backed resource - that can change (buffer resize, or
+        // an unloaded buffer being re-created), leaving a cached GPUBindGroup
+        // pointing at the old GPUBuffer. Revalidate before using the cache.
+        // (This also touches the buffers, so actively bound buffers are never
+        // treated as unused by the GC.)
+        if (entry && !this._validate(entry)) entry = null;
+
+        entry = entry || this._createBindGroup(key, bindGroup, program, groupIndex);
+
+        return entry.gpuBindGroup;
     }
 
-    private _createBindGroup(key: string, group: BindGroup, program: GpuProgram, groupIndex: number): GPUBindGroup
+    private _validate(entry: BindGroupCacheEntry): boolean
+    {
+        const { srcBuffers, gpuBuffers } = entry;
+
+        if (!srcBuffers) return true;
+
+        const bufferSystem = this._renderer.buffer;
+
+        for (let i = 0; i < srcBuffers.length; i++)
+        {
+            if (bufferSystem.getGPUBuffer(srcBuffers[i]) !== gpuBuffers[i]) return false;
+        }
+
+        return true;
+    }
+
+    private _createBindGroup(key: string, group: BindGroup, program: GpuProgram, groupIndex: number): BindGroupCacheEntry
     {
         const device = this._gpu.device;
         const groupLayout = program.layout[groupIndex];
         const entries: GPUBindGroupEntry[] = [];
         const renderer = this._renderer;
+        let srcBuffers: Buffer[] = null;
+        let gpuBuffers: GPUBuffer[] = null;
+        const trackBuffer = (buffer: Buffer, gpuBuffer: GPUBuffer) =>
+        {
+            (srcBuffers ??= []).push(buffer);
+            (gpuBuffers ??= []).push(gpuBuffer);
+        };
 
         for (const j in groupLayout)
         {
@@ -87,9 +129,11 @@ export class BindGroupSystem implements System
                 renderer.ubo.updateUniformGroup(uniformGroup as UniformGroup);
 
                 const buffer = uniformGroup.buffer;
+                const gpuBuffer = renderer.buffer.getGPUBuffer(buffer);
 
+                trackBuffer(buffer, gpuBuffer);
                 gpuResource = {
-                    buffer: renderer.buffer.getGPUBuffer(buffer),
+                    buffer: gpuBuffer,
                     offset: 0,
                     size: buffer.descriptor.size,
                 };
@@ -97,9 +141,11 @@ export class BindGroupSystem implements System
             else if (resource._resourceType === 'buffer')
             {
                 const buffer = resource as Buffer;
+                const gpuBuffer = renderer.buffer.getGPUBuffer(buffer);
 
+                trackBuffer(buffer, gpuBuffer);
                 gpuResource = {
-                    buffer: renderer.buffer.getGPUBuffer(buffer),
+                    buffer: gpuBuffer,
                     offset: 0,
                     size: buffer.descriptor.size,
                 };
@@ -107,9 +153,11 @@ export class BindGroupSystem implements System
             else if (resource._resourceType === 'bufferResource')
             {
                 const bufferResource = resource as BufferResource;
+                const gpuBuffer = renderer.buffer.getGPUBuffer(bufferResource.buffer);
 
+                trackBuffer(bufferResource.buffer, gpuBuffer);
                 gpuResource = {
-                    buffer: renderer.buffer.getGPUBuffer(bufferResource.buffer),
+                    buffer: gpuBuffer,
                     offset: bufferResource.offset,
                     size: bufferResource.size ?? bufferResource.buffer.descriptor.size,
                 };
@@ -146,9 +194,11 @@ export class BindGroupSystem implements System
             entries,
         });
 
-        this._hash[key] = gpuBindGroup;
+        const entry: BindGroupCacheEntry = { gpuBindGroup, srcBuffers, gpuBuffers };
 
-        return gpuBindGroup;
+        this._hash[key] = entry;
+
+        return entry;
     }
 
     public destroy(): void

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -39,6 +39,9 @@ export class GpuEncoderSystem implements System
     } as const;
 
     public commandEncoder: GPUCommandEncoder;
+
+    /** command buffers to submit ahead of this frame's own, in the frame's queue.submit call */
+    private readonly _preFrameCommandBuffers: GPUCommandBuffer[] = [];
     /**
      * The active command target that draws and state are recorded into. This is the live render
      * pass during normal rendering, or a {@link GPURenderBundleEncoder} while a render bundle is
@@ -505,11 +508,42 @@ export class GpuEncoderSystem implements System
         }
     }
 
+    /**
+     * Queues a command buffer to be submitted immediately before this frame's
+     * command buffer, in the same `queue.submit` call. Execution order is
+     * identical to submitting it directly at the call site (submits execute in
+     * queue order, and array order within a submit is queue order), but the
+     * driver only sees one submission per frame.
+     * @param commandBuffer - the command buffer to submit before the frame's own
+     */
+    public submitBeforeFrame(commandBuffer: GPUCommandBuffer): void
+    {
+        // outside a frame there is nothing to piggyback on - submit directly
+        if (!this.commandEncoder)
+        {
+            this._gpu.device.queue.submit([commandBuffer]);
+
+            return;
+        }
+
+        this._preFrameCommandBuffers.push(commandBuffer);
+    }
+
     public postrender()
     {
         this.finishRenderPass();
 
-        this._gpu.device.queue.submit([this.commandEncoder.finish()]);
+        if (this._preFrameCommandBuffers.length)
+        {
+            // one submit for [uploads..., frame]: array order is queue order,
+            // identical to submitting them separately, minus a driver round trip
+            this._gpu.device.queue.submit([...this._preFrameCommandBuffers, this.commandEncoder.finish()]);
+            this._preFrameCommandBuffers.length = 0;
+        }
+        else
+        {
+            this._gpu.device.queue.submit([this.commandEncoder.finish()]);
+        }
 
         this._resolveCommandFinished();
 

--- a/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
+++ b/src/rendering/renderers/gpu/GpuUniformBatchPipe.ts
@@ -169,8 +169,9 @@ export class GpuUniformBatchPipe
             );
         }
 
-        // TODO make a system that will que up all commands in to one array?
-        this._renderer.gpu.device.queue.submit([commandEncoder.finish()]);
+        // fused into the frame's queue.submit (same execution order: renderEnd
+        // precedes postrender, and array order within a submit is queue order)
+        this._renderer.encoder.submitBeforeFrame(commandEncoder.finish());
     }
 
     public destroy()

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -8,25 +8,43 @@ import type { System } from '../../shared/system/System';
 import type { GPU } from '../GpuDeviceSystem';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
+const MAPPABLE_USAGE = 0x0001 | 0x0002; // GPUBufferUsage.MAP_READ | MAP_WRITE
+const GPU_WRITTEN_USAGE = 0x0100 | 0x0200; // GPUBufferUsage.INDIRECT | QUERY_RESOLVE
+
 /** @internal */
 export class GpuBufferData implements GPUData
 {
     public gpuBuffer: GPUBuffer;
+    /** size/usage captured at creation so the buffer can be recycled even after the pixi Buffer is torn down */
+    public readonly size: number;
+    public readonly usage: number;
 
-    constructor(gpuBuffer: GPUBuffer)
+    constructor(gpuBuffer: GPUBuffer, size: number, usage: number)
     {
         this.gpuBuffer = gpuBuffer;
+        this.size = size;
+        this.usage = usage;
     }
 
     public destroy()
     {
-        this.gpuBuffer.destroy();
+        // the owning GpuBufferSystem may have taken the GPUBuffer for reuse
+        this.gpuBuffer?.destroy();
         this.gpuBuffer = null;
     }
 }
 
 /**
  * System plugin to the renderer to manage buffers.
+ *
+ * Released `GPUBuffer`s (buffer resize, buffer destroy, GC unload) are pooled by
+ * `size:usage` class and reused by {@link GpuBufferSystem#createGPUBuffer} instead of
+ * hitting `device.createBuffer` again — in steady-state scenes that rebuild display
+ * objects per frame this takes per-frame buffer allocation to ~zero. Reuse is
+ * queue-order safe: a pooled buffer only becomes available after the frame that
+ * released it has been submitted (see `postrender`), and its new contents are
+ * written with `queue.writeBuffer`, which executes after all previously submitted
+ * work on the same queue.
  * @category rendering
  * @advanced
  */
@@ -40,9 +58,19 @@ export class GpuBufferSystem implements System
         name: 'buffer',
     } as const;
 
+    /** The maximum total bytes of released GPU buffers kept for reuse. Overflow is destroyed instead of pooled. */
+    public maxPooledBytes = 64 * 1024 * 1024;
+
     protected CONTEXT_UID: number;
     private readonly _renderer: WebGPURenderer;
     private readonly _managedBuffers: GCManagedHash<Buffer>;
+
+    /** released GPUBuffers ready for reuse, keyed by `${size}:${usage}` */
+    private readonly _pool: Map<string, GPUBuffer[]> = new Map();
+    /** released this frame — becomes reusable only after this frame's submit */
+    private readonly _pendingRecycle: { gpuBuffer: GPUBuffer; size: number; usage: number }[] = [];
+    private _poolBytes = 0;
+    private _scratch: Uint8Array | null = null;
 
     private _gpu: GPU;
 
@@ -60,6 +88,7 @@ export class GpuBufferSystem implements System
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+        this._drainPool();
     }
 
     public getGPUBuffer(buffer: Buffer): GPUBuffer
@@ -98,34 +127,65 @@ export class GpuBufferSystem implements System
     public destroyAll(): void
     {
         this._managedBuffers.removeAll();
+        this._drainPool();
     }
 
     protected onBufferUnload(buffer: Buffer): void
     {
+        const gpuData = buffer._gpuData[this._renderer.uid] as GpuBufferData;
+
+        if (gpuData?.gpuBuffer)
+        {
+            this._recycle(gpuData.gpuBuffer, gpuData.size, gpuData.usage);
+            gpuData.gpuBuffer = null;
+        }
+
         buffer.off('update', this.updateBuffer, this);
         buffer.off('change', this.onBufferChange, this);
     }
 
     public createGPUBuffer(buffer: Buffer): GPUBuffer
     {
-        const gpuBuffer = this._gpu.device.createBuffer(buffer.descriptor);
+        const { size, usage } = buffer.descriptor;
+        let gpuBuffer = this._acquire(size, usage);
+
+        if (gpuBuffer)
+        {
+            // restore fresh-buffer semantics: zero-initialised, then the CPU
+            // data on top. queue.writeBuffer is queue-ordered, so overwriting
+            // bytes still referenced by already-submitted work is safe.
+            const scratch = this._zeroScratch(size);
+
+            if (buffer.data)
+            {
+                const src = new Uint8Array(buffer.data.buffer, buffer.data.byteOffset, buffer.data.byteLength);
+
+                scratch.set(src.byteLength > size ? src.subarray(0, size) : src);
+            }
+
+            this._gpu.device.queue.writeBuffer(gpuBuffer, 0, scratch.buffer, 0, size);
+        }
+        else
+        {
+            gpuBuffer = this._gpu.device.createBuffer(buffer.descriptor);
+
+            if (buffer.data)
+            {
+                // TODO if data is static, this can be mapped at creation
+                fastCopy(
+                    buffer.data.buffer as ArrayBuffer,
+                    gpuBuffer.getMappedRange(),
+                    buffer.data.byteOffset,
+                    buffer.data.byteLength
+                );
+
+                gpuBuffer.unmap();
+            }
+        }
 
         buffer._updateID = 0;
 
-        if (buffer.data)
-        {
-            // TODO if data is static, this can be mapped at creation
-            fastCopy(
-                buffer.data.buffer as ArrayBuffer,
-                gpuBuffer.getMappedRange(),
-                buffer.data.byteOffset,
-                buffer.data.byteLength
-            );
-
-            gpuBuffer.unmap();
-        }
-
-        buffer._gpuData[this._renderer.uid] = new GpuBufferData(gpuBuffer);
+        buffer._gpuData[this._renderer.uid] = new GpuBufferData(gpuBuffer, size, usage);
         if (this._managedBuffers.add(buffer))
         {
             buffer.on('update', this.updateBuffer, this);
@@ -142,11 +202,92 @@ export class GpuBufferSystem implements System
         this.createGPUBuffer(buffer);
     }
 
+    /** makes buffers released during this frame available for reuse (the frame is submitted by now) */
+    protected postrender(): void
+    {
+        const pending = this._pendingRecycle;
+
+        for (let i = 0; i < pending.length; i++)
+        {
+            const { gpuBuffer, size, usage } = pending[i];
+            const key = `${size}:${usage}`;
+            let list = this._pool.get(key);
+
+            if (!list) this._pool.set(key, list = []);
+            list.push(gpuBuffer);
+        }
+
+        pending.length = 0;
+    }
+
+    private _poolable(size: number, usage: number): boolean
+    {
+        return size > 0
+            && size % 4 === 0
+            && (usage & (MAPPABLE_USAGE | GPU_WRITTEN_USAGE)) === 0;
+    }
+
+    private _recycle(gpuBuffer: GPUBuffer, size: number, usage: number): void
+    {
+        if (!this._poolable(size, usage) || this._poolBytes + size > this.maxPooledBytes)
+        {
+            gpuBuffer.destroy();
+
+            return;
+        }
+
+        this._pendingRecycle.push({ gpuBuffer, size, usage });
+        this._poolBytes += size;
+    }
+
+    private _acquire(size: number, usage: number): GPUBuffer | null
+    {
+        if (!this._poolable(size, usage)) return null;
+
+        const list = this._pool.get(`${size}:${usage}`);
+
+        if (!list?.length) return null;
+
+        this._poolBytes -= size;
+
+        return list.pop();
+    }
+
+    private _zeroScratch(size: number): Uint8Array
+    {
+        if (!this._scratch || this._scratch.byteLength < size)
+        {
+            this._scratch = new Uint8Array(size);
+        }
+        else
+        {
+            this._scratch.fill(0, 0, size);
+        }
+
+        return this._scratch;
+    }
+
+    private _drainPool(): void
+    {
+        for (const list of this._pool.values())
+        {
+            for (let i = 0; i < list.length; i++) list[i].destroy();
+        }
+        for (let i = 0; i < this._pendingRecycle.length; i++)
+        {
+            this._pendingRecycle[i].gpuBuffer.destroy();
+        }
+        this._pool.clear();
+        this._pendingRecycle.length = 0;
+        this._poolBytes = 0;
+    }
+
     public destroy(): void
     {
         this._managedBuffers.destroy();
+        this._drainPool();
         (this._renderer as null) = null;
         this._gpu = null;
+        this._scratch = null;
     }
 }
-

--- a/src/rendering/renderers/shared/instructions/InstructionSet.ts
+++ b/src/rendering/renderers/shared/instructions/InstructionSet.ts
@@ -41,6 +41,17 @@ export class InstructionSet
      */
     public destroy()
     {
+        // let every pipe that holds per-instruction-set state (keyed by this
+        // uid) release it - e.g. BatcherPipe returns its batchers (and their
+        // GPU buffers) to a pool for reuse instead of leaking them
+        if (this.renderPipes)
+        {
+            for (const i in this.renderPipes)
+            {
+                this.renderPipes[i].destroyInstructionSet?.(this);
+            }
+        }
+
         this.instructions.length = 0;
         this.renderables.length = 0;
 

--- a/src/rendering/renderers/shared/instructions/RenderPipe.ts
+++ b/src/rendering/renderers/shared/instructions/RenderPipe.ts
@@ -119,6 +119,12 @@ export interface BatchPipe
      * @param instructionSet - the instruction set currently being built
      */
     break: (instructionSet: InstructionSet) => void;
+    /**
+     * Called when an instruction set is destroyed, so the pipe can release
+     * (and possibly recycle) any state it keyed to that instruction set.
+     * @param instructionSet - the instruction set being destroyed
+     */
+    destroyInstructionSet?: (instructionSet: InstructionSet) => void;
 }
 
 /**

--- a/src/scene/container/RenderGroup.ts
+++ b/src/scene/container/RenderGroup.ts
@@ -379,6 +379,8 @@ export class RenderGroup implements Instruction
     {
         this.disableCacheAsTexture();
 
+        this.instructionSet?.destroy();
+
         this.renderGroupParent = null;
         this.root = null;
         (this.childrenRenderablesToUpdate as any) = null;


### PR DESCRIPTION
Fixes #12163 — the WebGPU renderer re-creating GPU buffers with `device.createBuffer` every frame for any workload that (re)builds display objects per frame, and the related retention of per-instruction-set batch state.

### What changes

**1. Batch buffers are reused across frames (the source fix).**
`RenderGroup#destroy` now destroys its `InstructionSet`, and `InstructionSet#destroy` notifies pipes through a new optional `destroyInstructionSet` hook. `BatcherPipe` implements it: batchers released by destroyed instruction sets go to a per-pipe pool (keyed by batcher name, capped) and `buildStart` serves new instruction sets from that pool. A reused batcher brings its `BatchGeometry` and `Buffer` objects with it, so the same `GPUBuffer`s are written each frame instead of fresh ones being created — and the previous behavior of retaining every dead instruction set's batchers in `_batchersByInstructionSet` forever is gone.

**2. Released `GPUBuffer`s are recycled in `GpuBufferSystem`.**
Buffers released by the resize path (`onBufferChange`), buffer destroy, or GC unload are pooled by `size:usage` class instead of destroyed, and `createGPUBuffer` serves an exact-class match from the pool. Semantics are identical to a fresh buffer: the reused buffer is zero-filled and the CPU-side data written on top via `queue.writeBuffer`. The pool is byte-budget capped (`maxPooledBytes`, default 64 MiB — overflow is destroyed); mappable (`MAP_READ`/`MAP_WRITE`), `INDIRECT`/`QUERY_RESOLVE`, zero-size and non-4-byte-aligned buffers are never pooled.

**3. The bind-group cache revalidates buffer identity.**
The cache key (`bindGroup._key`) tracks resource ids, but not the identity of the `GPUBuffer` behind a buffer-backed resource — which can change (resize, or a GC-unloaded buffer being re-created on next use). A cached `GPUBindGroup` is now revalidated against the current `GPUBuffer` of each buffer-backed resource before use, and rebuilt if any changed. Two side benefits: revalidation touches those buffers every frame, so the GC can no longer unload a buffer that is only ever reached through a cached bind group (previously that unload would leave the cached bind group pointing at a destroyed `GPUBuffer`); and it is what makes reuse safe for uniform buffers at all.

**Companion (one-liner scale):** `GpuUniformBatchPipe._uploadBindGroups` no longer issues its own `queue.submit`; the upload command buffer is handed to `GpuEncoderSystem` and submitted as `[uploadCB, frameCB]` in the frame's single submit. Execution order is identical (runner order guarantees `renderEnd` → `postrender`; submits execute in queue order and array order within a submit is queue order) — it just removes one driver submission per `render()` call.

### Why reuse is safe (the ordering argument)

A `GPUBuffer` released during frame N may still be referenced by frame N's not-yet-submitted passes, so releases are parked in a pending list and only enter the pool at `postrender` — after frame N's `queue.submit`. A pooled buffer acquired in frame N+1 gets its new contents via `queue.writeBuffer`, which executes after all previously submitted work on the same queue, so in-flight GPU work from earlier frames reads the bytes it was submitted with. Batcher reuse (1) gets the same property for free: a batcher is only released outside a frame (instruction-set destroy) and its buffers' new contents are queue-ordered writes.

### Validation

Repro from #12163 (headless Node 22 + Dawn, this machine = Apple Silicon/Metal), same script against a stock `dev` build and this branch:

```
dev:    frame 1..31:  16 createBuffer, 0.16 MB   (every frame, forever)
branch: frame 1..31:   0 createBuffer
```

Render-target readback after the run: SHA-256 **byte-identical** between stock `dev` and this branch (512×512 RGBA).

The same mechanism (backported to a production 8.3.4 tree) was validated on a production-scale headless Node.js server-side rendering workload (Linux, RTX 4060 Ti, Vulkan; each job builds a scene, renders it plus intermediate render-to-texture passes, tears it down):

- steady-state `device.createBuffer`: **24/render → 0/render**;
- output parity: raw RGBA framebuffer SHA-256 **byte-identical** to stock for 4 fixed test cases (two scenes × two output sizes), both cold and after warm-up;
- stability: 250 mixed renders, zero errors, RSS flat (oscillating around ~900 MB with no growth trend between render 50 and render 250);
- throughput on the same box with 6 renderer processes sharing the GPU: sustained rps **+74–104%** and p90 latency roughly **halved** vs stock — on Vulkan each `createBuffer` is expensive and buffer churn contends device-wide, so removing it pays far beyond the allocation itself.

What I ran in this repo (macOS, Node 22):

- `tsc --noEmit` on both `tsconfig.json` (0 errors in `src/`; `examples/` has pre-existing errors on stock `dev` too) and `.configs/tsconfig.types.json` (clean);
- full jest unit suite via the repo runner (`jest src`): **185 suites / 1974 tests passed** (1 suite skipped by its own guard);
- visual suite (`jest tests/visual`): **1670 passed**;
- eslint on the changed files: clean.

I did not run the browser/e2e CI jobs — happy to iterate if anything trips there.

### Notes for reviewers

- `RenderGroup#destroy` previously nulled `instructionSet` without destroying it, so `InstructionSet#destroy` was dead code and pipes never learned an instruction set died — that is what made per-frame scene rebuilds leak batchers. If there is a reason instruction sets must outlive their render group, the hook call is the only line that depends on the new ordering.
- The `destroyInstructionSet` hook is optional on the pipe interface, so third-party pipes are unaffected.
- `GpuBufferData` now records `size`/`usage` at creation so a buffer can be recycled even when its descriptor is already torn down, and its `destroy()` tolerates the system having taken the `GPUBuffer` for reuse.
- WebGL is untouched apart from batcher reuse, which benefits it the same way (`GlBufferSystem` keys by buffer uid, so reused batch buffers reuse GL buffers too).
