### PR TITLE
fix: release cached GPU render targets on RenderTarget destroy

### DIFF
--- a/src/rendering/renderers/__tests__/GlRenderTargetAdaptor.test.ts
+++ b/src/rendering/renderers/__tests__/GlRenderTargetAdaptor.test.ts
@@ -1,0 +1,55 @@
+import { RenderTarget } from '../shared/renderTarget/RenderTarget';
+import { TextureSource } from '../shared/texture/sources/TextureSource';
+import { getWebGLRenderer } from '@test-utils';
+
+import type { WebGLRenderer } from '../gl/WebGLRenderer';
+
+describe('GlRenderTargetAdaptor', () =>
+{
+    let renderer: WebGLRenderer;
+
+    afterEach(() =>
+    {
+        renderer?.destroy();
+        renderer = null;
+    });
+
+    it('should make a repeat destroyGpuRenderTarget a no-op', async () =>
+    {
+        renderer = await getWebGLRenderer({});
+
+        const renderTarget = new RenderTarget({
+            colorTextures: [new TextureSource({ width: 64, height: 64, antialias: true })],
+            stencil: true,
+        });
+
+        renderer.renderTarget.bind({ target: renderTarget });
+        renderer.renderTarget.finishRenderPass();
+
+        const gpuRenderTarget = renderer.renderTarget.getGpuRenderTarget(renderTarget);
+
+        // every delete branch needs something to free: the msaa view and resolve framebuffers,
+        // one msaa colour renderbuffer and the depth-stencil renderbuffer
+        expect(gpuRenderTarget.msaa).toBe(true);
+        expect(gpuRenderTarget.msaaRenderBuffer).toHaveLength(1);
+        expect(gpuRenderTarget.depthStencilRenderBuffer).toBeTruthy();
+
+        const deleteFramebuffer = jest.spyOn(renderer.gl, 'deleteFramebuffer');
+        const deleteRenderbuffer = jest.spyOn(renderer.gl, 'deleteRenderbuffer');
+        const { adaptor } = renderer.renderTarget;
+
+        adaptor.destroyGpuRenderTarget(gpuRenderTarget);
+
+        expect(deleteFramebuffer).toHaveBeenCalledTimes(2);
+        expect(deleteRenderbuffer).toHaveBeenCalledTimes(2);
+
+        expect(() => adaptor.destroyGpuRenderTarget(gpuRenderTarget)).not.toThrow();
+
+        expect(deleteFramebuffer).toHaveBeenCalledTimes(2);
+        expect(deleteRenderbuffer).toHaveBeenCalledTimes(2);
+        expect(gpuRenderTarget.framebuffer).toBeNull();
+        expect(gpuRenderTarget.resolveTargetFramebuffer).toBeNull();
+        expect(gpuRenderTarget.depthStencilRenderBuffer).toBeNull();
+        expect(gpuRenderTarget.msaaRenderBuffer).toEqual([]);
+    });
+});

--- a/src/rendering/renderers/__tests__/RenderTarget.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTarget.test.ts
@@ -129,7 +129,7 @@ describe('isRenderingToScreen', () =>
 
         expect(glRenderTarget.framebuffer).toBeNull();
         expect(glRenderTarget.resolveTargetFramebuffer).toBeNull();
-        expect(glRenderTarget.msaaRenderBuffer).toBeNull();
+        expect(glRenderTarget.msaaRenderBuffer).toEqual([]);
 
         expect(glRenderTarget).toBeInstanceOf(GlRenderTarget);
     });

--- a/src/rendering/renderers/__tests__/RenderTarget.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTarget.test.ts
@@ -5,7 +5,7 @@ import { RenderTexture } from '../shared/texture/RenderTexture';
 import { CanvasSource } from '../shared/texture/sources/CanvasSource';
 import { TextureSource } from '../shared/texture/sources/TextureSource';
 import { Texture } from '../shared/texture/Texture';
-import { getWebGLRenderer, getWebGPURenderer } from '@test-utils';
+import { describeLocalOnly, getWebGLRenderer, getWebGPURenderer } from '@test-utils';
 import { DOMAdapter } from '~/environment';
 import { Container } from '~/scene/container/Container';
 
@@ -276,11 +276,6 @@ describe('caller-owned RenderTarget lifecycle', () =>
         colorTextures: [new TextureSource({ width: 16, height: 16 })],
     });
 
