### PR TITLE
fix: restore the WebGPU renderer after a device loss

### DIFF
--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -41,6 +41,7 @@ export class BindGroupSystem implements System
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+        this._hash = Object.create(null);
     }
 
     public getBindGroup(bindGroup: BindGroup, program: GpuProgram, groupIndex: number): GPUBindGroup

--- a/src/rendering/renderers/gpu/GpuDeviceSystem.ts
+++ b/src/rendering/renderers/gpu/GpuDeviceSystem.ts
@@ -1,5 +1,6 @@
 import { DOMAdapter } from '../../../environment/adapter';
 import { ExtensionType } from '../../../extensions/Extensions';
+import { warn } from '../../../utils/logging/warn';
 
 import type { System } from '../shared/system/System';
 import type { GpuPowerPreference } from '../types';
@@ -87,6 +88,7 @@ export class GpuDeviceSystem implements System<GpuContextOptions>
 
     private _renderer: WebGPURenderer;
     private _initPromise: Promise<void>;
+    private _options: GpuContextOptions;
 
     /**
      * @param {WebGPURenderer} renderer - The renderer this System works for.
@@ -100,20 +102,49 @@ export class GpuDeviceSystem implements System<GpuContextOptions>
     {
         if (this._initPromise) return this._initPromise;
 
+        this._options = options;
         this._initPromise = (options.gpu ? Promise.resolve(options.gpu) : this._createDeviceAndAdaptor(options))
-            .then((gpu) =>
-            {
-                this.gpu = gpu;
-
-                this.extensions = {
-                    transientAttachment:
-                        typeof (GPUTextureUsage as { TRANSIENT_ATTACHMENT?: number }).TRANSIENT_ATTACHMENT === 'number',
-                };
-
-                this._renderer.runners.contextChange.emit(this.gpu);
-            });
+            .then((gpu) => this._setGpu(gpu));
 
         return this._initPromise;
+    }
+
+    private _setGpu(gpu: GPU): void
+    {
+        this.gpu = gpu;
+
+        this.extensions = {
+            transientAttachment:
+                typeof (GPUTextureUsage as { TRANSIENT_ATTACHMENT?: number }).TRANSIENT_ATTACHMENT === 'number',
+        };
+
+        // a shared device belongs to the engine that created it, so only restore our own
+        if (!this._options.gpu)
+        {
+            void gpu.device.lost
+                .then(() => this._restoreDevice())
+                .catch((e) => warn('WebGPU device was lost and could not be restored', e));
+        }
+
+        this._renderer.runners.contextChange.emit(this.gpu);
+    }
+
+    private async _restoreDevice(): Promise<void>
+    {
+        // the renderer was destroyed, so there is nothing to restore
+        if (!this._renderer) return;
+
+        const gpu = await this._createDeviceAndAdaptor(this._options);
+
+        // destroyed while the new device was being requested
+        if (!this._renderer)
+        {
+            gpu.device.destroy();
+
+            return;
+        }
+
+        this._setGpu(gpu);
     }
 
     /**
@@ -165,6 +196,11 @@ export class GpuDeviceSystem implements System<GpuContextOptions>
 
     public destroy(): void
     {
+        if (!this._options?.gpu)
+        {
+            this.gpu?.device.destroy();
+        }
+
         this.gpu = null;
         this.extensions = null;
         this._renderer = null;

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -183,7 +183,7 @@ export class GpuEncoderSystem implements System
         this.renderPassEncoder = this._passEncoder;
         this._clearCache();
 
-        return new RenderBundle(gpuBundle, this._bundleStateKey, this._bundleLabel);
+        return new RenderBundle(gpuBundle, this._bundleStateKey, this._gpu.device, this._bundleLabel);
     }
 
     /**
@@ -204,7 +204,7 @@ export class GpuEncoderSystem implements System
      */
     public isBundleValid(bundle: RenderBundle): boolean
     {
-        return bundle?.stateKey === this._renderer.pipeline.bundleStateKey;
+        return bundle?.stateKey === this._renderer.pipeline.bundleStateKey && bundle.device === this._gpu.device;
     }
 
     /**
@@ -253,7 +253,7 @@ export class GpuEncoderSystem implements System
         if (!this.isBundleValid(bundle))
         {
             warn(`Render bundle ${bundle?.label ?? '(unlabeled)'} was recorded against a different render `
-                + 'target state. Re-record it — replaying it will either be rejected by WebGPU or draw '
+                + 'target state or on a lost device. Re-record it — replaying it will either be rejected by WebGPU or draw '
                 + 'with the wrong winding. Check encoder.isBundleValid(bundle) before executing.');
         }
         // #endif

--- a/src/rendering/renderers/gpu/RenderBundle.ts
+++ b/src/rendering/renderers/gpu/RenderBundle.ts
@@ -43,18 +43,22 @@ export class RenderBundle
      * render target — which is exactly what {@link GpuEncoderSystem.isBundleValid} does.
      */
     public readonly stateKey: number;
