### PR TITLE
fix: release VAOs and buffer listeners when a Geometry is destroyed

### DIFF
--- a/src/rendering/renderers/__tests__/Geometry.test.ts
+++ b/src/rendering/renderers/__tests__/Geometry.test.ts
@@ -106,6 +106,77 @@ describe('Geometry', () =>
         expect(indexBuffer.data).toBeNull();
     });
 
+    it('should delete its VAOs and leave the managed hash when destroyed', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getWebGLRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const vao = geometry._gpuData[renderer.uid].vaoCache[program._key];
+        const deleteSpy = jest.spyOn(renderer.gl, 'deleteVertexArray');
+
+        expect(renderer.geometry._managedGeometries.items[geometry.uid]).toBe(geometry);
+
+        geometry.destroy();
+
+        expect(deleteSpy).toHaveBeenCalledWith(vao);
+        expect(renderer.geometry._managedGeometries.items[geometry.uid]).toBeNil();
+        expect(geometry._gpuData).toBeEmptyObject();
+    });
+
+    it('should emit unload after destroy when destroyed', () =>
+    {
+        const geometry = getGeometry();
+        const events: string[] = [];
+
+        geometry.once('destroy', () => events.push('destroy'));
+        geometry.once('unload', () => events.push('unload'));
+
+        geometry.destroy();
+
+        expect(events).toEqual(['destroy', 'unload']);
+        expect(geometry.eventNames()).toEqual([]);
+    });
+
+    it('should stop listening to surviving buffers when destroyed', () =>
+    {
+        const shared = new Buffer({
+            data: new Float32Array([0, 0, 1, 0, 1, 1]),
+            usage: BufferUsage.VERTEX,
+        });
+        const survivor = new Geometry({
+            attributes: {
+                aPosition: shared,
+            },
+        });
+        const geometry = new Geometry({
+            attributes: {
+                aPosition: shared,
+                aUv: [0, 0, 1, 0, 1, 1],
+            },
+            indexBuffer: [0, 1, 2],
+        });
+        const own = geometry.buffers[1];
+        const updateSpy = jest.fn();
+
+        survivor.on('update', updateSpy);
+
+        geometry.destroy(false);
+
+        expect(shared.listenerCount('update')).toBe(1);
+        expect(shared.listenerCount('change')).toBe(1);
+        expect(own.listenerCount('update')).toBe(0);
+        expect(own.listenerCount('change')).toBe(0);
+
+        shared.update();
+
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should set a cast data correctly', () =>
     {
         const buffer = new Buffer({

--- a/src/rendering/renderers/__tests__/Geometry.test.ts
+++ b/src/rendering/renderers/__tests__/Geometry.test.ts
@@ -128,6 +128,47 @@ describe('Geometry', () =>
         expect(geometry._gpuData).toBeEmptyObject();
     });
 
+    it('should reset the geometry system when the bound geometry is destroyed', async () =>
+    {
+        const geometry = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getWebGLRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(geometry, program);
+
+        const bindSpy = jest.spyOn(renderer.gl, 'bindVertexArray');
+
+        geometry.destroy();
+
+        expect(bindSpy).toHaveBeenCalledWith(null);
+        expect(renderer.geometry._activeVao).toBeNull();
+        expect(renderer.geometry['_activeGeometry']).toBeNull();
+    });
+
+    it('should keep the bound geometry when another geometry is destroyed', async () =>
+    {
+        const bound = getGeometry();
+        const other = getGeometry();
+
+        const program = getGlProgram();
+
+        const renderer = (await getWebGLRenderer()) as WebGLRenderer;
+
+        renderer.geometry.bind(other, program);
+        renderer.geometry.bind(bound, program);
+
+        const vao = bound._gpuData[renderer.uid].vaoCache[program._key];
+        const bindSpy = jest.spyOn(renderer.gl, 'bindVertexArray');
+
+        other.destroy();
+
+        expect(bindSpy).not.toHaveBeenCalled();
+        expect(renderer.geometry._activeVao).toBe(vao);
+        expect(renderer.geometry['_activeGeometry']).toBe(bound);
+    });
+
     it('should emit unload after destroy when destroyed', () =>
     {
         const geometry = getGeometry();

--- a/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
+++ b/src/rendering/renderers/gl/geometry/GlGeometrySystem.ts
@@ -327,7 +327,7 @@ export class GlGeometrySystem implements System
         {
             for (const i in vaoCache)
             {
-                if (this._activeVao !== vaoCache[i])
+                if (this._activeVao === vaoCache[i])
                 {
                     this.resetState();
                 }

--- a/src/rendering/renderers/shared/geometry/Geometry.ts
+++ b/src/rendering/renderers/shared/geometry/Geometry.ts
@@ -368,14 +368,21 @@ export class Geometry extends EventEmitter<{
     {
         this.emit('destroy', this);
 
-        this.removeAllListeners();
-
-        if (destroyBuffers)
+        // a buffer that outlives the geometry (shared, or destroyBuffers false) must not
+        // keep retaining and calling into it
+        for (const buffer of this.buffers)
         {
-            this.buffers.forEach((buffer) => buffer.destroy());
+            buffer.off('update', this.onBufferUpdate, this);
+            buffer.off('change', this.onBufferUpdate, this);
+
+            if (destroyBuffers) buffer.destroy();
         }
 
         this.unload();
+
+        // must come after unload() - the renderer geometry systems listen for 'unload'
+        // to delete their VAOs and release their managed-hash entry
+        this.removeAllListeners();
 
         (this.attributes as null) = null;
         (this.buffers as null) = null;


### PR DESCRIPTION
### Overview

`Geometry.destroy()` removed all listeners before calling `unload()`, so the `unload` event that lets the WebGL geometry system delete VAOs and release its managed-hash entry never reached it: every destroyed geometry leaked its VAOs and an entry the GC could never reclaim. The geometry also never unsubscribed from its buffers, so a buffer that outlived it kept a strong reference to the dead geometry. While there, the GL system's unload handler had its check inverted: it reset the bound state whenever an unrelated VAO was deleted and left a stale pointer when the bound one was.

#### Fixes
- `Geometry.destroy()` emits `unload` before removing its listeners, so WebGL VAOs are deleted and the geometry leaves the renderer's GC hash
- `Geometry.destroy()` detaches its buffer listeners, so buffers that outlive the geometry no longer retain it
- `GlGeometrySystem` resets its bound state only when the VAO being deleted is the bound one

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
