### PR TITLE
fix: make the GC resource sweep safe under re-entrant unload listeners

### DIFF
--- a/src/rendering/renderers/shared/GCSystem.ts
+++ b/src/rendering/renderers/shared/GCSystem.ts
@@ -123,7 +123,7 @@ export class GCSystem implements System<GCSystemOptions>
     private _renderer: Renderer;
 
     /** Array of resources being tracked for garbage collection */
-    private readonly _managedResources: GCableEventEmitter[] = [];
+    private readonly _managedResources: (GCableEventEmitter | null)[] = [];
     private readonly _managedResourceHashes: GCResourceHashEntry[] = [];
     private readonly _managedCollections: {context: any, collection: string, type: 'hash' | 'array'}[] = [];
 
@@ -138,6 +138,7 @@ export class GCSystem implements System<GCSystemOptions>
     public now: number;
 
     private _ready = false;
+    private _running = false;
 
     /**
      * Creates a new GCSystem instance.
@@ -317,16 +318,25 @@ export class GCSystem implements System<GCSystemOptions>
         const index = gcData.index;
         const last = this._managedResources.length - 1;
 
-        // Swap with last element for O(1) removal
-        if (index !== last)
+        if (this._running)
         {
-            const lastResource = this._managedResources[last];
+            // Keep sweep indices stable when unload listeners remove other resources.
+            this._managedResources[index] = null;
+        }
+        else
+        {
+            // Swap with last element for O(1) removal outside a sweep.
+            if (index !== last)
+            {
+                const lastResource = this._managedResources[last];
 
-            this._managedResources[index] = lastResource;
-            lastResource._gcData.index = index;
+                this._managedResources[index] = lastResource;
+                lastResource._gcData.index = index;
+            }
+
+            this._managedResources.length--;
         }
 
-        this._managedResources.length--;
         resource._gcData = null;
         resource._gcLastUsed = -1;
     }
@@ -357,20 +367,54 @@ export class GCSystem implements System<GCSystemOptions>
      */
     public run(): void
     {
+        if (this._running) return;
+
         const now = performance.now();
         const managedResourceHashes = this._managedResourceHashes;
+        const managedResources = this._managedResources;
 
-        for (const hashEntry of managedResourceHashes)
+        this._running = true;
+
+        try
         {
-            this.runOnHash(hashEntry, now);
+            for (const hashEntry of managedResourceHashes)
+            {
+                this.runOnHash(hashEntry, now);
+            }
+
+            // Removals leave null slots until the sweep ends. Only visit the starting entries,
+            // so resources registered by unload listeners wait until the next sweep.
+            const length = managedResources.length;
+
+            for (let i = 0; i < length; i++)
+            {
+                const resource = managedResources[i];
+
+                if (resource) this.runOnResource(resource, now);
+            }
         }
-
-        // Unloading a resource can synchronously unload other tracked resources (a GraphicsContext takes its
-        // dependent Graphics with it), each of which untracks itself through removeResource. Sweeping a
-        // snapshot keeps those removals from disturbing the walk.
-        for (const resource of this._managedResources.slice())
+        finally
         {
-            if (resource._gcData) this.runOnResource(resource, now);
+            // Compact without allocating, including when an unload listener throws.
+            let writeIndex = 0;
+
+            for (let i = 0; i < managedResources.length; i++)
+            {
+                const resource = managedResources[i];
+
+                if (!resource) continue;
+
+                if (writeIndex !== i)
+                {
+                    managedResources[writeIndex] = resource;
+                    resource._gcData.index = writeIndex;
+                }
+
+                writeIndex++;
+            }
+
+            managedResources.length = writeIndex;
+            this._running = false;
         }
     }
 
@@ -521,7 +565,7 @@ export class GCSystem implements System<GCSystemOptions>
 
         this._managedResources.forEach((resource) =>
         {
-            resource.off('unload', this.removeResource, this);
+            resource?.off('unload', this.removeResource, this);
         });
         this._managedResources.length = 0;
         this._managedResourceHashes.length = 0;

--- a/src/rendering/renderers/shared/GCSystem.ts
+++ b/src/rendering/renderers/shared/GCSystem.ts
@@ -399,11 +399,11 @@ export class GCSystem implements System<GCSystemOptions>
 
         if (isRecentlyUsed || !resource.autoGarbageCollect) return;
 
-        // Stop tracking before unloading: unload() emits 'unload' synchronously, so the listener from
-        // addResource must be gone and the bookkeeping settled before any listener runs.
+        // Detach the GC's own listener so unload() cannot untrack the resource mid-unload, and untrack last:
+        // a listener that stamps _gcLastUsed during unload() must not be able to block re-registration.
         resource.off('unload', this.removeResource, this);