+    /** The device the bundle was recorded on. A bundle cannot be replayed on the device that replaces it after a loss. */
+    public readonly device: GPUDevice;
     /** Optional debug label — names the bundle in GPU captures and in WebGPU validation errors. */
     public readonly label?: string;
 
     /**
      * @param gpuBundle - The recorded native render bundle.
      * @param stateKey - The pipeline state key captured when recording began.
+     * @param device - The device the bundle was recorded on.
      * @param label - Optional debug label for the bundle.
      */
-    constructor(gpuBundle: GPURenderBundle, stateKey: number, label?: string)
+    constructor(gpuBundle: GPURenderBundle, stateKey: number, device: GPUDevice, label?: string)
     {
         this.gpuBundle = gpuBundle;
         this.stateKey = stateKey;
+        this.device = device;
         this.label = label;
     }
 }

--- a/src/rendering/renderers/gpu/__tests__/GpuDeviceSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/GpuDeviceSystem.test.ts
@@ -1,0 +1,69 @@
+import { Texture } from '../../shared/texture/Texture';
+import { describeLocalOnly, getWebGPURenderer, loseAndRestoreDevice, nextTick, wait } from '@test-utils';
+import { Sprite } from '~/scene';
+
+import type { WebGPURenderer } from '../WebGPURenderer';
+
+describeLocalOnly('GpuDeviceSystem', () =>
+{
+    let renderer: WebGPURenderer;
+
+    beforeEach(async () =>
+    {
+        renderer = await getWebGPURenderer({ width: 64, height: 64 });
+    });
+
+    afterEach(() =>
+    {
+        renderer?.destroy();
+    });
+
+    describe('device loss', () =>
+    {
+        it('should render the same scene after the device is lost', async () =>
+        {
+            const sprite = new Sprite({ texture: Texture.WHITE, width: 32, height: 32, tint: 0xff0000 });
+
+            renderer.render(sprite);
+
+            const before = renderer.extract.pixels(sprite).pixels;
+
+            expect(before.some((value) => value > 0)).toBe(true);
+
+            await loseAndRestoreDevice(renderer);
+
+            renderer.render(sprite);
+
+            expect(renderer.extract.pixels(sprite).pixels).toEqual(before);
+        });
+
+        it('should destroy the device it created with the renderer, without requesting another', async () =>
+        {
+            const { device } = renderer.gpu;
+            const requestAdapter = jest.spyOn(navigator.gpu, 'requestAdapter');
+
+            renderer.destroy();
+            renderer = null;
+
+            await expect(device.lost).resolves.toMatchObject({ reason: 'destroyed' });
+            await nextTick();
+
+            expect(requestAdapter).not.toHaveBeenCalled();
+            requestAdapter.mockRestore();
+        });
+
+        it('should leave a shared device alone when the renderer is destroyed', async () =>
+        {
+            const { device } = renderer.gpu;
+            const sharing = await getWebGPURenderer({ width: 64, height: 64, gpu: renderer.gpu });
+            let lost = false;
+
+            void device.lost.then(() => { lost = true; });
+
+            sharing.destroy();
+            await wait(100);
+
+            expect(lost).toBe(false);
+        });
+    });
+});

--- a/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/GpuEncoderSystem.test.ts
@@ -1,7 +1,7 @@
 import { RenderTarget } from '../../shared/renderTarget/RenderTarget';
 import { TextureSource } from '../../shared/texture/sources/TextureSource';
 import { RenderBundle } from '../RenderBundle';
-import { describeLocalOnly, getWebGPURenderer } from '@test-utils';
+import { describeLocalOnly, getWebGPURenderer, loseAndRestoreDevice } from '@test-utils';
 
 import type { TEXTURE_FORMATS } from '../../shared/texture/const';
 import type { WebGPURenderer } from '../WebGPURenderer';