-    const backends: [string, () => Promise<WebGLRenderer | WebGPURenderer>][] = [
-        ['WebGL', getWebGLRenderer],
-        ['WebGPU', getWebGPURenderer],
-    ];
-
     it('should emit destroy once, before its attachments are released', () =>
     {
         const renderTarget = makeTarget();
@@ -296,7 +291,7 @@ describe('caller-owned RenderTarget lifecycle', () =>
         expect(renderTarget.colorAttachments).toBeNull();
     });
 
-    describe.each(backends)('on %s', (_backend, getRenderer) =>
+    const backendLifecycleTests = (getRenderer: () => Promise<WebGLRenderer | WebGPURenderer>) =>
     {
         it('should drop its caches and free the backend counterpart when the target is destroyed', async () =>
         {
@@ -344,6 +339,16 @@ describe('caller-owned RenderTarget lifecycle', () =>
             expect(renderTarget.listenerCount('destroy')).toBe(0);
             expect(() => renderTarget.destroy()).not.toThrow();
         });
+    };
+
+    describe('on WebGL', () =>
+    {
+        backendLifecycleTests(getWebGLRenderer);
+    });
+
+    describeLocalOnly('on WebGPU', () =>
+    {
+        backendLifecycleTests(getWebGPURenderer);
     });
 
     it('should delete the framebuffers of a destroyed target in WebGL', async () =>

--- a/src/rendering/renderers/__tests__/RenderTarget.test.ts
+++ b/src/rendering/renderers/__tests__/RenderTarget.test.ts
@@ -5,8 +5,12 @@ import { RenderTexture } from '../shared/texture/RenderTexture';
 import { CanvasSource } from '../shared/texture/sources/CanvasSource';
 import { TextureSource } from '../shared/texture/sources/TextureSource';
 import { Texture } from '../shared/texture/Texture';
-import { getWebGLRenderer } from '@test-utils';
+import { getWebGLRenderer, getWebGPURenderer } from '@test-utils';
 import { DOMAdapter } from '~/environment';
+import { Container } from '~/scene/container/Container';
+
+import type { WebGLRenderer } from '../gl/WebGLRenderer';
+import type { WebGPURenderer } from '../gpu/WebGPURenderer';
 
 describe('isRenderingToScreen', () =>
 {
@@ -263,5 +267,98 @@ describe('Depth-only RenderTarget', () =>
         expect(() => renderer.renderTarget.bind({ target: renderTarget, clear: true })).not.toThrow();
 
         renderTarget.destroy();
+    });
+});
+
+describe('caller-owned RenderTarget lifecycle', () =>
+{
+    const makeTarget = () => new RenderTarget({
+        colorTextures: [new TextureSource({ width: 16, height: 16 })],
+    });
+
+    const backends: [string, () => Promise<WebGLRenderer | WebGPURenderer>][] = [
+        ['WebGL', getWebGLRenderer],
+        ['WebGPU', getWebGPURenderer],
+    ];
+
+    it('should emit destroy once, before its attachments are released', () =>
+    {
+        const renderTarget = makeTarget();
+        const onDestroy = jest.fn((target: RenderTarget) => target.colorTextures.length);
+
+        renderTarget.on('destroy', onDestroy);
+        renderTarget.destroy();
+        renderTarget.on('destroy', onDestroy);
+
+        expect(() => renderTarget.destroy()).not.toThrow();
+        expect(onDestroy).toHaveBeenCalledTimes(1);
+        expect(onDestroy).toHaveReturnedWith(1);
+        expect(renderTarget.colorAttachments).toBeNull();
+    });
+
+    describe.each(backends)('on %s', (_backend, getRenderer) =>
+    {
+        it('should drop its caches and free the backend counterpart when the target is destroyed', async () =>
+        {
+            const renderer = await getRenderer();
+            const system = renderer.renderTarget;
+            const renderTarget = makeTarget();
+
+            renderer.render({ container: new Container(), target: renderTarget });
+
+            expect(system['_renderSurfaceToRenderTargetHash'].get(renderTarget)).toBe(renderTarget);
+            expect(system['_gpuRenderTargetHash'][renderTarget.uid]).toBeDefined();
+
+            const destroyGpuRenderTargetSpy = jest.spyOn(system.adaptor, 'destroyGpuRenderTarget');
+            const destroySpy = jest.spyOn(renderTarget, 'destroy');
+
+            renderTarget.destroy();
+
+            expect(system['_renderSurfaceToRenderTargetHash'].has(renderTarget)).toBe(false);
+            expect(system['_gpuRenderTargetHash'][renderTarget.uid]).toBeNull();
+            expect(destroyGpuRenderTargetSpy).toHaveBeenCalledTimes(1);
+            expect(destroySpy).toHaveBeenCalledTimes(1);
+
+            renderer.destroy();
+        });
+
+        it('should free the backend counterpart on renderer teardown and leave the target intact', async () =>
+        {
+            const renderer = await getRenderer();
+            const system = renderer.renderTarget;
+            const renderTarget = makeTarget();
+
+            renderer.render({ container: new Container(), target: renderTarget });
+
+            const gpuRenderTarget = system.getGpuRenderTarget(renderTarget);
+            const destroyGpuRenderTargetSpy = jest.spyOn(system.adaptor, 'destroyGpuRenderTarget');
+            const destroySpy = jest.spyOn(renderTarget, 'destroy');
+
+            renderer.destroy();
+
+            const releases = destroyGpuRenderTargetSpy.mock.calls.filter(([target]) => target === gpuRenderTarget);
+
+            expect(releases).toHaveLength(1);
+            expect(destroySpy).not.toHaveBeenCalled();
+            expect(renderTarget.colorTextures).toHaveLength(1);
+            expect(renderTarget.listenerCount('destroy')).toBe(0);
+            expect(() => renderTarget.destroy()).not.toThrow();
+        });
+    });
+
+    it('should delete the framebuffers of a destroyed target in WebGL', async () =>
+    {
+        const renderer = await getWebGLRenderer();
+        const renderTarget = makeTarget();
+
+        renderer.render({ container: new Container(), target: renderTarget });
+
+        const deleteFramebufferSpy = jest.spyOn(renderer.gl, 'deleteFramebuffer');
+
+        renderTarget.destroy();
+
+        expect(deleteFramebufferSpy).toHaveBeenCalled();
+
+        renderer.destroy();
     });
 });

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -385,7 +385,8 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
             gl.deleteRenderbuffer(renderBuffer);
         });
 
-        gpuRenderTarget.msaaRenderBuffer = null;
+        // emptied rather than nulled so a repeat destroy is a no-op
+        gpuRenderTarget.msaaRenderBuffer.length = 0;
     }
 
     public clear(

--- a/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gl/renderTarget/GlRenderTargetAdaptor.ts
@@ -385,7 +385,7 @@ export class GlRenderTargetAdaptor implements RenderTargetAdaptor<GlRenderTarget
             gl.deleteRenderbuffer(renderBuffer);
         });
 
