### PR TITLE
fix: keep per-target stencil state on the backend render target

### DIFF
--- a/src/rendering/mask/stencil/StencilMaskPipe.ts
+++ b/src/rendering/mask/stencil/StencilMaskPipe.ts
@@ -26,9 +26,6 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
 
     private _renderer: Renderer;
 
-    // used when building and also when executing..
-    private _maskStackHash: Record<number, number> = {};
-
     private _maskHash = new WeakMap<StencilMask, {
         instructionsStart: number,
         instructionsLength: number,
@@ -94,10 +91,6 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
         const instructionsLength = instructionSet.instructionSize - maskData.instructionsStart - 1;
 
         maskData.instructionsLength = instructionsLength;
-
-        const renderTargetUid = renderer.renderTarget.renderTarget.uid;
-
-        this._maskStackHash[renderTargetUid] ??= 0;
     }
 
     public pop(mask: Effect, _container: Container, instructionSet: InstructionSet): void
@@ -137,9 +130,9 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
         const renderer = this._renderer;
 
         const gpuRenderer = renderer as WebGLRenderer | WebGPURenderer;
-        const renderTargetUid = renderer.renderTarget.renderTarget.uid;
+        const gpuRenderTarget = gpuRenderer.renderTarget.getGpuRenderTarget(gpuRenderer.renderTarget.renderTarget);
 
-        let maskStackIndex = this._maskStackHash[renderTargetUid] ??= 0;
+        let maskStackIndex = gpuRenderTarget.maskStackIndex;
 
         if (instruction.action === 'pushMaskBegin')
         {
@@ -196,13 +189,12 @@ export class StencilMaskPipe implements InstructionPipe<StencilMaskInstruction>
             gpuRenderer.colorMask.setMask(0xF);
         }
 
-        this._maskStackHash[renderTargetUid] = maskStackIndex;
+        gpuRenderTarget.maskStackIndex = maskStackIndex;
     }
 
     public destroy()
     {
         this._renderer = null;
-        this._maskStackHash = null;
         this._maskHash = null;
     }
 }