@@ -76,6 +76,18 @@ describeLocalOnly('GpuEncoderSystem render bundles', () =>
         const bundles: RenderBundle[] = [];
 
         expect(renderer.encoder.isBundleValid(bundles[0])).toBe(false);
+    });
+
+    it('invalidates a bundle recorded on a device that has since been lost', async () =>
+    {
+        renderer = await getWebGPURenderer();
+        const target = colorTarget();
+        const bundle = record(target);
+
+        await loseAndRestoreDevice(renderer);
+        renderer.pipeline.setRenderTarget(target);
+
+        expect(renderer.encoder.isBundleValid(bundle)).toBe(false);
     });
 
     it('invalidates a bundle when the sample count changes', async () =>

--- a/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
+++ b/src/rendering/renderers/gpu/buffer/GpuBufferSystem.ts
@@ -60,6 +60,7 @@ export class GpuBufferSystem implements System
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+        this.destroyAll();
     }
 
     public getGPUBuffer(buffer: Buffer): GPUBuffer

--- a/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
+++ b/src/rendering/renderers/gpu/pipeline/PipelineSystem.ts
@@ -222,7 +222,7 @@ export class PipelineSystem implements System
     private readonly _bindingNamesCache: Record<string, Record<string, string>> = Object.create(null);
 
     private _pipeCache: PipeHash = new Map();
-    private readonly _pipeStateCaches: Record<number, PipeHash> = Object.create(null);
+    private _pipeStateCaches: Record<number, PipeHash> = Object.create(null);
 
     private _gpu: GPU;
     private _stencilState: StencilState;
@@ -247,6 +247,8 @@ export class PipelineSystem implements System
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+        this._moduleCache = Object.create(null);
+        this._pipeStateCaches = Object.create(null);
         this.setStencilMode(STENCIL_MODES.DISABLED);
 
         this._updatePipeHash();
@@ -751,7 +753,7 @@ export class PipelineSystem implements System
         this._gpu = null;
         (this._renderer as null) = null;
         (this._bindingNamesCache as null) = null;
-        (this._pipeStateCaches as null) = null;
+        this._pipeStateCaches = null;
         (this._moduleCache as null) = null;
     }
 }

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -490,39 +490,35 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
 
             if (colorTexture instanceof CanvasSource)
             {
-                if (!colorTexture._gpuContext)
+                const context = colorTexture._gpuContext ??= colorTexture.resource.getContext(
+                    'webgpu'
+                ) as unknown as GPUCanvasContext;
+
+                const alphaMode = colorTexture.transparent ? 'premultiplied' : 'opaque';
+                const canvasFormat = getCanvasContextFormat(colorTexture.format);
+
+                // configured every time, as a device replaced after a loss needs it configured again
+                try
                 {
-                    const context = colorTexture.resource.getContext(
-                        'webgpu'
-                    ) as unknown as GPUCanvasContext;
-
-                    const alphaMode = colorTexture.transparent ? 'premultiplied' : 'opaque';
-                    const canvasFormat = getCanvasContextFormat(colorTexture.format);
-
-                    try
-                    {
-                        context.configure({
-                            device: this._renderer.gpu.device,
-                            usage: GPUTextureUsage.TEXTURE_BINDING
-                                | GPUTextureUsage.COPY_DST
-                                | GPUTextureUsage.RENDER_ATTACHMENT
-                                | GPUTextureUsage.COPY_SRC,
-                            format: canvasFormat,
-                            alphaMode,
-                            ...(canvasFormat === 'rgba16float'
-                                ? { toneMapping: { mode: 'extended' } }
-                                : {}),
-                        });
-                    }
-                    catch (e)
-                    {
-                        console.error(e);
-                    }
-
-                    colorTexture._gpuContext = context;
+                    context.configure({
+                        device: this._renderer.gpu.device,
+                        usage: GPUTextureUsage.TEXTURE_BINDING
+                            | GPUTextureUsage.COPY_DST
+                            | GPUTextureUsage.RENDER_ATTACHMENT
+                            | GPUTextureUsage.COPY_SRC,
+                        format: canvasFormat,
+                        alphaMode,
+                        ...(canvasFormat === 'rgba16float'
+                            ? { toneMapping: { mode: 'extended' } }
+                            : {}),
+                    });
+                }
+                catch (e)
+                {
+                    console.error(e);
                 }
 
-                gpuRenderTarget.contexts[i] = colorTexture._gpuContext;
+                gpuRenderTarget.contexts[i] = context;
             }
 
             gpuRenderTarget.msaa = colorTexture.source.antialias;

