### PR TITLE
feat: add Geometry.indexCount for drawing a prefix of a shared index buffer

### DIFF
--- a/src/rendering/renderers/__tests__/GeometryIndexCount.test.ts
+++ b/src/rendering/renderers/__tests__/GeometryIndexCount.test.ts
@@ -1,0 +1,162 @@
+import { Geometry } from '../shared/geometry/Geometry';
+import { Shader } from '../shared/shader/Shader';
+import { State } from '../shared/state/State';
+import { describeLocalOnly, getGlProgram, getWebGLRenderer, getWebGPURenderer } from '@test-utils';
+
+import type { WebGLRenderer } from '../gl/WebGLRenderer';
+import type { WebGPURenderer } from '../gpu/WebGPURenderer';
+
+const ONE_QUAD = 6;
+const TWO_QUADS = 12;
+
+// two quads out of one index buffer: the shape indexCount exists for, where a buffer is sized for
+// the biggest batch and each geometry sharing it draws a prefix
+function quadGeometry(indexCount?: number): Geometry
+{
+    return new Geometry({
+        attributes: {
+            aPosition: [
+                0, 0, 1, 0, 1, 1, 0, 1,
+                2, 0, 3, 0, 3, 1, 2, 1,
+            ],
+        },
+        indexBuffer: new Uint16Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]),
+        indexCount,
+    });
+}
+
+describe('Geometry indexCount', () =>
+{
+    it('should default to 0 and take its value from the descriptor', () =>
+    {
+        expect(quadGeometry().indexCount).toBe(0);
+        expect(quadGeometry(ONE_QUAD).indexCount).toBe(ONE_QUAD);
+    });
+});
+
+describe('Geometry indexCount on WebGL', () =>
+{
+    let renderer: WebGLRenderer;
+
+    beforeAll(async () =>
+    {
+        renderer = (await getWebGLRenderer()) as WebGLRenderer;
+    });
+
+    afterAll(() =>
+    {
+        renderer.destroy();
+        renderer = null;
+    });
+
+    // the count handed to gl.drawElements is the whole story here, and there is no program bound to
+    // draw with, so the call is captured rather than let through
+    function drawCount(geometry: Geometry, size?: number): number
+    {
+        renderer.geometry.bind(geometry, getGlProgram());
+
+        const drawElements = jest.spyOn(renderer.gl, 'drawElements')
+            .mockImplementation(() => { /* captured, not drawn */ });
+
+        renderer.geometry.draw(undefined, size);
+
+        const count = drawElements.mock.calls[0][1];
+
+        drawElements.mockRestore();
+
+        return count;
+    }
+
+    it('should draw indexCount indices when one is set', () =>
+    {
+        expect(drawCount(quadGeometry(ONE_QUAD))).toBe(ONE_QUAD);
+    });
+
+    it('should draw the whole index buffer when indexCount is 0', () =>
+    {
+        expect(drawCount(quadGeometry())).toBe(TWO_QUADS);
+    });
+
+    it('should let an explicit size win over indexCount', () =>
+    {
+        expect(drawCount(quadGeometry(ONE_QUAD), 3)).toBe(3);
+    });
+});
+
+describeLocalOnly('Geometry indexCount on WebGPU', () =>
+{
+    let renderer: WebGPURenderer;
+    let shader: Shader;
+    let state: State;
+
+    beforeAll(async () =>
+    {
+        renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        // clip-space positions, no uniforms — the pipeline just has to be buildable
+        shader = Shader.from({
+            gpu: {
+                vertex: {
+                    entryPoint: 'main',
+                    source: /* wgsl */`
+                        @vertex
+                        fn main(@location(0) aPosition : vec2<f32>) -> @builtin(position) vec4<f32> {
+                            return vec4<f32>(aPosition, 0.0, 1.0);
+                        };
+                    `,
+                },
+                fragment: {
+                    entryPoint: 'main',
+                    source: /* wgsl */`
+                        @fragment
+                        fn main() -> @location(0) vec4<f32> {
+                            return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+                        }
+                    `,
+                },
+            },
+        });
+
+        state = State.for2d();
+    });
+
+    afterAll(() =>
+    {
+        renderer.destroy();
+        renderer = null;
+    });
+
+    // the pipeline, buffers and bind groups are all built for real against the device; only the
+    // recording target stands in, so the draw parameters the encoder computes can be read back
+    function drawCount(geometry: Geometry, size?: number): number
+    {
+        const drawIndexed = jest.fn();
+
+        renderer.encoder.renderPassEncoder = {
+            setPipeline: jest.fn(),
+            setVertexBuffer: jest.fn(),
+            setIndexBuffer: jest.fn(),
+            setBindGroup: jest.fn(),
+            drawIndexed,
+        } as unknown as GPURenderPassEncoder;
+
+        renderer.encoder.draw({ geometry, shader, state, size });
+
+        return drawIndexed.mock.calls[0][0];
+    }
+
+    it('should draw indexCount indices when one is set', () =>
+    {
+        expect(drawCount(quadGeometry(ONE_QUAD))).toBe(ONE_QUAD);
+    });
+
+    it('should draw the whole index buffer when indexCount is 0', () =>
+    {
+        expect(drawCount(quadGeometry())).toBe(TWO_QUADS);
+    });
+
+    it('should let an explicit size win over indexCount', () =>
+    {
+        expect(drawCount(quadGeometry(ONE_QUAD), 3)).toBe(3);
+    });
+});

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -433,8 +433,9 @@ export class GlGeometrySystem implements System
     /**
      * Draws the currently bound geometry.
      * @param topology - The type primitive to render.
-     * @param size - The number of elements to be rendered. If not specified, all vertices after the
-     *  starting vertex will be drawn.
+     * @param size - The number of elements to be rendered. If not specified, an indexed geometry
+     *  falls back to {@link Geometry.indexCount} and then to its whole index buffer, and a
+     *  non-indexed one to {@link Geometry.vertexCount}.
      * @param start - The starting vertex in the geometry to start drawing from. If not specified,
      *  drawing will start from the first vertex.
      * @param instanceCount - The number of instances of the set of elements to execute. If not specified,
@@ -454,16 +455,16 @@ export class GlGeometrySystem implements System
         {
             const byteSize = geometry.indexBuffer.data.BYTES_PER_ELEMENT;
             const glType = byteSize === 2 ? gl.UNSIGNED_SHORT : gl.UNSIGNED_INT;
+            const count = size || geometry.indexCount || geometry.indexBuffer.data.length;
+            const byteOffset = (start || 0) * byteSize;
 
             if (instanceCount !== 1)
             {
-                /* eslint-disable max-len */
-                gl.drawElementsInstanced(glTopology, size || geometry.indexBuffer.data.length, glType, (start || 0) * byteSize, instanceCount);
-                /* eslint-enable max-len */
+                gl.drawElementsInstanced(glTopology, count, glType, byteOffset, instanceCount);
             }
             else
             {
-                gl.drawElements(glTopology, size || geometry.indexBuffer.data.length, glType, (start || 0) * byteSize);
+                gl.drawElements(glTopology, count, glType, byteOffset);
             }
         }
         else if (instanceCount !== 1)

