### PR TITLE
feat: add renderer loader extensions for lazy backend imports

### DIFF
--- a/skills/pixijs-core-concepts/SKILL.md
+++ b/skills/pixijs-core-concepts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pixijs-core-concepts
-description: "Use this skill when understanding how PixiJS v8 renders frames: the systems-and-pipes renderer, the render loop, and how the library adapts to different environments. Covers WebGLRenderer/WebGPURenderer/CanvasRenderer selection, renderer.render() pipeline, environment detection, and pointers to per-topic deep dives. Triggers on: renderer, WebGL, WebGPU, Canvas, render loop, render pipeline, systems, environments, autoDetectRenderer."
+description: "Use this skill when understanding how PixiJS v8 renders frames: the systems-and-pipes renderer, the render loop, and how the library adapts to different environments. Covers WebGLRenderer/WebGPURenderer/CanvasRenderer selection, renderer.render() pipeline, environment detection, and pointers to per-topic deep dives. Triggers on: renderer, WebGL, WebGPU, Canvas, render loop, render pipeline, systems, environments, autoDetectRenderer, WebGLLoader, WebGPULoader, CanvasLoader."
 license: MIT
 ---
 
@@ -47,7 +47,7 @@ For deep dives into any single topic, open the corresponding reference file. Non
 
 ### Renderer = systems + pipes
 
-Each renderer is composed of `Systems` (lifecycle services: textures, buffers, state, filters, masks) and `RenderPipes` (per-renderable instruction builders: sprite, graphics, mesh, particle, text, tiling). Writing a custom renderable means implementing a `RenderPipe` and registering it via extensions.
+Each renderer is composed of `Systems` (lifecycle services: textures, buffers, state, filters, masks) and `RenderPipes` (per-renderable instruction builders: sprite, graphics, mesh, particle, text, tiling). Writing a custom renderable means implementing a `RenderPipe` and registering it via extensions. Backend-specific systems and pipes can be dynamic-imported through a renderer loader extension (`WebGLLoader`, `WebGPULoader`, `CanvasLoader`); see `references/renderers.md`.
 
 ### The render loop
 