--- a/src/rendering/mask/stencil/__tests__/StencilMaskPipe.test.ts
+++ b/src/rendering/mask/stencil/__tests__/StencilMaskPipe.test.ts
@@ -1,0 +1,197 @@
+import {
+    describeLocalOnly,
+    getWebGLRenderer,
+    getWebGPURenderer,
+    loseAndRestoreContext,
+    loseAndRestoreDevice,
+} from '@test-utils';
+import { RenderTarget, RenderTexture, STENCIL_MODES, Texture, TextureSource } from '~/rendering';
+import { Container, Graphics, Sprite } from '~/scene';
+
+import type { WebGLRenderer, WebGPURenderer } from '~/rendering';
+
+type GpuRenderer = WebGLRenderer | WebGPURenderer;
+
+// a red sprite filling the texture, with a mask that only uncovers its left half
+function createMaskedScene(): Container
+{
+    const scene = new Container();
+    const content = new Sprite(Texture.WHITE);
+
+    content.setSize(32, 32);
+    content.tint = 0xff0000;
+
+    const mask = new Graphics().rect(0, 0, 16, 32).fill(0xffffff);
+
+    scene.addChild(content, mask);
+    content.mask = mask;
+
+    return scene;
+}
+
+function createRenderTarget(): RenderTarget
+{
+    return new RenderTarget({ colorTextures: [new TextureSource({ width: 32, height: 32 })] });
+}
+
+function pixelAt(renderer: GpuRenderer, texture: RenderTexture, x: number, y: number): number[]
+{
+    const { pixels, width } = renderer.extract.pixels(texture);
+    const i = ((y * width) + x) * 4;
+
+    return Array.from(pixels.slice(i, i + 4));
+}
+
+function stencilMaskSuite(
+    getRenderer: () => Promise<GpuRenderer>,
+    loseAndRestore: (renderer: GpuRenderer) => Promise<void>
+)
+{
+    let renderer: GpuRenderer;
+    let scene: Container;
+    let textureA: RenderTexture;
+    let textureB: RenderTexture;
+
+    beforeEach(async () =>
+    {
+        renderer = await getRenderer();
+        scene = createMaskedScene();
+        textureA = RenderTexture.create({ width: 32, height: 32 });
+        textureB = RenderTexture.create({ width: 32, height: 32 });
+    });
+
+    afterEach(() =>
+    {
+        jest.restoreAllMocks();
+        renderer.destroy();
+    });
+
+    it('should track the mask stack and stencil state per render target', () =>
+    {
+        const spy = jest.spyOn(renderer.stencil, 'setStencilMode');
+
+        for (let i = 0; i < 3; i++)
+        {
+            renderer.render({ container: scene, target: textureA });
+            renderer.render({ container: scene, target: textureB });
+        }
+
+        const targetA = renderer.renderTarget.getRenderTarget(textureA);
+        const targetB = renderer.renderTarget.getRenderTarget(textureB);
+        const gpuTargetA = renderer.renderTarget.getGpuRenderTarget(targetA);
+        const gpuTargetB = renderer.renderTarget.getGpuRenderTarget(targetB);
+
+        expect(gpuTargetA).not.toBe(gpuTargetB);
+
+        // every mask push started at reference 0: neither target's counter bled into the other's frames
+        const pushes = spy.mock.calls.filter(([mode]) => mode === STENCIL_MODES.RENDERING_MASK_ADD);
+
+        expect(pushes).toHaveLength(6);
+        expect(pushes.every(([, reference]) => reference === 0)).toBe(true);
+
+        // and every push was matched by a pop
+        expect(gpuTargetA.maskStackIndex).toBe(0);
+        expect(gpuTargetB.maskStackIndex).toBe(0);
+
+        // the state a masked frame leaves behind stays on the target's own backend object
+        expect(gpuTargetA.stencilMode).toBe(STENCIL_MODES.MASK_ACTIVE);
+        expect(gpuTargetB.stencilMode).toBe(STENCIL_MODES.MASK_ACTIVE);
+
+        renderer.render({ container: scene, target: textureA });
+
+        // a target seen again keeps its backend object rather than getting a fresh one
+        expect(renderer.renderTarget.getGpuRenderTarget(targetA)).toBe(gpuTargetA);
+    });
+
+    it('should restore each render target\'s own stencil state when switching between them', () =>
+    {
+        const plain = new Sprite(Texture.WHITE);
+
+        renderer.render({ container: scene, target: textureA });
+        renderer.render({ container: plain, target: textureB });
+
+        const spy = jest.spyOn(renderer.stencil, 'setStencilMode');
+
+        // binding A brings back the state its last masked frame left behind
+        renderer.render({ container: scene, target: textureA });
+
+        expect(spy.mock.calls[0]).toEqual([STENCIL_MODES.MASK_ACTIVE, 0]);
+
+        spy.mockClear();
+
+        // binding B brings back its own untouched default, not A's state
+        renderer.render({ container: plain, target: textureB });
+
+        expect(spy.mock.calls[0]).toEqual([STENCIL_MODES.DISABLED, 0]);
+    });
+
+    it('should keep masking into a surviving render texture after another one is destroyed', () =>
+    {
+        renderer.render({ container: scene, target: textureA });
+        renderer.render({ container: scene, target: textureB });
+
+        textureA.destroy(true);
+
+        expect(() => renderer.render({ container: scene, target: textureB })).not.toThrow();
+
+        expect(pixelAt(renderer, textureB, 8, 16)).toEqual([255, 0, 0, 255]);
+        expect(pixelAt(renderer, textureB, 24, 16)[0]).toBe(0);
+    });
+
+    it('should free the tracked state with the backend object when a caller-owned target is destroyed', () =>
+    {
+        const target = createRenderTarget();
+
+        renderer.render({ container: scene, target });
+
+        expect(renderer.renderTarget.getGpuRenderTarget(target).stencilMode).toBe(STENCIL_MODES.MASK_ACTIVE);
+
+        target.destroy();
+
+        expect(renderer.renderTarget['_gpuRenderTargetHash'][target.uid]).toBeNull();
+
+        // a new target starts from the defaults rather than inheriting anything the old one left behind
+        const next = createRenderTarget();
+        const spy = jest.spyOn(renderer.stencil, 'setStencilMode');
+
+        renderer.render({ container: new Sprite(Texture.WHITE), target: next });
+
+        expect(spy.mock.calls[0]).toEqual([STENCIL_MODES.DISABLED, 0]);
+        expect(renderer.renderTarget.getGpuRenderTarget(next)).toMatchObject({
+            stencilMode: STENCIL_MODES.DISABLED,
+            stencilReference: 0,
+            maskStackIndex: 0,
+        });
+    });
+
+    it('should track the state on the rebuilt backend object after the context is restored', async () =>
+    {
+        renderer.render({ container: scene, target: textureA });
+
+        const targetA = renderer.renderTarget.getRenderTarget(textureA);
+        const before = renderer.renderTarget.getGpuRenderTarget(targetA);
+
+        await loseAndRestore(renderer);
+
+        // the same target is bound again, so no change event announces the rebuilt backend object
+        renderer.render({ container: scene, target: textureA });
+
+        const after = renderer.renderTarget.getGpuRenderTarget(targetA);
+
+        expect(after).not.toBe(before);
+        expect(after.stencilMode).toBe(STENCIL_MODES.MASK_ACTIVE);
+        expect(after.maskStackIndex).toBe(0);
+        expect(pixelAt(renderer, textureA, 8, 16)).toEqual([255, 0, 0, 255]);
+        expect(pixelAt(renderer, textureA, 24, 16)[0]).toBe(0);
+    });
+}
+
+describe('StencilMaskPipe (WebGL)', () =>
+{
+    stencilMaskSuite(getWebGLRenderer, (renderer) => loseAndRestoreContext(renderer as WebGLRenderer));
+});
+
+describeLocalOnly('StencilMaskPipe (WebGPU)', () =>
+{
+    stencilMaskSuite(getWebGPURenderer, (renderer) => loseAndRestoreDevice(renderer as WebGPURenderer));
+});

