### PR TITLE
fix: regenerate Text/HTMLText textures after WebGL context loss

### DIFF
--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -32,6 +32,7 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -50,6 +51,18 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
             {
                 text.onViewUpdate();
             }
+        }
+    }
+
+    /**
+     * HTMLText textures are uploaded from pooled images that are reused for the next text,
+     * so they cannot be re-uploaded after a context loss. Unload them and regenerate on the next render.
+     */
+    protected contextChange()
+    {
+        for (const key in this._managedTexts.items)
+        {
+            this._managedTexts.items[key]?.unload();
         }
     }
 
@@ -132,7 +145,12 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
         batchableHTMLText.texturePromise = texturePromise;
         batchableHTMLText.currentKey = htmlText.styleKey;
 
-        batchableHTMLText.texture = await texturePromise;
+        const texture = await texturePromise;
+
+        // the text was unloaded while generating, so this batchable has been discarded
+        if (!batchableHTMLText.renderable) return;
+
+        batchableHTMLText.texture = texture;
 
         // need a rerender...
         const renderGroup = htmlText.renderGroup || htmlText.parentRenderGroup;

--- a/src/scene/text-html/HTMLTextSystem.ts
+++ b/src/scene/text-html/HTMLTextSystem.ts
@@ -213,9 +213,11 @@ export class HTMLTextSystem implements System
 
         if (textureStyle) texture.source.style = textureStyle;
 
+        // upload now, as the image and canvas go back to their pools and are reused by the next text
+        this._renderer?.texture.initSource(texture.source);
+
         if (this._createCanvas)
         {
-            this._renderer.texture.initSource(texture.source);
             CanvasPool.returnCanvasAndContext(canvasAndContext);
         }
 

--- a/src/scene/text-html/__tests__/HTMLText.test.ts
+++ b/src/scene/text-html/__tests__/HTMLText.test.ts
@@ -1,6 +1,27 @@
 import { HTMLText } from '../HTMLText';
-import { getWebGLRenderer } from '@test-utils';
+import { getWebGLRenderer, loseAndRestoreContext, nextTick, waitForPendingHTMLText } from '@test-utils';
 import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
+
+import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+
+// generates the textures one after the other, so each text reuses the pooled render data of the previous one
+async function renderInSequence(renderer: WebGLRenderer, ...texts: HTMLText[]): Promise<void>
+{
+    for (const text of texts)
+    {
+        renderer.render(text);
+        await waitForPendingHTMLText(text, renderer);
+    }
+}
+
+function channelSum(pixels: Uint8ClampedArray, channel: number): number
+{
+    let sum = 0;
+
+    for (let i = channel; i < pixels.length; i += 4) sum += pixels[i];
+
+    return sum;
+}
 
 describe('HTMLText', () =>
 {
@@ -226,6 +247,70 @@ describe('HTMLText', () =>
 
             center.destroy();
             left.destroy();
+        });
+    });
+
+    describe('texture generation', () =>
+    {
+        it('should upload its texture before the pooled render data is reused by another HTMLText', async () =>
+        {
+            const renderer = await getWebGLRenderer({ width: 64, height: 64 });
+            const red = new HTMLText({ text: 'A', style: { fontSize: 40, fill: 'red' } });
+            const blue = new HTMLText({ text: 'B', style: { fontSize: 40, fill: 'blue' } });
+
+            await renderInSequence(renderer, red, blue);
+
+            const { pixels } = renderer.extract.pixels(red);
+
+            expect(channelSum(pixels, 0)).toBeGreaterThan(0);
+            expect(channelSum(pixels, 2)).toBe(0);
+
+            red.destroy();
+            blue.destroy();
+            renderer.destroy();
+        });
+
+        it('should not error when destroyed while its texture is generating', async () =>
+        {
+            const renderer = await getWebGLRenderer();
+            const text = new HTMLText({ text: 'foo' });
+            const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+            renderer.render(text);
+
+            const generating = waitForPendingHTMLText(text, renderer);
+
+            text.destroy();
+            await generating;
+            await nextTick();
+
+            expect(errorSpy).not.toHaveBeenCalled();
+
+            errorSpy.mockRestore();
+            renderer.destroy();
+        });
+    });
+
+    describe('context loss', () =>
+    {
+        it('should keep its own content after the WebGL context is lost and restored', async () =>
+        {
+            const renderer = await getWebGLRenderer({ width: 64, height: 64 });
+            const red = new HTMLText({ text: 'A', style: { fontSize: 40, fill: 'red' } });
+            const blue = new HTMLText({ text: 'B', style: { fontSize: 40, fill: 'blue' } });
+
+            await renderInSequence(renderer, red, blue);
+            await loseAndRestoreContext(renderer);
+            await renderInSequence(renderer, red);
+
+            const { pixels } = renderer.extract.pixels(red);
+
+            expect(channelSum(pixels, 0)).toBeGreaterThan(0);
+            expect(channelSum(pixels, 2)).toBe(0);
+
+            red.destroy();
+            blue.destroy();
+            renderer.destroy();
         });
     });
 });

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -7,7 +7,7 @@ import { TextStyle } from '../TextStyle';
 import '../../graphics/init';
 import '../../text-bitmap/init';
 import '../init';
