### PR TITLE
fix: handle strokes wider than the shape in Ellipse.strokeContains

### DIFF
--- a/src/maths/__tests__/Ellipse.test.ts
+++ b/src/maths/__tests__/Ellipse.test.ts
@@ -114,6 +114,50 @@ describe('Ellipse', () =>
             expect(ellipse.strokeContains(9, 0, 3, 1)).toBe(true);
             expect(ellipse.strokeContains(8, 0, 3, 1)).toBe(false);
         });
+
+        it('should stroke the whole shape when the stroke reaches past the center', () =>
+        {
+            // both half-axes are 10, so an inner stroke of 40 leaves no unstroked interior and
+            // every point out to the unchanged outer edge lies on the stroke
+            const ellipse = new Ellipse(2, 2, 10, 10);
+
+            expect(ellipse.strokeContains(2, 2, 40, 1)).toBe(true);
+            expect(ellipse.strokeContains(8, 2, 40, 1)).toBe(true);
+            expect(ellipse.strokeContains(2, 11, 40, 1)).toBe(true);
+            expect(ellipse.strokeContains(12, 2, 40, 1)).toBe(true);
+
+            // beyond the outer edge is still not stroked
+            expect(ellipse.strokeContains(13, 2, 40, 1)).toBe(false);
+            expect(ellipse.strokeContains(2, -9, 40, 1)).toBe(false);
+        });
+
+        it('should stroke the whole shape when the stroke reaches exactly the center', () =>
+        {
+            // a centered stroke of 20 puts 10 of it inside, landing both inner half-axes on
+            // exactly 0, so the unstroked interior has shrunk to nothing
+            const ellipse = new Ellipse(0, 0, 10, 10);
+
+            expect(ellipse.strokeContains(0, 0, 20, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(5, 0, 20, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(0, 5, 20, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(5, 5, 20, 0.5)).toBe(true);
+
+            // the other 10 grows the outer edge to 20, and beyond it is still not stroked
+            expect(ellipse.strokeContains(20, 0, 20, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(21, 0, 20, 0.5)).toBe(false);
+        });
+
+        it('should stroke the whole shape when only the shorter axis is covered', () =>
+        {
+            // the half-width of 50 keeps an inner half-width of 35, but the inner stroke of 15
+            // covers the whole half-height of 10, so there is no unstroked interior left
+            const ellipse = new Ellipse(0, 0, 50, 10);
+
+            expect(ellipse.strokeContains(0, 0, 30, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(20, 0, 30, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(64, 0, 30, 0.5)).toBe(true);
+            expect(ellipse.strokeContains(66, 0, 30, 0.5)).toBe(false);
+        });
     });
 
     it('should return framing rectangle', () =>

--- a/src/maths/shapes/Ellipse.ts
+++ b/src/maths/shapes/Ellipse.ts
@@ -189,6 +189,7 @@ export class Ellipse implements ShapePrimitive
      * - Uses normalized ellipse equations
      * - Considers stroke alignment
      * - Returns false if dimensions are 0
+     * - A stroke wider than the shape covers it entirely, leaving no unstroked interior
      * @param x - The X coordinate of the point to test
      * @param y - The Y coordinate of the point to test
      * @param strokeWidth - The width of the line to check
@@ -218,13 +219,21 @@ export class Ellipse implements ShapePrimitive
         const normalizedX = x - this.x;
         const normalizedY = y - this.y;
 
-        const innerEllipse = ((normalizedX * normalizedX) / (innerHorizontal * innerHorizontal))
-            + ((normalizedY * normalizedY) / (innerVertical * innerVertical));
-
         const outerEllipse = ((normalizedX * normalizedX) / (outerHorizontal * outerHorizontal))
             + ((normalizedY * normalizedY) / (outerVertical * outerVertical));
 
-        return innerEllipse > 1 && outerEllipse <= 1;
+        if (outerEllipse > 1) return false;
+
+        // Once the inward part of the stroke reaches the center on either axis there is no
+        // unstroked interior left, so everything inside the outer edge is on the stroke.
+        // Squaring a negative half-axis would revive it as a smaller positive ellipse and
+        // carve a hole out of the middle of the stroke.
+        if (innerHorizontal <= 0 || innerVertical <= 0) return true;
+
+        const innerEllipse = ((normalizedX * normalizedX) / (innerHorizontal * innerHorizontal))
+            + ((normalizedY * normalizedY) / (innerVertical * innerVertical));
+
+        return innerEllipse > 1;
     }
 
     /**


### PR DESCRIPTION
### Overview

`Ellipse.strokeContains` subtracted the inward part of the stroke from each half-axis without clamping at zero. Squaring a negative half-axis revived it as a smaller positive ellipse, so a stroke wider than the shape excluded a phantom interior and `Graphics.containsPoint` returned `false` across the middle of a thickly stroked ellipse. `Circle`, `Rectangle` and `RoundedRectangle` already treat this case as fully stroked; this brings `Ellipse` in line.

The method now tests the outer edge first and, once either inner half-axis has reached zero or less, treats every point inside the outer edge as stroked. Points where both inner half-axes stay positive follow the same arithmetic as before, and alignment `0` never reaches the new branch.

#### Fixes
- `Ellipse.strokeContains` (and therefore `Graphics.containsPoint`) reports the whole interior as stroked when the stroke is wider than the shape, instead of punching a hole through the middle

```ts
const g = new Graphics().ellipse(0, 0, 10, 10).stroke({ width: 40, alignment: 1 });

g.containsPoint({ x: 0, y: 0 });  // was false, now true
g.containsPoint({ x: 13, y: 0 }); // still false: past the outer edge
```

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added