### PR TITLE
Add null check for textureBatch before clearing

### DIFF
--- a/src/rendering/batcher/shared/Batcher.ts
+++ b/src/rendering/batcher/shared/Batcher.ts
@@ -492,7 +492,8 @@ export abstract class Batcher
         let batch = getBatchFromPool();
         let textureBatch = batch.textures;
 
-        textureBatch.clear();
+        // batch.textures will return null if PixiOverlay is updated rapidly (>10x/sec)
+        if ( textureBatch ) textureBatch.clear();
 
         const firstElement = elements[this.elementStart];
         let blendMode = getAdjustedBlendModeBlend(firstElement.blendMode, firstElement.texture._source);


### PR DESCRIPTION
Add null check before clearing textureBatch to prevent errors when PixiOverlay updates rapidly.

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