--- a/src/rendering/renderers/gpu/GpuEncoderSystem.ts
+++ b/src/rendering/renderers/gpu/GpuEncoderSystem.ts
@@ -438,7 +438,7 @@ export class GpuEncoderSystem implements System
         if (geometry.indexBuffer)
         {
             this.renderPassEncoder.drawIndexed(
-                size || geometry.indexBuffer.data.length,
+                size || geometry.indexCount || geometry.indexBuffer.data.length,
                 instanceCount ?? geometry.instanceCount,
                 start || 0,
                 baseVertex || 0,

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -83,7 +83,10 @@ export interface GeometryDescriptor
     /** the topology of the geometry, defaults to 'triangle-list' */
     topology?: Topology;
 
+    /** the number of instances to draw, defaults to 1. See {@link Geometry.instanceCount} */
     instanceCount?: number;
+    /** the number of indices to draw, defaults to 0 - the whole index buffer. See {@link Geometry.indexCount} */
+    indexCount?: number;
 }
 function ensureIsAttribute(attribute: AttributeOption): Attribute
 {
@@ -168,6 +171,19 @@ export class Geometry extends EventEmitter<{
     /** the instance count of the geometry to draw */
     public instanceCount = 1;
 
+    /**
+     * The number of indices to draw, or `0` to draw the whole index buffer.
+     *
+     * Set this when a geometry only covers a prefix of an index buffer it shares with others - a
+     * pool of identical quads, say, where one buffer holds the six indices per quad for the largest
+     * batch and each geometry draws as many quads as it currently holds. A `size` passed to the
+     * draw call still wins, and a geometry with no index buffer ignores this entirely
+     * ({@link Geometry.vertexCount} drives those). Read at draw time only, so changing it never
+     * re-uploads or re-lays-out anything.
+     * @default 0
+     */
+    public indexCount = 0;
+
     private readonly _bounds: Bounds = new Bounds();
     private _boundsDirty = true;
 
@@ -197,6 +213,7 @@ export class Geometry extends EventEmitter<{
         }
 
         this.instanceCount = options.instanceCount ?? 1;
+        this.indexCount = options.indexCount ?? 0;
 
         if (indexBuffer)
         {


### PR DESCRIPTION
##### Description of change

Adds `indexCount` to `Geometry`, next to `instanceCount`, and has both backends default their draw's index count from it the same way they already default the instance count.

Today a draw covers the whole index buffer unless the caller passes `size`, which makes it impossible for several geometries to share one index buffer and each draw a prefix of it — exactly what a pool of identical quads wants (particle containers, sprite batches, anything where the indices are the same six per quad stepped by four). `instanceCount` already solves this for the other draw parameter; this is its twin.

**Semantics**

- `geometry.indexCount: number`, default `0`, meaning "the whole index buffer".
- A draw with no explicit `size` uses `geometry.indexCount || indexBuffer.data.length`.
- An explicit `size` on the draw call still wins, as it does now.
- A geometry with no index buffer ignores the field; `vertexCount` keeps driving `drawArrays`.
- Read at draw time only — setting it triggers no GPU re-upload or layout change.

```ts
// one index buffer sized for the biggest batch, several geometries drawing a prefix of it
const geometry = new Geometry({ attributes, indexBuffer: sharedIndices, indexCount: quads * 6 });
```

**Nothing existing changes behaviour.** The default `0` makes `0 || X → X`, identical to today, and no call site in the repo sets the field. Every high-volume path short-circuits on `size` before the new read is even reached — `GlBatchAdaptor` and `GlGraphicsAdaptor` pass `batch.size`, `GpuParticleContainerAdaptor` passes its own, and `GpuBatchAdaptor` / `GlParticleContainerAdaptor` call `drawIndexed` / `gl.drawElements` directly. The paths that do read it (mesh adaptors, `TilingSpritePipe`, `FilterSystem`, `GlBackBufferSystem`) pay one monomorphic load of a plain number field beside a three-hop `indexBuffer.data.length` chain they were already walking.

While in `GlGeometrySystem.draw`, the fallback expression was duplicated across the instanced and non-instanced branches, so it is hoisted to a single `count`. The `/* eslint-disable max-len */` around `drawElementsInstanced` falls out with it.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)

New `GeometryIndexCount.test.ts` covers, on both backends: `indexCount: 6` over a 12-index buffer draws 6, `indexCount: 0` draws 12, and an explicit `size` overrides it. WebGL captures `gl.drawElements`; WebGPU builds the pipeline, buffers and bind groups for real against the device and stands in only for the recording target, so `drawIndexed`'s parameters can be read back (under `describeLocalOnly`, matching `GpuEncoderSystem.test.ts` — CI runners have no GPU). Verified the tests discriminate: removing `geometry.indexCount ||` from both draw sites fails them with `Expected: 6, Received: 12`.

Full gauntlet green locally: lint, types (3 configs), index, prune, 1984 unit tests, 1670 visual tests with baselines unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)