--- a/src/rendering/renderers/gl/GlRenderTarget.ts
+++ b/src/rendering/renderers/gl/GlRenderTarget.ts
@@ -1,3 +1,5 @@
+import { STENCIL_MODES } from '../shared/state/const';
+
 /**
  * Represents a render target.
  * @category rendering
@@ -24,4 +26,14 @@ export class GlRenderTarget
     public resolveTargetFramebuffer: WebGLFramebuffer;
     public msaaRenderBuffer: WebGLRenderbuffer[] = [];
     public depthStencilRenderBuffer: WebGLRenderbuffer;
+    /**
+     * The stencil state the stencil system and the mask pipe track for this target on this renderer.
+     * It lives here rather than in a uid-keyed record so it is restored when the target is bound again
+     * and freed with the backend object when the target dies.
+     */
+    public stencilMode: STENCIL_MODES = STENCIL_MODES.DISABLED;
+    /** the stencil reference value that goes with `stencilMode` */
+    public stencilReference = 0;
+    /** how many stencil masks are currently pushed on this target */
+    public maskStackIndex = 0;
 }

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -171,6 +171,7 @@ export class GlStencilSystem implements System
         this._renderer.renderTarget.onRenderTargetChange.remove(this);
 
         (this._renderer as null) = null;
+        this._gl = null;
 
         this._activeRenderTarget = null;
         this._activeGpuRenderTarget = null;

--- a/src/rendering/renderers/gl/GlStencilSystem.ts
+++ b/src/rendering/renderers/gl/GlStencilSystem.ts
@@ -4,6 +4,7 @@ import { STENCIL_MODES } from '../shared/state/const';
 
 import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
 import type { System } from '../shared/system/System';
