### PR TITLE
fix: sweep idle WebGPU bind groups with the renderer GC

### DIFF
--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -2,6 +2,7 @@ import { ExtensionType } from '../../../extensions/Extensions';
 
 import type { Buffer } from '../shared/buffer/Buffer';
 import type { BufferResource } from '../shared/buffer/BufferResource';
+import type { GCable } from '../shared/GCSystem';
 import type { UniformGroup } from '../shared/shader/UniformGroup';
 import type { System } from '../shared/system/System';
 import type { TextureSource } from '../shared/texture/sources/TextureSource';
@@ -12,6 +13,37 @@ import type { BindGroup } from './shader/BindGroup';
 import type { BindResource } from './shader/BindResource';
 import type { GpuProgram } from './shader/GpuProgram';
 import type { WebGPURenderer } from './WebGPURenderer';
+
+/**
+ * A cached native bind group, shaped so the renderer's GC can sweep it. Cache keys are built from
+ * resource ids that change whenever a resource is unloaded, resized or destroyed, so an entry that
+ * stops being requested can never be hit again and would otherwise live as long as the device.
+ * @internal
+ */
+class GpuBindGroupEntry implements GCable
+{
+    public gpuBindGroup: GPUBindGroup;
+    public _gcLastUsed: number;
+    public readonly autoGarbageCollect = true;
+    /** Part of the {@link GCable} contract; a cached bind group owns no per-renderer GPU data. */
+    public readonly _gpuData: GCable['_gpuData'] = null;
+
+    constructor(gpuBindGroup: GPUBindGroup, now: number)
+    {
+        this.gpuBindGroup = gpuBindGroup;
+        this._gcLastUsed = now;
+    }
+
+    /**
+     * Native bind groups have no destroy; dropping the reference is the whole release. Anything
+     * still holding the group (a recorded render bundle, a graphics batch) keeps it alive, and the
+     * next immediate-mode bind simply recreates the cache entry.
+     */
+    public unload(): void
+    {
+        this.gpuBindGroup = null;
+    }
+}
 
 /**
  * This manages the WebGPU bind groups. this is how data is bound to a shader when rendering
@@ -30,12 +62,16 @@ export class BindGroupSystem implements System
 
     private readonly _renderer: WebGPURenderer;
 
-    private _hash: Record<string, GPUBindGroup> = Object.create(null);
+    private _hash: Record<string, GpuBindGroupEntry> = Object.create(null);
     private _gpu: GPU;
 
     constructor(renderer: WebGPURenderer)
     {
         this._renderer = renderer;
+
+        // the GC reads the hash off this system by name on every sweep, so replacing the object in
+        // contextChange or nulling it in destroy needs no re-registration
+        renderer.gc.addResourceHash(this, '_hash', 'resource');
     }
 
     protected contextChange(gpu: GPU): void
@@ -52,10 +88,17 @@ export class BindGroupSystem implements System
         // even if they use the same resources.
         // Bit shift combines layoutKey and groupIndex into single number (groupIndex < 16)
         const key = `${bindGroup._key}:${(program._layoutKey << 4) | groupIndex}`;
+        const entry = this._hash[key];
 
-        const gpuBindGroup = this._hash[key] || this._createBindGroup(key, bindGroup, program, groupIndex);
+        // a swept slot holds null rather than being deleted, so this covers both kinds of miss
+        if (entry)
+        {
+            entry._gcLastUsed = this._renderer.gc.now;
 
-        return gpuBindGroup;
+            return entry.gpuBindGroup;
+        }
+
+        return this._createBindGroup(key, bindGroup, program, groupIndex);
     }
 
     private _createBindGroup(key: string, group: BindGroup, program: GpuProgram, groupIndex: number): GPUBindGroup
@@ -147,7 +190,7 @@ export class BindGroupSystem implements System
             entries,
         });
 
-        this._hash[key] = gpuBindGroup;
+        this._hash[key] = new GpuBindGroupEntry(gpuBindGroup, renderer.gc.now);
 
         return gpuBindGroup;
     }

--- a/src/rendering/renderers/gpu/BindGroupSystem.ts
+++ b/src/rendering/renderers/gpu/BindGroupSystem.ts
@@ -69,9 +69,11 @@ export class BindGroupSystem implements System
     {
         this._renderer = renderer;
 
-        // the GC reads the hash off this system by name on every sweep, so replacing the object in
-        // contextChange or nulling it in destroy needs no re-registration
+        // the sweep nulls idle slots and the periodic clean pass compacts the nulls away; both read
+        // the hash off this system by name, so replacing the object in contextChange or nulling it
+        // in destroy needs no re-registration
         renderer.gc.addResourceHash(this, '_hash', 'resource');
+        renderer.gc.addCollection(this, '_hash', 'hash');
     }
 
     protected contextChange(gpu: GPU): void

--- a/src/rendering/renderers/gpu/__tests__/BindGroupSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/BindGroupSystem.test.ts
@@ -28,6 +28,14 @@ function backdate(entries: { _gcLastUsed: number }[]): void
     }
 }
 
+// the GC schedules its clean pass through the renderer's scheduler; fire that task directly
+function runCleanPass(): void
+{
+    const id = renderer.gc['_collectionsHandler'];
+
+    renderer.scheduler['_tasks'].find((task) => task.id === id).func(0);
+}
+
 describeLocalOnly('BindGroupSystem cache sweep', () =>
 {
     it('re-stamps entries on a cache hit instead of growing the cache', async () =>
@@ -132,5 +140,34 @@ describeLocalOnly('BindGroupSystem cache sweep', () =>
         renderer.gc.run();
 
         expect(liveEntries()).toHaveLength(0);
+    });
+
+    it('compacts swept slots out of the hash on the GC clean pass', async () =>
+    {
+        renderer = await getWebGPURenderer();
+
+        const registration = renderer.gc['_managedCollections'].find((entry) => entry.context === renderer.bindGroup);
+
+        expect(registration).toMatchObject({ collection: '_hash', type: 'hash' });
+
+        const sprite = new Sprite({ texture: getTexture() });
+
+        renderer.render(sprite);
+
+        const keys = Object.keys(renderer.bindGroup['_hash']);
+
+        backdate(liveEntries());
+        renderer.gc.run();
+
+        // the sweep only nulls slots; the keys stay until the clean pass rebuilds the hash
+        expect(Object.keys(renderer.bindGroup['_hash'])).toEqual(keys);
+
+        runCleanPass();
+
+        expect(Object.keys(renderer.bindGroup['_hash'])).toHaveLength(0);
+
+        renderer.render(sprite);
+
+        expect(liveEntries()).toHaveLength(keys.length);
     });
 });

--- a/src/rendering/renderers/gpu/__tests__/BindGroupSystem.test.ts
+++ b/src/rendering/renderers/gpu/__tests__/BindGroupSystem.test.ts
@@ -1,0 +1,136 @@
+import { describeLocalOnly, getTexture, getWebGPURenderer, loseAndRestoreDevice } from '@test-utils';
+import { Sprite } from '~/scene';
+
+import type { WebGPURenderer } from '../WebGPURenderer';
+
+let renderer: WebGPURenderer;
+
+afterEach(() =>
+{
+    renderer?.destroy();
+    renderer = null;
+});
+
+// the sweep nulls a slot rather than deleting it, so "live" means non-null
+function liveEntries()
+{
+    return Object.values(renderer.bindGroup['_hash']).filter(Boolean);
+}
+
+// old enough that the next sweep treats the entry as idle
+function backdate(entries: { _gcLastUsed: number }[]): void
+{
+    const stale = performance.now() - renderer.gc.maxUnusedTime;
+
+    for (const entry of entries)
+    {
+        entry._gcLastUsed = stale;
+    }
+}
+
+describeLocalOnly('BindGroupSystem cache sweep', () =>
+{
+    it('re-stamps entries on a cache hit instead of growing the cache', async () =>
+    {
+        renderer = await getWebGPURenderer();
+        const sprite = new Sprite({ texture: getTexture() });
+
+        renderer.render(sprite);
+
+        const first = liveEntries();
+
+        expect(first.length).toBeGreaterThan(0);
+
+        backdate(first);
+        renderer.render(sprite);
+
+        const second = liveEntries();
+
+        expect(second).toHaveLength(first.length);
+        expect(second).toEqual(expect.arrayContaining(first));
+
+        for (const entry of first)
+        {
+            expect(entry._gcLastUsed).toBe(renderer.gc.now);
+        }
+    });
+
+    it('sweeps the entries a texture unload strands and keeps the ones still in use', async () =>
+    {
+        renderer = await getWebGPURenderer();
+        const texture = getTexture();
+        const sprite = new Sprite({ texture });
+
+        renderer.render(sprite);
+
+        const before = liveEntries();
+
+        // only the entries the next frame touches get a fresh stamp back
+        backdate(before);
+        texture.source.unload();
+        renderer.render(sprite);
+
+        const after = liveEntries();
+        const used = after.filter((entry) => entry._gcLastUsed === renderer.gc.now);
+        const stranded = after.filter((entry) => !used.includes(entry));
+
+        expect(stranded.length).toBeGreaterThan(0);
+        expect(after).toHaveLength(before.length + stranded.length);
+
+        renderer.gc.run();
+
+        const survivors = liveEntries();
+
+        expect(survivors).toHaveLength(before.length);
+        expect(survivors).toEqual(expect.arrayContaining(used));
+
+        for (const entry of stranded)
+        {
+            expect(survivors).not.toContain(entry);
+            expect(entry.gpuBindGroup).toBeNull();
+        }
+    });
+
+    it('renders again after a sweep, rebuilding only what the frame needs', async () =>
+    {
+        renderer = await getWebGPURenderer();
+        const sprite = new Sprite({ texture: getTexture() });
+
+        renderer.render(sprite);
+
+        const count = liveEntries().length;
+
+        backdate(liveEntries());
+        renderer.gc.run();
+
+        expect(liveEntries()).toHaveLength(0);
+
+        expect(() => renderer.render(sprite)).not.toThrow();
+        expect(liveEntries()).toHaveLength(count);
+        expect(renderer.extract.pixels(sprite).pixels.some((value) => value > 0)).toBe(true);
+    });
+
+    it('starts a fresh cache after a device loss and keeps sweeping it', async () =>
+    {
+        renderer = await getWebGPURenderer();
+        const sprite = new Sprite({ texture: getTexture() });
+
+        renderer.render(sprite);
+
+        const previousHash = renderer.bindGroup['_hash'];
+
+        await loseAndRestoreDevice(renderer);
+
+        expect(renderer.bindGroup['_hash']).not.toBe(previousHash);
+        expect(liveEntries()).toHaveLength(0);
+
+        renderer.render(sprite);
+
+        expect(liveEntries().length).toBeGreaterThan(0);
+
+        backdate(liveEntries());
+        renderer.gc.run();
+
+        expect(liveEntries()).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
### Overview

WebGPU's `BindGroupSystem` cached native bind groups under keys built from resource ids. Those ids change whenever a buffer or texture is unloaded, resized or destroyed (the re-keying added in #12147 to stop stale bind groups referencing destroyed buffers), and nothing ever evicted the old entries, so the cache grew for the life of the device; the renderer GC's own texture unloads fed it on a timer. Each cache entry is now a GC-managed record stamped on use and registered with `renderer.gc`, so idle entries are dropped like other GPU state and recreated on the next bind. Recorded bundles keep their own reference to the native group, so a swept entry costs one re-creation, never a stale bind.

#### Fixes
- WebGPU bind groups idle for longer than `gcMaxUnusedTime` are dropped by the renderer GC instead of accumulating for the life of the device

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