--- a/skills/pixijs-core-concepts/references/renderers.md
+++ b/skills/pixijs-core-concepts/references/renderers.md
@@ -65,6 +65,21 @@ Each renderer is composed of a fixed set of `System`s (lifecycle services: textu
 
 Writing a custom renderable means implementing a `RenderPipe`, a `BatchableX` class, and registering both via the extensions system. See `pixijs-custom-rendering`.
 
+### Lazy-loading backend-specific systems and pipes
+
+Systems and pipes that only one backend needs can stay out of the main bundle. Register a renderer loader (`ExtensionType.WebGLLoader`, `ExtensionType.WebGPULoader`, or `ExtensionType.CanvasLoader`) whose `load()` dynamic-imports the module that registers them. During `init`, the renderer awaits every loader for its own backend after the environment extensions load and before it creates its systems and pipes; loaders for other backends never run.
+
+```ts
+import { extensions, ExtensionType } from "pixi.js";
+
+extensions.add({
+  extension: { type: ExtensionType.WebGLLoader, name: "my-plugin" },
+  load: () => import("./gl/register"), // registers WebGL systems and pipes on import
+});
+```
+
+Loader names are unique per backend; a second loader with the same name is ignored. `skipExtensionImports: true` skips loaders too, so custom builds import backend modules directly.
+
 ### Direct renderer construction
 
 ```ts

--- a/skills/pixijs-core-concepts/references/renderers.md
+++ b/skills/pixijs-core-concepts/references/renderers.md
@@ -78,7 +78,7 @@ extensions.add({
 });
 ```
 
-Loader names are unique per backend; a second loader with the same name is ignored. `skipExtensionImports: true` skips loaders too, so custom builds import backend modules directly.
+Loader names are unique per backend; a second loader with the same name is ignored. Loaders run concurrently; registered systems and pipes are ordered by their own `priority`, not by loader completion. `skipExtensionImports: true` skips loaders too, so custom builds import backend modules directly.
 
 ### Direct renderer construction
 

--- a/skills/pixijs/references/index.md
+++ b/skills/pixijs/references/index.md
@@ -12,7 +12,7 @@ Create and configure a PixiJS v8 `Application`. Covers `new Application()` + asy
 ### pixijs-core-concepts
 How PixiJS v8 renders frames: the systems-and-pipes renderer, the render loop, and how the library adapts to different environments. Covers `WebGLRenderer`/`WebGPURenderer`/`CanvasRenderer` selection, `renderer.render()` pipeline, environment detection, and pointers to per-topic deep dives.
 
-**Triggers:** renderer, WebGL, WebGPU, Canvas, render loop, render pipeline, systems, environments, autoDetectRenderer.
+**Triggers:** renderer, WebGL, WebGPU, Canvas, render loop, render pipeline, systems, environments, autoDetectRenderer, WebGLLoader, WebGPULoader, CanvasLoader.
 
 ### pixijs-create
 Scaffold a new PixiJS v8 project with the `create-pixi` CLI. Covers npm/yarn/pnpm/bun create commands, interactive vs non-interactive flows, available template presets (bundler-vite, bundler-webpack, bundler-esbuild, bundler-import-map, creation-web, framework-react, extension-default), Node version requirements, and post-scaffold dev flow.

--- a/src/__docs__/concepts/architecture.md
+++ b/src/__docs__/concepts/architecture.md
@@ -46,6 +46,7 @@ An extension is any object with an `extension` metadata field that tells PixiJS 
 - `ExtensionType.WebGLSystem`, `ExtensionType.WebGPUSystem`, `ExtensionType.CanvasSystem`: Add systems to their respective renderers. These systems can vary widely in functionality, from managing textures to accessibility features.
 - `ExtensionType.WebGLPipes`, `ExtensionType.WebGPUPipes`, `ExtensionType.CanvasPipes`: Add a new rendering pipe. RenderPipes are specifically used to render Renderables like a Mesh
 - `ExtensionType.WebGLPipesAdaptor`, `ExtensionType.WebGPUPipesAdaptor`, `ExtensionType.CanvasPipesAdaptor`: Adapt rendering pipes for the respective renderers.
+- `ExtensionType.WebGLLoader`, `ExtensionType.WebGPULoader`, `ExtensionType.CanvasLoader`: Run an async hook while the matching renderer initialises, before it creates its systems and pipes. Plugins use these to `import()` backend-specific systems and pipes only for the renderer in use.
 
 ### Application
 

--- a/src/extensions/Extensions.ts
+++ b/src/extensions/Extensions.ts
@@ -44,11 +44,11 @@ enum ExtensionType
      */
     WebGPULoader = 'webgpu-loader',
 
-    /** extensions that are registered as Canvas render pipes */
+    /** extensions that are registered as Canvas render systems */
     CanvasSystem = 'canvas-system',
     /** extensions that are registered as Canvas render pipes adaptors */
     CanvasPipesAdaptor = 'canvas-pipes-adaptor',
-    /** extensions that are registered as Canvas render systems */
+    /** extensions that are registered as Canvas render pipes */
     CanvasPipes = 'canvas-pipes',
     /**
      * An async hook awaited while a Canvas renderer initialises, after the environment extensions load

--- a/src/extensions/Extensions.ts
+++ b/src/extensions/Extensions.ts
@@ -14,6 +14,21 @@ enum ExtensionType
     WebGLPipesAdaptor = 'webgl-pipes-adaptor',
     /** extensions that are registered as WebGL render systems */
     WebGLSystem = 'webgl-system',
+    /**
+     * An async hook awaited while a WebGL renderer initialises, after the environment extensions load
+     * and before the renderer creates its systems and pipes. Use it to `import()` WebGL-only systems and
+     * pipes so they stay out of the main bundle. Skipped when `skipExtensionImports` is true.
+     * A loader needs a `name`; the renderer dedupes loaders by it.
+     * @example
+     * ```ts
+     * extensions.add({
+     *     extension: { type: ExtensionType.WebGLLoader, name: 'my-plugin' },
+     *     // the module registers its WebGL systems and pipes with `extensions.add` on import
+     *     load: () => import('./gl/init'),
+     * });
+     * ```
+     */
+    WebGLLoader = 'webgl-loader',
 
     /** extensions that are registered as WebGPU render pipes */
     WebGPUPipes = 'webgpu-pipes',
@@ -21,6 +36,13 @@ enum ExtensionType
     WebGPUPipesAdaptor = 'webgpu-pipes-adaptor',
     /** extensions that are registered as WebGPU render systems */
     WebGPUSystem = 'webgpu-system',
+    /**
+     * An async hook awaited while a WebGPU renderer initialises, after the environment extensions load
+     * and before the renderer creates its systems and pipes. Use it to `import()` WebGPU-only systems and
+     * pipes so they stay out of the main bundle. Skipped when `skipExtensionImports` is true.
+     * A loader needs a `name`; the renderer dedupes loaders by it.
+     */
+    WebGPULoader = 'webgpu-loader',
 
     /** extensions that are registered as Canvas render pipes */
     CanvasSystem = 'canvas-system',
@@ -28,6 +50,13 @@ enum ExtensionType
     CanvasPipesAdaptor = 'canvas-pipes-adaptor',
     /** extensions that are registered as Canvas render systems */
     CanvasPipes = 'canvas-pipes',
+    /**
+     * An async hook awaited while a Canvas renderer initialises, after the environment extensions load
+     * and before the renderer creates its systems and pipes. Use it to `import()` Canvas-only systems and
+     * pipes so they stay out of the main bundle. Skipped when `skipExtensionImports` is true.
+     * A loader needs a `name`; the renderer dedupes loaders by it.
+     */
+    CanvasLoader = 'canvas-loader',
 
     /** extensions that combine the other Asset extensions */
     Asset = 'asset',

--- a/src/extensions/__docs__/extensions.md
+++ b/src/extensions/__docs__/extensions.md
@@ -161,7 +161,7 @@ extensions.add(
 );
 ```
 
-Loader names are unique per backend; a second loader registered under the same name is ignored. Loaders are skipped when the renderer is created with `skipExtensionImports: true`, so custom builds must import the backend modules themselves.
+Loader names are unique per backend; a second loader registered under the same name is ignored. Loaders run concurrently, so don't rely on one plugin's module evaluating before another's; the systems and pipes they register are ordered by their own `priority`. Loaders are skipped when the renderer is created with `skipExtensionImports: true`, so custom builds must import the backend modules themselves.
 
 ### Application plugins
 

--- a/src/extensions/__docs__/extensions.md
+++ b/src/extensions/__docs__/extensions.md
@@ -143,6 +143,26 @@ const customPipe = {
 };
 ```
 
+#### Loading backend-specific code lazily
+
+A renderer loader is an async hook the renderer awaits while it initialises, after the environment extensions load and before it creates its systems and pipes. Use one to `import()` the systems and pipes that only one backend needs, so the other backends' code stays out of the main bundle. The imported module registers them with `extensions.add`, and the renderer picks them up once every loader for its backend has resolved.
+
+```ts
+// Each backend gets its own loader; only the loaders for the renderer in use run
+extensions.add(
+    {
+        extension: { type: ExtensionType.WebGLLoader, name: 'my-plugin' },
+        load: () => import('./gl/register'), // registers WebGL systems and pipes on import
+    },
+    {
+        extension: { type: ExtensionType.WebGPULoader, name: 'my-plugin' },
+        load: () => import('./gpu/register'),
+    },
+);
+```
+
+Loader names are unique per backend; a second loader registered under the same name is ignored. Loaders are skipped when the renderer is created with `skipExtensionImports: true`, so custom builds must import the backend modules themselves.
+
 ### Application plugins
 
 Application plugins extend the core `Application` class. Plugins use static `init` and `destroy` methods. During `init`, `this` refers to the Application instance:
@@ -186,12 +206,15 @@ Plugins initialize in registration order and destroy in reverse order.
 - `ExtensionType.WebGLSystem`: WebGL systems
 - `ExtensionType.WebGLPipes`: WebGL render pipes
 - `ExtensionType.WebGLPipesAdaptor`: WebGL render pipe adaptors
+- `ExtensionType.WebGLLoader`: Async hooks awaited while a WebGL renderer initialises
 - `ExtensionType.WebGPUSystem`: WebGPU systems
 - `ExtensionType.WebGPUPipes`: WebGPU render pipes
 - `ExtensionType.WebGPUPipesAdaptor`: WebGPU render pipe adaptors
+- `ExtensionType.WebGPULoader`: Async hooks awaited while a WebGPU renderer initialises
 - `ExtensionType.CanvasSystem`: Canvas systems
 - `ExtensionType.CanvasPipes`: Canvas render pipes
 - `ExtensionType.CanvasPipesAdaptor`: Canvas render pipe adaptors
+- `ExtensionType.CanvasLoader`: Async hooks awaited while a Canvas renderer initialises
 
 ### Advanced features
 
@@ -211,6 +234,7 @@ These extension types are for specialized use cases. Most applications won't nee
 - See {@link Application} for application plugins
 - See {@link Assets} for the asset loading system
 - See {@link Renderer} for rendering extensions
+- See {@link RendererLoader} for the renderer loader interface
 - See {@link LoaderParser} for asset loader interface
 - See {@link ResolveURLParser} for URL resolution interface
 - See {@link CacheParser} for cache parser interface

--- a/src/rendering/renderers/__tests__/RendererLoader.test.ts
+++ b/src/rendering/renderers/__tests__/RendererLoader.test.ts
@@ -1,0 +1,72 @@
+import { getWebGLRenderer } from '@test-utils';
+import { extensions, ExtensionType } from '~/extensions';
+
+class LoaderTestSystem
+{
+    public static extension = {
+        type: ExtensionType.WebGLSystem,
+        name: 'loaderTestSystem',
+    };
+
+    public destroy(): void
+    {
+        // nothing to release
+    }
+}
+
+const webglLoader = {
+    extension: { type: ExtensionType.WebGLLoader, name: 'loaderTest' },
+    load: jest.fn(async () =>
+    {
+        extensions.add(LoaderTestSystem);
+    }),
+};
+
+const webgpuLoader = {
+    extension: { type: ExtensionType.WebGPULoader, name: 'loaderTest' },
+    load: jest.fn(() => Promise.resolve()),
+};
+
+describe('RendererLoader', () =>
+{
+    beforeEach(() =>
+    {
+        webglLoader.load.mockClear();
+        webgpuLoader.load.mockClear();
+        extensions.add(webglLoader, webgpuLoader);
+    });
+
+    afterEach(() =>
+    {
+        extensions.remove(webglLoader, webgpuLoader, LoaderTestSystem);
+    });
+
+    it('should await WebGL loaders before adding systems', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        expect(webglLoader.load).toHaveBeenCalledTimes(1);
+        expect((renderer as any).loaderTestSystem).toBeInstanceOf(LoaderTestSystem);
+
+        renderer.destroy();
+    });
+
+    it('should not run loaders registered for another renderer', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+
+        expect(webgpuLoader.load).not.toHaveBeenCalled();
+
+        renderer.destroy();
+    });
+
+    it('should skip loaders when skipExtensionImports is true', async () =>
+    {
+        const renderer = await getWebGLRenderer({ skipExtensionImports: true });
+
+        expect(webglLoader.load).not.toHaveBeenCalled();
+        expect((renderer as any).loaderTestSystem).toBeUndefined();
+
+        renderer.destroy();
+    });
+});