-import { getWebGLRenderer } from '@test-utils';
+import { getWebGLRenderer, loseAndRestoreContext } from '@test-utils';
 import { Point } from '~/maths';
 import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
 
@@ -602,6 +602,30 @@ describe('Text', () =>
             });
 
             expect(text.height).toBeCloseTo(metrics.height, 0);
+        });
+    });
+
+    describe('context loss', () =>
+    {
+        it('should render the text again after the WebGL context is lost and restored', async () =>
+        {
+            const renderer = await getWebGLRenderer({ width: 64, height: 64 });
+            const text = new Text({ text: 'Hi', style: { fontSize: 40, fill: 'white' } });
+
+            renderer.render(text);
+
+            const before = renderer.extract.pixels(text).pixels;
+
+            expect(before.some((value) => value > 0)).toBe(true);
+
+            await loseAndRestoreContext(renderer);
+
+            renderer.render(text);
+
+            expect(renderer.extract.pixels(text).pixels).toEqual(before);
+
+            text.destroy();
+            renderer.destroy();
         });
     });
 });

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -28,6 +28,7 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         this._renderer = renderer;
         renderer.runners.resolutionChange.add(this);
+        renderer.runners.contextChange.add(this);
         this._managedTexts = new GCManagedHash({
             renderer,
             type: 'renderable',
@@ -43,6 +44,18 @@ export class CanvasTextPipe implements RenderPipe<Text>
             const text = this._managedTexts.items[key];
 
             if (text?._autoResolution) text.onViewUpdate();
+        }
+    }
+
+    /**
+     * Text textures are uploaded from pooled canvases that are cleared and reused straight after upload,
+     * so they cannot be re-uploaded after a context loss. Unload them and regenerate on the next render.
+     */
+    protected contextChange()
+    {
+        for (const key in this._managedTexts.items)
+        {
+            this._managedTexts.items[key]?.unload();
         }
     }
 

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -7,4 +7,6 @@ export * from './getGlProgram';
 export * from './getRenderer';
 export * from './getTexture';
 export * from './localTest';
+export * from './loseContext';
 export * from './toArrayBuffer';
+export * from './waitForPendingHTMLText';

--- a/tests/utils/loseContext.ts
+++ b/tests/utils/loseContext.ts
@@ -1,0 +1,22 @@
+import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+
+/**
+ * Forces a WebGL context loss and resolves once the renderer has restored the context.
+ * @param renderer - The renderer whose context to lose.
+ */
+export function loseAndRestoreContext(renderer: WebGLRenderer): Promise<void>
+{
+    if (!renderer.context.extensions.loseContext)
+    {
+        throw new Error('WEBGL_lose_context is not available, cannot force a context loss');
+    }
+
+    const restored = new Promise<void>((resolve) =>
+    {
+        renderer.canvas.addEventListener('webglcontextrestored', () => resolve(), { once: true });
+    });
+
+    renderer.context.forceContextLoss();
+
+    return restored;
+}