-        // emptied rather than nulled so a repeat destroy is a no-op
+        // stays an array so destroying the same target again finds nothing to delete
         gpuRenderTarget.msaaRenderBuffer.length = 0;
     }
 

--- a/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTarget.ts
@@ -1,5 +1,6 @@
 // what we are building is a platform and a framework.
 // import { Matrix } from '../../shared/maths/Matrix';
+import EventEmitter from 'eventemitter3';
 import { uid } from '../../../../utils/data/uid';
 import { TextureSource } from '../texture/sources/TextureSource';
 import { Texture } from '../texture/Texture';
@@ -121,8 +122,16 @@ export interface PixiDepthStencilAttachment extends Omit<GPURenderPassDepthStenc
  * @category rendering
  * @advanced
  */
-export class RenderTarget
+export class RenderTarget extends EventEmitter<{
+    destroy: RenderTarget,
+}>
 {
+    /**
+     * emits when the render target is destroyed, before its attachments are released.
+     * letting the renderer know that it needs to free the framebuffers and MSAA buffers it built for it
+     * @event destroy
+     */
+
     /** The default options for a render target */
     public static defaultOptions: RenderTargetOptions = {
         /** the width of the RenderTarget */
@@ -189,6 +198,8 @@ export class RenderTarget
      */
     constructor(options: RenderTargetOptions | RenderTargetDescriptor = {})
     {
+        super();
+
         const descriptor = 'colorAttachments' in options ? options : this._normalizeOptions(options);
 
         this.isRoot = descriptor.isRoot ?? false;
@@ -423,6 +434,9 @@ export class RenderTarget
     {
         // return if already destroyed
         if (!this.colorAttachments && !this.depthStencilAttachment) return;
+
+        // announced before the attachments go, so listeners can still reach them
+        this.emit('destroy', this);
         this.sizeSource.off('resize', this.onSourceResize, this);
 
         if (this._managedColorTextures)
@@ -441,6 +455,7 @@ export class RenderTarget
 
         this.colorAttachments = null;
         this._colorTextures = null;
+        this.removeAllListeners();
     }
 
     /**

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1059,7 +1059,7 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
 
         this._renderSurfaceToRenderTargetHash.clear();
 
-        // what the releases above left behind was built for caller-owned targets
+        // free the backend targets built for caller-owned surfaces, which the loop above leaves intact
         for (const gpuRenderTarget of Object.values(this._gpuRenderTargetHash))
         {
             if (gpuRenderTarget) this.adaptor.destroyGpuRenderTarget(gpuRenderTarget);

--- a/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
+++ b/src/rendering/renderers/shared/renderTarget/RenderTargetSystem.ts
@@ -1050,9 +1050,20 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
             {
                 this._releaseRenderTarget(key as TextureSource, renderTarget);
             }
+            else
+            {
+                // a caller-owned target outlives the system: stop listening, leave it intact
+                renderTarget.off('destroy', this._onRenderTargetDestroy, this);
+            }
         });
 
         this._renderSurfaceToRenderTargetHash.clear();
+
+        // what the releases above left behind was built for caller-owned targets
+        for (const gpuRenderTarget of Object.values(this._gpuRenderTargetHash))
+        {
+            if (gpuRenderTarget) this.adaptor.destroyGpuRenderTarget(gpuRenderTarget);
+        }
 
         this._gpuRenderTargetHash = Object.create(null);
     }
@@ -1069,6 +1080,8 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         if (renderSurface instanceof RenderTarget)
         {
             renderTarget = renderSurface;
+
+            renderSurface.once('destroy', this._onRenderTargetDestroy, this);
         }
         else if (renderSurface instanceof TextureSource)
         {
@@ -1101,6 +1114,17 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
     }
 
     /**
+     * A caller-owned render target is tearing itself down. It releases its own attachments,
+     * so only the system's references to it and the backend objects built for it go here.
+     * @param renderTarget - the render target being destroyed
+     */
+    private _onRenderTargetDestroy(renderTarget: RenderTarget): void
+    {
+        this._renderSurfaceToRenderTargetHash.delete(renderTarget);
+        this._releaseGpuRenderTarget(renderTarget);
+    }
+
+    /**
      * Tears down a render target that wraps a texture source, removing every reference the
      * system holds to it so neither the system's own teardown nor the source's `destroy`
      * event can destroy it a second time.
@@ -1112,7 +1136,15 @@ export class RenderTargetSystem<RENDER_TARGET extends RendererRenderTarget> impl
         renderTarget.destroy();
         this._renderSurfaceToRenderTargetHash.delete(renderSurface);
         renderSurface.off('destroy', this._onRenderSurfaceDestroy, this);
+        this._releaseGpuRenderTarget(renderTarget);
+    }
 
+    /**
+     * Frees the backend objects (framebuffers, renderbuffers, MSAA textures) cached for a render target.
+     * @param renderTarget - the render target whose backend counterpart is no longer needed
+     */
+    private _releaseGpuRenderTarget(renderTarget: RenderTarget): void
+    {
         const gpuRenderTarget = this._gpuRenderTargetHash[renderTarget.uid];
 
         if (gpuRenderTarget)


### PR DESCRIPTION
### Overview

`RenderTargetSystem` only listened for `destroy` on `TextureSource` surfaces (#12095). A `RenderTarget` constructed by the caller and bound directly could not be listened to, so it stayed in both of the system's hashes forever: WebGL kept its framebuffers and renderbuffers, WebGPU its MSAA textures, and the target's attachments stayed reachable. Renderer teardown skipped those entries as well. `RenderTarget` is now an emitter with a `destroy` event, and the system treats caller-owned targets the way it treats sources.

#### Breaking Changes / Behavior Changes
- `RenderTarget` now extends `EventEmitter` and emits `destroy` before its attachments are released
- On WebGPU, `renderer.destroy()` now unconfigures the main canvas context, so a canvas left in the DOM goes blank after destroy, as it already did on WebGL

#### Fixes
- Destroying a caller-owned `RenderTarget` releases the renderer's cached framebuffers, renderbuffers and MSAA textures and removes it from the render target system
```ts
const target = new RenderTarget({ colorTextures: [texture] });
renderer.render({ container, target });
target.destroy(); // the GPU objects built for it are released with it
```
- Renderer teardown frees the GPU objects built for caller-owned render targets without destroying the targets themselves
- `GlRenderTargetAdaptor.destroyGpuRenderTarget` is safe to call more than once

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