--- a/src/rendering/renderers/canvas/CanvasRenderer.ts
+++ b/src/rendering/renderers/canvas/CanvasRenderer.ts
@@ -19,6 +19,7 @@ import { CanvasTextureSystem } from './texture/CanvasTextureSystem';
 
 import type { ICanvas } from '../../../environment/canvas/ICanvas';
 import type { PipeConstructor } from '../shared/instructions/RenderPipe';
+import type { RendererLoader } from '../shared/system/AbstractRenderer';
 import type { SharedRendererOptions } from '../shared/system/SharedSystems';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
@@ -50,10 +51,12 @@ const DefaultCanvasAdapters = [
 const systems: { name: string; value: SystemConstructor }[] = [];
 const renderPipes: { name: string; value: PipeConstructor }[] = [];
 const renderPipeAdaptors: { name: string; value: any }[] = [];
+const loaders: { name: string; value: RendererLoader }[] = [];
 
 extensions.handleByNamedList(ExtensionType.CanvasSystem, systems);
 extensions.handleByNamedList(ExtensionType.CanvasPipes, renderPipes);
 extensions.handleByNamedList(ExtensionType.CanvasPipesAdaptor, renderPipeAdaptors);
+extensions.handleByNamedList(ExtensionType.CanvasLoader, loaders);
 
 // add all the default systems as well as any user defined ones from the extensions
 extensions.add(...DefaultCanvasSystems, ...DefaultCanvasPipes, ...DefaultCanvasAdapters);
@@ -107,6 +110,7 @@ export class CanvasRenderer<T extends ICanvas = HTMLCanvasElement>
             systems,
             renderPipes,
             renderPipeAdaptors,
+            loaders,
         };
 
         super(systemConfig);

