### PR TITLE
chore: update Assets texture-loading examples for v8

### DIFF
--- a/src/assets/Assets.ts
+++ b/src/assets/Assets.ts
@@ -349,7 +349,7 @@ export class AssetsClass
      *                 {
      *                     alias: 'hero',
      *                     src: 'hero.{png,webp}',
-     *                     data: { scaleMode: SCALE_MODES.NEAREST }
+     *                     data: { scaleMode: 'nearest' }
      *                 },
      *                 {
      *                     alias: 'map',
@@ -547,8 +547,8 @@ export class AssetsClass
      *     alias: 'sprite',
      *     src: 'sprite.png',
      *     data: {
-     *         scaleMode: SCALE_MODES.NEAREST,
-     *         mipmap: MIPMAP_MODES.ON
+     *         scaleMode: 'nearest',
+     *         autoGenerateMipmaps: true
      *     }
      * });
      *
@@ -556,7 +556,7 @@ export class AssetsClass
      * const image = await Assets.load({
      *    alias: 'imageWithoutExtension',
      *    src: 'images/imageWithoutExtension',
-     *    parser: 'texture' // Use the JSON loader
+     *    parser: 'texture' // Use the texture loader
      * });
      * ```
      * @remarks


### PR DESCRIPTION
##### Description of change

Update the texture-loading examples in `Assets.init` and `Assets.load` to use the current texture source options:

- Use `scaleMode: 'nearest'` instead of the deprecated `SCALE_MODES.NEAREST` constant.
- Replace `mipmap: MIPMAP_MODES.ON` with `autoGenerateMipmaps: true`. `MIPMAP_MODES` is no longer exported, and the legacy `mipmap` option does not enable mipmap generation on `TextureSource`.
- Correct the texture parser example's comment from "JSON loader" to "texture loader". The `texture` parser id stays unchanged.

This changes documentation examples only.

Validation: options extracted from the updated example were used to instantiate `TextureSource`; `autoGenerateMipmaps === true` and `style.scaleMode === 'nearest'` were verified. ESLint, all three type-check configurations, index checks, and Knip passed. The full `npm test` run passed 189 unit test suites, including `Assets.test.ts`, but failed in `TextMetrics`, `Text`, `CompressedTextures`, and `VideoSource`; visual tests were not reached. A serial rerun with the original upstream `Assets.ts` reproduced the two text-suite failures, while the two media suites passed. The full-suite tests checkbox remains unchecked.

##### Pre-Merge Checklist

- [x] Documentation is changed or added
- [x] Lint process passed
- [ ] Tests passed (`npm test`)