--- a/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
+++ b/src/rendering/renderers/gpu/shader/GpuShaderSystem.ts
@@ -32,11 +32,12 @@ export class GpuShaderSystem
 
     private _gpu: GPU;
 
-    private readonly _gpuProgramData: Record<number, GPUProgramData> = Object.create(null);
+    private _gpuProgramData: Record<number, GPUProgramData> = Object.create(null);
 
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+        this._gpuProgramData = Object.create(null);
     }
 
     public getProgramData(program: GpuProgram)

--- a/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
+++ b/src/rendering/renderers/gpu/texture/GpuTextureSystem.ts
@@ -129,6 +129,11 @@ export class GpuTextureSystem implements System, CanvasGenerator
     protected contextChange(gpu: GPU): void
     {
         this._gpu = gpu;
+
+        // everything created by the previous device died with it
+        this._managedTextures.removeAll();
+        this._gpuSamplers = Object.create(null);
+        this._mipmapGenerator = null;
     }
 
     /**

--- a/src/scene/text-html/__tests__/HTMLText.test.ts
+++ b/src/scene/text-html/__tests__/HTMLText.test.ts
@@ -1,11 +1,19 @@
 import { HTMLText } from '../HTMLText';
-import { getWebGLRenderer, loseAndRestoreContext, nextTick, waitForPendingHTMLText } from '@test-utils';
+import {
+    getWebGLRenderer,
+    getWebGPURenderer,
+    itLocalOnly,
+    loseAndRestoreContext,
+    loseAndRestoreDevice,
+    nextTick,
+    waitForPendingHTMLText,
+} from '@test-utils';
 import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
 
-import type { WebGLRenderer } from '~/rendering/renderers/gl/WebGLRenderer';
+import type { Renderer } from '~/rendering/renderers/types';
 
 // generates the textures one after the other, so each text reuses the pooled render data of the previous one
-async function renderInSequence(renderer: WebGLRenderer, ...texts: HTMLText[]): Promise<void>
+async function renderInSequence(renderer: Renderer, ...texts: HTMLText[]): Promise<void>
 {
     for (const text of texts)
     {
@@ -301,6 +309,26 @@ describe('HTMLText', () =>
 
             await renderInSequence(renderer, red, blue);
             await loseAndRestoreContext(renderer);
+            await renderInSequence(renderer, red);
+
+            const { pixels } = renderer.extract.pixels(red);
+
+            expect(channelSum(pixels, 0)).toBeGreaterThan(0);
+            expect(channelSum(pixels, 2)).toBe(0);
+
+            red.destroy();
+            blue.destroy();
+            renderer.destroy();
+        });
+
+        itLocalOnly('should keep its own content after the WebGPU device is lost', async () =>
+        {
+            const renderer = await getWebGPURenderer({ width: 64, height: 64 });
+            const red = new HTMLText({ text: 'A', style: { fontSize: 40, fill: 'red' } });
+            const blue = new HTMLText({ text: 'B', style: { fontSize: 40, fill: 'blue' } });
+
+            await renderInSequence(renderer, red, blue);
+            await loseAndRestoreDevice(renderer);
             await renderInSequence(renderer, red);
 
             const { pixels } = renderer.extract.pixels(red);

--- a/src/scene/text/__tests__/Text.test.ts
+++ b/src/scene/text/__tests__/Text.test.ts
@@ -7,7 +7,7 @@ import { TextStyle } from '../TextStyle';
 import '../../graphics/init';
 import '../../text-bitmap/init';
 import '../init';
-import { getWebGLRenderer, loseAndRestoreContext } from '@test-utils';
+import { getWebGLRenderer, getWebGPURenderer, itLocalOnly, loseAndRestoreContext, loseAndRestoreDevice } from '@test-utils';
 import { Point } from '~/maths';
 import { TextureSource } from '~/rendering/renderers/shared/texture/sources/TextureSource';
 
@@ -619,6 +619,27 @@ describe('Text', () =>
             expect(before.some((value) => value > 0)).toBe(true);
 
             await loseAndRestoreContext(renderer);
+
+            renderer.render(text);
+
+            expect(renderer.extract.pixels(text).pixels).toEqual(before);
+
+            text.destroy();
+            renderer.destroy();
+        });
+
+        itLocalOnly('should render the text again after the WebGPU device is lost', async () =>
+        {
+            const renderer = await getWebGPURenderer({ width: 64, height: 64 });
+            const text = new Text({ text: 'Hi', style: { fontSize: 40, fill: 'white' } });
+
+            renderer.render(text);
+
+            const before = renderer.extract.pixels(text).pixels;
+
+            expect(before.some((value) => value > 0)).toBe(true);
+
+            await loseAndRestoreDevice(renderer);
 
             renderer.render(text);
 

--- a/src/utils/data/GCManagedHash.ts
+++ b/src/utils/data/GCManagedHash.ts
@@ -63,6 +63,7 @@ export class GCManagedHash<T extends GCable & { uid: number } & Pick<EventEmitte
 
         this._onUnload?.(item, ...args);
 
+        item.off('unload', this.remove, this);
         gpuData.destroy();
         item._gpuData[this._renderer.uid] = null;
         this.items[item.uid] = null;

--- a/tests/utils/async.ts
+++ b/tests/utils/async.ts
@@ -1,5 +1,13 @@
-export function nextTick(): Promise<void>
+/**
+ * Resolves after the given number of milliseconds.
+ * @param ms - The delay in milliseconds.
+ */
+export function wait(ms: number): Promise<void>
 {
-    return new Promise((resolve) => setTimeout(resolve, 0));
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function nextTick(): Promise<void>
+{
+    return wait(0);
+}

--- a/tests/utils/loseContext.ts
+++ b/tests/utils/loseContext.ts
@@ -1,4 +1,5 @@
 import type { WebGLRenderer } from '../../src/rendering/renderers/gl/WebGLRenderer';
+import type { WebGPURenderer } from '../../src/rendering/renderers/gpu/WebGPURenderer';
 
 /**
  * Forces a WebGL context loss and resolves once the renderer has restored the context.
@@ -17,6 +18,30 @@ export function loseAndRestoreContext(renderer: WebGLRenderer): Promise<void>
     });
 
     renderer.context.forceContextLoss();
+
+    return restored;
+}
+
+/**
+ * Destroys the WebGPU device and resolves once the renderer has replaced it with a new one.
+ * @param renderer - The renderer whose device to lose.
+ */
+export function loseAndRestoreDevice(renderer: WebGPURenderer): Promise<void>
+{
+    const restored = new Promise<void>((resolve) =>
+    {
+        const listener = {
+            contextChange: () =>
+            {
+                renderer.runners.contextChange.remove(listener);
+                resolve();
+            },
+        };
+
+        renderer.runners.contextChange.add(listener);
+    });
+
+    renderer.gpu.device.destroy();
 
     return restored;
 }


### PR DESCRIPTION
### Overview

WebGPU device loss (`GPUDevice.lost`, e.g. a GPU process crash) was never handled: the renderer kept using the dead device and every system kept the GPU objects it had created with it, so rendering went blank for good. This stacks on #12170 and reuses the same `contextChange` path: `GpuDeviceSystem` requests a new adapter and device when the current one is lost and re-emits `contextChange`, and each WebGPU system drops the GPU objects it cached from the old device so they are recreated on the next render.

#### Breaking Changes / Behavior Changes
- Destroying a `WebGPURenderer` now destroys the `GPUDevice` it created. A device passed in through the `gpu` option is left untouched.
- `RenderBundle` records the device it was recorded on, and `encoder.isBundleValid()` returns `false` for a bundle from a lost device; re-record it as you would for any other stale bundle. The `RenderBundle` constructor gains a `device` parameter.

#### Fixes
- The WebGPU renderer recovers from a device loss: textures, buffers, shader modules, pipelines, bind groups and the canvas context are recreated for the new device.
- `Text` and `HTMLText` regenerate their textures after a WebGPU device loss.
- A canvas whose WebGPU context was unconfigured is configured again when its render target is re-initialised.

#### Chores
- `GCManagedHash.remove` detaches its `unload` listener, so repeated context or device losses no longer accumulate listeners on textures and buffers.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