-        this.removeResource(resource);
         resource.unload();
+        this.removeResource(resource);
     }
 
     /**

--- a/src/rendering/renderers/shared/GCSystem.ts
+++ b/src/rendering/renderers/shared/GCSystem.ts
@@ -365,16 +365,13 @@ export class GCSystem implements System<GCSystemOptions>
             this.runOnHash(hashEntry, now);
         }
 
-        let writeIndex = 0;
-
-        for (let i = 0; i < this._managedResources.length; i++)
+        // Unloading a resource can synchronously unload other tracked resources (a GraphicsContext takes its
+        // dependent Graphics with it), each of which untracks itself through removeResource. Sweeping a
+        // snapshot keeps those removals from disturbing the walk.
+        for (const resource of this._managedResources.slice())
         {
-            const resource = this._managedResources[i];
-
-            writeIndex = this.runOnResource(resource, now, writeIndex);
+            if (resource._gcData) this.runOnResource(resource, now);
         }
-
-        this._managedResources.length = writeIndex;
     }
 
     protected updateRenderableGCTick(renderable: Renderable & GCable, now: number): void
@@ -390,34 +387,23 @@ export class GCSystem implements System<GCSystemOptions>
         }
     }
 
-    protected runOnResource(resource: GCableEventEmitter, now: number, writeIndex: number): number
+    protected runOnResource(resource: GCableEventEmitter, now: number): void
     {
-        const gcData = resource._gcData;
-
         // special case for renderables as we do not check every frame if they are being used
-        if (gcData.type === 'renderable')
+        if (resource._gcData.type === 'renderable')
         {
             this.updateRenderableGCTick(resource as Renderable, now);
         }
 
         const isRecentlyUsed = now - resource._gcLastUsed < this.maxUnusedTime;
 
-        if (isRecentlyUsed || !resource.autoGarbageCollect)
-        {
-            this._managedResources[writeIndex] = resource;
-            gcData.index = writeIndex;
-            writeIndex++;
-        }
-        else
-        {
-            // Call the cleanup function
-            resource.unload();
-            resource._gcData = null;
-            resource._gcLastUsed = -1;
-            resource.off('unload', this.removeResource, this);
-        }
+        if (isRecentlyUsed || !resource.autoGarbageCollect) return;
 
-        return writeIndex;
+        // Stop tracking before unloading: unload() emits 'unload' synchronously, so the listener from
+        // addResource must be gone and the bookkeeping settled before any listener runs.
+        resource.off('unload', this.removeResource, this);
+        this.removeResource(resource);
+        resource.unload();
     }
 
     /**

--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -1,8 +1,8 @@
 import { GCSystem } from '../GCSystem';
-import { type NOOP } from '~/utils';
+import { EventEmitter, type NOOP } from '~/utils';
 
 import type { Renderer } from '../../types';
-import type { GCable, GCSystemOptions } from '../GCSystem';
+import type { GCable, GCData, GCSystemOptions } from '../GCSystem';
 
 // Mock resource that implements GCable interface
 function createMockResource(options: Partial<GCable> = {}): GCable & { once: jest.Mock; off: jest.Mock; unload: jest.Mock }
@@ -405,6 +405,111 @@ describe('GCSystem', () =>
             gcSystem.run();
 
             expect(resource.off).toHaveBeenCalledWith('unload', gcSystem.removeResource, gcSystem);
+        });
+    });
+
+    describe('run with resources that emit unload', () =>
+    {
+        type UnloadingResource = EventEmitter & GCable & { unloadCount: number };
+
+        // Mirrors TextureSource, Buffer and Geometry: unload() emits 'unload' synchronously, which fires the
+        // listener the GC registered in addResource while the sweep is still walking the array.
+        function createUnloadingResource(): UnloadingResource
+        {
+            const resource: UnloadingResource = Object.assign(new EventEmitter(), {
+                _gpuData: {},
+                _gcLastUsed: -1,
+                _gcData: null as GCData | null,
+                autoGarbageCollect: true,
+                unloadCount: 0,
+                unload: () =>
+                {
+                    resource.unloadCount++;
+                    resource.emit('unload', resource);
+                },
+            });
+
+            return resource;
+        }
+
+        let nowSpy: jest.SpyInstance;
+        let managedResources: GCable[];
+
+        function isTracked(resource: GCable): boolean
+        {
+            return !!resource._gcData && managedResources[resource._gcData.index] === resource;
+        }
+
+        function addStaleThenFresh(): [UnloadingResource, UnloadingResource, UnloadingResource]
+        {
+            const a = createUnloadingResource();
+            const b = createUnloadingResource();
+            const c = createUnloadingResource();
+
+            gcSystem.addResource(a, 'resource');
+            gcSystem.addResource(b, 'resource');
+            gcSystem.addResource(c, 'resource');
+            a._gcLastUsed = gcSystem.now - 2000;
+
+            return [a, b, c];
+        }
+
+        beforeEach(() =>
+        {
+            nowSpy = jest.spyOn(performance, 'now').mockReturnValue(1_000_000);
+            gcSystem.init({ gcActive: true, gcMaxUnusedTime: 1000, gcFrequency: 100 });
+            managedResources = (gcSystem as any)._managedResources;
+        });
+
+        afterEach(() =>
+        {
+            nowSpy.mockRestore();
+        });
+
+        it('should keep tracking the resources after a stale one whose unload event fires mid-sweep', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+
+            gcSystem.run();
+
+            expect(a.unloadCount).toBe(1);
+            expect(a._gcData).toBeNull();
+            expect(a.listenerCount('unload')).toBe(0);
+            expect(isTracked(b)).toBe(true);
+            expect(isTracked(c)).toBe(true);
+            expect(managedResources).toHaveLength(2);
+        });
+
+        it('should survive an unload that cascades into another tracked resource', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+
+            // Like a Graphics listening to its GraphicsContext: unloading a takes b down with it
+            a.on('unload', () => b.unload());
+
+            expect(() => gcSystem.run()).not.toThrow();
+
+            expect(a.unloadCount).toBe(1);
+            expect(b.unloadCount).toBe(1);
+            expect(a._gcData).toBeNull();
+            expect(b._gcData).toBeNull();
+            expect(isTracked(c)).toBe(true);
+            expect(managedResources).toHaveLength(1);
+        });
+
+        it('should re-register a collected resource and leave a still-tracked one alone', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+
+            gcSystem.run();
+
+            gcSystem.addResource(a, 'resource');
+            gcSystem.addResource(c, 'resource');
+
+            expect(isTracked(a)).toBe(true);
+            expect(isTracked(b)).toBe(true);
+            expect(isTracked(c)).toBe(true);
+            expect(managedResources).toHaveLength(3);
         });
     });
 

--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -497,6 +497,133 @@ describe('GCSystem', () =>
             expect(managedResources).toHaveLength(1);
         });
 
+        it('should visit surviving entries once when unload removes earlier and later entries', () =>
+        {
+            const resources = Array.from({ length: 5 }, () => createUnloadingResource());
+            const [a, b, c, d, e] = resources;
+            const visit = jest.spyOn(gcSystem as any, 'runOnResource');
+
+            resources.forEach((resource) => gcSystem.addResource(resource, 'resource'));
+            c._gcLastUsed = gcSystem.now - 2000;
+            c.on('unload', () =>
+            {
+                a.unload();
+                b.unload();
+                d.unload();
+            });
+
+            gcSystem.run();
+
+            expect(visit.mock.calls.map(([resource]) => resource)).toEqual([a, b, c, e]);
+            expect(resources.map((resource) => resource.unloadCount)).toEqual([1, 1, 1, 1, 0]);
+            expect(managedResources).toEqual([e]);
+            expect(isTracked(e)).toBe(true);
+        });
+
+        it('should collect every stale entry without skipping the entries after removals', () =>
+        {
+            const resources = Array.from({ length: 8 }, () => createUnloadingResource());
+            const [first, , , , dependent] = resources;
+
+            resources.forEach((resource) =>
+            {
+                gcSystem.addResource(resource, 'resource');
+                resource._gcLastUsed = gcSystem.now - 2000;
+            });
+            first.on('unload', () => dependent.unload());
+
+            gcSystem.run();
+
+            expect(resources.map((resource) => resource.unloadCount)).toEqual(Array(8).fill(1));
+            expect(resources.every((resource) => resource._gcData === null)).toBe(true);
+            expect(managedResources).toHaveLength(0);
+        });
+
+        it('should defer new and re-registered resources until the next sweep', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+            const added = createUnloadingResource();
+            const visit = jest.spyOn(gcSystem as any, 'runOnResource');
+
+            a.on('unload', () =>
+            {
+                b.unload();
+                gcSystem.addResource(b, 'resource');
+                gcSystem.addResource(added, 'resource');
+                b._gcLastUsed = gcSystem.now - 2000;
+                added._gcLastUsed = gcSystem.now - 2000;
+            });
+
+            gcSystem.run();
+
+            expect(visit.mock.calls.map(([resource]) => resource)).toEqual([a, c]);
+            expect(b.unloadCount).toBe(1);
+            expect(added.unloadCount).toBe(0);
+            expect(managedResources).toEqual([c, b, added]);
+            expect(managedResources.every(isTracked)).toBe(true);
+
+            gcSystem.run();
+
+            expect(b.unloadCount).toBe(2);
+            expect(added.unloadCount).toBe(1);
+            expect(managedResources).toEqual([c]);
+            expect(isTracked(c)).toBe(true);
+        });
+
+        it('should ignore a recursive sweep requested by an unload listener', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+            const visit = jest.spyOn(gcSystem as any, 'runOnResource');
+
+            a.on('unload', () => gcSystem.run());
+
+            gcSystem.run();
+
+            expect(a.unloadCount).toBe(1);
+            expect(visit.mock.calls.map(([resource]) => resource)).toEqual([a, b, c]);
+            expect(managedResources).toEqual([b, c]);
+            expect(managedResources.every(isTracked)).toBe(true);
+        });
+
+        it('should compact removals and allow another sweep after an unload listener throws', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+
+            a.once('unload', () =>
+            {
+                b.unload();
+                throw new Error('unload failed');
+            });
+
+            expect(() => gcSystem.run()).toThrow('unload failed');
+            expect(managedResources).toEqual([a, c]);
+            expect(managedResources.every(isTracked)).toBe(true);
+
+            gcSystem.removeResource(c);
+
+            expect(managedResources).toEqual([a]);
+
+            gcSystem.run();
+
+            expect(a.unloadCount).toBe(2);
+            expect(managedResources).toHaveLength(0);
+        });
+
+        it('should allow destruction during an unload after another entry was removed', () =>
+        {
+            const [a, b, c] = addStaleThenFresh();
+
+            a.on('unload', () =>
+            {
+                b.unload();
+                gcSystem.destroy();
+            });
+
+            expect(() => gcSystem.run()).not.toThrow();
+            expect(managedResources).toHaveLength(0);
+            expect(c.listenerCount('unload')).toBe(0);
+        });
+
         it('should re-register a collected resource and leave a still-tracked one alone', () =>
         {
             const [a, b, c] = addStaleThenFresh();

--- a/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
+++ b/src/rendering/renderers/shared/__tests__/GCSystem.test.ts
@@ -511,6 +511,41 @@ describe('GCSystem', () =>
             expect(isTracked(c)).toBe(true);
             expect(managedResources).toHaveLength(3);
         });
+
+        it('should re-register a collected resource whose unload listener touched it', () =>
+        {
+            const [a] = addStaleThenFresh();
+
+            // Any use during unload (a bind, an upload) stamps the last-used time
+            a.on('unload', () =>
+            {
+                a._gcLastUsed = gcSystem.now;
+            });
+
+            gcSystem.run();
+            gcSystem.addResource(a, 'resource');
+
+            expect(a.unloadCount).toBe(1);
+            expect(isTracked(a)).toBe(true);
+            expect(managedResources).toHaveLength(3);
+        });
+
+        it('should unload a resource while it is still tracked, then clear both sentinels', () =>
+        {
+            const [a] = addStaleThenFresh();
+            let trackedDuringUnload = false;
+
+            a.on('unload', () =>
+            {
+                trackedDuringUnload = isTracked(a);
+            });
+
+            gcSystem.run();
+
+            expect(trackedDuringUnload).toBe(true);
+            expect(a._gcData).toBeNull();
+            expect(a._gcLastUsed).toBe(-1);
+        });
     });
 
     describe('addResourceHash', () =>


### PR DESCRIPTION
### Overview

`GCSystem.run()` compacted `_managedResources` in place while calling `unload()` on stale entries. Every core `unload()` emits `unload` synchronously, and `addResource` registers `removeResource` on that event, so the swap-remove ran underneath the compaction: with `[A, B, C]` and A stale, C was never visited and stayed untracked for good with its `_gcData` intact. Only `gc.addResource` users are affected; core tracks through the hash path. The sweep now walks a snapshot and routes every removal through `removeResource`.

#### Breaking Changes / Behavior Changes
- `GCSystem.runOnResource` (protected) is now `(resource, now): void`; it no longer takes or returns a write index

#### Fixes
- The GC resource sweep no longer loses tracked resources when an `unload` listener removes the resource itself or another tracked one
- A resource collected by the sweep is unloaded before it is untracked, so a listener that touches it during unload cannot block it from being registered again

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