--- a/src/rendering/renderers/gl/WebGLRenderer.ts
+++ b/src/rendering/renderers/gl/WebGLRenderer.ts
@@ -22,6 +22,7 @@ import { GlTextureSystem } from './texture/GlTextureSystem';
 
 import type { ICanvas } from '../../../environment/canvas/ICanvas';
 import type { PipeConstructor } from '../shared/instructions/RenderPipe';
+import type { RendererLoader } from '../shared/system/AbstractRenderer';
 import type { SharedRendererOptions } from '../shared/system/SharedSystems';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
@@ -51,10 +52,12 @@ const DefaultWebGLAdapters = [GlBatchAdaptor, GlMeshAdaptor, GlGraphicsAdaptor];
 const systems: { name: string; value: SystemConstructor }[] = [];
 const renderPipes: { name: string; value: PipeConstructor }[] = [];
 const renderPipeAdaptors: { name: string; value: any }[] = [];
+const loaders: { name: string; value: RendererLoader }[] = [];
 
 extensions.handleByNamedList(ExtensionType.WebGLSystem, systems);
 extensions.handleByNamedList(ExtensionType.WebGLPipes, renderPipes);
 extensions.handleByNamedList(ExtensionType.WebGLPipesAdaptor, renderPipeAdaptors);
