### PR TITLE
fix: render Text, HTMLText and Graphics with a second renderer

### DIFF
--- a/src/scene/__tests__/secondRenderer.test.ts
+++ b/src/scene/__tests__/secondRenderer.test.ts
@@ -1,0 +1,86 @@
+import { Container } from '../container/Container';
+import { Graphics } from '../graphics/shared/Graphics';
+import { Sprite } from '../sprite/Sprite';
+import { Text } from '../text/Text';
+import { HTMLText } from '../text-html/HTMLText';
+import '../graphics/init';
+import '../text/init';
+import '../text-html/init';
+import { getWebGLRenderer } from '@test-utils';
+import { Texture } from '~/rendering/renderers/shared/texture/Texture';
+
+import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+
+// mirrors #12165: render a layer with one renderer, then move it to a stage rendered by a second renderer.
+// `settle` awaits anything the node generates asynchronously after a render.
+async function moveToSecondRenderer(node: Container, settle: (renderer: WebGLRenderer) => unknown = () => undefined)
+{
+    const layer = new Container();
+    const stageA = new Container();
+    const stageB = new Container();
+
+    layer.addChild(node);
+    stageA.addChild(layer);
+
+    const rendererA = await getWebGLRenderer();
+
+    rendererA.render(stageA);
+    await settle(rendererA);
+
+    const expected = rendererA.extract.pixels(stageA).pixels;
+
+    stageA.removeChild(layer);
+    stageB.addChild(layer);
+
+    const rendererB = await getWebGLRenderer();
+
+    rendererB.render(stageB);
+    await settle(rendererB);
+
+    const actual = rendererB.extract.pixels(stageB).pixels;
+
+    rendererA.destroy();
+    rendererB.destroy();
+
+    return { expected, actual };
+}
+
+describe('rendering a container with a second renderer', () =>
+{
+    it('should render a sprite', async () =>
+    {
+        const sprite = new Sprite({ texture: Texture.WHITE, width: 16, height: 16 });
+        const { expected, actual } = await moveToSecondRenderer(sprite);
+
+        expect(expected.some((value) => value > 0)).toBe(true);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should render a text', async () =>
+    {
+        const { expected, actual } = await moveToSecondRenderer(new Text({ text: 'hello', style: { fill: 'white' } }));
+
+        expect(expected.some((value) => value > 0)).toBe(true);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should render a graphics', async () =>
+    {
+        const { expected, actual } = await moveToSecondRenderer(new Graphics().rect(0, 0, 16, 16).fill(0xff0000));
+
+        expect(expected.some((value) => value > 0)).toBe(true);
+        expect(actual).toEqual(expected);
+    });
+
+    it('should render an html text', async () =>
+    {
+        const text = new HTMLText({ text: 'hello', style: { fill: 'white' } });
+        const { expected, actual } = await moveToSecondRenderer(
+            text,
+            (renderer) => text._gpuData[renderer.uid].texturePromise
+        );
+
+        expect(expected.some((value) => value > 0)).toBe(true);
+        expect(actual).toEqual(expected);
+    });
+});

--- a/src/scene/graphics/shared/GraphicsPipe.ts
+++ b/src/scene/graphics/shared/GraphicsPipe.ts
@@ -103,7 +103,8 @@ export class GraphicsPipe implements RenderPipe<Graphics>
 
         // need to get batches here.. as we need to know if we can batch or not..
         // this also overrides the current batches..
-        if (graphics.didViewUpdate)
+        // also rebuild when this renderer has no batches yet, e.g. the graphics was first rendered elsewhere
+        if (graphics.didViewUpdate || !graphics._gpuData[this.renderer.uid])
         {
             this._rebuild(graphics);
         }

--- a/src/scene/text-html/HTMLTextPipe.ts
+++ b/src/scene/text-html/HTMLTextPipe.ts
@@ -71,7 +71,8 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         const batchableHTMLText = this._getGpuText(htmlText);
 
-        if (htmlText._didTextUpdate)
+        // also update when this renderer has no texture for the text yet, e.g. the text was first rendered elsewhere
+        if (htmlText._didTextUpdate || batchableHTMLText.currentKey !== htmlText.styleKey)
         {
             const resolution = htmlText._autoResolution ? this._renderer.resolution : htmlText.resolution;
 
@@ -175,7 +176,8 @@ export class HTMLTextPipe implements RenderPipe<HTMLText>
     {
         const gpuData = text._gpuData[this._renderer.uid];
 
-        if (!gpuData) return;
+        // nothing to release if no texture was ever requested for this renderer
+        if (!gpuData?.texturePromise) return;
 
         const { htmlText } = this._renderer;
 

--- a/src/scene/text-html/__tests__/HTMLText.test.ts
+++ b/src/scene/text-html/__tests__/HTMLText.test.ts
@@ -31,6 +31,18 @@ describe('HTMLText', () =>
         text.destroy();
     });
 
+    it('should destroy a text whose gpu data was initialised but never rendered', async () =>
+    {
+        const text = new HTMLText({ text: 'foo' });
+        const renderer = await getWebGLRenderer();
+
+        renderer.renderPipes.htmlText.initGpuText(text);
+
+        expect(() => text.destroy()).not.toThrow();
+
+        renderer.destroy();
+    });
+
     it('should handle resolution changes after html text destruction', async () =>
     {
         const text = new HTMLText({ text: 'foo' });

--- a/src/scene/text/canvas/CanvasTextPipe.ts
+++ b/src/scene/text/canvas/CanvasTextPipe.ts
@@ -61,7 +61,8 @@ export class CanvasTextPipe implements RenderPipe<Text>
     {
         const batchableText = this._getGpuText(text);
 
-        if (text._didTextUpdate)
+        // also update when this renderer has no texture for the text yet, e.g. the text was first rendered elsewhere
+        if (text._didTextUpdate || batchableText.currentKey !== text.styleKey)
         {
             const resolution = text._autoResolution ? this._renderer.resolution : text.resolution;
 


### PR DESCRIPTION
### Overview

When a container is first rendered by one renderer and later by another (e.g. rebuilding the app after an unrecoverable context loss), the text and graphics pipes only built their per-renderer GPU data when the object's own "did update" flag was set, and the first renderer had already cleared it. `Text` threw in `Batcher.break`, while `Graphics` and `HTMLText` silently rendered nothing on the second renderer. The pipes now do the full update whenever the renderer has no up-to-date data for the object, matching what `Sprite` and `BitmapText` already did.

Closes #12165, replaces #12168

#### Fixes
- `Text` no longer throws `Cannot read properties of undefined (reading '_source')` when rendered by a second renderer (#12165)
- `Graphics` and `HTMLText` now render on a second renderer instead of drawing nothing
- `HTMLText` no longer throws when destroyed after `prepare.upload()` without having been rendered

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