+import type { GlRenderTarget } from './GlRenderTarget';
 import type { WebGLRenderer } from './WebGLRenderer';
 
 /**
@@ -21,6 +22,7 @@ export class GlStencilSystem implements System
         name: 'stencil',
     } as const;
 
+    private readonly _renderer: WebGLRenderer;
     private _gl: WebGLRenderingContext;
 
     private readonly _stencilCache = {
@@ -28,11 +30,6 @@ export class GlStencilSystem implements System
         stencilReference: 0,
         stencilMode: STENCIL_MODES.NONE,
     };
-
-    private _renderTargetStencilState: Record<number, {
-        stencilMode: STENCIL_MODES;
-        stencilReference: number;
-    }> = Object.create(null);
 
     private _stencilOpsMapping: {
         keep: number;
@@ -57,9 +54,13 @@ export class GlStencilSystem implements System
     };
 
     private _activeRenderTarget: RenderTarget;
+    /** the backend counterpart of the active render target, which carries the stencil state being tracked */
+    private _activeGpuRenderTarget: GlRenderTarget;
 
     constructor(renderer: WebGLRenderer)
     {
+        this._renderer = renderer;
+
         renderer.renderTarget.onRenderTargetChange.add(this);
     }
 
@@ -91,6 +92,10 @@ export class GlStencilSystem implements System
             'decrement-wrap': gl.DECR_WRAP,
         };
 
+        // the backend render targets were rebuilt with the context, so the stencil state starts over;
+        // the next setStencilMode picks up the rebuilt object, as no change event announces it
+        this._activeGpuRenderTarget = null;
+
         this.resetState();
     }
 
@@ -100,18 +105,12 @@ export class GlStencilSystem implements System
 
         this._activeRenderTarget = renderTarget;
 
-        let stencilState = this._renderTargetStencilState[renderTarget.uid];
+        const gpuRenderTarget = this._renderer.renderTarget.getGpuRenderTarget(renderTarget);
 
-        if (!stencilState)
-        {
-            stencilState = this._renderTargetStencilState[renderTarget.uid] = {
-                stencilMode: STENCIL_MODES.DISABLED,
-                stencilReference: 0,
-            };
-        }
+        this._activeGpuRenderTarget = gpuRenderTarget;
 
         // restore the current render targets stencil state..
-        this.setStencilMode(stencilState.stencilMode, stencilState.stencilReference);
+        this.setStencilMode(gpuRenderTarget.stencilMode, gpuRenderTarget.stencilReference);
     }
 
     public resetState()
@@ -124,7 +123,8 @@ export class GlStencilSystem implements System
 
     public setStencilMode(stencilMode: STENCIL_MODES, stencilReference: number)
     {
-        const stencilState = this._renderTargetStencilState[this._activeRenderTarget.uid];
+        const gpuRenderTarget = this._activeGpuRenderTarget
+            ??= this._renderer.renderTarget.getGpuRenderTarget(this._activeRenderTarget);
 
         const gl = this._gl;
         const mode = GpuStencilModesToPixi[stencilMode];
@@ -132,8 +132,8 @@ export class GlStencilSystem implements System
         const _stencilCache = this._stencilCache;
 
         // store the stencil state for restoration later, if a render target changes
-        stencilState.stencilMode = stencilMode;
-        stencilState.stencilReference = stencilReference;
+        gpuRenderTarget.stencilMode = stencilMode;
+        gpuRenderTarget.stencilReference = stencilReference;
 
         if (stencilMode === STENCIL_MODES.DISABLED)
         {
@@ -166,5 +166,13 @@ export class GlStencilSystem implements System
         }
     }
 
-    public destroy?: () => void;
+    public destroy()
+    {
+        this._renderer.renderTarget.onRenderTargetChange.remove(this);
+
+        (this._renderer as null) = null;
+
+        this._activeRenderTarget = null;
+        this._activeGpuRenderTarget = null;
+    }
 }

--- a/src/rendering/renderers/gpu/GpuStencilSystem.ts
+++ b/src/rendering/renderers/gpu/GpuStencilSystem.ts
@@ -1,8 +1,9 @@
 import { ExtensionType } from '../../../extensions/Extensions';
-import { STENCIL_MODES } from '../shared/state/const';
 
 import type { RenderTarget } from '../shared/renderTarget/RenderTarget';
+import type { STENCIL_MODES } from '../shared/state/const';
 import type { System } from '../shared/system/System';