+extensions.handleByNamedList(ExtensionType.WebGLLoader, loaders);
 
 // add all the default systems as well as any user defined ones from the extensions
 extensions.add(...DefaultWebGLSystems, ...DefaultWebGLPipes, ...DefaultWebGLAdapters);
@@ -171,6 +174,7 @@ export class WebGLRenderer<T extends ICanvas = HTMLCanvasElement>
             systems,
             renderPipes,
             renderPipeAdaptors,
+            loaders,
         };
 
         super(systemConfig);

--- a/src/rendering/renderers/gpu/WebGPURenderer.ts
+++ b/src/rendering/renderers/gpu/WebGPURenderer.ts
@@ -22,6 +22,7 @@ import { GpuTextureSystem } from './texture/GpuTextureSystem';
 
 import type { ICanvas } from '../../../environment/canvas/ICanvas';
 import type { PipeConstructor } from '../shared/instructions/RenderPipe';
+import type { RendererLoader } from '../shared/system/AbstractRenderer';
 import type { SharedRendererOptions } from '../shared/system/SharedSystems';
 import type { SystemConstructor } from '../shared/system/System';
 import type { ExtractRendererOptions, ExtractSystemTypes } from '../shared/system/utils/typeUtils';
@@ -49,10 +50,12 @@ const DefaultWebGPUAdapters = [GpuBatchAdaptor, GpuMeshAdapter, GpuGraphicsAdapt
 const systems: { name: string; value: SystemConstructor }[] = [];
 const renderPipes: { name: string; value: PipeConstructor }[] = [];
 const renderPipeAdaptors: { name: string; value: any }[] = [];
+const loaders: { name: string; value: RendererLoader }[] = [];
 
 extensions.handleByNamedList(ExtensionType.WebGPUSystem, systems);
 extensions.handleByNamedList(ExtensionType.WebGPUPipes, renderPipes);
 extensions.handleByNamedList(ExtensionType.WebGPUPipesAdaptor, renderPipeAdaptors);
+extensions.handleByNamedList(ExtensionType.WebGPULoader, loaders);
 
 // add all the default systems as well as any user defined ones from the extensions
 extensions.add(...DefaultWebGPUSystems, ...DefaultWebGPUPipes, ...DefaultWebGPUAdapters);
@@ -167,6 +170,7 @@ export class WebGPURenderer<T extends ICanvas = HTMLCanvasElement>
             systems,
             renderPipes,
             renderPipeAdaptors,
+            loaders,
         };
 
         super(systemConfig);

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -29,7 +29,8 @@ import type { System, SystemConstructor } from './System';
  * An async hook a renderer awaits while it initialises, after the environment extensions load and
  * before it creates its systems and pipes. Registered as a `WebGLLoader`, `WebGPULoader` or
  * `CanvasLoader` extension, it lets a package `import()` backend-specific systems and pipes and
