### PR TITLE
fix: render text after moving it to another renderer

### DIFF
--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -92,6 +92,42 @@ describe('Text', () =>
         });
     });
 
+    describe('rendering', () =>
+    {
+        it('should render when moved to a second renderer', async () =>
+        {
+            const rendererA = await getWebGLRenderer({ width: 64, height: 64 });
+            const text = new Text({ text: 'hello' });
+            const layer = new Container();
+            const stageA = new Container();
+            const stageB = new Container();
+            let rendererB: Awaited<ReturnType<typeof getWebGLRenderer>> | undefined;
+
+            layer.addChild(text);
+            stageA.addChild(layer);
+
+            try
+            {
+                rendererA.render(stageA);
+                stageA.removeChild(layer);
+                stageB.addChild(layer);
+
+                rendererB = await getWebGLRenderer({ width: 64, height: 64 });
+
+                expect(() => rendererB.render(stageB)).not.toThrow();
+            }
+            finally
+            {
+                text.destroy();
+                layer.destroy();
+                stageA.destroy();
+                stageB.destroy();
+                rendererA.destroy();
+                rendererB?.destroy();
+            }
+        });
+    });
+
     describe('destroy', () =>
     {
         it('should call through to Sprite.destroy', () =>

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -60,17 +60,19 @@ export class CanvasTextPipe implements RenderPipe<Text>
     public addRenderable(text: Text, instructionSet: InstructionSet)
     {
         const batchableText = this._getGpuText(text);
+        const resolution = text._autoResolution ? this._renderer.resolution : text.resolution;
+        const needsTextureUpdate = !batchableText.texture
+            || batchableText.currentKey !== text.styleKey
+            || text._resolution !== resolution;
 
-        if (text._didTextUpdate)
+        if (needsTextureUpdate)
         {
-            const resolution = text._autoResolution ? this._renderer.resolution : text.resolution;
+            // Keep the texture in sync with this renderer's GPU text
+            this._updateGpuText(text);
+        }
 
-            if (batchableText.currentKey !== text.styleKey || text._resolution !== resolution)
-            {
-                // If the text has changed, we need to update the GPU text
-                this._updateGpuText(text);
-            }
-
+        if (text._didTextUpdate || needsTextureUpdate)
+        {
             text._didTextUpdate = false;
 
             updateTextBounds(batchableText, text);


### PR DESCRIPTION
##### Description of change

Fixes #12165.

`Text` stores its GPU data per renderer, while `_didTextUpdate` is shared by the `Text` instance.

After the first renderer processed the text, it reset `_didTextUpdate`. When the same text was later rendered by another renderer, the newly created `BatchableText` did not have a texture, but `CanvasTextPipe` skipped its initialization. The batcher then attempted to access the source of an undefined texture.

This change makes `CanvasTextPipe` determine whether the texture needs to be updated from the state associated with the current renderer. It initializes missing textures, handles stale style or resolution data, and updates the corresponding bounds.

A regression test was added that renders a text container with one WebGL renderer, moves it to another stage, and renders it with a second renderer.

##### Testing

- The new regression test passes.
- The remaining `Text.test.ts` tests pass, excluding an existing Windows-specific floating-point assertion.
- ESLint passes.
- TypeScript checks for the build, examples, and playground configurations pass.
- Index validation and Knip pass.
- The full local unit run has the same pre-existing Windows-specific font metric failures before and after this change.
- Local visual tests have broad platform-specific snapshot differences unrelated to this change.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`) — targeted tests and static checks pass; the full local run has existing platform-specific failures described above