+import type { GpuRenderTarget } from './renderTarget/GpuRenderTarget';
 import type { WebGPURenderer } from './WebGPURenderer';
 
 /**
@@ -22,12 +23,9 @@ export class GpuStencilSystem implements System
 
     private readonly _renderer: WebGPURenderer;
 
-    private _renderTargetStencilState: Record<number, {
-        stencilMode: STENCIL_MODES;
-        stencilReference: number;
-    }> = Object.create(null);
-
     private _activeRenderTarget: RenderTarget;
+    /** the backend counterpart of the active render target, which carries the stencil state being tracked */
+    private _activeGpuRenderTarget: GpuRenderTarget;
 
     constructor(renderer: WebGPURenderer)
     {
@@ -36,29 +34,30 @@ export class GpuStencilSystem implements System
         renderer.renderTarget.onRenderTargetChange.add(this);
     }
 
+    protected contextChange(): void
+    {
+        // the backend render targets were rebuilt with the device, so the stencil state starts over;
+        // the next setStencilMode picks up the rebuilt object, as no change event announces it
+        this._activeGpuRenderTarget = null;
+    }
+
     protected onRenderTargetChange(renderTarget: RenderTarget)
     {
-        let stencilState = this._renderTargetStencilState[renderTarget.uid];
-
-        if (!stencilState)
-        {
-            stencilState = this._renderTargetStencilState[renderTarget.uid] = {
-                stencilMode: STENCIL_MODES.DISABLED,
-                stencilReference: 0,
-            };
-        }
+        const gpuRenderTarget = this._renderer.renderTarget.getGpuRenderTarget(renderTarget);
 
         this._activeRenderTarget = renderTarget;
+        this._activeGpuRenderTarget = gpuRenderTarget;
 
-        this.setStencilMode(stencilState.stencilMode, stencilState.stencilReference);
+        this.setStencilMode(gpuRenderTarget.stencilMode, gpuRenderTarget.stencilReference);
     }
 
     public setStencilMode(stencilMode: STENCIL_MODES, stencilReference: number)
     {
-        const stencilState = this._renderTargetStencilState[this._activeRenderTarget.uid];
+        const gpuRenderTarget = this._activeGpuRenderTarget
+            ??= this._renderer.renderTarget.getGpuRenderTarget(this._activeRenderTarget);
 
-        stencilState.stencilMode = stencilMode;
-        stencilState.stencilReference = stencilReference;
+        gpuRenderTarget.stencilMode = stencilMode;
+        gpuRenderTarget.stencilReference = stencilReference;
 
         const renderer = this._renderer;
 
@@ -73,6 +72,6 @@ export class GpuStencilSystem implements System
         (this._renderer as null) = null;
 
         this._activeRenderTarget = null;
-        this._renderTargetStencilState = null;
+        this._activeGpuRenderTarget = null;
     }
 }

--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTarget.ts
@@ -1,3 +1,5 @@
+import { STENCIL_MODES } from '../../shared/state/const';
+
 import type { TextureSource } from '../../shared/texture/sources/TextureSource';
 
 /**
@@ -14,4 +16,14 @@ export class GpuRenderTarget
     public width: number;
     public height: number;
     public descriptor: GPURenderPassDescriptor;
+    /**
+     * The stencil state the stencil system and the mask pipe track for this target on this renderer.
+     * It lives here rather than in a uid-keyed record so it is restored when the target is bound again
+     * and freed with the backend object when the target dies.
+     */
+    public stencilMode: STENCIL_MODES = STENCIL_MODES.DISABLED;
+    /** the stencil reference value that goes with `stencilMode` */
+    public stencilReference = 0;
+    /** how many stencil masks are currently pushed on this target */
+    public maskStackIndex = 0;
 }


### PR DESCRIPTION
### Overview

Stacked on #12192, which frees a render target's backend object when the target is destroyed.

The stencil systems and the stencil mask pipe kept per-render-target state (stencil mode, reference, mask-stack depth) in records keyed by `renderTarget.uid` that nothing ever cleared, so every render target ever drawn to left its entry behind. The state now lives on `GlRenderTarget` / `GpuRenderTarget`, which the render target system already caches per target and frees with it. The stencil systems keep the active backend object cached, so `setStencilMode` no longer does a lookup, and the mask pipe keeps its single lookup per instruction.

#### Fixes
- Per-render-target stencil state and mask-stack depth are released when the render target is destroyed instead of accumulating for the life of the renderer

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