- * register them in time for the renderer to pick them up.
+ * register them in time for the renderer to pick them up. Loaders for a backend run concurrently;
+ * the systems and pipes they register are ordered by their own `priority`, not by which loader finished first.
  * @category rendering
  * @advanced
  */

--- a/src/rendering/renderers/shared/system/AbstractRenderer.ts
+++ b/src/rendering/renderers/shared/system/AbstractRenderer.ts
@@ -26,6 +26,20 @@ import type { SharedRendererOptions } from './SharedSystems';
 import type { System, SystemConstructor } from './System';
 
 /**
+ * An async hook a renderer awaits while it initialises, after the environment extensions load and
+ * before it creates its systems and pipes. Registered as a `WebGLLoader`, `WebGPULoader` or
+ * `CanvasLoader` extension, it lets a package `import()` backend-specific systems and pipes and
+ * register them in time for the renderer to pick them up.
+ * @category rendering
+ * @advanced
+ */
+export interface RendererLoader
+{
+    /** Called once per renderer init. The renderer waits for the returned promise before adding its systems. */
+    load(): Promise<unknown>;
+}
+
+/**
  * The configuration for the renderer.
  * This is used to define the systems and render pipes that will be used by the renderer.
  * @category rendering
@@ -39,6 +53,8 @@ export interface RendererConfig
     systems: {name: string, value: SystemConstructor}[];
     renderPipes: {name: string, value: PipeConstructor}[];
     renderPipeAdaptors: {name: string, value: any}[];
+    /** Async hooks awaited during `init`, after the environment extensions load and before systems are added. */
+    loaders?: {name: string, value: RendererLoader}[];
 }
 
 /**
@@ -282,6 +298,11 @@ export class AbstractRenderer<
         const skip = options.skipExtensionImports === true ? true : options.manageImports === false;
 
         await loadEnvironmentExtensions(skip);
+
+        if (!skip && this.config.loaders)
+        {
+            await Promise.all(this.config.loaders.map((loader) => loader.value.load()));
+        }
 
         this._addSystems(this.config.systems);
         this._addPipes(this.config.renderPipes, this.config.renderPipeAdaptors);

--- a/src/rendering/renderers/shared/system/SharedSystems.ts
+++ b/src/rendering/renderers/shared/system/SharedSystems.ts
@@ -69,6 +69,7 @@ export interface SharedRendererOptions extends ExtractRendererOptions<typeof Sha
      * It is false by default, and means PixiJS will load all the default extensions, based
      * on the environment e.g browser/webworker.
      * If you set this to true, then you will need to manually import the systems and extensions you need.
+     * Renderer loader extensions (`WebGLLoader`, `WebGPULoader`, `CanvasLoader`) are skipped too.
      *
      * e.g.
      * ```js


### PR DESCRIPTION
### Overview

Third-party packages with WebGL-only and WebGPU-only systems and pipes (such as `@pixi/3d`) had no way to `import()` them lazily the way `autoDetectRenderer` does for the renderers themselves, because `AbstractRenderer.init` instantiates its systems and pipes synchronously right after the environment extensions load. This adds an async, per-renderer-type hook awaited at that point, so a package can register a small loader in its root entry and keep each backend's code in its own chunk. The hook honours `skipExtensionImports` like the environment imports do.

#### Features
- Added `ExtensionType.WebGLLoader`, `ExtensionType.WebGPULoader` and `ExtensionType.CanvasLoader`: async hooks a renderer awaits during `init()`, after environment extensions load and before its systems and pipes are created. Systems and pipes registered inside `load()` are picked up by that init.
  ```ts
  extensions.add(
    { extension: { type: ExtensionType.WebGLLoader, name: 'my-plugin' }, load: () => import('./gl/init') },
    { extension: { type: ExtensionType.WebGPULoader, name: 'my-plugin' }, load: () => import('./gpu/init') },
  );
  ```
- Added the `RendererLoader` interface and an optional `loaders` list on `RendererConfig`.
- `skipExtensionImports: true` now also skips renderer loader extensions.

#### Chores
- Documented the loader extensions in the extensions and architecture guides and in the shipped core-concepts skill.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
