### PR TITLE
fix: don't inherit autoGenerateMipmaps on WebGPU MSAA textures

### DIFF
--- a/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
+++ b/src/rendering/renderers/gpu/renderTarget/GpuRenderTargetAdaptor.ts
@@ -537,6 +537,9 @@ export class GpuRenderTargetAdaptor implements RenderTargetAdaptor<GpuRenderTarg
                     width: 0,
                     height: 0,
                     sampleCount: 4,
+                    // WebGPU requires multisampled textures to have exactly 1 mip level, so this must never
+                    // inherit TextureSource.defaultOptions.autoGenerateMipmaps
+                    autoGenerateMipmaps: false,
                     transient: colorTexture.transient,
                     arrayLayerCount: colorTexture.arrayLayerCount,
                     format: colorTexture.format,

--- a/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
+++ b/src/rendering/renderers/gpu/renderTarget/__tests__/GpuRenderTargetAdaptor.test.ts
@@ -74,3 +74,44 @@ describeLocalOnly('GpuRenderTargetAdaptor labels', () =>
         renderer.destroy();
     });
 });
+
+describeLocalOnly('GpuRenderTargetAdaptor msaa textures', () =>
+{
+    it('should not inherit autoGenerateMipmaps from TextureSource.defaultOptions', async () =>
+    {
+        const originalAutoGenerateMipmaps = TextureSource.defaultOptions.autoGenerateMipmaps;
+
+        TextureSource.defaultOptions.autoGenerateMipmaps = true;
+
+        const renderer = (await getWebGPURenderer()) as WebGPURenderer;
+
+        try
+        {
+            const target = new RenderTarget({
+                colorTextures: [new TextureSource({ width: 16, height: 16, antialias: true })],
+            });
+
+            const device = renderer.gpu.device;
+
+            device.pushErrorScope('validation');
+
+            renderer.encoder.renderStart();
+            renderer.renderTarget.bind({ target, clear: true });
+
+            const msaaTexture = renderer.renderTarget.getGpuRenderTarget(target).msaaTextures[0];
+
+            // multisampled textures must have exactly 1 mip level
+            expect(msaaTexture.autoGenerateMipmaps).toBe(false);
+            expect(msaaTexture.mipLevelCount).toBe(1);
+
+            renderer.encoder.postrender();
+
+            expect(await device.popErrorScope()).toBeNull();
+        }
+        finally
+        {
+            TextureSource.defaultOptions.autoGenerateMipmaps = originalAutoGenerateMipmaps;
+            renderer.destroy();
+        }
+    });
+});


### PR DESCRIPTION
##### Description of change

Fixes #10598, where setting `TextureSource.defaultOptions.autoGenerateMipmaps = true` breaks all rendering on WebGPU when antialiasing is enabled.

**The problem:**

`GpuRenderTargetAdaptor.initGpuRenderTarget()` creates the 4x multisampled texture for an antialiased render target without specifying `autoGenerateMipmaps`, so it inherits the global default. `GpuTextureSystem._initSource()` then computes a mip level count from the texture's size, but WebGPU requires multisampled textures to have exactly 1 mip level. Texture creation fails, and every subsequent frame fails validation against the resulting invalid texture view:

```
GPUValidationError: The mip level count (11) of a multisampled texture is not 1.
 - While calling [Device].CreateTexture([TextureDescriptor]).

GPUValidationError: [Invalid TextureView] is invalid due to a previous error.
 - While validating colorAttachments[0].
```

The result is a blank canvas. Nothing is reported through the console, since WebGPU validation errors don't surface there, which makes this hard to diagnose. WebGL is unaffected.

**The fix:**

Explicitly set `autoGenerateMipmaps: false` on the MSAA texture, so it is never affected by the global default. This mirrors what `RenderTarget` and (since #11865) `TexturePool` already do for their internal textures.

Minimal repro (also in #10598): set `TextureSource.defaultOptions.autoGenerateMipmaps = true`, then `autoDetectRenderer({ preference: 'webgpu', antialias: true })` and render anything.

The added test fails without the fix (the MSAA texture's `autoGenerateMipmaps` is `true`) and passes with it.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run test lint`)
- [x] Tests passed (`npm run test unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