--- a/tests/utils/waitForPendingHTMLText.ts
+++ b/tests/utils/waitForPendingHTMLText.ts
@@ -1,0 +1,34 @@
+import type { Renderer } from '../../src/rendering/renderers/types';
+import type { Container } from '../../src/scene/container/Container';
+import type { BatchableHTMLText } from '../../src/scene/text-html/BatchableHTMLText';
+
+/**
+ * After `renderer.render()`, HTMLText asynchronously generates its texture (font fetch,
+ * SVG image load). On slow CI runs this can outlast a fixed `setTimeout` in the scene,
+ * causing extract.canvas to read an empty texture and produce a flaky pixel diff. This
+ * walks the container and awaits every in-flight HTMLText texture promise so extraction always
+ * sees the resolved texture.
+ * @param container - The container (or HTMLText) to wait for.
+ * @param renderer - The renderer the texts were rendered with.
+ */
+export async function waitForPendingHTMLText(container: Container, renderer: Renderer): Promise<void>
+{
+    const promises: Promise<unknown>[] = [];
+
+    const visit = (c: Container): void =>
+    {
+        if (c.renderPipeId === 'htmlText')
+        {
+            const gpuData = (c as unknown as { _gpuData: Record<number, BatchableHTMLText> })
+                ._gpuData[renderer.uid];
+
+            if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
+        }
+
+        c.children.forEach(visit);
+    };
+
+    visit(container);
+
+    await Promise.all(promises);
+}

--- a/tests/visual/tester.ts
+++ b/tests/visual/tester.ts
@@ -2,44 +2,13 @@ import { ensureDirSync, existsSync, readFileSync, writeFile } from 'fs-extra';
 import { dirname } from 'path';
 import pixelmatch from 'pixelmatch';
 import { PNG } from 'pngjs';
+import { waitForPendingHTMLText } from '@test-utils';
 import { Rectangle } from '~/maths';
 import { autoDetectRenderer } from '~/rendering';
 import { Container, Graphics } from '~/scene';
 
 import type { RenderType } from './types';
 import type { Renderer, RendererOptions } from '~/rendering';
-import type { BatchableHTMLText } from '~/scene/text-html/BatchableHTMLText';
-
-/**
- * After `renderer.render()`, HTMLText asynchronously generates its texture (font fetch,
- * SVG image load). On slow CI runs this can outlast a fixed `setTimeout` in the scene,
- * causing extract.canvas to read an empty texture and produce a flaky pixel diff. This
- * walks the stage and awaits every in-flight HTMLText texture promise so extraction always
- * sees the resolved texture.
- * @param container
- * @param renderer
- */
-async function waitForPendingHTMLText(container: Container, renderer: Renderer): Promise<void>
-{
-    const promises: Promise<unknown>[] = [];
-
-    const visit = (c: Container): void =>
-    {
-        if (c.renderPipeId === 'htmlText')
-        {
-            const gpuData = (c as unknown as { _gpuData: Record<number, BatchableHTMLText> })
-                ._gpuData[renderer.uid];
-
-            if (gpuData?.texturePromise) promises.push(gpuData.texturePromise.catch((): undefined => undefined));
-        }
-
-        c.children.forEach(visit);
-    };
-
-    visit(container);
-
-    await Promise.all(promises);
-}
 
 function toArrayBuffer(buf: Buffer): ArrayBuffer
 {


### PR DESCRIPTION
### Overview

After a WebGL context loss, `Text` and `HTMLText` stayed invisible or showed another text's content once the context was restored (#11685). Their textures are uploaded from pooled canvases/images that are cleared or reused right after the upload, so the re-upload on `webglcontextrestored` had nothing valid to read. The text pipes now hook `contextChange` and unload their managed texts (the same path the GC uses), so the next render regenerates the textures through the normal path.

Closes #11685
Closes #12134

#### Fixes
- `Text` and `HTMLText` are regenerated after the WebGL context is lost and restored, instead of disappearing or showing stale content (#11685)
- `HTMLText` uploads its WebGL texture before its pooled render image is reused, so a text no longer shows the content of the next `HTMLText` created before it was first rendered
- `HTMLText` no longer logs an error when destroyed while its texture is still generating

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added



