### PR TITLE
fix: clamp blur samples to the input frame

### DIFF
--- a/src/filters/defaults/blur/__tests__/BlurFilterRendering.test.ts
+++ b/src/filters/defaults/blur/__tests__/BlurFilterRendering.test.ts
@@ -1,0 +1,104 @@
+import '~/scene/graphics/init';
+import '~/rendering/init';
+import { BlurFilter } from '../BlurFilter';
+import { getWebGLRenderer } from '@test-utils';
+import { RenderTexture, TexturePool } from '~/rendering';
+import { Container, Graphics } from '~/scene';
+
+describe('BlurFilter rendering', () =>
+{
+    it.each<[1 | 2, number]>([[1, 1], [1, 4], [2, 1], [2, 4]])(
+        'should not sample pooled pixels with WebGL %i and quality %i', async (preferWebGLVersion, quality) =>
+        {
+            const renderer = await getWebGLRenderer({ width: 1000, height: 560, preferWebGLVersion });
+            const output = RenderTexture.create({ width: 1000, height: 560 });
+            const stage = new Container();
+            const big = new Container({ x: 20, y: 50 });
+            const small = new Container({ x: 600, y: 50 });
+            const bigBlur = new BlurFilter({ strength: 8 });
+            const smallBlur = new BlurFilter({ strength: 30, quality });
+
+            big.addChild(new Graphics().rect(0, 0, 460, 460).fill(0xffffff));
+            big.filters = [bigBlur];
+            small.addChild(new Graphics()
+                .circle(14, 14, 14).fill(0x44ff88)
+                .circle(286, 286, 14)
+                .fill(0x44ff88));
+            small.filters = [smallBlur];
+            stage.addChild(small);
+
+            try
+            {
+                TexturePool.clear();
+                renderer.render({ container: stage, target: output, clear: true });
+                const expected = renderer.extract.pixels(output).pixels;
+
+                TexturePool.clear();
+                // Both filter frames use 512x512 pooled textures. Rendering the larger
+                // object first leaves pixels outside the smaller object's filter frame.
+                stage.addChildAt(big, 0);
+                renderer.render({ container: stage, target: output, clear: true });
+                const actual = renderer.extract.pixels(output).pixels;
+                let maxDifference = 0;
+                let maxAlpha = 0;
+
+                for (let y = 0; y < 560; y++)
+                {
+                    for (let x = 540; x < 1000; x++)
+                    {
+                        const offset = ((y * 1000) + x) * 4;
+
+                        maxAlpha = Math.max(maxAlpha, expected[offset + 3]);
+                        for (let channel = 0; channel < 4; channel++)
+                        {
+                            const difference = Math.abs(actual[offset + channel] - expected[offset + channel]);
+
+                            maxDifference = Math.max(maxDifference, difference);
+                        }
+                    }
+                }
+
+                expect(maxAlpha).toBeGreaterThan(0);
+                expect(maxDifference).toBeLessThanOrEqual(1);
+            }
+            finally
+            {
+                stage.destroy({ children: true });
+                bigBlur.destroy();
+                smallBlur.destroy();
+                output.destroy(true);
+                TexturePool.clear();
+                renderer.destroy();
+            }
+        });
+
+    it.each([1, 4])('should repeat edge pixels with quality %i', async (quality) =>
+    {
+        const renderer = await getWebGLRenderer();
+        const output = RenderTexture.create({ width: 40, height: 40 });
+        const graphics = new Graphics().rect(0, 0, 40, 40).fill(0xffffff);
+        const filter = new BlurFilter({ strength: 8, quality });
+
+        filter.repeatEdgePixels = true;
+        graphics.filters = [filter];
+
+        try
+        {
+            TexturePool.clear();
+            renderer.render({ container: graphics, target: output, clear: true });
+            const { pixels } = renderer.extract.pixels(output);
+
+            // Repeating a solid white edge must keep the entire rectangle opaque,
+            // even when its backing texture is larger than the filter frame.
+            expect(pixels.every((value) => value >= 253)).toBe(true);
+        }
+        finally
+        {
+            graphics.destroy();
+            filter.destroy();
+            output.destroy(true);
+            TexturePool.clear();
+            renderer.destroy();
+        }
+    });
+});

--- a/src/filters/defaults/blur/gl/generateBlurFragSource.ts
+++ b/src/filters/defaults/blur/gl/generateBlurFragSource.ts
@@ -3,6 +3,7 @@ import { GAUSSIAN_VALUES } from '../const';
 const fragTemplate = [
     'in vec2 vBlurTexCoords[%size%];',
     'uniform sampler2D uTexture;',
+    'uniform vec4 uInputClamp;',
     'out vec4 finalColor;',
 
     'void main(void)',
@@ -24,7 +25,7 @@ export function generateBlurFragSource(kernelSize: number): string
     let blurLoop = '';
     const prefixFirst = 'finalColor = ';
     const prefixRest = '    + ';
-    const template = 'texture(uTexture, vBlurTexCoords[%index%]) * %value%';
+    const template = 'texture(uTexture, clamp(vBlurTexCoords[%index%], uInputClamp.xy, uInputClamp.zw)) * %value%';
 
     for (let i = 0; i < kernelSize; i++)
     {

--- a/src/filters/defaults/blur/gpu/generateBlurProgram.ts
+++ b/src/filters/defaults/blur/gpu/generateBlurProgram.ts
@@ -32,7 +32,8 @@ export function generateBlurProgram(horizontal: boolean, kernelSize: number)
         const kernelIndex = i < halfLength ? i : (kernelSize - i - 1);
         const kernelValue = kernel[kernelIndex].toString();
 
-        blurSamplingSource[i] = `finalColor += textureSample(uTexture, uSampler, offset${i}) * ${kernelValue};`;
+        blurSamplingSource[i] = `finalColor += textureSample(uTexture, uSampler,
+            clamp(offset${i}, gfu.uInputClamp.xy, gfu.uInputClamp.zw)) * ${kernelValue};`;
     }
 
     const blurStruct = blurStructSource.join('\n');
@@ -57,4 +58,3 @@ export function generateBlurProgram(horizontal: boolean, kernelSize: number)
         },
     });
 }
-


### PR DESCRIPTION
##### Description of change

Clamp blur texture samples to `uInputClamp` in the GLSL and WGSL generators. This prevents a smaller filtered object from sampling pixels left outside its input frame by a previous user of the pooled texture.

Add six pixel-based regression cases covering pooled-texture reuse in WebGL 1/2 at quality 1/4, and `repeatEdgePixels` at quality 1/4. The initial reproduction failed before the fix with a maximum channel difference of 156 between clean-pool and reused-pool output; it passes with the fix (tolerance: 1).

Fixes #12171.

Verification on Windows:

- `npm run test -- unit --testPathPattern=src/filters --runInBand`: 22 tests passed.
- With `SCENE_FILTER=blur-filter*.scene.ts`, `npm run test -- visual --runInBand`: all 6 existing blur visual tests passed across WebGL 1, WebGL 2 and WebGPU, including legacy mode. No baselines changed.
- `npm run test -- lint types index`: all three type checks and the index check passed. Default lint is blocked by CRLF checkouts of unchanged files (`core.autocrlf=true`).
- ESLint passes on all changed files with no rules disabled. A separate full-repository ESLint run with only `linebreak-style` disabled passes with zero warnings; no lint configuration was changed.
- `git diff --check` passed. The full `npm test` suite and production build were not run.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
