### PR TITLE
fix: cache encoder key lists to stop per-draw for-in allocations over null-prototype maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ dist
 lib
 out
 
+# local perf/GC benchmark scripts and traces (see src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts)
+.bench
+
 # jetBrains IDE ignores
 .idea
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default tseslint.config(
     ...config,
     {
         ignores: [
+            '.bench',
             '.s3_uploads',
             '.context',
             'out',

--- a/src/rendering/renderers/__tests__/BindGroup.test.ts
+++ b/src/rendering/renderers/__tests__/BindGroup.test.ts
@@ -193,6 +193,70 @@ describe('BindGroup', () =>
         expect(bufferResource._gcLastUsed).toBe(123);
     });
 
+    it('_touch should re-enumerate resources after a new slot is added (key cache invalidation)', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array(64),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const bufferResource = new BufferResource({
+            buffer,
+            offset: 0,
+            size: 128,
+        });
+
+        const bindGroup = new BindGroup({
+            0: bufferResource,
+        });
+
+        // warm the key list cache
+        bindGroup._touch(1, 1);
+        expect(bufferResource._gcLastUsed).toBe(1);
+
+        // adding a resource at a new index must invalidate the cached key list
+        const buffer2 = new Buffer({
+            data: new Float32Array(64),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const bufferResource2 = new BufferResource({
+            buffer: buffer2,
+            offset: 0,
+            size: 128,
+        });
+
+        bindGroup.setResource(bufferResource2, 1);
+
+        bindGroup._touch(2, 2);
+
+        // both slots touched — the key cache was rebuilt rather than reused stale keys
+        expect(bufferResource2._gcLastUsed).toBe(2);
+        expect(buffer._gcLastUsed).toBe(2);
+    });
+
+    it('destroy should clear the cached key list so consumers stop indexing stale keys', () =>
+    {
+        const buffer = new Buffer({
+            data: new Float32Array(64),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+
+        const bindGroup = new BindGroup({ 0: buffer });
+
+        // warm the key list cache
+        expect(bindGroup._resourceKeys).toEqual(['0']);
+
+        bindGroup.destroy();
+
+        // a stale cache would still return ['0'] and make _key/_touch index into the
+        // now-null resources map (the original `for-in null` was a silent no-op)
+        expect(bindGroup.resources).toBeNull();
+        expect(bindGroup._resourceKeys).toEqual([]);
+        expect(() => bindGroup._key).not.toThrow();
+        expect(() => bindGroup._touch(0, 0)).not.toThrow();
+    });
+
     it('should let have a unique id for a bind group, no clashes', () =>
     {
         resetUids();

--- a/src/rendering/renderers/__tests__/Shader.test.ts
+++ b/src/rendering/renderers/__tests__/Shader.test.ts
@@ -38,4 +38,37 @@ describe('Shader', () =>
 
         expect(glProgram._attributeData).toBeNull();
     });
+
+    it('_groupKeyCache should re-enumerate groups after addResource inserts a new group', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        // warm the cache with an empty group map
+        expect(shader._groupKeyCache).toEqual([]);
+
+        shader.addResource('uFoo', 0, 0);
+
+        // the new group must be visible — the cache was invalidated rather than reused
+        expect(shader._groupKeyCache).toEqual([0]);
+    });
+
+    it('destroy should clear the group key cache', () =>
+    {
+        const shader = new Shader({
+            glProgram: getGlProgram(),
+            resources: {}
+        });
+
+        shader.addResource('uFoo', 0, 0);
+
+        expect(shader._groupKeyCache).toEqual([0]);
+
+        shader.destroy();
+
+        expect(shader.groups).toBeNull();
+        expect(shader._groupKeyCache).toEqual([]);
+    });
 });

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -64,6 +64,13 @@ export class GpuEncoderSystem implements System
     private _boundIndexBuffer: Buffer;
     private _boundPipeline: GPURenderPipeline;
     /**
+     * Cached key list per cached {@link PipelineSystem.getBufferNamesToBind} result. The pipeline
+     * reuses the same null-prototype map for a given (geometry, program), so a key list cached in a
+     * WeakMap is stable and collected with the map. Iterating it avoids re-enumerating the map (and
+     * the per-bind `parseInt`) on every draw call.
+     */
+    private readonly _bufferKeys = new WeakMap<Record<string, string>, number[]>();
+    /**
      * The real render pass encoder. Unlike {@link renderPassEncoder}, this is never swapped out for
      * a bundle encoder, so pass-level commands (viewport, stencil, executeBundles, end) always have
      * a correctly typed target — even while a bundle is being recorded.
@@ -365,9 +372,20 @@ export class GpuEncoderSystem implements System
         // essentially only binding a single time for any buffers that are interleaved.
         const buffersToBind = this._renderer.pipeline.getBufferNamesToBind(geometry, program);
 
-        for (const i in buffersToBind)
+        // `buffersToBind` is reused per (geometry, program) by the pipeline's cache, so a key list
+        // cached in a WeakMap is stable. Iterating indices avoids re-enumerating the null-prototype
+        // map (and the per-bind `parseInt`) on every draw call.
+        let bufferKeys = this._bufferKeys.get(buffersToBind);
+
+        if (!bufferKeys)
         {
-            this._setVertexBuffer(parseInt(i, 10), geometry.attributes[buffersToBind[i]].buffer);
+            bufferKeys = Object.keys(buffersToBind).map(Number);
+            this._bufferKeys.set(buffersToBind, bufferKeys);
+        }
+
+        for (let i = 0; i < bufferKeys.length; i++)
+        {
+            this._setVertexBuffer(bufferKeys[i], geometry.attributes[buffersToBind[bufferKeys[i]]].buffer);
         }
 
         if (geometry.indexBuffer)
@@ -379,15 +397,20 @@ export class GpuEncoderSystem implements System
     private _setShaderBindGroups(shader: Shader, skipSync?: boolean)
     {
         const program = shader.gpuProgram;
+        // iterate the cached key list instead of `for-in` over the group map, which
+        // re-enumerates (and allocates) on every draw call
+        const groupKeys = shader._groupKeyCache;
 
-        for (const i in shader.groups)
+        for (let i = 0; i < groupKeys.length; i++)
         {
+            const groupIndex = groupKeys[i];
+
             // resources that only exist for the other backend (e.g. GL-fallback uniforms,
             // parked in group 99 by Shader.from) have no entry in this program's layout —
             // there is nothing to sync or bind for them
-            if (!program.layout[i as unknown as number]) continue;
+            if (!program.layout[groupIndex]) continue;
 
-            const bindGroup = shader.groups[i] as BindGroup;
+            const bindGroup = shader.groups[groupIndex] as BindGroup;
 
             // update any uniforms?
             if (!skipSync)
@@ -395,15 +418,18 @@ export class GpuEncoderSystem implements System
                 this._syncBindGroup(bindGroup);
             }
 
-            this.setBindGroup(i as unknown as number, bindGroup, program);
+            this.setBindGroup(groupIndex, bindGroup, program);
         }
     }
 
     private _syncBindGroup(bindGroup: BindGroup)
     {
-        for (const j in bindGroup.resources)
+        const resources = bindGroup.resources;
+        const resourceKeys = bindGroup._resourceKeys;
+
+        for (let i = 0; i < resourceKeys.length; i++)
         {
-            const resource = bindGroup.resources[j];
+            const resource = resources[resourceKeys[i]];
 
             // a destroyed buffer-like resource leaves a null slot (see BindGroup.onResourceChange)
             if (!resource) continue;

--- a/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
@@ -1,9 +1,17 @@
+import { Buffer } from '../../shared/buffer/Buffer';
+import { BufferResource } from '../../shared/buffer/BufferResource';
+import { BufferUsage } from '../../shared/buffer/const';
 import { RenderTarget } from '../../shared/renderTarget/RenderTarget';
+import { Shader } from '../../shared/shader/Shader';
 import { TextureSource } from '../../shared/texture/sources/TextureSource';
+import { GpuEncoderSystem } from '../GpuEncoderSystem';
 import { RenderBundle } from '../RenderBundle';
+import { BindGroup } from '../shader/BindGroup';
 import { describeLocalOnly, getWebGPURenderer } from '@test-utils';
 
+import type { Geometry } from '../../shared/geometry/Geometry';
 import type { TEXTURE_FORMATS } from '../../shared/texture/const';
+import type { GpuProgram } from '../shader/GpuProgram';
 import type { WebGPURenderer } from '../WebGPURenderer';
 
 let renderer: WebGPURenderer;
@@ -194,5 +202,174 @@ describeLocalOnly('GpuEncoderSystem render bundles', () =>
         renderer.pipeline.setRenderTarget(readOnlyTarget);
 
         expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
+    });
+});
+
+// --- key-list caching for pixijs#12151 (no WebGPU device needed, so these run in CI) ---
+// The `.bench/` scripts quantify the win; these tests pin the behaviour it depends on:
+// the null-prototype buffer/group maps are enumerated exactly once per map, not per draw.
+
+function stubRenderer(): { renderer: WebGPURenderer, getBufferNamesToBind: jest.Mock }
+{
+    const getBufferNamesToBind = jest.fn(() => ({}));
+
+    const renderer = {
+        pipeline: {
+            getBufferNamesToBind,
+            getPipeline: jest.fn(() => ({})),
+        },
+        buffer: { updateBuffer: (buffer: Buffer) => buffer },
+        ubo: { updateUniformGroup: jest.fn() },
+        gc: { now: 0 },
+        tick: 0,
+        bindGroup: { getBindGroup: jest.fn(() => ({})) },
+    } as unknown as WebGPURenderer;
+
+    return { renderer, getBufferNamesToBind };
+}
+
+describe('GpuEncoderSystem key-list caching', () =>
+{
+    it('enumerates a buffersToBind map exactly once across repeated draws', () =>
+    {
+        const { renderer, getBufferNamesToBind } = stubRenderer();
+        const encoder = new GpuEncoderSystem(renderer);
+
+        const setVertexBuffer = jest.fn();
+
+        (encoder as unknown as { renderPassEncoder: unknown }).renderPassEncoder = { setVertexBuffer };
+
+        // a null-prototype map with integer bind-location keys, shaped exactly like
+        // PipelineSystem.getBufferNamesToBind produces and reuses per (geometry, program)
+        let ownKeysCalls = 0;
+
+        const buffersToBind = new Proxy(Object.create(null) as Record<string, string>, {
+            ownKeys(target)
+            {
+                ownKeysCalls++;
+
+                return Reflect.ownKeys(target);
+            },
+        });
+
+        buffersToBind[0] = 'aPosition';
+        buffersToBind[1] = 'aUV';
+
+        getBufferNamesToBind.mockReturnValue(buffersToBind);
+
+        const bufferA = {} as Buffer;
+        const bufferB = {} as Buffer;
+        const geometry = {
+            attributes: { aPosition: { buffer: bufferA }, aUV: { buffer: bufferB } },
+            indexBuffer: null,
+        } as unknown as Geometry;
+        const program = {} as GpuProgram;
+
+        encoder.setGeometry(geometry, program);
+        encoder.setGeometry(geometry, program);
+
+        // the whole point of the fix: the cached key list, not the map, is iterated from
+        // the second draw on — one enumeration total, not one per draw
+        expect(ownKeysCalls).toBe(1);
+
+        // bind locations still resolve, in order, to the right buffers
+        expect(setVertexBuffer).toHaveBeenCalledWith(0, bufferA);
+        expect(setVertexBuffer).toHaveBeenCalledWith(1, bufferB);
+    });
+
+    it('keeps a separate cache entry per buffersToBind map', () =>
+    {
+        const { renderer, getBufferNamesToBind } = stubRenderer();
+        const encoder = new GpuEncoderSystem(renderer);
+
+        const setVertexBuffer = jest.fn();
+
+        (encoder as unknown as { renderPassEncoder: unknown }).renderPassEncoder = { setVertexBuffer };
+
+        const makeMap = () =>
+        {
+            let ownKeysCalls = 0;
+
+            const map = new Proxy(Object.create(null) as Record<string, string>, {
+                ownKeys(target)
+                {
+                    ownKeysCalls++;
+
+                    return Reflect.ownKeys(target);
+                },
+            });
+
+            map[0] = 'aPosition';
+
+            return { map, ownKeysCalls: () => ownKeysCalls };
+        };
+
+        const first = makeMap();
+        const second = makeMap();
+
+        getBufferNamesToBind
+            .mockReturnValueOnce(first.map)
+            .mockReturnValue(second.map);
+
+        const buffer = {} as Buffer;
+        const geometry = {
+            attributes: { aPosition: { buffer } },
+            indexBuffer: null,
+        } as unknown as Geometry;
+        const program = {} as GpuProgram;
+
+        encoder.setGeometry(geometry, program);
+        encoder.setGeometry(geometry, program); // cache hit on the first map
+        encoder.setGeometry(geometry, program); // second map → its own fresh enumeration
+
+        expect(first.ownKeysCalls()).toBe(1);
+        expect(second.ownKeysCalls()).toBe(1);
+        expect(setVertexBuffer).toHaveBeenCalledWith(0, buffer);
+    });
+
+    it('draws safely when a bound bind group has been destroyed (null resources)', () =>
+    {
+        const { renderer } = stubRenderer();
+        const encoder = new GpuEncoderSystem(renderer);
+
+        const setBindGroup = jest.fn();
+        const draw = jest.fn();
+
+        (encoder as unknown as { renderPassEncoder: unknown }).renderPassEncoder = {
+            setPipeline: jest.fn(),
+            setVertexBuffer: jest.fn(),
+            setBindGroup,
+            draw,
+        };
+
+        const buffer = new Buffer({
+            data: new Float32Array(64),
+            usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
+        });
+        const bufferResource = new BufferResource({ buffer, offset: 0, size: 128 });
+
+        const bindGroup = new BindGroup({ 0: bufferResource });
+
+        expect(bindGroup._key).toBeTruthy(); // warm the key so _keyValue survives destroy
+
+        bindGroup.destroy();
+        expect(bindGroup.resources).toBeNull();
+
+        // build the shader through the groups overload: the destroyed bind group is passed
+        // straight through, and the fake gpuProgram's layout drives which groups get synced
+        const fakeGpuProgram = { layout: { 0: {} } } as unknown as GpuProgram;
+        const shader = new Shader({ groups: { 0: bindGroup }, gpuProgram: fakeGpuProgram, groupMap: {} });
+
+        const geometry = {
+            attributes: {},
+            indexBuffer: null,
+            vertexCount: 3,
+            instanceCount: 1,
+        } as unknown as Geometry;
+
+        // a stale _resourceKeys cache would index into the now-null resources map and throw here
+        expect(() => encoder.draw({ geometry, shader })).not.toThrow();
+        expect(draw).toHaveBeenCalled();
+        expect(setBindGroup).toHaveBeenCalled();
     });
 });

--- a/src/rendering/renderers/gpu/shader/BindGroup.ts
+++ b/src/rendering/renderers/gpu/shader/BindGroup.ts
@@ -36,6 +36,24 @@ export class BindGroup
     public resources: Record<string, BindResource> = Object.create(null);
 
     /**
+     * A cached array of the keys in `resources`, lazily rebuilt when the map changes.
+     * The GPU encoder iterates this instead of the null-prototype map itself, since
+     * enumerating that map with `for-in` allocates a fresh key list on every draw call.
+     * @internal
+     */
+    public get _resourceKeys(): string[]
+    {
+        if (!this._resourceKeysCache)
+        {
+            this._resourceKeysCache = Object.keys(this.resources ?? {});
+        }
+
+        return this._resourceKeysCache;
+    }
+
+    private _resourceKeysCache: string[] | null = null;
+
+    /**
      * A key used internally to match it up to a WebGPU BindGroup.
      * Lazily rebuilt from resource IDs when dirty.
      * @internal
@@ -47,12 +65,14 @@ export class BindGroup
             this._dirty = false;
 
             const keyParts = [];
-            let index = 0;
+            const keys = this._resourceKeys;
 
-            for (const i in this.resources)
+            for (let i = 0; i < keys.length; i++)
             {
                 // -1 marks a destroyed buffer-like resource's null slot
-                keyParts[index++] = this.resources[i] ? this.resources[i]._resourceId : -1;
+                const resource = this.resources[keys[i]];
+
+                keyParts[i] = resource ? resource._resourceId : -1;
             }
 
             this._keyValue = keyParts.join('|');
@@ -102,6 +122,7 @@ export class BindGroup
 
         this.resources[index] = resource;
         this._dirty = true;
+        this._resourceKeysCache = null;
     }
 
     /**
@@ -124,10 +145,11 @@ export class BindGroup
     public _touch(now: number, tick: number): void
     {
         const resources = this.resources;
+        const keys = this._resourceKeys;
 
-        for (const i in resources)
+        for (let i = 0; i < keys.length; i++)
         {
-            const resource = resources[i] as BindResource & GCable;
+            const resource = resources[keys[i]] as BindResource & GCable;
 
             if (!resource) continue;
 
@@ -149,6 +171,7 @@ export class BindGroup
         }
 
         this.resources = null;
+        this._resourceKeysCache = null;
     }
 
     protected onResourceChange(resource: BindResource)
@@ -160,14 +183,17 @@ export class BindGroup
         if (resource.destroyed)
         {
             const resources = this.resources;
+            const keys = this._resourceKeys;
 
-            for (const i in resources)
+            for (let i = 0; i < keys.length; i++)
             {
-                if (resources[i] === resource)
+                if (resources[keys[i]] === resource)
                 {
-                    resources[i] = null;
+                    resources[keys[i]] = null;
                 }
             }
+
+            this._resourceKeysCache = null;
 
             // #if _DEBUG
             warn(`[BindGroup] a '${resource._resourceType}' was destroyed while still bound to a shader. `

--- a/src/rendering/renderers/shared/shader/Shader.ts
+++ b/src/rendering/renderers/shared/shader/Shader.ts
@@ -214,6 +214,31 @@ export class Shader extends EventEmitter<{'destroy': Shader}>
     public readonly compatibleRenderers: number;
     /** */
     public groups: Record<number, BindGroup>;
+    /**
+     * A cached array of the group indices in `groups`, lazily rebuilt when the map changes.
+     * The GPU encoder iterates this instead of the map itself, since enumerating the group
+     * map with `for-in` allocates a fresh key list on every draw call.
+     *
+     * Invalidated by {@link addResource} when it inserts a new group. Group indices that
+     * already exist must be re-resourced via the BindGroup's own setResource rather than by
+     * assigning `shader.groups[i]` to a fresh group, or this cache goes stale.
+     *
+     * The renderer's adapters do assign `shader.groups[i]` directly; those assignments are
+     * safe because they overwrite indices the constructor already created, run before the
+     * first draw (which triggers this cache), and are constant per shader — the key set is
+     * frozen after the first frame. Do not add a brand-new index this way after a draw.
+     * @internal
+     */
+    public get _groupKeyCache(): number[]
+    {
+        if (!this._groupKeyCacheValue)
+        {
+            this._groupKeyCacheValue = Object.keys(this.groups ?? {}).map(Number);
+        }
+
+        return this._groupKeyCacheValue;
+    }
+    private _groupKeyCacheValue: number[] = null;
     /** A record of the resources used by the shader. */
     public resources: Record<string, any>;
     /**
@@ -424,6 +449,9 @@ export class Shader extends EventEmitter<{'destroy': Shader}>
         {
             this.groups[groupIndex] = new BindGroup();
             this._ownedBindGroups.push(this.groups[groupIndex]);
+
+            // the group set changed — drop the cached key list so the encoder re-enumerates
+            this._groupKeyCacheValue = null;
         }
     }
 
@@ -486,6 +514,7 @@ export class Shader extends EventEmitter<{'destroy': Shader}>
 
         this.resources = null;
         this.groups = null;
+        this._groupKeyCacheValue = null;
 
         (this._overrides as null) = null;
     }


### PR DESCRIPTION
Closes #12151

### Summary

Fixes pixijs/pixijs **#12151** — the WebGPU encoder hot path enumerates null-prototype maps with `for-in` on every draw call. Because null-prototype objects run in V8 dictionary mode, each `for-in` re-enumerates the keys and allocates a fresh key list, plus a `parseInt` per binding. Profiling identifies this as the encoder's single largest allocation source (`_setShaderBindGroups`, 11.4 MB / 10 s).

This PR replaces the per-draw `for-in` on the four hot paths with **cached key lists**, rebuilt lazily only when the underlying map actually changes:

- `GpuEncoderSystem.setGeometry` — a new `_bufferKeys` WeakMap caches the index list per cached `buffersToBind` map. The pipeline reuses the *same* map object for a given (geometry, program), so object identity is a stable cache key.
- `GpuEncoderSystem._setShaderBindGroups` / `_syncBindGroup` — iterate `Shader._groupKeyCache` and `BindGroup._resourceKeys` instead of the maps.
- `BindGroup._key` / `_touch` / `onResourceChange` — iterate the cached `_resourceKeys` list.
- **Invalidation**: `BindGroup.setResource`, destroyed-slot nulling, and `destroy`; `Shader.addResource` (new group) and `destroy` all clear the caches.

**Correctness is preserved by construction**: on a null-prototype object, `for-in` and `Object.keys` enumerate own enumerable keys in identical order (integer keys ascending, then string keys in insertion order), so iterating the cached list is a drop-in replacement that keeps binding order and `_key` strings unchanged.

### Benchmarks (local `.bench/` scripts — tooling, not part of CI)

| metric | before | after |
|---|---|---|
| aggregate speedup | — | **6.7×** |
| isolated wall-clock | 309.6 ms | **27.8 ms (11.1×)** |
| allocations per 400k draws | 354.1 MB | **177.2 MB** (= empty-loop baseline) |

Per-path: `setGeometry` **5.5×**, `_setShaderBindGroups` **9.0×**, `_touch` **6.7×**. With the caches warm, the paths allocate identically to a no-op loop — the fix is complete, not partial (~442 bytes/draw eliminated).

### Tests

New regression + behaviour coverage:

- `BindGroup.destroy()` clears `_resourceKeys` — previously a stale list indexed into the now-null `resources` map and threw a `TypeError` where the original `for-in null` was a silent no-op.
- `BindGroup.setResource` invalidates the key cache; `Shader.addResource` / `destroy` invalidate `_groupKeyCache`.
- `GpuEncoderSystem` unit tests (no WebGPU device required, run in CI): a `buffersToBind` map is enumerated **exactly once** across repeated draws (asserted via an `ownKeys` proxy trap), a separate cache entry is kept per map, and `draw()` is safe when a bound bind group has been destroyed.

Verification: 3 target suites **32/32**; full unit suite **1883 passed / 16 skipped / 0 failed**; `tsc` 0 errors; `eslint` 0 warnings.

### Safety notes (also documented in code)

- Seven renderer adapters assign `shader.groups[i]` directly. These overwrite indices the constructor already created, run before the first draw, and are constant per shader — the key set is frozen after the first frame, so the lazily-built cache is always read after those assignments. **Adding a brand-new group index that way after a draw would silently stale the cache** (see the `_groupKeyCache` doc comment).
- `_resourceKeys` / `_groupKeyCache` return internal arrays; consumers must not mutate them.
